### PR TITLE
Revert to old flow syntax (always named function arguments)

### DIFF
--- a/lib/modules/database/reference.js
+++ b/lib/modules/database/reference.js
@@ -375,8 +375,16 @@ export default class Reference extends ReferenceBase {
    * @param onComplete
    * @param applyLocally
    */
-  transaction(transactionUpdate: Function, onComplete: (?Error, boolean, ?Snapshot) => *, applyLocally: boolean = false) {
-    if (!isFunction(transactionUpdate)) return Promise.reject(new Error('Missing transactionUpdate function argument.'));
+  transaction(
+    transactionUpdate: Function,
+    onComplete: (error: ?Error, committed: boolean, snapshot: ?Snapshot) => *,
+    applyLocally: boolean = false
+  ) {
+    if (!isFunction(transactionUpdate)) {
+      return Promise.reject(
+        new Error('Missing transactionUpdate function argument.')
+      );
+    }
 
     return new Promise((resolve, reject) => {
       const onCompleteWrapper = (error, committed, snapshotData) => {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -165,7 +165,7 @@ export function promisify(
   fn: Function | string,
   NativeModule: Object,
   errorPrefix?: string
-): (any) => Promise<> {
+): (args: any) => Promise<> {
   return (...args) => {
     return new Promise((resolve, reject) => {
       const _fn = typeof fn === 'function' ? fn : NativeModule[fn];


### PR DESCRIPTION
Fixes #104 