### PR TITLE
Remove React podspec dependency

### DIFF
--- a/RNFirebase.podspec
+++ b/RNFirebase.podspec
@@ -16,5 +16,4 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "8.0"
   s.preserve_paths      = 'README.md', 'package.json', '*.js'
   s.source_files        = 'ios/RNFirebase/**/*.{h,m}'
-  s.dependency          'React'
 end


### PR DESCRIPTION
Hello,

As explained in https://github.com/invertase/react-native-firebase/issues/324, the React dependency in the podspec is deprecated (0.11), and only create problems on some Cocoapods setups.