### PR TITLE
Exclude lib folder from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -62,6 +62,8 @@ ios/RnFirebase.xcodeproj/xcuserdata
 .Trashes
 ehthumbs.db
 Thumbs.dbandroid/gradle
+
+# Project folders
 android/gradlew
 android/build
 android/gradlew.bat
@@ -71,7 +73,7 @@ docs
 coverage
 yarn.lock
 tests
-lib/.watchmanconfig
+lib
 buddybuild_postclone.sh
 bin/test.js
 .github


### PR DESCRIPTION
We exclude the `lib` folder to:
- avoid duplicate module errors from Flow*
- to reduce the package size

Example of the duplicated module error:
```
Error: node_modules/react-native-firebase/lib/modules/core/firebase.js:0
Firebase. Duplicate module provider
current provider. See: node_modules/react-native-firebase/dist/modules/core/firebase.js:0
```

See context https://github.com/invertase/react-native-firebase/issues/834

WARNING: If some users are using the `lib` folder directly then it will fail for them.