### PR TITLE
Guard against NPE in deleteChannelGroup

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
@@ -176,8 +176,13 @@ public class RNFirebaseNotifications extends ReactContextBaseJavaModule implemen
 
   @ReactMethod
   public void deleteChannelGroup(String channelId, Promise promise) {
-    notificationManager.deleteChannelGroup(channelId);
-    promise.resolve(null);
+    try {
+      notificationManager.deleteChannelGroup(channelId);
+      promise.resolve(null);
+    } catch (NullPointerException e) {
+      promise.reject("notifications/channel-group-not-found",
+        "The requested NotificationChannelGroup does not exist, have you created it?");
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
This pull request is for https://github.com/invertase/react-native-firebase/issues/1478

Fixes Android Oreo & higher devices that experience NPE when trying to delete a channelGroupId that is unknown to the system.