### PR TITLE
fix cancelAlarm on android

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
@@ -196,7 +196,7 @@ public class RNFirebaseNotificationManager {
   }
 
   private void cancelAlarm(String notificationId) {
-    Intent notificationIntent = new Intent(context, RNFirebaseNotificationManager.class);
+    Intent notificationIntent = new Intent(context, RNFirebaseNotificationReceiver.class);
     PendingIntent pendingIntent = PendingIntent.getBroadcast(context, notificationId.hashCode(), notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
     alarmManager.cancel(pendingIntent);
   }


### PR DESCRIPTION
I noticed that firebase.notifications().cancelAllNotifications() has no effect on android phones. All scheduled notifications still appear. The propsed change fixes this. It was "inspired" by https://stackoverflow.com/questions/35341682/cancel-the-scheduled-android-notification/35342066#35342066