### PR TITLE
simplify obtaining notification title and body

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
@@ -323,10 +323,8 @@ public class RNFirebaseNotifications extends ReactContextBaseJavaModule implemen
       Context ctx = getReactApplicationContext();
       int resId = getResId(ctx, bodyLocKey);
       return ctx.getResources().getString(resId, (Object[]) bodyLocArgs);
-    } else if (body != null) {
-      return body;
     } else {
-      return null;
+      return body;
     }
   }
 
@@ -338,10 +336,8 @@ public class RNFirebaseNotifications extends ReactContextBaseJavaModule implemen
       Context ctx = getReactApplicationContext();
       int resId = getResId(ctx, titleLocKey);
       return ctx.getResources().getString(resId, (Object[]) titleLocArgs);
-    } else if (title != null) {
-      return title;
     } else {
-      return null;
+      return title;
     }
   }
 


### PR DESCRIPTION
this is a follow-up on https://github.com/invertase/react-native-firebase/pull/1337: I somehow missed out that we can do the following simplification since `notification.getBody()` and `notification.getTitle()` both return null if none are specified. If somebody isn't sure if those calls return null, there is still the `@Nullable` annotation that tells that.