### PR TITLE
Fix repository errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,8 @@
 buildscript {
   repositories {
+    maven { 
+      url 'https://maven.google.com'
+    }
     jcenter()
     google()
     maven {


### PR DESCRIPTION
It seems that jcenter has some issues with providing dependencies to the project. Adding maven repositories should fix it. 

See this: https://stackoverflow.com/questions/50563338/could-not-find-runtime-jar-android-arch-lifecycleruntime1-0-0