### PR TITLE
fixes races bug in react-native > 0.52

### DIFF
--- a/ios/RNFirebase/analytics/RNFirebaseAnalytics.m
+++ b/ios/RNFirebase/analytics/RNFirebaseAnalytics.m
@@ -5,6 +5,7 @@
 #import <FirebaseAnalytics/FIRAnalyticsConfiguration.h>
 
 @implementation RNFirebaseAnalytics
+@synthesize methodQueue = _methodQueue;
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(logEvent:(NSString *)name props:(NSDictionary *)props) {
@@ -16,7 +17,7 @@ RCT_EXPORT_METHOD(setAnalyticsCollectionEnabled:(BOOL) enabled) {
 }
 
 RCT_EXPORT_METHOD(setCurrentScreen:(NSString *) screenName screenClass:(NSString *) screenClassOverriew) {
-  dispatch_async(dispatch_get_main_queue(), ^{
+  dispatch_sync(dispatch_get_main_queue(), ^{
     [FIRAnalytics setScreenName:screenName screenClass:screenClassOverriew];
   });
 }

--- a/ios/RNFirebase/analytics/RNFirebaseAnalytics.m
+++ b/ios/RNFirebase/analytics/RNFirebaseAnalytics.m
@@ -5,7 +5,6 @@
 #import <FirebaseAnalytics/FIRAnalyticsConfiguration.h>
 
 @implementation RNFirebaseAnalytics
-@synthesize methodQueue = _methodQueue;
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(logEvent:(NSString *)name props:(NSDictionary *)props) {


### PR DESCRIPTION
In newer versions of react-native `dispatch_async` in `setCurrentScreen` causes mixed order. It's obvious if you make several calls of `setCurrentScreen` and `logEvent` in a small amount of time.

See: https://github.com/facebook/react-native/blob/0.54-stable/React/Base/RCTBridgeModule.h#L112