### PR TITLE
Type declaration of AuthProvider.credential allows null token

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -853,7 +853,7 @@ declare module 'react-native-firebase' {
 
       type AuthProvider = {
         PROVIDER_ID: string;
-        credential: (token: string, secret?: string) => AuthCredential;
+        credential: (token?: string, secret?: string) => AuthCredential;
       };
 
       type EmailAuthProvider = {


### PR DESCRIPTION
The token (or idToken) can be also be null on the credential method. Modifies the signature of the method to allow for that.

https://firebase.google.com/docs/reference/js/firebase.auth.GoogleAuthProvider#.credential