### PR TITLE
Firestore: Allow setting the iOS dispatch queue for callbacks.

### DIFF
--- a/ios/RNFirebase/firestore/RNFirebaseFirestore.m
+++ b/ios/RNFirebase/firestore/RNFirebaseFirestore.m
@@ -357,6 +357,9 @@ RCT_EXPORT_METHOD(settings:(NSString *)appDisplayName
         // TODO: Enable when available on Android
         // firestoreSettings.timestampsInSnapshotsEnabled = settings[@"timestampsInSnapshots"];
     }
+    if (settings[@"dispatchQueueName"]) {
+        firestoreSettings.dispatchQueue = dispatch_queue_create([settings[@"dispatchQueueName"] UTF8String], NULL);
+    }
     [firestore setSettings:firestoreSettings];
     resolve(nil);
 }


### PR DESCRIPTION
Use case is preventing processing in the main thread and UI hitches.

For larger documents the time spent converting from the document dictionary to a folly object to be passed into react native can take significant time and cause hitches in UI rendering.  This allows the developer to specify a dispatch queue to handle events in. This seemed like the lowest-impact way to allow this.

I'd argue that by default the firestore dispatch queue should specified to be something other than the main thread.  Since after the work is done it goes to the react native js thread, there's no need to clutter the main thread with this kind of work.  But I'm still pretty new to firebase/firestore, so I may be missing something. 

Thanks!