### PR TITLE
Flow: Use literal values for strings 

### DIFF
--- a/lib/modules/config/index.js
+++ b/lib/modules/config/index.js
@@ -123,7 +123,7 @@ export default class RemoteConfig extends ModuleBase {
    *    "source" : OneOf<String>(remoteConfigSourceRemote|remoteConfigSourceDefault|remoteConfigSourceStatic)
    *  }
    */
-  getValue(key: String) {
+  getValue(key: string) {
     return getNativeModule(this)
       .getValue(key || '')
       .then(this._nativeValueToJS);
@@ -160,7 +160,7 @@ export default class RemoteConfig extends ModuleBase {
    * @param prefix: The key prefix to look for. If prefix is nil or empty, returns all the keys.
    * @returns {*|Promise.<Array<String>>}
    */
-  getKeysByPrefix(prefix?: String) {
+  getKeysByPrefix(prefix?: string) {
     return getNativeModule(this).getKeysByPrefix(prefix);
   }
 
@@ -176,7 +176,7 @@ export default class RemoteConfig extends ModuleBase {
    * Sets default configs from plist for default namespace;
    * @param resource: The plist file name or resource ID
    */
-  setDefaultsFromResource(resource: String | number) {
+  setDefaultsFromResource(resource: string | number) {
     getNativeModule(this).setDefaultsFromResource(resource);
   }
 }

--- a/lib/utils/emitter/EventEmitter.js
+++ b/lib/utils/emitter/EventEmitter.js
@@ -201,7 +201,7 @@ class EventEmitter {
    *   }); // removes the listener if already registered
    *
    */
-  removeListener(eventType: String, listener) {
+  removeListener(eventType: string, listener) {
     const subscriptions: ?[EmitterSubscription] = (this._subscriber.getSubscriptionsForType(eventType): any);
     if (subscriptions) {
       for (let i = 0, l = subscriptions.length; i < l; i++) {

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -282,7 +282,7 @@ export function typeOf(value: any): string {
 //  * @param string
 //  * @return {string}
 //  */
-// export function capitalizeFirstLetter(string: String) {
+// export function capitalizeFirstLetter(string: string) {
 //   return `${string.charAt(0).toUpperCase()}${string.slice(1)}`;
 // }
 


### PR DESCRIPTION
I understand that you are working on improving the Flow types and doing some rewriting. But I think I found a long hanging fruit, that I tried to fix.

A few places `react-native-firebase` is not using literal values (`string`) for Flow strings types, but object wrapper (`String`). This seems like a bug to me... And this actually causes a project using  remote config to fail Flow validation:
```
Error: src/main.js:139
139:         .getValue('hasExperimentalFeature')
                       ^^^^^^^^^^^^^^^^^^^^^^^^ string. This type is incompatible with the expected param type of
126:   getValue(key: String) {
                     ^^^^^^ String. See: node_modules/react-native-firebase/dist/modules/config/index.js.flow:126
```

### Background
https://flow.org/en/docs/types/primitives/

https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoAxnAdgZwC5g4CMAXIXgE4CWWA5mALxgDkAngKY7Mbb6EBMZAMqUa9JsyxxmQA