### PR TITLE
Set opened_from_tray for local_notification

### DIFF
--- a/ios/RNFirebase/messaging/RNFirebaseMessaging.m
+++ b/ios/RNFirebase/messaging/RNFirebaseMessaging.m
@@ -142,6 +142,7 @@ RCT_EXPORT_MODULE()
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification {
     NSMutableDictionary* data = [[NSMutableDictionary alloc] initWithDictionary: notification.userInfo];
     [data setValue:@"local_notification" forKey:@"_notificationType"];
+    [data setValue:@(RCTSharedApplication().applicationState == UIApplicationStateInactive) forKey:@"opened_from_tray"];
     [[NSNotificationCenter defaultCenter] postNotificationName:MESSAGING_NOTIFICATION_RECEIVED object:self userInfo:@{@"data": data}];
 }
 


### PR DESCRIPTION
Set opened_from_tray true if a local notification is clicked from notification center/tray.

Currently its only set for a remove_notification line 131.