### PR TITLE
Fix short link crash

### DIFF
--- a/ios/RNFirebase/links/RNFirebaseLinks.m
+++ b/ios/RNFirebase/links/RNFirebaseLinks.m
@@ -161,9 +161,11 @@ RCT_EXPORT_METHOD(createShortDynamicLink: (NSDictionary *) metadata resolver:(RC
                 NSLog(@"create short dynamic link failure %@", [error localizedDescription]);
                 reject(@"links/failure", @"Failed to create Short Dynamic Link", error);
             }
-            NSURL *shortLink = shortURL;
-            NSLog(@"created short dynamic link: %@", shortLink.absoluteString);
-            resolve(shortLink.absoluteString);
+            else {
+                NSURL *shortLink = shortURL;
+                NSLog(@"created short dynamic link: %@", shortLink.absoluteString);
+                resolve(shortLink.absoluteString);
+            }
         }];
     }
     @catch(NSException * e) {

--- a/lib/modules/links/index.js
+++ b/lib/modules/links/index.js
@@ -108,9 +108,13 @@ export default class Links extends ModuleBase {
    * @returns {Promise.<String>}
    */
   createDynamicLink(parameters: Object = {}): Promise<string> {
-    checkForMandatoryParameters(parameters);
-    validateParameters(parameters);
-    return getNativeModule(this).createDynamicLink(parameters);
+    try {
+      checkForMandatoryParameters(parameters);
+      validateParameters(parameters);
+      return getNativeModule(this).createDynamicLink(parameters);
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -119,9 +123,13 @@ export default class Links extends ModuleBase {
    * @returns {Promise.<String>}
    */
   createShortDynamicLink(parameters: Object = {}): Promise<String> {
-    checkForMandatoryParameters(parameters);
-    validateParameters(parameters);
-    return getNativeModule(this).createShortDynamicLink(parameters);
+    try {
+      checkForMandatoryParameters(parameters);
+      validateParameters(parameters);
+      return getNativeModule(this).createShortDynamicLink(parameters);
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
 }
 

--- a/lib/modules/links/index.js
+++ b/lib/modules/links/index.js
@@ -108,13 +108,9 @@ export default class Links extends ModuleBase {
    * @returns {Promise.<String>}
    */
   createDynamicLink(parameters: Object = {}): Promise<string> {
-    try {
-      checkForMandatoryParameters(parameters);
-      validateParameters(parameters);
-      return getNativeModule(this).createDynamicLink(parameters);
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    checkForMandatoryParameters(parameters);
+    validateParameters(parameters);
+    return getNativeModule(this).createDynamicLink(parameters);
   }
 
   /**
@@ -123,13 +119,9 @@ export default class Links extends ModuleBase {
    * @returns {Promise.<String>}
    */
   createShortDynamicLink(parameters: Object = {}): Promise<String> {
-    try {
-      checkForMandatoryParameters(parameters);
-      validateParameters(parameters);
-      return getNativeModule(this).createShortDynamicLink(parameters);
-    } catch (error) {
-      return Promise.reject(error);
-    }
+    checkForMandatoryParameters(parameters);
+    validateParameters(parameters);
+    return getNativeModule(this).createShortDynamicLink(parameters);
   }
 }
 


### PR DESCRIPTION
Relates to #717 
There was a missing else in the short dynamic link creation of the ios native module, which in case of error, caused to resolve to be called after reject.
Regarding try/catch in the javascript module: they are essential since the are thrown exceptions from the input validation functions.