### PR TITLE
allow using ringtones from RingtoneManager

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
@@ -560,7 +560,9 @@ public class RNFirebaseNotificationManager {
   }
 
   private Uri getSound(String sound) {
-    if (sound.equalsIgnoreCase("default")) {
+    if (sound.contains("://")) {
+      return Uri.parse(sound);
+    } else if (sound.equalsIgnoreCase("default")) {
       return RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
     } else {
       int soundResourceId = getResourceId("raw", sound);


### PR DESCRIPTION
when allowing users to pick a sound from RingtoneManager, RNFirebaseNotification should detect we are passing a Uri instead of trying to load this file from our bundle.