### PR TITLE
Fix for Invites Module error requestCode must be in 16 bits

### DIFF
--- a/android/src/main/java/io/invertase/firebase/invites/RNFirebaseInvites.java
+++ b/android/src/main/java/io/invertase/firebase/invites/RNFirebaseInvites.java
@@ -31,7 +31,7 @@ import io.invertase.firebase.Utils;
 
 public class RNFirebaseInvites extends ReactContextBaseJavaModule implements ActivityEventListener, LifecycleEventListener {
   private static final String TAG = "RNFirebaseInvites";
-  private static final int REQUEST_INVITE = 81283;
+  private static final int REQUEST_INVITE = 17517;
   private boolean mInitialInvitationInitialized = false;
   private String mInitialDeepLink = null;
   private String mInitialInvitationId = null;


### PR DESCRIPTION
changed REQUEST_INVITE to value below 2^16 to fix error requestCode must be in 16 bits error
Issue is here: https://github.com/invertase/react-native-firebase/issues/1458