### PR TITLE
Remove createJSModules @overide marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/io/invertase/firebase/RNFirebasePackage.java
+++ b/android/src/main/java/io/invertase/firebase/RNFirebasePackage.java
@@ -38,7 +38,7 @@ public class RNFirebasePackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobPackage.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobPackage.java
@@ -36,7 +36,7 @@ public class RNFirebaseAdMobPackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/analytics/RNFirebaseAnalyticsPackage.java
+++ b/android/src/main/java/io/invertase/firebase/analytics/RNFirebaseAnalyticsPackage.java
@@ -35,7 +35,7 @@ public class RNFirebaseAnalyticsPackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/auth/RNFirebaseAuthPackage.java
+++ b/android/src/main/java/io/invertase/firebase/auth/RNFirebaseAuthPackage.java
@@ -35,7 +35,7 @@ public class RNFirebaseAuthPackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/config/RNFirebaseRemoteConfigPackage.java
+++ b/android/src/main/java/io/invertase/firebase/config/RNFirebaseRemoteConfigPackage.java
@@ -35,7 +35,7 @@ public class RNFirebaseRemoteConfigPackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/crash/RNFirebaseCrashPackage.java
+++ b/android/src/main/java/io/invertase/firebase/crash/RNFirebaseCrashPackage.java
@@ -35,7 +35,7 @@ public class RNFirebaseCrashPackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/database/RNFirebaseDatabasePackage.java
+++ b/android/src/main/java/io/invertase/firebase/database/RNFirebaseDatabasePackage.java
@@ -35,7 +35,7 @@ public class RNFirebaseDatabasePackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessagingPackage.java
+++ b/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessagingPackage.java
@@ -35,7 +35,7 @@ public class RNFirebaseMessagingPackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/perf/RNFirebasePerformancePackage.java
+++ b/android/src/main/java/io/invertase/firebase/perf/RNFirebasePerformancePackage.java
@@ -35,7 +35,7 @@ public class RNFirebasePerformancePackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStoragePackage.java
+++ b/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStoragePackage.java
@@ -35,7 +35,7 @@ public class RNFirebaseStoragePackage implements ReactPackage {
    * listed here. Also listing a native module here doesn't imply that the JS implementation of it
    * will be automatically included in the JS bundle.
    */
-  @Override
+  // Deprecated RN 0.47
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker. #297 is similar but seems that this one is better for backwards compatibility.