### PR TITLE
ViewPropTypes is not undefined in React-native 0.42 and View.propType…

### DIFF
--- a/lib/modules/admob/AdMobComponent.js
+++ b/lib/modules/admob/AdMobComponent.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ViewPropTypes, requireNativeComponent } from 'react-native';
+import { View, requireNativeComponent } from 'react-native';
 import PropTypes from 'prop-types';
 import EventTypes, { NativeExpressEventTypes } from './EventTypes';
 import { nativeToJSError } from '../../utils';
@@ -8,7 +8,7 @@ import AdRequest from './AdRequest';
 import VideoOptions from './VideoOptions';
 
 const adMobPropTypes = {
-  ...ViewPropTypes,
+  ...View.propTypes,
   size: PropTypes.string.isRequired,
   unitId: PropTypes.string.isRequired,
   request: PropTypes.object,


### PR DESCRIPTION
ViewPropTypes is not undefined in React-native 0.42 and View.propType is still accessible in React-Native 0.47

This caused : `AdMobComponent` has no propType for native prop `RNFirebaseAdMobBanner.accessibilityLabel` of native type `String`