### PR TITLE
adds missing android step to v1/v2 migration guide

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -33,21 +33,44 @@ The below is a quick summary of steps to take when migrating from v1 to v2 of RN
 
 
 
-##### 4) Android - Update `app/build.gradle`:
+##### 4) Android - Update `android/build.gradle`:
+
+
+The latest google-services version needs to be used:
+
+```groovy
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.google.gms:google-services:3.1.0'
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+```
+
+
+
+
+
+##### 5) Android - Update `app/build.gradle`:
 
 
 All firebase modules are now optional so you only need to import the Firebase functionality that you require in your application.
 
 You need to make a couple of changes to your `app/build.gradle` file.  Update the react-native-firebase compile statement to read:
 
-```gradle
+```groovy
 compile(project(':react-native-firebase')) {
   transitive = false
 }
 compile "com.google.firebase:firebase-core:11.0.0"
 ```
 Add each of the firebase modules you need from the following list:
-```gradle
+```groovy
 compile "com.google.firebase:firebase-ads:11.0.0"
 compile "com.google.firebase:firebase-analytics:11.0.0"
 compile "com.google.firebase:firebase-auth:11.0.0"
@@ -63,7 +86,7 @@ compile "com.google.firebase:firebase-storage:11.0.0"
 
 
 
-##### 5) Android - Update `MainApplication.java`:
+##### 6) Android - Update `MainApplication.java`:
 
 
 
@@ -106,7 +129,7 @@ Add the packages to the `getPackages()` method as required:
 
 
 
-##### 6) iOS - Update podfile:
+##### 7) iOS - Update podfile:
 
 First, delete your `Podfile.lock` file, and after making any changes from the below re-run `pod install` in your ios directory.
 


### PR DESCRIPTION
after following the migration guide to the letter, i was unable to install the 11.0.0 versions of firebase packages. i checked out the official DIY guides and saw that there was a google-services bump, too.

the error message: 
```
* What went wrong:
A problem occurred configuring project ':app'.
> Could not resolve all dependencies for configuration ':app:_debugApkCopy'.
   > Could not find com.google.firebase:firebase-core:11.0.0.
     Required by:
         Lifekeyrn:app:unspecified
   > Could not find com.google.firebase:firebase-messaging:11.0.0.
     Required by:
         Lifekeyrn:app:unspecified

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 2 mins 50.32 secs
```