### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,14 +39,6 @@ android {
 }
 
 
-allprojects {
-  repositories {
-    jcenter()
-    mavenLocal()
-    google()
-  }
-}
-
 rootProject.gradle.buildFinished { buildResult ->
   if (buildResult.getFailure() != null) {
     try {


### PR DESCRIPTION
Don't set global policy on which gradle versions to support.

`google()` is only supported on newer gradle versions.
An `allprojects{..}` setting shouldn't exist in a component should it?