### PR TITLE
API change for RN 0.48

### DIFF
--- a/lib/modules/base.js
+++ b/lib/modules/base.js
@@ -2,7 +2,7 @@
  * @flow
  */
 
-import EventEmitter from 'react-native/Libraries/EventEmitter/EventEmitter';
+import EventEmitter from 'react-native/Libraries/vendor/emitter/EventEmitter';
 import Log from '../utils/log';
 
 const logs = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-firebase",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "author": "Invertase <contact@invertase.io> (http://invertase.io)",
   "description": "A well tested, feature rich Firebase implementation for React Native, supporting iOS & Android. Individual module support for Auth, Database, Messaging (FCM), Remote Config, Storage, Admob, Analytics, Crash Reporting, and Performance.",
   "main": "index",


### PR DESCRIPTION
This fixes the issue #386 with latest RN version:

> Unable to resolve module `react-native/Libraries/EventEmitter/EventEmitter`

Fix by @lovince https://github.com/invertase/react-native-firebase/issues/386#issuecomment-327077051

You can install this manually by installing this branch:

`yarn upgrade 'react-native-firebase@jerolimov/react-native-firebase#eb2ec4b0471865f151b7d32cc0bd7ffe8b314485'`