### PR TITLE
Support InboxStyle of Android notifications.

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/DisplayNotificationTask.java
@@ -173,6 +173,29 @@ public class DisplayNotificationTask extends AsyncTask<Void, Void, Void> {
           nb = nb.setLargeIcon(largeIcon);
         }
       }
+      // https://developer.android.com/reference/android/app/Notification.InboxStyle
+      if (android.containsKey("inboxStyle")) {
+        Bundle inboxStyle = android.getBundle("inboxStyle");
+
+        if (inboxStyle != null) {
+          NotificationCompat.InboxStyle is = new NotificationCompat.InboxStyle();
+          if (inboxStyle.containsKey("contentTitle")) {
+            is = is.setBigContentTitle(inboxStyle.getString("contentTitle"));
+          }
+          if (inboxStyle.containsKey("summaryText")) {
+            is = is.setSummaryText(inboxStyle.getString("summaryText"));
+          }
+          if (inboxStyle.containsKey("lines")) {
+            ArrayList<String> linesArray = inboxStyle.getStringArrayList("lines");
+            if (linesArray != null) {
+              for (String line : linesArray) {
+                is = is.addLine(line);
+              }
+            }
+          }
+          nb = nb.setStyle(is);
+        }
+      }
       if (android.containsKey("lights")) {
         Bundle lights = android.getBundle("lights");
         Double argb = lights.getDouble("argb");

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1199,6 +1199,7 @@ declare module 'react-native-firebase' {
         group?: string;
         groupAlertBehaviour?: Android.GroupAlert;
         groupSummary?: boolean;
+        inboxStyle?: Android.InboxStyle;
         largeIcon?: string;
         lights?: Android.Lights;
         localOnly?: boolean;
@@ -1247,6 +1248,11 @@ declare module 'react-native-firebase' {
           groupAlertBehaviour: Android.GroupAlert
         ): Notification;
         setGroupSummary(groupSummary: boolean): Notification;
+        setInboxStyle(
+          lines: string[],
+          contentTitle?: string,
+          summaryText?: string
+        ): Notification;
         setLargeIcon(largeIcon: string): Notification;
         setLights(argb: number, onMs: number, offMs: number): Notification;
         setLocalOnly(localOnly: boolean): Notification;
@@ -1415,6 +1421,12 @@ declare module 'react-native-firebase' {
           Private = 0,
           Public = 1,
           Secret = -1,
+        }
+
+        class InboxStyle {
+          lines: string[];
+          contentTitle?: string;
+          summaryText?: string;
         }
 
         class Lights {

--- a/lib/modules/notifications/AndroidNotification.js
+++ b/lib/modules/notifications/AndroidNotification.js
@@ -12,6 +12,7 @@ import type {
   CategoryType,
   DefaultsType,
   GroupAlertType,
+  InboxStyle,
   Lights,
   NativeAndroidNotification,
   PriorityType,
@@ -36,6 +37,7 @@ export default class AndroidNotification {
   _group: string | void;
   _groupAlertBehaviour: GroupAlertType | void;
   _groupSummary: boolean | void;
+  _inboxStyle: InboxStyle | void;
   _largeIcon: string | void;
   _lights: Lights | void;
   _localOnly: boolean | void;
@@ -91,6 +93,7 @@ export default class AndroidNotification {
       this._group = data.group;
       this._groupAlertBehaviour = data.groupAlertBehaviour;
       this._groupSummary = data.groupSummary;
+      this._inboxStyle = data.inboxStyle;
       this._largeIcon = data.largeIcon;
       this._lights = data.lights;
       this._localOnly = data.localOnly;
@@ -180,6 +183,10 @@ export default class AndroidNotification {
 
   get groupSummary(): ?boolean {
     return this._groupSummary;
+  }
+
+  get inboxStyle(): ?InboxStyle {
+    return this._inboxStyle;
   }
 
   get largeIcon(): ?string {
@@ -452,6 +459,26 @@ export default class AndroidNotification {
 
   /**
    *
+   * @param lines
+   * @param contentTitle
+   * @param summaryText
+   * @returns {Notification}
+   */
+  setInboxStyle(
+    lines: string[],
+    contentTitle?: string,
+    summaryText?: string
+  ): Notification {
+    this._inboxStyle = {
+      contentTitle,
+      summaryText,
+      lines,
+    };
+    return this._notification;
+  }
+
+  /**
+   *
    * @param largeIcon
    * @returns {Notification}
    */
@@ -703,6 +730,7 @@ export default class AndroidNotification {
       group: this._group,
       groupAlertBehaviour: this._groupAlertBehaviour,
       groupSummary: this._groupSummary,
+      inboxStyle: this._inboxStyle,
       largeIcon: this._largeIcon,
       lights: this._lights,
       localOnly: this._localOnly,

--- a/lib/modules/notifications/types.js
+++ b/lib/modules/notifications/types.js
@@ -98,6 +98,12 @@ export type BigText = {|
   text: string,
 |};
 
+export type InboxStyle = {|
+  contentTitle?: string,
+  summaryText?: string,
+  lines: string[],
+|};
+
 export type Lights = {|
   argb: number,
   onMs: number,
@@ -154,6 +160,7 @@ export type NativeAndroidNotification = {|
   group?: string,
   groupAlertBehaviour?: GroupAlertType,
   groupSummary?: boolean,
+  inboxStyle?: InboxStyle,
   largeIcon?: string,
   lights?: Lights,
   localOnly?: boolean,


### PR DESCRIPTION
This commit adds suport for the [InboxStyle](https://developer.android.com/reference/android/support/v4/app/NotificationCompat.InboxStyle) of Android notifications.

An overview is in the guides [Create a Group of Notifications](https://developer.android.com/training/notify-user/group) and [Create an Expandable Notification](https://developer.android.com/training/notify-user/expanded) of the Google Developers docs.

The commit includes Flow and Typescript definitions, but no test nor documentation.

The InboxStyle is supported from API level 16 and NotificationCompat 22.1.0.