### PR TITLE
Bump build tools version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
There have been 2 major releases of the build tools SDK since the one in
this project.

This bumps the version to keep up-to-date with the SDK released in April
2017. The changelog for the versions since 23 contain mostly bugfixes.