### PR TITLE
Fix custom metadata

### DIFF
--- a/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
+++ b/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -428,10 +429,26 @@ public class RNFirebaseStorage extends ReactContextBaseJavaModule {
    */
   private StorageMetadata buildMetadataFromMap(ReadableMap metadata) {
     StorageMetadata.Builder metadataBuilder = new StorageMetadata.Builder();
-    Map<String, Object> m = Utils.recursivelyDeconstructReadableMap(metadata);
 
-    for (Map.Entry<String, Object> entry : m.entrySet()) {
-      metadataBuilder.setCustomMetadata(entry.getKey(), entry.getValue().toString());
+    try {
+
+      Map<String, Object> m = Utils.recursivelyDeconstructReadableMap(metadata);
+
+      Map<String, Object> customMetadata = (Map<String, Object>) m.get("customMetadata");
+      if (customMetadata != null) {
+        for (Map.Entry<String, Object> entry : customMetadata.entrySet()) {
+          metadataBuilder.setCustomMetadata(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+      }
+
+      metadataBuilder.setCacheControl((String) m.get("cacheControl"));
+      metadataBuilder.setContentDisposition((String) m.get("contentDisposition"));
+      metadataBuilder.setContentEncoding((String) m.get("contentEncoding"));
+      metadataBuilder.setContentLanguage((String) m.get("contentLanguage"));
+      metadataBuilder.setContentType((String) m.get("contentType"));
+
+    } catch (Exception e) {
+      Log.e(TAG, "error while building meta data " + e.getMessage());
     }
 
     return metadataBuilder.build();

--- a/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
+++ b/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -44,6 +44,7 @@ const unsubscribe = uploadTask.on('state_changed', snapshot => {
                             //Success
                             unsubscribe();
                         });
+                        
 uploadTask.catch(err => {
                             //Error
                             unsubscribe();

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -9,14 +9,14 @@ providing some iOS and Android specific functionality.
 
 ```javascript
 firebase.storage()
-    .ref('/files/1234')
-    .putFile('/path/to/file/1234')
-    .then(uploadedFile => {
-        //success
-    })
-    .catch(err => {
-        //Error
-    });
+.ref('/files/1234')
+.putFile('/path/to/file/1234')
+.then(uploadedFile => {
+//success
+})
+.catch(err => {
+//Error
+});
 ```
 
 
@@ -24,31 +24,28 @@ firebase.storage()
 
 ```javascript
 const metadata = {
-    contentType: 'image/jpeg'
+contentType: 'image/jpeg'
 }
 firebase.storage()
-    .ref('/files/1234')
-    .putFile('/path/to/file/1234', metadata)
+.ref('/files/1234')
+.putFile('/path/to/file/1234', metadata)
 ```
 
 ### Listen to upload state
 
 ```javascript
-const uploadTask = firebase.storage()
-                        .ref('/files/1234')
-                        .putFile('/path/to/file/1234');
-                        
-const unsubscribe = uploadTask.on('state_changed', snapshot => {
-                            //Current upload state
-                        }, null, uploadedFile => {
-                            //Success
-                            unsubscribe();
-                        });
-                        
-uploadTask.catch(err => {
-                            //Error
-                            unsubscribe();
-                        });
+const unsubscribe = firebase.storage()
+.ref('/files/1234')
+.putFile('/path/to/file/1234')
+.on('state_changed', snapshot => {
+//Current upload state
+}, err => {
+//Error
+unsubscribe();
+}, uploadedFile => {
+//Success
+unsubscribe();
+});
 ```
 
 ## Downloading files
@@ -57,31 +54,31 @@ uploadTask.catch(err => {
 
 ```javascript
 firebase.storage()
-    .ref('/files/1234')
-    .downloadFile('/path/to/save/file')
-    .then(downloadedFile => {
-        //success
-    })
-    .catch(err => {
-        //Error
-    });
+.ref('/files/1234')
+.downloadFile('/path/to/save/file')
+.then(downloadedFile => {
+//success
+})
+.catch(err => {
+//Error
+});
 ```
 
 ### Listen to download state
 
 ```javascript
 const unsubscribe = firebase.storage()
-                        .ref('/files/1234')
-                        .downloadFile('/path/to/save/file')
-                        .on('state_changed', snapshot => {
-                            //Current download state
-                        }, err => {
-                            //Error
-                            unsubscribe();
-                        }, downloadedFile => {
-                            //Success
-                            unsubscribe();
-                        });
+.ref('/files/1234')
+.downloadFile('/path/to/save/file')
+.on('state_changed', snapshot => {
+//Current download state
+}, err => {
+//Error
+unsubscribe();
+}, downloadedFile => {
+//Success
+unsubscribe();
+});
 ```
 
 ## TODO

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -34,16 +34,18 @@ firebase.storage()
 ### Listen to upload state
 
 ```javascript
-const unsubscribe = firebase.storage()
+const uploadTask = firebase.storage()
                         .ref('/files/1234')
-                        .putFile('/path/to/file/1234')
-                        .on('state_changed', snapshot => {
+                        .putFile('/path/to/file/1234');
+                        
+const unsubscribe = uploadTask.on('state_changed', snapshot => {
                             //Current upload state
-                        }, err => {
-                            //Error
-                            unsubscribe();
-                        }, uploadedFile => {
+                        }, null, uploadedFile => {
                             //Success
+                            unsubscribe();
+                        });
+uploadTask.catch(err => {
+                            //Error
                             unsubscribe();
                         });
 ```

--- a/docs/modules/storage.md
+++ b/docs/modules/storage.md
@@ -9,14 +9,14 @@ providing some iOS and Android specific functionality.
 
 ```javascript
 firebase.storage()
-.ref('/files/1234')
-.putFile('/path/to/file/1234')
-.then(uploadedFile => {
-//success
-})
-.catch(err => {
-//Error
-});
+    .ref('/files/1234')
+    .putFile('/path/to/file/1234')
+    .then(uploadedFile => {
+        //success
+    })
+    .catch(err => {
+        //Error
+    });
 ```
 
 
@@ -24,28 +24,28 @@ firebase.storage()
 
 ```javascript
 const metadata = {
-contentType: 'image/jpeg'
+    contentType: 'image/jpeg'
 }
 firebase.storage()
-.ref('/files/1234')
-.putFile('/path/to/file/1234', metadata)
+    .ref('/files/1234')
+    .putFile('/path/to/file/1234', metadata)
 ```
 
 ### Listen to upload state
 
 ```javascript
 const unsubscribe = firebase.storage()
-.ref('/files/1234')
-.putFile('/path/to/file/1234')
-.on('state_changed', snapshot => {
-//Current upload state
-}, err => {
-//Error
-unsubscribe();
-}, uploadedFile => {
-//Success
-unsubscribe();
-});
+                        .ref('/files/1234')
+                        .putFile('/path/to/file/1234')
+                        .on('state_changed', snapshot => {
+                            //Current upload state
+                        }, err => {
+                            //Error
+                            unsubscribe();
+                        }, uploadedFile => {
+                            //Success
+                            unsubscribe();
+                        });
 ```
 
 ## Downloading files
@@ -54,31 +54,31 @@ unsubscribe();
 
 ```javascript
 firebase.storage()
-.ref('/files/1234')
-.downloadFile('/path/to/save/file')
-.then(downloadedFile => {
-//success
-})
-.catch(err => {
-//Error
-});
+    .ref('/files/1234')
+    .downloadFile('/path/to/save/file')
+    .then(downloadedFile => {
+        //success
+    })
+    .catch(err => {
+        //Error
+    });
 ```
 
 ### Listen to download state
 
 ```javascript
 const unsubscribe = firebase.storage()
-.ref('/files/1234')
-.downloadFile('/path/to/save/file')
-.on('state_changed', snapshot => {
-//Current download state
-}, err => {
-//Error
-unsubscribe();
-}, downloadedFile => {
-//Success
-unsubscribe();
-});
+                        .ref('/files/1234')
+                        .downloadFile('/path/to/save/file')
+                        .on('state_changed', snapshot => {
+                            //Current download state
+                        }, err => {
+                            //Error
+                            unsubscribe();
+                        }, downloadedFile => {
+                            //Success
+                            unsubscribe();
+                        });
 ```
 
 ## TODO

--- a/ios/RNFirebase/storage/RNFirebaseStorage.m
+++ b/ios/RNFirebase/storage/RNFirebaseStorage.m
@@ -5,6 +5,7 @@
 #import <Photos/Photos.h>
 #import "Firebase.h"
 
+
 @implementation RNFirebaseStorage
 
 RCT_EXPORT_MODULE(RNFirebaseStorage);
@@ -154,7 +155,7 @@ RCT_EXPORT_METHOD(getMetadata: (NSString *) path resolver:(RCTPromiseResolveBloc
  */
 RCT_EXPORT_METHOD(updateMetadata: (NSString *) path metadata:(NSDictionary *) metadata resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     FIRStorageReference *fileRef = [self getReference:path];
-    FIRStorageMetadata *firmetadata = [[FIRStorageMetadata alloc] initWithDictionary:metadata];
+    FIRStorageMetadata *firmetadata = [self buildMetadataFromMap:metadata];
 
     [fileRef updateMetadata:firmetadata completion:^(FIRStorageMetadata * _Nullable metadata, NSError * _Nullable error) {
         if (error != nil) {
@@ -317,14 +318,14 @@ RCT_EXPORT_METHOD(putFile:(NSString *) path localPath:(NSString *)localPath meta
 
 - (void) uploadFile:(NSURL *) url metadata:(NSDictionary *) metadata path:(NSString *) path resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
     FIRStorageReference *fileRef = [self getReference:path];
-    FIRStorageMetadata *firmetadata = [[FIRStorageMetadata alloc] initWithDictionary:metadata];
+    FIRStorageMetadata *firmetadata = [self buildMetadataFromMap:metadata];
     FIRStorageUploadTask *uploadTask = [fileRef putFile:url metadata:firmetadata];
     [self addUploadObservers:uploadTask path:path resolver:resolve rejecter:reject];
 }
 
 - (void) uploadData:(NSData *) data metadata:(NSDictionary *) metadata path:(NSString *) path resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject{
     FIRStorageReference *fileRef = [self getReference:path];
-    FIRStorageMetadata *firmetadata = [[FIRStorageMetadata alloc] initWithDictionary:metadata];
+    FIRStorageMetadata *firmetadata = [self buildMetadataFromMap:metadata];
     FIRStorageUploadTask *uploadTask = [fileRef putData:data metadata:firmetadata];
     [self addUploadObservers:uploadTask path:path resolver:resolve rejecter:reject];
 }
@@ -392,6 +393,13 @@ RCT_EXPORT_METHOD(putFile:(NSString *) path localPath:(NSString *)localPath meta
              @"state": [self getTaskStatus:task.status],
              @"totalBytes": @(task.progress.totalUnitCount)
              };
+}
+
+- (FIRStorageMetadata *)buildMetadataFromMap:(NSDictionary *)metadata {
+    NSMutableDictionary *result = [metadata mutableCopy];
+    result[@"metadata"] = metadata[@"customMetadata"];
+    [result removeObjectForKey:@"customMetadata"];
+    return [[FIRStorageMetadata alloc] initWithDictionary:result];
 }
 
 - (NSString *)getTaskStatus:(FIRStorageTaskStatus)status {

--- a/ios/RNFirebase/storage/RNFirebaseStorage.m
+++ b/ios/RNFirebase/storage/RNFirebaseStorage.m
@@ -5,7 +5,6 @@
 #import <Photos/Photos.h>
 #import "Firebase.h"
 
-
 @implementation RNFirebaseStorage
 
 RCT_EXPORT_MODULE(RNFirebaseStorage);


### PR DESCRIPTION
This fixes issues in iOS and android and allows to specify meta data according to the corresponding [type definition](https://github.com/invertase/react-native-firebase/blob/master/index.d.ts#L198).

In iOS it wasn't working at all because they use the key "metadata" for "customMetadata" (see [here](https://github.com/firebase/firebase-ios-sdk/blob/master/Firebase/Storage/FIRStorageMetadata.m#L40) and [here](https://github.com/firebase/firebase-ios-sdk/blob/master/Firebase/Storage/FIRStorageConstants.m#L55)). I tried importing their key name from [there](https://github.com/firebase/firebase-ios-sdk/blob/master/Firebase/Storage/FIRStorageConstants.m#L55) and use it in my fix but I'm a Java/JS dev and don't know if that's possible in objective C (I think it's not).