### PR TITLE
TypeScript compiler validation of lib/index.d.ts

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,6 +5,13 @@
 
 declare module "react-native-firebase" {
 
+  /** 3rd party provider Credentials */
+  type AuthCredential = {
+    providerId: string,
+    token: string,
+    secret: string
+  }
+
   type AuthProvider = {
     PROVIDER_ID: string,
     credential: (token: string, secret?: string) => AuthCredential,
@@ -594,7 +601,7 @@ declare module "react-native-firebase" {
        *
        * @param forceRefresh: boolean - default to false
        */
-      getIdToken(forceRefresh: boolean?): Promise<string>
+      getIdToken(forceRefresh?: boolean): Promise<string>
 
       /**
        * Link the user with a 3rd party credential provider.
@@ -640,13 +647,6 @@ declare module "react-native-firebase" {
        * Profile data should be an object of fields to update:
        */
       updateProfile(updates: UpdateProfile): Promise<void>
-    }
-
-    /** 3rd party provider Credentials */
-    type AuthCredential = {
-      providerId: string,
-      token: string,
-      secret: string
     }
 
     type ActionCodeSettings = {
@@ -1032,7 +1032,7 @@ declare module "react-native-firebase" {
          * Returns an unsubscribe function, call the returned function to
          * unsubscribe from all future events.
          */
-        onLink(listener: (url) => void): () => void;
+        onLink(listener: (url: string) => void): () => void;
       }
 
       /**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "genversion lib/version.js && npm run build-lib && npm run build-flow",
     "build-flow": "flow-copy-source -i */__tests__* lib dist",
-    "build-lib": "BABEL_ENV=publish babel lib -d dist --ignore __tests__ --copy-files",
+    "build-lib": "npm run validate-ts-declarations && BABEL_ENV=publish babel lib -d dist --ignore __tests__ --copy-files",
     "clean": "rimraf dist/",
     "flow": "flow",
     "format": "eslint --fix ./lib ./tests/src ./tests/lib",
@@ -21,7 +21,8 @@
     "tests-npm-install": "cd tests && npm install",
     "tests-pod-install": "cd tests && npm run ios:pod:install",
     "tests-watch-start": "npm run test-cli watch init start",
-    "tests-watch-stop": "npm run test-cli watch stop"
+    "tests-watch-stop": "npm run test-cli watch stop",
+    "validate-ts-declarations": "tsc --project ./"
   },
   "repository": {
     "type": "git",
@@ -101,6 +102,7 @@
     "react-native": "^0.52.0",
     "rimraf": "^2.6.2",
     "shelljs": "^0.7.8",
+    "typescript": "^2.6.2",
     "wml": "0.0.82"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+      "target": "es5",
+      "module": "commonjs",
+      "jsx": "react",
+      "sourceMap": true,
+      "strict": true,
+      "noUnusedLocals": true,
+      "noUnusedParameters": true,
+      "noImplicitReturns": true,
+      "noFallthroughCasesInSwitch": true,
+      "moduleResolution": "node",
+      "experimentalDecorators": true,
+      "emitDecoratorMetadata": true,
+      "lib": [
+          "es2015",
+          "es2016",
+          "esnext",
+          "dom"
+      ]
+  },
+  "files": [
+      "./lib/index.d.ts"
+  ]
+}


### PR DESCRIPTION
I've noticed that there were some lingering errors in the typescript declaration file and that it's really easy to make these small syntax errors when editing the file.
When you then try to use this project in a TypeScript application you will have a lot of trouble because your TypeScript compiler (`tsc`) will always throw them as errors. 

This PR introduces typescript as a devDependency and adds a `tsconfig.json` to configure the compiler to be fairly strict and only look at `lib/index.d.ts` without scanning for other files.

Further, a new npm task is added to `package.json` called `validate-ts-declarations` which just starts `tsc` with the options specified in tsconfig.json.

The validate-ts-declarations command is also added as a prerequisite for `build-lib`. This means that generating the `dist/` folder will fail if `lib/index.d.ts` is broken.

Note: This does not mean that the build will fail because the type declarations don't accurately reflect the actual code. It just checks that the present declarations are valid TypeScript.

Also the compiler will not produce any output files. It will either silently complete or throw compiler errors of the form:

>  tsc --project ./
>
> lib/index.d.ts(10,53): error TS2304: Cannot find name 'AuthCredential'.
> lib/index.d.ts(597,32): error TS8020: JSDoc types can only be used inside documentation comments.
> lib/index.d.ts(1035,27): error TS7006: Parameter 'url' implicitly has an 'any' type. 

I think it would really help to have this in the project in order to make it easier and safer to contribute missing TypeScript declarations.