### PR TITLE
Fixed Deadlock

### DIFF
--- a/ios/RNFirebase/RNFirebase.m
+++ b/ios/RNFirebase/RNFirebase.m
@@ -1,6 +1,7 @@
 #import "RNFirebase.h"
 #import "RNFirebaseUtil.h"
 #import <FirebaseCore/FirebaseCore.h>
+#import <React/RCTUtils.h>
 
 @implementation RNFirebase
 RCT_EXPORT_MODULE(RNFirebase);
@@ -28,7 +29,7 @@ RCT_EXPORT_METHOD(initializeApp:
             callback:
             (RCTResponseSenderBlock) callback) {
 
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    RCTUnsafeExecuteOnMainQueueSync(^{
         FIRApp *existingApp = [RNFirebaseUtil getApp:appDisplayName];
 
         if (!existingApp) {

--- a/ios/RNFirebase/analytics/RNFirebaseAnalytics.m
+++ b/ios/RNFirebase/analytics/RNFirebaseAnalytics.m
@@ -1,4 +1,5 @@
 #import "RNFirebaseAnalytics.h"
+#import <React/RCTUtils.h>
 
 #if __has_include(<FirebaseAnalytics/FIRAnalytics.h>)
 #import <FirebaseAnalytics/FIRAnalytics.h>
@@ -16,7 +17,7 @@ RCT_EXPORT_METHOD(setAnalyticsCollectionEnabled:(BOOL) enabled) {
 }
 
 RCT_EXPORT_METHOD(setCurrentScreen:(NSString *) screenName screenClass:(NSString *) screenClassOverriew) {
-  dispatch_sync(dispatch_get_main_queue(), ^{
+  RCTUnsafeExecuteOnMainQueueSync(^{
     [FIRAnalytics setScreenName:screenName screenClass:screenClassOverriew];
   });
 }

--- a/ios/RNFirebase/storage/RNFirebaseStorage.m
+++ b/ios/RNFirebase/storage/RNFirebaseStorage.m
@@ -7,6 +7,7 @@
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <Photos/Photos.h>
 #import <Firebase.h>
+#import <React/RCTUtils.h>
 
 @implementation RNFirebaseStorage
 
@@ -120,7 +121,7 @@ RCT_EXPORT_METHOD(downloadFile:(NSString *) appDisplayName
     NSURL *localFile = [NSURL fileURLWithPath:localPath];
     
     __block FIRStorageDownloadTask *downloadTask;
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    RCTUnsafeExecuteOnMainQueueSync(^{
         downloadTask = [fileRef writeToFile:localFile];
     });
 
@@ -298,7 +299,7 @@ RCT_EXPORT_METHOD(putFile:(NSString *) appDisplayName
 - (void)uploadFile:(NSString *)appDisplayName url:(NSURL *)url firmetadata:(FIRStorageMetadata *)firmetadata path:(NSString *)path resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
     FIRStorageReference *fileRef = [self getReference:path appDisplayName:appDisplayName];
     __block FIRStorageUploadTask *uploadTask;
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    RCTUnsafeExecuteOnMainQueueSync(^{
         uploadTask = [fileRef putFile:url metadata:firmetadata];
     });
     [self addUploadObservers:appDisplayName uploadTask:uploadTask path:path resolver:resolve rejecter:reject];
@@ -307,7 +308,7 @@ RCT_EXPORT_METHOD(putFile:(NSString *) appDisplayName
 - (void)uploadData:(NSString *)appDisplayName data:(NSData *)data firmetadata:(FIRStorageMetadata *)firmetadata path:(NSString *)path resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject {
     FIRStorageReference *fileRef = [self getReference:path appDisplayName:appDisplayName];
     __block FIRStorageUploadTask *uploadTask;
-    dispatch_sync(dispatch_get_main_queue(), ^{
+    RCTUnsafeExecuteOnMainQueueSync(^{
         uploadTask = [fileRef putData:data metadata:firmetadata];
     });
     [self addUploadObservers:appDisplayName uploadTask:uploadTask path:path resolver:resolve rejecter:reject];


### PR DESCRIPTION
Trying to upload an image in a detached [ExpoKit](https://github.com/expo/expo) project will deadlock from thread issues.
---
I've replaced `dispatch_sync(dispatch_get_main_queue(), ^{});`  with `RCTUnsafeExecuteOnMainQueueSync(^{});` to fix this.

I only hit the error in the `RNFirebaseStorage.m` but it seems like the `RNFirebaseAnalytics.m` and `RNFirebase.m` modules could also have the same issue.

`RCTUnsafeExecuteOnMainQueueSync` checks to see if the method is being executed on the main thread before trying to sync to the main thread. 
If you try to sync on the main thread while on the main thread, you hit a deadlock.

You can read more about it here: [StackOverflow](https://stackoverflow.com/questions/12379059/why-is-this-dispatch-sync-call-freezing?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa)

## Testing

The only testing I did was in a separate detached ExpoKit project running v27.

Running this javascript would cause the crash.
**javascript**
```js
const { status } = await Expo.Permissions.askAsync(
  Expo.Permissions.CAMERA_ROLL,
);
if (status !== 'granted') {
  alert('failed to get library asset, please enable and restart demo');
  return;
}

const { edges } = await CameraRoll.getPhotos({ first: 1 });
const imageUri = edges.map(
  ({ node: { image, timestamp } }, index) => image.uri,
)[0];

// imageUri looks like this: "assets-library://asset/asset.JPG?id=99D53A1F-FEEF-40E1-8BB3-7DD55A43C8B7&ext=JPG"

const uploadUri = "images/image.jpeg"

await firebase
      .storage()
      .ref(uploadUri)
      .putFile(imageUri);
```

**Podfile**
```rb
  pod 'Firebase/Core', '~> 5.0.1'
  pod 'Firebase/Database'
  pod 'Firebase/Auth'
  pod 'Firebase/Firestore'
  pod 'Firebase/Messaging'
  pod 'Firebase/Crash'
  pod 'Firebase/DynamicLinks'
  pod 'Firebase/RemoteConfig'
  pod 'Firebase/Storage'
  pod 'Firebase/Performance'
```

**package.json**
```json
{
  "dependencies": {
    "expo": "^27.0.0",
    "react": "16.4.0",
    "react-native": "https://github.com/expo/react-native/archive/sdk-27.0.0.tar.gz",
    "react-native-firebase": "^4.2.0"
  }
}
```


