### PR TITLE
Set NSNumber to nonnull for storage config calls

### DIFF
--- a/ios/RNFirebase/storage/RNFirebaseStorage.m
+++ b/ios/RNFirebase/storage/RNFirebaseStorage.m
@@ -162,7 +162,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSString *) appDisplayName
  @param NSNumber milliseconds
  */
 RCT_EXPORT_METHOD(setMaxDownloadRetryTime:(NSString *) appDisplayName
-                             milliseconds:(NSNumber *) milliseconds) {
+                             milliseconds:(nonnull NSNumber *) milliseconds) {
     FIRApp *firApp = [RNFirebaseUtil getApp:appDisplayName];
     [[FIRStorage storageForApp:firApp] setMaxDownloadRetryTime:[milliseconds doubleValue]];
 }
@@ -174,7 +174,7 @@ RCT_EXPORT_METHOD(setMaxDownloadRetryTime:(NSString *) appDisplayName
  @param NSNumber milliseconds
  */
 RCT_EXPORT_METHOD(setMaxOperationRetryTime:(NSString *) appDisplayName
-                              milliseconds:(NSNumber *) milliseconds) {
+                              milliseconds:(nonnull NSNumber *) milliseconds) {
     FIRApp *firApp = [RNFirebaseUtil getApp:appDisplayName];
     [[FIRStorage storageForApp:firApp] setMaxOperationRetryTime:[milliseconds doubleValue]];
 }
@@ -185,7 +185,7 @@ RCT_EXPORT_METHOD(setMaxOperationRetryTime:(NSString *) appDisplayName
  @url https://firebase.google.com/docs/reference/js/firebase.storage.Storage#setMaxUploadRetryTime
  */
 RCT_EXPORT_METHOD(setMaxUploadRetryTime:(NSString *) appDisplayName
-                           milliseconds:(NSNumber *) milliseconds) {
+                           milliseconds:(nonnull NSNumber *) milliseconds) {
     FIRApp *firApp = [RNFirebaseUtil getApp:appDisplayName];
     [[FIRStorage storageForApp:firApp] setMaxUploadRetryTime:[milliseconds doubleValue]];
 }


### PR DESCRIPTION
Made change requested by @chrisbianca via Discord chat. New versions of react-native require that all NSNumber arguments are explicitly marked as `nonnull` to ensure compatibility with Android.

Only changed for a few storage methods. The other method exports with NSNumber will probably need to be updated as well, but I did not have a project setup to test them.