### PR TITLE
Fixed auth function call in example.

### DIFF
--- a/docs/modules/authentication.md
+++ b/docs/modules/authentication.md
@@ -305,7 +305,7 @@ LoginManager
   })
   .then(data => {
     // create a new firebase credential with the token
-    const credential = firebase.auth.FacebookAuthProvider.credential(data.accessToken);
+    const credential = firebase.auth().FacebookAuthProvider.credential(data.accessToken);
 
     // login with credential
     return firebase.auth().signInWithCredential(credential);


### PR DESCRIPTION
Without calling auth as a function, the call fails on iOS. 