### PR TITLE
Fixed: attempt to insert nil object from objects[0]

### DIFF
--- a/ios/RNFirebase/links/RNFirebaseLinks.m
+++ b/ios/RNFirebase/links/RNFirebaseLinks.m
@@ -6,10 +6,12 @@
 
 
 static void sendDynamicLink(NSURL *url, id sender) {
-    [[NSNotificationCenter defaultCenter] postNotificationName:LINKS_DYNAMIC_LINK_RECEIVED
-                                                        object:sender
-                                                      userInfo:@{@"url": url.absoluteString}];
-    NSLog(@"sendDynamicLink Success: %@", url.absoluteString);
+    if (url) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:LINKS_DYNAMIC_LINK_RECEIVED
+                                                            object:sender
+                                                          userInfo:@{@"url": url.absoluteString}];
+        NSLog(@"sendDynamicLink Success: %@", url.absoluteString);
+    }
 }
 
 @implementation RNFirebaseLinks


### PR DESCRIPTION
Fixed the issue that was causing a crash in my application:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]'
*** First throw call stack:
(
	0   CoreFoundation                      0x000000011310e12b __exceptionPreprocess + 171
	1   libobjc.A.dylib                     0x00000001127a6f41 objc_exception_throw + 48
	2   CoreFoundation                      0x000000011314e0cc _CFThrowFormattedException + 194
	3   CoreFoundation                      0x0000000113022951 -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 321
	4   CoreFoundation                      0x00000001130227db +[NSDictionary dictionaryWithObjects:forKeys:count:] + 59
	5   Mesghal                             0x000000010ace08c2 sendDynamicLink + 226
	6   Mesghal                             0x000000010ace0d0f __71+[RNFirebaseLinks application:continueUserActivity:restorationHandler:]_block_invoke + 447
	7   libdispatch.dylib                   0x0000000113fcd2f7 _dispatch_call_block_and_release + 12
	8   libdispatch.dylib                   0x0000000113fce33d _dispatch_client_callout + 8
	9   libdispatch.dylib                   0x0000000113fd95f9 _dispatch_main_queue_callback_4CF + 628
	10  CoreFoundation                      0x00000001130d0e39 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
	11  CoreFoundation                      0x0000000113095462 __CFRunLoopRun + 2402
	12  CoreFoundation                      0x0000000113094889 CFRunLoopRunSpecific + 409
	13  GraphicsServices                    0x00000001154d29c6 GSEventRunModal + 62
	14  UIKit                               0x000000010f60b5d6 UIApplicationMain + 159
	15  Mesghal                             0x000000010a6b688f main + 111
	16  libdyld.dylib                       0x000000011404ad81 start + 1
)
```