### PR TITLE
Closes #1216 : AndroidNotification.setVisibility does not exists

### DIFF
--- a/lib/modules/notifications/AndroidNotification.js
+++ b/lib/modules/notifications/AndroidNotification.js
@@ -657,6 +657,16 @@ export default class AndroidNotification {
 
   /**
    *
+   * @param visibility
+   * @returns {Notification}
+   */
+  setVisibility(visibility: VisibilityType): Notification {
+    this._visibility = visibility;
+    return this._notification
+  }
+
+  /**
+   *
    * @param when
    * @returns {Notification}
    */


### PR DESCRIPTION
This commit adds a missing method to `firebase.notifications.AndroidNotification`.