### PR TITLE
[types] Use literal values for strings

### DIFF
--- a/lib/modules/config/index.js
+++ b/lib/modules/config/index.js
@@ -143,11 +143,11 @@ export default class RemoteConfig extends ModuleBase {
    *    "source" : OneOf<String>(remoteConfigSourceRemote|remoteConfigSourceDefault|remoteConfigSourceStatic)
    *  }
    */
-  getValues(keys: Array<String>) {
+  getValues(keys: Array<string>) {
     return getNativeModule(this)
       .getValues(keys || [])
       .then(nativeValues => {
-        const values: { [String]: Object } = {};
+        const values: { [string]: Object } = {};
         for (let i = 0, len = keys.length; i < len; i++) {
           values[keys[i]] = this._nativeValueToJS(nativeValues[i]);
         }


### PR DESCRIPTION
In https://github.com/invertase/react-native-firebase/pull/832 I fixed some incorrect usage of not using the literal values (`string`) for Flow strings types, but object wrapper (`String`) inside the remote config code.

Turns out I clearly missed two cased. : )