### PR TITLE
Add '|| exit' 0 to opencollective

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flow": "flow",
     "lint": "eslint ./src",
     "prepublish": "npm run clean && npm run build",
-    "postinstall": "postinstall-build dist && opencollective postinstall",
+    "postinstall": "postinstall-build dist && opencollective postinstall || exit 0",
     "test-cli": "node ./bin/test.js",
     "tests-packager": "cd tests && npm run start",
     "tests-npm-install": "cd tests && npm install",


### PR DESCRIPTION
https://github.com/opencollective/opencollective-postinstall

Why || exit 0 in scripts.postinstall?
Since we are adding the dependency in devDependencies, the script ./node_modules/.bin/opencollective-postinstall won't be installed in production. Therefore, the postinstall script will return an error and will interrupt the npm install process. Adding || exit 0 makes sure that this postinstall script always returns true.