### PR TITLE
Remove error log from RNFirebaseRemoteConfig

### DIFF
--- a/ios/RNFirebase/config/RNFirebaseRemoteConfig.m
+++ b/ios/RNFirebase/config/RNFirebaseRemoteConfig.m
@@ -49,7 +49,6 @@ RCT_EXPORT_METHOD(fetch:
             (RCTPromiseRejectBlock) reject) {
     [[FIRRemoteConfig remoteConfig] fetchWithCompletionHandler:^(FIRRemoteConfigFetchStatus status, NSError *__nullable error) {
         if (error) {
-            RCTLogError(@"\nError: %@", RCTJSErrorFromNSError(error));
             reject(convertFIRRemoteConfigFetchStatusToNSString(status), error.localizedDescription, error);
         } else {
             resolve(convertFIRRemoteConfigFetchStatusToNSString(status));
@@ -64,7 +63,6 @@ RCT_EXPORT_METHOD(fetchWithExpirationDuration:
         rejecter:(RCTPromiseRejectBlock)reject) {
     [[FIRRemoteConfig remoteConfig] fetchWithExpirationDuration:expirationDuration.doubleValue completionHandler:^(FIRRemoteConfigFetchStatus status, NSError *__nullable error) {
         if (error) {
-            RCTLogError(@"\nError: %@", RCTJSErrorFromNSError(error));
             reject(convertFIRRemoteConfigFetchStatusToNSString(status), error.localizedDescription, error);
         } else {
             resolve(convertFIRRemoteConfigFetchStatusToNSString(status));


### PR DESCRIPTION

In case the app is offline and the consumer of this library is using Remote Config, it is perfectly fine to get a [`FIRRemoteConfigErrorInternalError`](https://firebase.google.com/docs/reference/ios/firebaseremoteconfig/api/reference/Enums/FIRRemoteConfigError) error, but there is really no reason to show a red error while developing.

![screenshot 2018-02-15 19 14 27](https://user-images.githubusercontent.com/1260305/36273332-74e2f348-1284-11e8-9541-e7433b7c1734.png)

Instead, we should leave it up to the consumer of this library to handle any errors.

It seems that only that only `RNFirebaseRemoteConfig.m` should be fixed to not use `RCTLogError` where we also reject.

`RNFirebaseMessaging.m` is also using `RCTLogError` but actual errors where `here is no completion handler with completionHandlerId`.
