### PR TITLE
Closes #1213 : Incorrect definition of Android.Importance.None

### DIFF
--- a/lib/modules/notifications/types.js
+++ b/lib/modules/notifications/types.js
@@ -44,7 +44,7 @@ export const Importance = {
   Low: 2,
   Max: 5,
   Min: 1,
-  None: 3,
+  None: 0,
   Unspecified: -1000,
 };
 


### PR DESCRIPTION
This commit changes `firebase.notifications.Android.Importance.None` to the value specified by Google reference [here](https://developer.android.com/reference/android/app/NotificationManager#IMPORTANCE_NONE).