### PR TITLE
Fix for attaching file to image with notification android

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
@@ -517,7 +517,7 @@ public class RNFirebaseNotificationManager {
     if (image.startsWith("http://") || image.startsWith("https://")) {
       return getBitmapFromUrl(image);
     } else if (image.startsWith("file://")) {
-      return BitmapFactory.decodeFile(image);
+      return BitmapFactory.decodeFile(image.replaceAll("^file://", ""));
     } else {
       int largeIconResId = getResourceId("mipmap", image);
       return BitmapFactory.decodeResource(context.getResources(), largeIconResId);


### PR DESCRIPTION
Supplying a string that is a file path for adding images to notifications in android like so `file:///data/user/0/com.example/files/RNFetchBlobTmp_cjyxt7xo568b470ekawvzw.jpg` can be used to recognise that it is a file location that has been submitted but when actually using the file to create a bitmap the `file://` part might need to be removed as it seems to prevent native android from actually finding the file.

Might not be the best way for replacing the `file://` pattern but should be fine.