### PR TITLE
Support javascript plain error object in crash.report

### DIFF
--- a/lib/modules/crash/index.js
+++ b/lib/modules/crash/index.js
@@ -56,7 +56,7 @@ export default class Crash {
    * @param maxStackSize
    */
   report(error: FirebaseError, maxStackSize: number = 10): void {
-    if (!error || !error.code || !error.message) return;
+    if (!error || !error.message) return;
 
     let errorMessage = `Message: ${error.message}\r\n`;
 


### PR DESCRIPTION
* I found that `crash().report(Error)` does not work, since it returns empty when error object does not contain `code`.
* `code` is only included in `FirebaseError`. Plain `Error` object does not contain `code`.
* Thus, I removed logic to check `code` in error object in `report()` function.