### PR TITLE
Make sure the promise is resolved/rejected for transaction

### DIFF
--- a/lib/modules/database/reference.js
+++ b/lib/modules/database/reference.js
@@ -195,8 +195,11 @@ export default class Reference extends ReferenceBase {
     return new Promise((resolve, reject) => {
       const onCompleteWrapper = (error, committed, snapshotData) => {
         if (isFunction(onComplete)) {
-          if (error) return onComplete(error, committed, null);
-          return onComplete(null, committed, new Snapshot(this, snapshotData));
+          if (error)  { 
+            onComplete(error, committed, null); 
+          } else {
+            onComplete(null, committed, new Snapshot(this, snapshotData));
+          }
         }
 
         if (error) return reject(error);


### PR DESCRIPTION
Right now the following code will be broken under v3.x.x:
```
async function() {
  await ref.transaction(
              function(foo) {
                 // deal with foo
              },
              function(error, committed, ss) { 
                 // additional work on complete callback
              },
              true     
          );
  // NOTE: Code from here will never execute because promise above never gets resolved
}
```
v2 will work because the promise is always resolved, v3 does not because it now depends on whether the promise is resolved in the completion callback

@kurtvan