### PR TITLE
Prevent crashes on 32bit devices

### DIFF
--- a/ios/RNFirebase/admob/BannerComponent.m
+++ b/ios/RNFirebase/admob/BannerComponent.m
@@ -31,6 +31,10 @@
 }
 
 - (void)requestAd {
+    #ifndef __LP64__
+        return; // prevent crash on 32bit
+    #endif
+
     if (_unitId == nil || _size == nil || _request == nil) {
         [self setRequested:NO];
         return;


### PR DESCRIPTION
https://github.com/invertase/react-native-firebase/issues/437

This disables bannerAds on 32bit devices. But this is far better than letting them  crash.