### PR TITLE
android/build: change repository order regarding requirements

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
-    jcenter()
     google()
+    jcenter()
     maven {
       url 'https://maven.fabric.io/public'
     }


### PR DESCRIPTION
The google() and jcenter() repository order is now changed regarding configuration requirements at: https://developer.android.com/studio/build/

Originally answered at: https://stackoverflow.com/questions/48242111/gradle-error-after-update-com-android-toolssdk-common

Fixes #1147 