### PR TITLE
[TestSuite] Upgrade test app navigation Fix invertase/react-native-fi…

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -37,7 +37,7 @@
     "react-native-firebase": "file:..",
     "react-native-simple-toast": "0.0.5",
     "react-native-vector-icons": "^4.0.0",
-    "react-navigation": "^1.0.0-beta.7",
+    "react-navigation": "^1.0.0-beta.9",
     "react-redux": "^5.0.3",
     "redux": "^3.6.0",
     "redux-logger": "^2.8.2",

--- a/tests/src/screens/Overview.js
+++ b/tests/src/screens/Overview.js
@@ -13,17 +13,11 @@ class Overview extends React.Component {
   // noinspection JSUnusedGlobalSymbols
   static navigationOptions = {
     title: 'Test Suites',
-    header: () => {
-      return {
-        style: { backgroundColor: '#0288d1' },
-        tintColor: '#ffffff',
-        right: (
-          <View style={{ marginRight: 8 }}>
-            <OverviewControlButton />
-          </View>
-        ),
-      };
-    },
+    headerTintColor: '#ffffff',
+    headerStyle: { backgroundColor: '#0288d1' },
+    headerRight: <View style={{ marginRight: 8 }}>
+      <OverviewControlButton />
+    </View>
   };
 
   /**

--- a/tests/src/screens/Suite.js
+++ b/tests/src/screens/Suite.js
@@ -11,25 +11,19 @@ import TestSuiteControlButton from '../components/TestSuiteControlButton';
 
 class Suite extends React.Component {
 
-  static navigationOptions = {
-    title: ({ state: { params: { title } } }) => {
-      return title;
-    },
-    header: ({ state: { params: { testSuiteId, onlyShowFailingTests } }, setParams }) => {
-      return {
-        style: { backgroundColor: '#0288d1' },
-        tintColor: '#ffffff',
-        right: (
-          <View style={{ flexDirection: 'row', marginRight: 8 }}>
-            <TestSuiteControlButton
-              testSuiteId={testSuiteId}
-              onlyShowFailingTests={onlyShowFailingTests}
-              onFilterChange={setParams}
-            />
-          </View>
-        ),
-      };
-    },
+  static navigationOptions = ({ navigation: { state: { params: { title, testSuiteId, onlyShowFailingTests } }, setParams } }) => {
+    return {
+      title,
+      headerTintColor: '#ffffff',
+      headerStyle: { backgroundColor: '#0288d1' },
+      headerRight: <View style={{ flexDirection: 'row', marginRight: 8 }}>
+        <TestSuiteControlButton
+          testSuiteId={testSuiteId}
+          onlyShowFailingTests={onlyShowFailingTests}
+          onFilterChange={setParams}
+        />
+      </View>,
+    };
   };
 
   /**

--- a/tests/src/screens/Test.js
+++ b/tests/src/screens/Test.js
@@ -9,21 +9,15 @@ import TestControlButton from '../components/TestControlButton';
 
 class Test extends React.Component {
 
-  static navigationOptions = {
-    title: ({ state: { params: { title } } }) => {
-      return title;
-    },
-    header: ({ state: { params: { testId } } }) => {
-      return {
-        style: { backgroundColor: '#0288d1' },
-        tintColor: '#ffffff',
-        right: (
-          <View style={{ marginRight: 8 }}>
-            <TestControlButton testId={testId} />
-          </View>
-        ),
-      };
-    },
+  static navigationOptions = ({ navigation: { state: { params: { title, testId } } } }) => {
+    return {
+      title,
+      headerTintColor: '#ffffff',
+      headerStyle: { backgroundColor: '#0288d1' },
+      headerRight: <View style={{ marginRight: 8 }}>
+        <TestControlButton testId={testId} />
+      </View>,
+    };
   };
 
   static renderBanner({ status, time }) {


### PR DESCRIPTION
Upgrade the usage of the `react-navigation` module in the test application so it's compliant with the `1.0.0-beta.9` API and increase the minimum version in the test application's `package.json`.