### PR TITLE
Fix missing Foundation import

### DIFF
--- a/ios/RNFirebase/database/RNFirebaseDatabaseReference.h
+++ b/ios/RNFirebase/database/RNFirebaseDatabaseReference.h
@@ -1,8 +1,6 @@
 #ifndef RNFirebaseDatabaseReference_h
 #define RNFirebaseDatabaseReference_h
 
-#import <Foundation/Foundation.h>
-
 #if __has_include(<FirebaseDatabase/FIRDatabase.h>)
 #import <React/RCTEventEmitter.h>
 #import "Firebase.h"
@@ -23,6 +21,7 @@
 @end
 
 #else
+#import <Foundation/Foundation.h>
 
 @interface RNFirebaseDatabaseReference : NSObject
 @end

--- a/ios/RNFirebase/database/RNFirebaseDatabaseReference.h
+++ b/ios/RNFirebase/database/RNFirebaseDatabaseReference.h
@@ -1,6 +1,8 @@
 #ifndef RNFirebaseDatabaseReference_h
 #define RNFirebaseDatabaseReference_h
 
+#import <Foundation/Foundation.h>
+
 #if __has_include(<FirebaseDatabase/FIRDatabase.h>)
 #import <React/RCTEventEmitter.h>
 #import "Firebase.h"


### PR DESCRIPTION
If we don't import the FirebaseDatabase SDK, `NSObject` will not be found.

<img width="1078" alt="screen shot 2017-08-10 at 22 26 18" src="https://user-images.githubusercontent.com/1902323/29190604-18c3b848-7e1b-11e7-927f-aec2deb434d0.png">

