### PR TITLE
[Android] Fix setDefaults in Notifications.

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
@@ -142,12 +142,19 @@ public class DisplayNotificationTask extends AsyncTask<Void, Void, Void> {
       if (android.containsKey("contentInfo")) {
         nb = nb.setContentInfo(android.getString("contentInfo"));
       }
-      if (notification.containsKey("defaults")) {
-        double[] defaultsArray = android.getDoubleArray("defaults");
-        int defaults = 0;
-        for (Double d : defaultsArray) {
-          defaults |= d.intValue();
+      if (android.containsKey("defaults")) {
+        Double defaultValues = android.getDouble("defaults");
+        int defaults = defaultValues.intValue();
+
+        if (defaults == 0) {
+          ArrayList<Integer> defaultsArray = android.getIntegerArrayList("defaults");
+          if(defaultsArray != null) {
+            for (Integer defaultValue : defaultsArray) {
+              defaults |= defaultValue;
+            }
+          }
         }
+
         nb = nb.setDefaults(defaults);
       }
       if (android.containsKey("group")) {


### PR DESCRIPTION
This fix makes defaults option work in Android as intended, and this makes function calls more flexible.

```js
const notification = new firebase.notifications.Notification();

// It works
notification.android.setDefaults(firebase.notifications.Android.Defaults.All);

// It works too
notification.android.setDefaults([
  firebase.notifications.Android.Defaults.Sound, 
  firebase.notifications.Android.Defaults.Vibrate
]);
```

I hope this helps.