### PR TITLE
[auth][unlink] Call native function instead of 'FirebaseAuth'

### DIFF
--- a/lib/modules/auth/user.js
+++ b/lib/modules/auth/user.js
@@ -120,7 +120,7 @@ export default class User {
    * @return {Promise.<TResult>|*}
    */
   unlink(providerId: string) {
-    return this._auth._interceptUserValue(FirebaseAuth.unlink(providerId));
+    return this._auth._interceptUserValue(this._auth._native.unlink(providerId));
   }
 
   /**


### PR DESCRIPTION
![screenshot_20170923-233751](https://user-images.githubusercontent.com/5485993/30777386-c60b5cf2-a0b9-11e7-93a1-04bfb621eca0.png)
