### PR TITLE
[Flow fix] Annotate `values` in RemoteConfig#getValues

### DIFF
--- a/lib/modules/config/index.js
+++ b/lib/modules/config/index.js
@@ -110,7 +110,7 @@ export default class RemoteConfig extends Base {
     return FirebaseRemoteConfig
       .getValues(keys || [])
       .then((nativeValues) => {
-        const values = {};
+        const values:{[String]: Object} = {};
         for (let i = 0, len = keys.length; i < len; i++) {
           values[keys[i]] = this._nativeValueToJS(nativeValues[i]);
         }


### PR DESCRIPTION
There's a Flow error that I can't figure out why exactly is happening, but that can be fixed by annotating the `values` variable.

This PR annotates that variable and fixes the error.

The difference can be seen with these two examples:

- [With error](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoKBXAdgYwC4CWcWYA5gKZ4BqAhjBuQM4AUA1uQJ6MBcYAggCcBNDgB4AyngEEspAHwBKMAG9UYMDmKM8YAG50GjdQF4VAXzVgocAWGYxKYAmFMAGADRgHJU+y4A6b1I8AAsAbicwUS9yLAiCAGoEpVV1dX16JgBtP0YsggBdApdzSwt1AUoMARIMw1QzIA)
- [Without error](https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoKBXAdgYwC4CWcWYA5gKZ4BqAhjBuQM4AUA1uQJ6MBcYAggCcBNDgB4AyngEEspAHwBKMAG9UYMDmKM8YAG50GPFQG1J02QF1eAeQBGAK3L4AvmAC8K52rBQ4AsMwwlGAE7mAADAA0YEEkHuxcAHSxpHgAFgDcIWCiMeRYWQQA1EVKqurq+vRMxgmMxgQWFmHKXuptYAKUGAIkVYaozkA)

