### PR TITLE
Typing Fix for Firestore Query `where` Function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1502,7 +1502,7 @@ declare module "react-native-firebase" {
         startAfter(...varargs: any[]): Query;
         startAt(snapshot: DocumentSnapshot): Query;
         startAt(...varargs: any[]): Query;
-        where(fieldPath: string, op: Types.QueryOperator, value: any): Query;
+        where(fieldPath: string | FieldPath, op: Types.QueryOperator, value: any): Query;
       }
 
       interface DocumentChange {
@@ -1598,7 +1598,7 @@ declare module "react-native-firebase" {
         startAfter(...varargs: any[]): Query;
         startAt(snapshot: DocumentSnapshot): Query;
         startAt(...varargs: any[]): Query;
-        where(fieldPath: string, op: Types.QueryOperator, value: any): Query;
+        where(fieldPath: string | FieldPath, op: Types.QueryOperator, value: any): Query;
       }
       namespace Query {
         interface NativeFieldPath {


### PR DESCRIPTION
Constructing and passing a FieldPath object to the `where` function of a Firestore query raises a type error since those functions are only typed to expect a `string` value. This fixes that issue by adding `FieldPath` as a type option to those functions, after confirming the functions operate as expected with the additional object type.