### PR TITLE
Fix android compilation (react-native v0.47)

### DIFF
--- a/android/src/main/java/io/invertase/firebase/RNFirebasePackage.java
+++ b/android/src/main/java/io/invertase/firebase/RNFirebasePackage.java
@@ -32,18 +32,6 @@ public class RNFirebasePackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */

--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobPackage.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobPackage.java
@@ -28,19 +28,7 @@ public class RNFirebaseAdMobPackage implements ReactPackage {
 
     return modules;
   }
-
-  /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
+  
   /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}

--- a/android/src/main/java/io/invertase/firebase/analytics/RNFirebaseAnalyticsPackage.java
+++ b/android/src/main/java/io/invertase/firebase/analytics/RNFirebaseAnalyticsPackage.java
@@ -29,18 +29,6 @@ public class RNFirebaseAnalyticsPackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */

--- a/android/src/main/java/io/invertase/firebase/auth/RNFirebaseAuthPackage.java
+++ b/android/src/main/java/io/invertase/firebase/auth/RNFirebaseAuthPackage.java
@@ -27,19 +27,7 @@ public class RNFirebaseAuthPackage implements ReactPackage {
 
     return modules;
   }
-
-  /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
+  
   /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}

--- a/android/src/main/java/io/invertase/firebase/config/RNFirebaseRemoteConfigPackage.java
+++ b/android/src/main/java/io/invertase/firebase/config/RNFirebaseRemoteConfigPackage.java
@@ -29,18 +29,6 @@ public class RNFirebaseRemoteConfigPackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */

--- a/android/src/main/java/io/invertase/firebase/crash/RNFirebaseCrashPackage.java
+++ b/android/src/main/java/io/invertase/firebase/crash/RNFirebaseCrashPackage.java
@@ -29,18 +29,6 @@ public class RNFirebaseCrashPackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */

--- a/android/src/main/java/io/invertase/firebase/database/RNFirebaseDatabasePackage.java
+++ b/android/src/main/java/io/invertase/firebase/database/RNFirebaseDatabasePackage.java
@@ -29,18 +29,6 @@ public class RNFirebaseDatabasePackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */

--- a/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessagingPackage.java
+++ b/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessagingPackage.java
@@ -29,18 +29,6 @@ public class RNFirebaseMessagingPackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */

--- a/android/src/main/java/io/invertase/firebase/perf/RNFirebasePerformancePackage.java
+++ b/android/src/main/java/io/invertase/firebase/perf/RNFirebasePerformancePackage.java
@@ -29,18 +29,6 @@ public class RNFirebasePerformancePackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */

--- a/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStoragePackage.java
+++ b/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStoragePackage.java
@@ -29,18 +29,6 @@ public class RNFirebaseStoragePackage implements ReactPackage {
   }
 
   /**
-   * @return list of JS modules to register with the newly created catalyst instance.
-   * <p/>
-   * IMPORTANT: Note that only modules that needs to be accessible from the native code should be
-   * listed here. Also listing a native module here doesn't imply that the JS implementation of it
-   * will be automatically included in the JS bundle.
-   */
-  @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-    return Collections.emptyList();
-  }
-
-  /**
    * @param reactContext
    * @return a list of view managers that should be registered with {@link UIManagerModule}
    */


### PR DESCRIPTION
According to the [changelog](https://github.com/facebook/react-native/releases/tag/v0.47.0) of react-native v0.47, `createJSModules` calls should be removed.