### PR TITLE
[firestore] Fix _metadata not defined error in DocumentSnapshot

### DIFF
--- a/lib/modules/firestore/DocumentSnapshot.js
+++ b/lib/modules/firestore/DocumentSnapshot.js
@@ -40,7 +40,7 @@ export default class DocumentSnapshot {
   }
 
   get metadata(): SnapshotMetadata {
-    return _metadata;
+    return this._metadata;
   }
 
   get ref(): DocumentReference {


### PR DESCRIPTION
Fix for the following error:

![image](https://user-images.githubusercontent.com/7766565/31507403-d182b57e-af7a-11e7-8786-980c571d7ae0.png)
