### PR TITLE
[iOS] Remove crash when calling crash().report()

### DIFF
--- a/ios/RNFirebase/crash/RNFirebaseCrash.m
+++ b/ios/RNFirebase/crash/RNFirebaseCrash.m
@@ -16,7 +16,6 @@ RCT_EXPORT_METHOD(logcat:(nonnull NSNumber *) level tag:(NSString *) tag message
 
 RCT_EXPORT_METHOD(report:(NSString *) message) {
   FIRCrashLog(@"%@", message);
-  assert(NO);
 }
 
 RCT_EXPORT_METHOD(setCrashCollectionEnabled:(BOOL *) enabled) {


### PR DESCRIPTION
It doesn't have the same behaviour as on Android. (and it's weird that it makes the app crash as it's non-fatal...)