### PR TITLE
[auth][phone] Allow for linkWithCredential() for PhoneAuthProvider.

### DIFF
--- a/android/src/main/java/io/invertase/firebase/auth/RNFirebaseAuth.java
+++ b/android/src/main/java/io/invertase/firebase/auth/RNFirebaseAuth.java
@@ -917,6 +917,8 @@ class RNFirebaseAuth extends ReactContextBaseJavaModule {
         return TwitterAuthProvider.getCredential(authToken, authSecret);
       case "github":
         return GithubAuthProvider.getCredential(authToken);
+      case "phone":
+        return PhoneAuthProvider.getCredential(authToken, authSecret);
       case "password":
         return EmailAuthProvider.getCredential(authToken, authSecret);
       default:

--- a/index.d.ts
+++ b/index.d.ts
@@ -455,6 +455,10 @@ declare module "react-native-firebase" {
        */
       reauthenticate(credential: Credential): Promise<void>
       /**
+       * Link the user with a 3rd party credential provider.
+       */
+      linkWithCredential(credential: Credential): Promise<User>
+      /**
        * Refreshes the current user.
        */
       reload(): Promise<void>

--- a/ios/RNFirebase/auth/RNFirebaseAuth.m
+++ b/ios/RNFirebase/auth/RNFirebaseAuth.m
@@ -825,6 +825,8 @@ RCT_EXPORT_METHOD(fetchProvidersForEmail:
         credential = [FIREmailAuthProvider credentialWithEmail:authToken password:authTokenSecret];
     } else if ([provider compare:@"github" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
         credential = [FIRGitHubAuthProvider credentialWithToken:authToken];
+    } else if ([provider compare:@"phone" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+        credential = [[FIRPhoneAuthProvider provider] credentialWithVerificationID:authToken verificationCode:authTokenSecret];
     } else {
         NSLog(@"Provider not yet handled: %@", provider);
     }


### PR DESCRIPTION
@chrisbianca Pull request for `linkWithCredential()` capability with `PhoneAuthProvider`. (re: https://github.com/invertase/react-native-firebase/issues/119#issuecomment-326510174)

This allows someone to link a phone to a currently logged in user, or sign the user in.

To test:

```
firebase.auth().signInWithPhoneNumber(phoneNumber)
      .then(confirmResult => this.setState({ confirmResult }))
```

Set the credential object with the six-digit SMS code (`codeInput`):
```
let credential = {
   provider: 'phone',
   token: this.state.confirmResult._verificationId,
   secret: codeInput
};
```

- If there is a logged-in/anonymous user, call: `firebase.auth().currentUser.linkWithCredential(credential);`

- If no one is logged in, call: `firebase.auth().signInWithCredential(credential);`
