### PR TITLE
Fix "Failed to resolve" errors in Android Studio 3.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,15 @@ rootProject.gradle.buildFinished { buildResult ->
   }
 }
 
+repositories {
+  google()
+  jcenter()
+  maven {
+      url "$rootDir/../node_modules/react-native/android"
+      name 'React Native (local)'
+  }
+}
+
 def supportVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 
 dependencies {


### PR DESCRIPTION
@Salakar , without this commit, Android Studio generates multiple errors when opening RNFB:

![image](https://user-images.githubusercontent.com/6636980/42976222-ff528bd6-8b85-11e8-8145-e779b556f429.png)
