### PR TITLE
[js][database] Add ref property for consistency with web API

### DIFF
--- a/lib/modules/database/reference.js
+++ b/lib/modules/database/reference.js
@@ -350,6 +350,14 @@ export default class Reference extends ReferenceBase {
     return new Reference(this.database, this.path.substring(0, this.path.lastIndexOf('/')));
   }
 
+  /**
+   * A reference to itself
+   * @type {!Reference}
+   * {@link https://firebase.google.com/docs/reference/js/firebase.database.Reference#ref}
+   */
+  get ref(): Reference {
+    return this;
+  }
 
   /**
    * Returns a ref to the root of db - '/'


### PR DESCRIPTION
This is a bit of a strange one. 

I think as more of an artefact of inheritance than actual utility, the web Reference API includes a `ref` property that - from what I can gather - just returns itself.

See https://firebase.google.com/docs/reference/js/firebase.database.Reference#ref for more information.

This pull request adds that method in the interest of being consistent with the web API.