### PR TITLE
fixed documentation of putFile with progress error handling

### DIFF
--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -44,6 +44,7 @@ const unsubscribe = uploadTask.on('state_changed', snapshot => {
                             //Success
                             unsubscribe();
                         });
+                        
 uploadTask.catch(err => {
                             //Error
                             unsubscribe();

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -34,16 +34,18 @@ firebase.storage()
 ### Listen to upload state
 
 ```javascript
-const unsubscribe = firebase.storage()
+const uploadTask = firebase.storage()
                         .ref('/files/1234')
-                        .putFile('/path/to/file/1234')
-                        .on('state_changed', snapshot => {
+                        .putFile('/path/to/file/1234');
+                        
+const unsubscribe = uploadTask.on('state_changed', snapshot => {
                             //Current upload state
-                        }, err => {
-                            //Error
-                            unsubscribe();
-                        }, uploadedFile => {
+                        }, null, uploadedFile => {
                             //Success
+                            unsubscribe();
+                        });
+uploadTask.catch(err => {
+                            //Error
                             unsubscribe();
                         });
 ```


### PR DESCRIPTION
Currently the docs are not in sync with the code here. When using the docs code, errors are swallowed (unhandled promise exception). I noticed that there is a [TODO](https://github.com/invertase/react-native-firebase/blob/master/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java#L351) which would make the current docs correct but at the moment neither android nor iOS support the event error handler.