### PR TITLE
adds support for getToken(string,string) and deleteToken()

### DIFF
--- a/android/src/main/java/io/invertase/firebase/instanceid/RNFirebaseInstanceId.java
+++ b/android/src/main/java/io/invertase/firebase/instanceid/RNFirebaseInstanceId.java
@@ -1,6 +1,8 @@
 package io.invertase.firebase.instanceid;
 
 
+import java.io.IOException;
+
 import android.util.Log;
 
 import com.facebook.react.bridge.Promise;
@@ -41,5 +43,27 @@ public class RNFirebaseInstanceId extends ReactContextBaseJavaModule {
   public void get(Promise promise){
     String id = FirebaseInstanceId.getInstance().getId();
     promise.resolve(id);
+  }
+
+  @ReactMethod
+  public void getToken(String authorizedEntity, String scope, Promise promise) {
+    try {
+      String token = FirebaseInstanceId.getInstance().getToken(authorizedEntity, scope);
+      Log.d(TAG, "Firebase token for " + authorizedEntity + ": " + token);
+      promise.resolve(token);
+    } catch (IOException e) {
+      promise.reject("iid/request-failed", "getToken request failed", e);
+    }
+  }
+
+  @ReactMethod
+  public void deleteToken(String authorizedEntity, String scope, Promise promise) {
+    try {
+      FirebaseInstanceId.getInstance().deleteToken(authorizedEntity, scope);
+      Log.d(TAG, "Firebase token deleted for " + authorizedEntity);
+      promise.resolve(null);
+    } catch (IOException e) {
+      promise.reject("iid/request-failed", "deleteToken request failed", e);
+    }
   }
 }

--- a/ios/RNFirebase/instanceid/RNFirebaseInstanceId.m
+++ b/ios/RNFirebase/instanceid/RNFirebaseInstanceId.m
@@ -1,6 +1,7 @@
 #import "RNFirebaseInstanceId.h"
 
 #if __has_include(<FirebaseInstanceID/FIRInstanceID.h>)
+#import <FirebaseMessaging/FirebaseMessaging.h>
 #import <FirebaseInstanceID/FIRInstanceID.h>
 
 @implementation RNFirebaseInstanceId
@@ -22,6 +23,36 @@ RCT_EXPORT_METHOD(get:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseReject
             reject(@"instance_id_error", @"Failed to get instance id", error);
         } else {
             resolve(identity);
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(getToken:(NSString *)authorizedEntity
+                  scope:(NSString *)scope
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    NSDictionary * options = nil;
+    if ([FIRMessaging messaging].APNSToken) {
+        options = @{@"apns_token": [FIRMessaging messaging].APNSToken};
+    }
+    [[FIRInstanceID instanceID] tokenWithAuthorizedEntity:authorizedEntity scope:scope options:options handler:^(NSString * _Nullable identity, NSError * _Nullable error) {
+        if (error) {
+            reject(@"instance_id_error", @"Failed to getToken", error);
+        } else {
+            resolve(identity);
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(deleteToken:(NSString *)authorizedEntity
+                  scope:(NSString *)scope
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    [[FIRInstanceID instanceID] deleteTokenWithAuthorizedEntity:authorizedEntity scope:scope handler:^(NSError * _Nullable error) {
+        if (error) {
+            reject(@"instance_id_error", @"Failed to deleteToken", error);
+        } else {
+            resolve(nil);
         }
     }];
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1088,6 +1088,8 @@ declare module 'react-native-firebase' {
       interface InstanceId {
         delete(): Promise<void>;
         get(): Promise<string>;
+        getToken(authorizedEntity: string, scope: string): Promise<string>;
+        deleteToken(authorizedEntity: string, scope: string): Promise<void>;
       }
     }
 

--- a/lib/modules/iid/index.js
+++ b/lib/modules/iid/index.js
@@ -27,6 +27,14 @@ export default class InstanceId extends ModuleBase {
   get(): Promise<string> {
     return getNativeModule(this).get();
   }
+
+  getToken(authorizedEntity: string, scope: string): Promise<string> {
+    return getNativeModule(this).getToken(authorizedEntity, scope);
+  }
+
+  deleteToken(authorizedEntity: string, scope: string): Promise<void> {
+    return getNativeModule(this).deleteToken(authorizedEntity, scope);
+  }
 }
 
 export const statics = {};

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -225,7 +225,7 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
-  - RNFirebase (4.1.0):
+  - RNFirebase (4.2.0):
     - Firebase/Core
     - React
   - yoga (0.54.4.React)

--- a/tests/src/tests/iid/iidTests.js
+++ b/tests/src/tests/iid/iidTests.js
@@ -1,0 +1,35 @@
+import should from 'should';
+
+function iidTests({ describe, it, firebase }) {
+  describe('iid', () => {
+    it('should delete the iid token', async () => {
+      await firebase.native.iid().delete();
+    });
+
+    it('it should return iid token from get', async () => {
+      const token = await firebase.native.iid().get();
+
+      token.should.be.a.String();
+    });
+
+    it('should return an FCM token from getToken with arguments', async () => {
+      await firebase.native.iid().delete();
+
+      const otherSenderIdToken = await firebase.native
+        .iid()
+        .getToken('305229645282', '*');
+
+      otherSenderIdToken.should.be.a.String();
+    });
+
+    it('should return nil from deleteToken', async () => {
+      const token = await firebase.native
+        .iid()
+        .deleteToken('305229645282', '*');
+
+      should.not.exist(token);
+    });
+  });
+}
+
+export default iidTests;

--- a/tests/src/tests/iid/index.js
+++ b/tests/src/tests/iid/index.js
@@ -1,0 +1,10 @@
+import firebase from '../../firebase';
+import TestSuite from '../../../lib/TestSuite';
+
+import iidTests from './iidTests';
+
+const suite = new TestSuite('Iid', 'firebase.id()', firebase);
+
+suite.addTests(iidTests);
+
+export default suite;

--- a/tests/src/tests/index.js
+++ b/tests/src/tests/index.js
@@ -12,6 +12,7 @@ import performance from './perf';
 import admob from './admob';
 import firestore from './firestore';
 import links from './links/index';
+import iid from './iid';
 
 window.getCoverage = function getCoverage() {
   return JSON.stringify(global.__coverage__);
@@ -31,6 +32,7 @@ const testSuiteInstances = [
   performance,
   storage,
   links,
+  iid,
 ];
 
 /*


### PR DESCRIPTION
I've added support for `deleteToken()` as well as the other form of `getToken()`. This allows for someone to request or delete FCM tokens for sender IDs other than the default senderid. I also added some tests for instanceId methods - they don't do much but at least will break if someone broke the native implementations.

* [deleteToken](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html#deleteToken(java.lang.String,%20java.lang.String))
* [getToken](https://firebase.google.com/docs/reference/android/com/google/firebase/iid/FirebaseInstanceId.html#getToken(java.lang.String,%20java.lang.String))