### PR TITLE
Update with Google Maven reference

### DIFF
--- a/docs/installation-android.md
+++ b/docs/installation-android.md
@@ -60,6 +60,19 @@ dependencies {
 }
 ```
 
+Google Play services from 11.2.0 onwards require their dependencies to be downloaded from Google's Maven respository so add the 
+required reference to the repositories section of the *project* level build.gradle
+`android/build.gradle`
+```allprojects {
+    repositories {
+         // ...
+        maven {
+            url 'https://maven.google.com'
+        }
+    }
+}
+```
+
 To install `react-native-firebase` in your project, you'll need to import the packages you need from `io.invertase.firebase` in your project's `android/app/src/main/java/com/[app name]/MainApplication.java` and list them as packages for ReactNative in the `getPackages()` function:
 
 ```java


### PR DESCRIPTION
I ran into this problem trying to follow your installation instructions.  The build kept failing with errors stating that it was unable to resolve the firebase packages. 

I could see that the 11.2.x packages weren't included in the latest Google Repository (58) and the latest release notes (https://developers.google.com/android/guides/releases) state that "Google Play services dependencies are now available via maven.google.com", so I added the Google Maven reference to the root build.gradle and it resolved the problem.