### PR TITLE
[ios] initializeApp initializes the default app if no appName is given

### DIFF
--- a/ios/RNFirebase/RNFirebase.m
+++ b/ios/RNFirebase/RNFirebase.m
@@ -45,7 +45,11 @@ RCT_EXPORT_METHOD(initializeApp:
             firOptions.bundleID = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
 
             NSString *appName = [RNFirebaseUtil getAppName:appDisplayName];
-            [FIRApp configureWithName:appName options:firOptions];
+            if([appName isEqualToString: @"__FIRAPP_DEFAULT"]){
+                [FIRApp configureWithOptions:firOptions];
+            }else {
+                [FIRApp configureWithName:appName options:firOptions];
+            }
         }
 
         callback(@[[NSNull null], @{@"result": @"success"}]);


### PR DESCRIPTION
iOS FIRApp throws when trying to initialize the app default app via the initializeApp(options) method.

Android version seems not to do that. 

This PR brings the two closer together by allowing the default app to be initialized from js with the initializeApp method.

