### PR TITLE
[Android] Support for areNotificationsEnabled

### DIFF
--- a/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessaging.java
+++ b/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessaging.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.support.v4.content.LocalBroadcastManager;
+import android.support.v4.app.NotificationManagerCompat;
 import android.util.Log;
 
 import com.facebook.react.bridge.Promise;
@@ -56,7 +57,8 @@ public class RNFirebaseMessaging extends ReactContextBaseJavaModule {
   // Non Web SDK methods
   @ReactMethod
   public void hasPermission(Promise promise) {
-    promise.resolve(true);
+    Boolean enabled = NotificationManagerCompat.from(getReactApplicationContext()).areNotificationsEnabled();
+    promise.resolve(enabled);
   }
 
   @ReactMethod


### PR DESCRIPTION
## Use case

In our app we'd like to know if the users have "blocked" the notifications so we can show them a snackbar with a button to the app's system settings so they can turn them on.

On **iOS** the `hasPermission` method works perfectly, returning true or false depending if they're on or not.

On **Android** it was always returning true, so I made this PR including [areNotificationsEnabled](https://developer.android.com/reference/android/support/v4/app/NotificationManagerCompat#areNotificationsEnabled()) in the same `hasPermission` method which will return true or false depending if the user has blocked them or not.

