### PR TITLE
Make database on method return successCallback

### DIFF
--- a/lib/modules/database/reference.js
+++ b/lib/modules/database/reference.js
@@ -99,16 +99,21 @@ export default class Reference extends ReferenceBase {
    * @param successCallback
    * @param failureCallback
    * @param context TODO
-   * @returns {*}
+   * @returns successCallback
    */
   on(eventType: string, successCallback: () => any, failureCallback: () => any) {
     if (!isFunction(successCallback)) throw new Error('The specified callback must be a function');
     if (failureCallback && !isFunction(failureCallback)) throw new Error('The specified error callback must be a function');
+
     const path = this._dbPath();
     const modifiers = this.query.getModifiers();
     const modifiersString = this.query.getModifiersString();
+
     this.log.debug('adding reference.on', path, modifiersString, eventType);
-    return this.db.on(path, modifiersString, modifiers, eventType, successCallback, failureCallback);
+
+    this.db.on(path, modifiersString, modifiers, eventType, successCallback, failureCallback);
+
+    return successCallback;
   }
 
   /**


### PR DESCRIPTION
As per https://firebase.google.com/docs/reference/js/firebase.database.Reference, the `on` method should return the `successCallback`.