### PR TITLE
fix allowedDataTypes in fromNativeAndroidRemoteInput

### DIFF
--- a/lib/modules/notifications/AndroidRemoteInput.js
+++ b/lib/modules/notifications/AndroidRemoteInput.js
@@ -103,9 +103,9 @@ export const fromNativeAndroidRemoteInput = (
   nativeRemoteInput: NativeAndroidRemoteInput
 ): AndroidRemoteInput => {
   const remoteInput = new AndroidRemoteInput(nativeRemoteInput.resultKey);
-  if (nativeRemoteInput.allowDataType) {
-    for (let i = 0; i < nativeRemoteInput.allowDataType.length; i++) {
-      const allowDataType = nativeRemoteInput.allowDataType[i];
+  if (nativeRemoteInput.allowedDataTypes) {
+    for (let i = 0; i < nativeRemoteInput.allowedDataTypes.length; i++) {
+      const allowDataType = nativeRemoteInput.allowedDataTypes[i];
       remoteInput.setAllowDataType(allowDataType.mimeType, allowDataType.allow);
     }
   }


### PR DESCRIPTION
this PR fix an incorrect attribute in notification/AndroidRemoteInput .


and according to `lib/modules/notifications/types.js` , the attribute name is `allowedDataTypes` .
```
export type NativeAndroidRemoteInput = {|
  allowedDataTypes: AndroidAllowDataType[],
  allowFreeFormInput?: boolean,
  choices: string[],
  label?: string,
  resultKey: string,
|};
```

