### PR TITLE
[firestore][ios] fix date formatter

### DIFF
--- a/ios/RNFirebase/firestore/RNFirebaseFirestoreDocumentReference.m
+++ b/ios/RNFirebase/firestore/RNFirebaseFirestoreDocumentReference.m
@@ -206,7 +206,8 @@ static NSMutableDictionary *_listeners;
     } else if ([value isKindOfClass:[NSDate class]]) {
         typeMap[@"type"] = @"date";
         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+        [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
         typeMap[@"value"] = [dateFormatter stringFromDate:(NSDate *)value];
     } else if ([value isKindOfClass:[NSNumber class]]) {
         NSNumber *number = (NSNumber *)value;
@@ -263,7 +264,8 @@ static NSMutableDictionary *_listeners;
         return [[FIRGeoPoint alloc] initWithLatitude:[latitude doubleValue] longitude:[longitude doubleValue]];
     } else if ([type isEqualToString:@"date"]) {
         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+        [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
         return [dateFormatter dateFromString:value];
     } else if ([type isEqualToString:@"fieldvalue"]) {
         NSString *string = (NSString*)value;


### PR DESCRIPTION
The previous format seems to only have worked when the chrome debugger was open due to different JS runtime environments (see: https://stackoverflow.com/questions/41874676/react-native-code-doesnt-work-without-remote-debugger-enabled).

By formatting it this way and setting the timezone to UTC, it appears to work properly with the firestore server date in both debug and non-debug modes.