### PR TITLE
Fix podspec so compilation works when RNFirebase is set in the Podfile

### DIFF
--- a/ios/RNFirebase.podspec
+++ b/ios/RNFirebase.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.platform            = :ios, "9.0"
   s.source_files        = 'RNFirebase/**/*.{h,m}'
   s.dependency          'React'
+  s.dependency          'Firebase/Core'
 end


### PR DESCRIPTION
Not sure when this broke, but this fixes compilation when used in a
project that pulls the dependency using CocoaPods and Xcode 9.3

Otherwise I was getting the following error:

`'Firebase.h' file not found with <angled> include; use "quotes" instead in RNFirebaseUtil.h`

This is the content of the `Podfile`

```ruby
pod 'Firebase/Core'
pod 'Firebase/Auth'
pod 'Firebase/Firestore'
pod 'RNFirebase', :path => '../node_modules/react-native-firebase/ios'
```