### PR TITLE
[database][js] Reject promise instead of resolving an error object

### DIFF
--- a/lib/modules/database/Reference.js
+++ b/lib/modules/database/Reference.js
@@ -289,7 +289,7 @@ export default class Reference extends ReferenceBase {
       })
       .catch(error => {
         if (isFunction(cancelOrContext)) return cancelOrContext(error);
-        return error;
+        throw error;
       });
   }
 


### PR DESCRIPTION
Currently `ref.once()` don't reject properly when a firebase call fails. This pull request fixes this and allows developers to properly handle those cases.

It could probably easiest be demonstrated by disallowing a path in in the database rules and than try a query like this:

```js
firebase.database()
    .ref(`not/allowed/path`)
    .once('value')
    .then(snap => {
      console.log(snap instanceof Error); // true
      console.log(snap.val); // undefined (because it is not a snapshot...)
    })
    .catch(err => {
      // Never called, but is expected to be called
    });
```

This pull request aline with the behavior of the firebase web sdk.