### PR TITLE
Adds support for drawable resources to AndroidNotification

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
@@ -387,7 +387,7 @@ public class DisplayNotificationTask extends AsyncTask<Void, Void, Void> {
     } else if (image.startsWith("file://")) {
       return BitmapFactory.decodeFile(image.replace("file://", ""));
     } else {
-      int largeIconResId = RNFirebaseNotificationManager.getResourceId(context,"mipmap", image);
+      int largeIconResId = getIcon(image);
       return BitmapFactory.decodeResource(context.getResources(), largeIconResId);
     }
   }


### PR DESCRIPTION
@chrisbianca ,

Currently, RNF does not support __drawable__ resources for images passed to the `setBigPicture` and `setLargeIcon` methods of AndroidNotification. On the other hand, RN does not support __mipmap__ resources as Image.source uri, which means duplicating these resources in both folders.

The icon in this notification is set through `.android.setLargeIcon('ai_medical')` (mipmap resource):

![image](https://user-images.githubusercontent.com/6636980/41502542-e6bc2474-7181-11e8-86d7-d48c8bb06441.png)

This icon in this card is set by `Image source={ uri: ic_medical }` (drawable resource):

![image](https://user-images.githubusercontent.com/6636980/41502574-ae48b96c-7182-11e8-89d1-08079da6638f.png)

This commit adds support for "drawable" to the `setBigPicture` and `setLargeIcon` methods.

Not sure if RN determine the correct folder/size of the result, but at least `BitmapFactory.decodeResource (getResources(), drawableId)` can decode drawables (I don't know how you make a test for this).

### Environment
Platform: Android
Development Operating System: Linux Mint 18.3
Build Tools: Android Studio 3.2, Android SDK 27
React Native version: 0.55.4
RNFirebase Version: 4.2
Firebase Module: notifications