### PR TITLE
Implement handling of Android actions in background

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseBackgroundNotificationActionReceiver.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseBackgroundNotificationActionReceiver.java
@@ -1,0 +1,50 @@
+package io.invertase.firebase.notifications;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.facebook.react.HeadlessJsTaskService;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableMap;
+
+import io.invertase.firebase.Utils;
+
+public class RNFirebaseBackgroundNotificationActionReceiver extends BroadcastReceiver {
+  static boolean isBackgroundNotficationIntent(Intent intent) {
+    return intent.getExtras() != null && intent.hasExtra("action") && intent.hasExtra("notification");
+  }
+
+  static WritableMap toNotificationOpenMap(Intent intent) {
+    Bundle extras = intent.getExtras();
+    WritableMap notificationMap = Arguments.makeNativeMap(extras.getBundle("notification"));
+    WritableMap notificationOpenMap = Arguments.createMap();
+    notificationOpenMap.putString("action", extras.getString("action"));
+    notificationOpenMap.putMap("notification", notificationMap);
+    return notificationOpenMap;
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    if (!isBackgroundNotficationIntent(intent)) {
+      return;
+    }
+
+    if (Utils.isAppInForeground(context)) {
+      WritableMap notificationOpenMap = toNotificationOpenMap(intent);
+
+      ReactApplication reactApplication =  (ReactApplication)context.getApplicationContext();
+      ReactContext reactContext = reactApplication.getReactNativeHost().getReactInstanceManager().getCurrentReactContext();
+
+      Utils.sendEvent(reactContext, "notifications_notification_opened", notificationOpenMap);
+    } else {
+      Intent serviceIntent = new Intent(context, RNFirebaseBackgroundNotificationActionsService.class);
+      serviceIntent.putExtras(intent.getExtras());
+      context.startService(serviceIntent);
+      HeadlessJsTaskService.acquireWakeLockNow(context);
+    }
+  }
+}

--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseBackgroundNotificationActionsService.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseBackgroundNotificationActionsService.java
@@ -1,0 +1,29 @@
+package io.invertase.firebase.notifications;
+
+import android.content.Intent;
+
+import com.facebook.react.HeadlessJsTaskService;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+
+import javax.annotation.Nullable;
+
+import static io.invertase.firebase.notifications.RNFirebaseBackgroundNotificationActionReceiver.isBackgroundNotficationIntent;
+import static io.invertase.firebase.notifications.RNFirebaseBackgroundNotificationActionReceiver.toNotificationOpenMap;
+
+public class RNFirebaseBackgroundNotificationActionsService extends HeadlessJsTaskService {
+  @Override
+  protected @Nullable HeadlessJsTaskConfig getTaskConfig(Intent intent) {
+    if (isBackgroundNotficationIntent(intent)) {
+      WritableMap notificationOpenMap = toNotificationOpenMap(intent);
+
+      return new HeadlessJsTaskConfig(
+        "RNFirebaseBackgroundNotificationAction",
+        notificationOpenMap,
+        60000,
+        true
+      );
+    }
+    return null;
+  }
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1277,6 +1277,7 @@ declare module 'react-native-firebase' {
           semanticAction?: SemanticAction;
           showUserInterface?: boolean;
           title: string;
+          runInBackground?: boolean;
 
           constructor(action: string, icon: string, title: string);
 
@@ -1284,6 +1285,7 @@ declare module 'react-native-firebase' {
           setAllowGenerateReplies(allowGeneratedReplies: boolean): Action;
           setSemanticAction(semanticAction: SemanticAction): Action;
           setShowUserInterface(showUserInterface: boolean): Action;
+          setRunInBackground(runInBackground: boolean): Action;
         }
 
         class RemoteInput {

--- a/lib/modules/notifications/AndroidAction.js
+++ b/lib/modules/notifications/AndroidAction.js
@@ -16,6 +16,7 @@ export default class AndroidAction {
   _semanticAction: SemanticActionType | void;
   _showUserInterface: boolean | void;
   _title: string;
+  _runInBackground: boolean | void;
 
   constructor(action: string, icon: string, title: string) {
     this._action = action;
@@ -50,6 +51,10 @@ export default class AndroidAction {
 
   get title(): string {
     return this._title;
+  }
+
+  get runInBackground(): ?boolean {
+    return this._runInBackground;
   }
 
   /**
@@ -102,6 +107,16 @@ export default class AndroidAction {
     return this;
   }
 
+  /**
+   * 
+   * @param runInBackground 
+   * @returns {AndroidAction}
+   */
+  setRunInBackground(runInBackground: boolean): AndroidAction {
+    this._runInBackground = runInBackground
+    return this;
+  }
+
   build(): NativeAndroidAction {
     if (!this._action) {
       throw new Error('AndroidAction: Missing required `action` property');
@@ -119,6 +134,7 @@ export default class AndroidAction {
       semanticAction: this._semanticAction,
       showUserInterface: this._showUserInterface,
       title: this._title,
+      runInBackground: this._runInBackground
     };
   }
 }
@@ -144,6 +160,9 @@ export const fromNativeAndroidAction = (
   }
   if (nativeAction.showUserInterface) {
     action.setShowUserInterface(nativeAction.showUserInterface);
+  }
+  if (nativeAction.runInBackground) {
+    action.setRunInBackground(nativeAction.runInBackground);
   }
 
   return action;

--- a/lib/modules/notifications/types.js
+++ b/lib/modules/notifications/types.js
@@ -136,6 +136,7 @@ export type NativeAndroidAction = {|
   semanticAction?: SemanticActionType,
   showUserInterface?: boolean,
   title: string,
+  runInBackground?: boolean,
 |};
 
 export type NativeAndroidNotification = {|


### PR DESCRIPTION
There are some cases when local notification action should be handled in
background eg. snoozing the reminder. In case of it launching app UI is
not necessary and would be confusing for the end user.

Therefore there should be a way to handle local notification action in
background.

For this reason new property 'runInBackground' was added to the
AndroidAction class and TypeScript type.

Also new broadcast receiver and service were implemented to handle
properly background actions.

In order to run particular action in background user need to set its
'runInBackground' property to 'true', eg:

```js
  ...
  .android.addAction(new firebase.notifications.Android.Action("snooze",
      "ic_snooze", "Snooze").setRunInBackground(true))
```

Then create a background asynchronous handler:

```js
  const handleAsyncTask = async (notificationOpen: NotifficationOpen) => {
    if (notificationOpen && notificationOpen.notification) {
      const action = notificationOpen.action;
      const notificationId = notificationOpen.notification.notificationId;
      if (action === "snooze") {
        console.log("Reschedule notification for later time", notificationId);
      } else {
        console.log("unsupported action", action);
      }
      // hide the notification
      firebase.notifications().removeDeliveredNotification(notificationId);
    }
  }
```

Next hander should be registered to an headless handler:

```js
  AppRegistry.registerHeadlessTask('RNFirebaseBackgroundNotification', () => handleAsyncTask);
```

Finally AndroidManifest.xml file must be modified, to include receiver
and service definition:

```xml
  <receiver
      android:name="io.invertase.firebase.notifications.RNFirebaseBackgroundNotificationReceiver"
      android:exported="true">
    <intent-filter>
      <action android:name="io.invertase.firebase.notifications.BackgroundAction"/>
    </intent-filter>
  </receiver>
  <service android:name="io.invertase.firebase.notifications.RNFirebaseBackgroundNotificationsService"/>
```

Now when ever 'Snooze' action is pressed it will launch
'handleAsyncTask' function in the background and reschedule the
notification for the later time.