### PR TITLE
BUGFIX: ReactMethod createChannelGroups() name fix

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
@@ -163,7 +163,7 @@ public class RNFirebaseNotifications extends ReactContextBaseJavaModule implemen
   }
 
   @ReactMethod
-  public void createChannelGroup(ReadableArray channelGroupsArray, Promise promise) {
+  public void createChannelGroups(ReadableArray channelGroupsArray, Promise promise) {
     notificationManager.createChannelGroups(channelGroupsArray);
     promise.resolve(null);
   }


### PR DESCRIPTION
Issue: https://github.com/invertase/react-native-firebase/issues/1462

Fixes naming issue that causes android native method to error
