### PR TITLE
FIX: Types for requestPermissions on iOS

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -954,7 +954,7 @@ declare module "react-native-firebase" {
          * IOS
          * Requests app notification permissions in an Alert dialog.
          */
-        requestPermissions(): void
+        requestPermissions(): Promise<{ granted: boolean }>;
 
         /**
          * Sets the badge number on the iOS app icon.


### PR DESCRIPTION
Currently returns void rather than a promise which causes TypeScript compilation to fail.