### PR TITLE
Fix flow to support setUserId(null)

### DIFF
--- a/lib/modules/analytics/index.js
+++ b/lib/modules/analytics/index.js
@@ -122,7 +122,7 @@ export default class Analytics extends ModuleBase {
    * Sets the user ID property.
    * @param id
    */
-  setUserId(id: string): void {
+  setUserId(id: ?string): void {
     getNativeModule(this).setUserId(id);
   }
 


### PR DESCRIPTION
`null` is accepted for `setUserId`, see [index.d.ts](https://github.com/invertase/react-native-firebase/blob/8060c949a2881cada885849c63c9a4ff93ec5d8c/lib/index.d.ts#L524)