### PR TITLE
Fix ClassCastException while parsing fireDate

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
@@ -309,17 +309,19 @@ public class RNFirebaseNotificationManager {
     // fireDate is stored in the Bundle as Long after notifications are rescheduled.
     // This would lead to a fireDate of 0.0 when trying to extract a Double from the bundle.
     // Instead always try extract a Long
-    Long fireDate = schedule.getLong("fireDate", -1);
-    if (fireDate == -1) {
+    Long fireDate = -1L;
+    try {
       fireDate = (long) schedule.getDouble("fireDate", -1);
-      if (fireDate == -1) {
-        if (promise == null) {
-          Log.e(TAG, "Missing schedule information");
-        } else {
-          promise.reject("notification/schedule_notification_error", "Missing fireDate information");
-        }
-        return;
+    } catch (ClassCastException e) {
+      fireDate = schedule.getLong("fireDate", -1);
+    }
+    if (fireDate == -1) {
+      if (promise == null) {
+        Log.e(TAG, "Missing schedule information");
+      } else {
+        promise.reject("notification/schedule_notification_error", "Missing fireDate information");
       }
+      return;
     }
 
     // Scheduled alarms are cleared on restart


### PR DESCRIPTION
ClassCastException was thrown on Android 8.1 while trying to schedule
local notification. Use try-catch approach instead of relaying on the
default parse value.