### PR TITLE
Upgrade Crashlytics

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   compile "com.google.firebase:firebase-ads:$firebaseVersion"
   compile "com.google.firebase:firebase-firestore:$firebaseVersion"
   compile "com.google.firebase:firebase-invites:$firebaseVersion"
-  compile('com.crashlytics.sdk.android:crashlytics:2.7.1@aar') {
+  compile('com.crashlytics.sdk.android:crashlytics:2.9.0@aar') {
     transitive = true
   }
 }


### PR DESCRIPTION
Upgrade Crashlytics to `2.9.0` as per https://fabric.io/kits/android/crashlytics/install