### PR TITLE
Resolve display notification promise

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
@@ -283,6 +283,11 @@ public class DisplayNotificationTask extends AsyncTask<Void, Void, Void> {
       if (reactContext != null) {
         Utils.sendEvent(reactContext, "notifications_notification_displayed", Arguments.fromBundle(notification));
       }
+      
+      if (promise != null) {
+        promise.resolve(null);
+      }
+      
     } catch (Exception e) {
       Log.e(TAG, "Failed to send notification", e);
       if (promise != null) {


### PR DESCRIPTION
Once the notification is created the promise was not being resolved so in a situation where the user is waiting on the promise to complete, they would not get a callback and in case a user used async/await this would cause the app to get stuck at that point.