### PR TITLE
iOS Dynamic Links now 'Survive' installation.

### DIFF
--- a/ios/RNFirebase/links/RNFirebaseLinks.m
+++ b/ios/RNFirebase/links/RNFirebaseLinks.m
@@ -16,6 +16,8 @@ static void sendDynamicLink(NSURL *url, id sender) {
 
 RCT_EXPORT_MODULE();
 
+static NSURL *installLink;
+
 - (id)init {
     self = [super init];
     if (self != nil) {
@@ -51,6 +53,9 @@ RCT_EXPORT_MODULE();
 }
 
 + (BOOL)handleLinkFromCustomSchemeURL:(NSURL *)url {
+    if(!installLink) {
+        installLink = url;
+    }
     FIRDynamicLink *dynamicLink =
     [[FIRDynamicLinks dynamicLinks] dynamicLinkFromCustomSchemeURL:url];
     if (dynamicLink && dynamicLink.url) {
@@ -124,7 +129,8 @@ RCT_EXPORT_METHOD(getInitialLink:(RCTPromiseResolveBlock)resolve rejecter:(RCTPr
     if (self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey]) {
         NSURL* url = (NSURL*)self.bridge.launchOptions[UIApplicationLaunchOptionsURLKey];
         [self handleInitialLinkFromCustomSchemeURL:url resolver:resolve rejecter:reject];
-        
+    } else if(installLink) {
+        [self handleInitialLinkFromCustomSchemeURL:installLink resolver:resolve rejecter:reject];
     } else {
         NSDictionary *userActivityDictionary =
         self.bridge.launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey];


### PR DESCRIPTION
Fixes #661 on iOS.

Problem was due to not handling Firebase calling onOpen instead of iOS.
See: [https://stackoverflow.com/questions/45415731/firebase-dynamic-links-not-survive-installation](https://stackoverflow.com/questions/45415731/firebase-dynamic-links-not-survive-installation)

Steps to reproduce.
1. Uninstall App
2. Create Dynamic Link in Firebase Console
3. Click on Dynamic Link on real device.
4. Install App. (via Xcode)
5. Dynamic Link not returned when calling _getInitialLink()_ on first open after install.

