### PR TITLE
Fix contentUrl in AdRequest on Android

### DIFF
--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobUtils.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobUtils.java
@@ -58,7 +58,7 @@ class RNFirebaseAdMobUtils {
     }
 
     if (request.hasKey("contentUrl")) {
-      requestBuilder.setContentUrl(request.getString("setContentUrl"));
+      requestBuilder.setContentUrl(request.getString("contentUrl"));
     }
 
     if (request.hasKey("requestAgent")) {
@@ -143,7 +143,7 @@ class RNFirebaseAdMobUtils {
       case "SMART_BANNER":
         return AdSize.SMART_BANNER;
       case "SMART_BANNER_LANDSCAPE":
-        return AdSize.SMART_BANNER;		
+        return AdSize.SMART_BANNER;
     }
   }
 }


### PR DESCRIPTION
The request checked if the `contentUrl` key was present but then tried to get the `setContentUrl` key which caused a crash.
