### PR TITLE
[auth] Support updatePhoneNumber

### DIFF
--- a/ios/RNFirebase/auth/RNFirebaseAuth.m
+++ b/ios/RNFirebase/auth/RNFirebaseAuth.m
@@ -445,6 +445,48 @@ RCT_EXPORT_METHOD(updatePassword:
     }
 }
 
+
+/**
+ updatePhoneNumber
+
+ @param NSString password
+ @param NSString provider
+ @param NSString authToken
+ @param NSString authSecret
+ @param RCTPromiseResolveBlock resolve
+ @param RCTPromiseRejectBlock reject
+ @return
+ */
+RCT_EXPORT_METHOD(updatePhoneNumber:(NSString *) appDisplayName
+                  provider:(NSString *) provider
+                  token:(NSString *) authToken
+                  secret:(NSString *) authSecret
+                  resolver:(RCTPromiseResolveBlock) resolve
+                  rejecter:(RCTPromiseRejectBlock) reject) {
+    FIRApp *firApp = [RNFirebaseUtil getApp:appDisplayName];
+
+    FIRUser *user = [FIRAuth authWithApp:firApp].currentUser;
+
+    if (user) {
+        FIRAuthCredential *credential = [self getCredentialForProvider:provider token:authToken secret:authSecret];
+
+        if (credential == nil) {
+            return reject(@"auth/invalid-credential", @"The supplied auth credential is malformed, has expired or is not currently supported.", nil);
+        }
+
+        [user updatePhoneNumberCredential:credential completion:^(NSError *_Nullable error) {
+            if (error) {
+                [self promiseRejectAuthException:reject error:error];
+            } else {
+                FIRUser *userAfterUpdate = [FIRAuth authWithApp:firApp].currentUser;
+                [self promiseWithUser:resolve rejecter:reject user:userAfterUpdate];
+            }
+        }];
+    } else {
+        [self promiseNoUser:resolve rejecter:reject isError:YES];
+    }
+}
+
 /**
  updateProfile
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -785,6 +785,13 @@ declare module 'react-native-firebase' {
       updatePassword(password: string): Promise<void>;
 
       /**
+       * Updates the user's phone number.
+       * See Firebase docs for more information on security & email validation.
+       * This will Promise reject is the user is anonymous.
+       */
+      updatePhoneNumber(credential: AuthCredential): Promise<void>;
+
+      /**
        * Updates a user's profile data.
        * Profile data should be an object of fields to update:
        */

--- a/src/modules/auth/User.js
+++ b/src/modules/auth/User.js
@@ -251,6 +251,24 @@ export default class User {
   }
 
   /**
+   * Update the current user's phone number
+   *
+   * @param  {AuthCredential} credential Auth credential with the _new_ phone number
+   * @return {Promise}
+   */
+  updatePhoneNumber(credential: AuthCredential): Promise<void> {
+    return getNativeModule(this._auth)
+      .updatePhoneNumber(
+        credential.providerId,
+        credential.token,
+        credential.secret
+      )
+      .then(user => {
+        this._auth._setUser(user);
+      });
+  }
+
+  /**
    * Update the current user's profile
    * @param  {Object} updates An object containing the keys listed [here](https://firebase.google.com/docs/auth/ios/manage-users#update_a_users_profile)
    * @return {Promise}
@@ -314,15 +332,6 @@ export default class User {
       INTERNALS.STRINGS.ERROR_UNSUPPORTED_CLASS_METHOD(
         'User',
         'reauthenticateWithRedirect'
-      )
-    );
-  }
-
-  updatePhoneNumber() {
-    throw new Error(
-      INTERNALS.STRINGS.ERROR_UNSUPPORTED_CLASS_METHOD(
-        'User',
-        'updatePhoneNumber'
       )
     );
   }

--- a/tests/e2e/auth/user.e2e.js
+++ b/tests/e2e/auth/user.e2e.js
@@ -461,18 +461,6 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('updatePhoneNumber()', () => {
-    it('should throw an unsupported error', async () => {
-      await firebase.auth().signInAnonymouslyAndRetrieveData();
-      (() => {
-        firebase.auth().currentUser.updatePhoneNumber();
-      }).should.throw(
-        'User.updatePhoneNumber() is unsupported by the native Firebase SDKs.'
-      );
-      await firebase.auth().signOut();
-    });
-  });
-
   describe('refreshToken', () => {
     it('should throw an unsupported error', async () => {
       await firebase.auth().signInAnonymouslyAndRetrieveData();


### PR DESCRIPTION
Regarding the `updatePhoneNumber` method, the documentation states 
>The following methods are not supported in RNFirebase as they cannot work in the React Native environment or have a different implementation.

I didn't see any reason why we couldn't support it, so went ahead and made an implementation. 

I've tried it manually on iOS and Android but didn't include any E2E tests as it requires some changed settings in the firebase account and could see phone auth is absent from current E2E suite. Please advice on how to proceed or if they should stay omitted for now. 