### PR TITLE
Fix wrong RNFirebaseDatabase implementation

### DIFF
--- a/ios/RNFirebase/database/RNFirebaseDatabaseReference.m
+++ b/ios/RNFirebase/database/RNFirebaseDatabaseReference.m
@@ -190,6 +190,6 @@
 @end
 
 #else
-@implementation RNFirebaseDatabase
+@implementation RNFirebaseDatabaseReference
 @end
 #endif


### PR DESCRIPTION
`RNFirebaseDatabase` => `RNFirebaseDatabaseReference` in `RNFirebaseDatabaseReference.m`

<img width="1068" alt="screen shot 2017-08-10 at 22 26 51" src="https://user-images.githubusercontent.com/1902323/29190672-4d2219e0-7e1b-11e7-8a6b-7ad64060f1ff.png">
