### PR TITLE
Update fabric tools version to 1.25.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.1.2'
-    classpath 'io.fabric.tools:gradle:1.25.1'
+    classpath 'io.fabric.tools:gradle:1.25.4'
   }
 }
 

--- a/bridge/android/build.gradle
+++ b/bridge/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.1.2'
     classpath 'com.google.gms:google-services:4.0.1'
     classpath 'com.google.firebase:firebase-plugins:1.1.1'
-    classpath 'io.fabric.tools:gradle:1.25.1'
+    classpath 'io.fabric.tools:gradle:1.25.4'
   }
 }
 

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.google.gms:google-services:4.0.1'
         classpath 'com.google.firebase:firebase-plugins:1.1.1'
-        classpath 'io.fabric.tools:gradle:1.25.1'
+        classpath 'io.fabric.tools:gradle:1.25.4'
     }
 }
 


### PR DESCRIPTION
Build failed for Android, need to update fabric tools version.

`The minimum supported version of the Crashlytics plugin (io.fabric.tools:gradle) is 1.25.4. Project 'react-native-firebase' is using version 1.25.1. See https://issuetracker.google.com/79997489 for details.`

<img width="721" alt="screen shot 2018-07-03 at 11 33 53 pm" src="https://user-images.githubusercontent.com/2672802/42229685-a87589d0-7f19-11e8-8ab0-f17cfe7ce818.png">

Environment
Application Target Platform: Android

Development Operating System: macOS High Sierra

Build Tools: gradle 4.8

React Native version: 0.53.3

React Native Firebase Version: 4.2.0

Firebase Module: Crashlytics