### PR TITLE
Fixing transitive dependencies vendored as static frameworks

### DIFF
--- a/ios/RNFirebase.podspec
+++ b/ios/RNFirebase.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/RNFirebase'
   s.platform            = :ios, "9.0"
   s.source_files        = 'RNFirebase/**/*.{h,m}'
+  s.static_frameworks   = true
   s.dependency          'React'
   s.dependency          'Firebase/Core'
 end

--- a/ios/RNFirebase.podspec
+++ b/ios/RNFirebase.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/RNFirebase'
   s.platform            = :ios, "9.0"
   s.source_files        = 'RNFirebase/**/*.{h,m}'
-  s.static_frameworks   = true
+  s.static_framework    = true
   s.dependency          'React'
   s.dependency          'Firebase/Core'
 end

--- a/ios/RNFirebase/RNFirebaseUtil.h
+++ b/ios/RNFirebase/RNFirebaseUtil.h
@@ -3,7 +3,7 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTEventEmitter.h>
-#import <Firebase.h>
+#import "Firebase.h"
 
 @interface RNFirebaseUtil : NSObject
 

--- a/ios/RNFirebase/auth/RNFirebaseAuth.h
+++ b/ios/RNFirebase/auth/RNFirebaseAuth.h
@@ -3,7 +3,7 @@
 #import <Foundation/Foundation.h>
 
 #if __has_include(<FirebaseAuth/FIRAuth.h>)
-#import <Firebase.h>
+#import "Firebase.h"
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 

--- a/ios/RNFirebase/database/RNFirebaseDatabase.m
+++ b/ios/RNFirebase/database/RNFirebaseDatabase.m
@@ -2,7 +2,7 @@
 
 #if __has_include(<FirebaseDatabase/FIRDatabase.h>)
 
-#import <Firebase.h>
+#import "Firebase.h"
 #import "RNFirebaseDatabaseReference.h"
 #import "RNFirebaseEvents.h"
 #import "RNFirebaseUtil.h"

--- a/ios/RNFirebase/links/RNFirebaseLinks.m
+++ b/ios/RNFirebase/links/RNFirebaseLinks.m
@@ -1,7 +1,7 @@
 #import "RNFirebaseLinks.h"
 
 #if __has_include(<FirebaseDynamicLinks/FirebaseDynamicLinks.h>)
-#import <Firebase.h>
+#import "Firebase.h"
 #import "RNFirebaseEvents.h"
 #import "RNFirebaseUtil.h"
 


### PR DESCRIPTION
Hello React native team!

First and most important, incredible work you're doing with this library.

I'd like to expose the issues we faced integrating this library into our project and how we tackle them. We thought it might help for the community to have this amend in the official repository.

**The Context**
Currently we're runnning a _swift_ based project with a _cocoapods_ setup for managing the dependencies.

**The Problem**
When we add this new dependency as another pod in our setup via standard procedure (pod install ..) we found this error:

```
The 'Our App' target has transitive dependencies that include static binaries: (firebase deps...)
```

**The Solution**
The solution we found is to let cocoapods (base on the recent version they deployed) to bundle react-native-firebase podspec with the flag `s.static_framework = true` to allow to be bundled as static dependency if needed.
Also for make this work we had to modify some import headers from `#import <RNFirebaseUtil.h>` to `#import "RNFirebaseUtil.h"`

And then problem solve. All happy here with RNFirebase integrated successfully in our iOS app.

Let us know what do you think guys.

Regards!
David.