### PR TITLE
Add search paths for ios/Firebase when not using CocoaPods

### DIFF
--- a/ios/RNFirebase.xcodeproj/project.pbxproj
+++ b/ios/RNFirebase.xcodeproj/project.pbxproj
@@ -445,11 +445,13 @@
 					"${SRCROOT}/../../../ios/Pods/FirebaseRemoteConfig/Frameworks",
 					"${SRCROOT}/../../../ios/Pods/FirebaseStorage/Frameworks",
 					"${SRCROOT}/../../../ios/Pods/Google-Mobile-Ads-SDK/Frameworks/frameworks",
+					"${SRCROOT}/../../../ios/Firebase/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
 					"${SRCROOT}/../../../ios/Pods/Firebase/**",
+					"${SRCROOT}/../../../ios/Firebase/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
@@ -484,11 +486,13 @@
 					"${SRCROOT}/../../../ios/Pods/FirebaseRemoteConfig/Frameworks",
 					"${SRCROOT}/../../../ios/Pods/FirebaseStorage/Frameworks",
 					"${SRCROOT}/../../../ios/Pods/Google-Mobile-Ads-SDK/Frameworks/frameworks",
+					"${SRCROOT}/../../../ios/Firebase/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../react-native/React/**",
 					"${SRCROOT}/../../../ios/Pods/Firebase/**",
+					"${SRCROOT}/../../../ios/Firebase/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";


### PR DESCRIPTION
Allows using `react-native-firebase` without CocoaPods. Instead Frameworks can be added manually in `/ios/Firebase` without having to mock an `/ios/Pods` directory.

Related to: https://github.com/invertase/react-native-firebase/issues/153