### PR TITLE
[Android] Fix for setting past time in the scheduling.

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotificationManager.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
 
@@ -357,6 +358,21 @@ public class RNFirebaseNotificationManager {
       notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
     if (schedule.containsKey("repeatInterval")) {
+      // If fireDate you specify is in the past, the alarm triggers immediately.
+      // So we need to adjust the time for correct operation.
+      if (fireDate < System.currentTimeMillis()) {
+        Calendar newFireDate = Calendar.getInstance();
+        Calendar currentFireDate = Calendar.getInstance();
+        currentFireDate.setTimeInMillis(fireDate);
+
+        newFireDate.add(Calendar.DATE, 1);
+        newFireDate.set(Calendar.HOUR_OF_DAY, currentFireDate.get(Calendar.HOUR_OF_DAY));
+        newFireDate.set(Calendar.MINUTE, currentFireDate.get(Calendar.MINUTE));
+        newFireDate.set(Calendar.SECOND, currentFireDate.get(Calendar.SECOND));
+
+        fireDate = newFireDate.getTimeInMillis();
+      }
+
       Long interval = null;
       switch (schedule.getString("repeatInterval")) {
         case "minute":


### PR DESCRIPTION
When I try to use scheduling notifications, If `fireDate` is in the past, the notification is displayed immediately. This is probably not the intended operation. especially, in the process of rebooting.

```
# fireDate : 2018-07-04 10:00:00, repeatInterval : day

1) 2018-07-05 10:00:00 => OK
2) 2018-07-06 10:00:00 => OK
3) rebooting and register alarm in past time (2018-07-04 10:00:00)
4) 2018-07-06 10:05:00 => Wrong
```

So time adjustment is required for proper operation.

I hope this helps.