### PR TITLE
add smartbanner landscape for iOS

### DIFF
--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobUtils.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobUtils.java
@@ -142,6 +142,8 @@ class RNFirebaseAdMobUtils {
         return AdSize.LEADERBOARD;
       case "SMART_BANNER":
         return AdSize.SMART_BANNER;
+      case "SMART_BANNER_LANDSCAPE":
+        return AdSize.SMART_BANNER;		
     }
   }
 }

--- a/ios/RNFirebase/admob/RNFirebaseAdMob.m
+++ b/ios/RNFirebase/admob/RNFirebaseAdMob.m
@@ -210,6 +210,8 @@ RCT_EXPORT_METHOD(clearInterstitial:
         return kGADAdSizeLeaderboard;
     } else if ([value isEqualToString:@"SMART_BANNER"]) {
         return kGADAdSizeSmartBannerPortrait;
+    } else if ([value isEqualToString:@"SMART_BANNER_LANDSCAPE"]) {
+        return kGADAdSizeSmartBannerLandscape;
     } else {
         return kGADAdSizeBanner;
     }


### PR DESCRIPTION
Smart Banner Landscape on iOS should have a height of 32 points in landscape.
For this purpose we need to use "kGADAdSizeSmartBannerLandscape" when the Screen is in Landscape mode.

https://developers.google.com/mobile-ads-sdk/docs/dfp/ios/banner