### PR TITLE
[android][utils] `isAppInForeground` not accounting for React Native LifecycleState

### DIFF
--- a/android/src/main/java/io/invertase/firebase/Utils.java
+++ b/android/src/main/java/io/invertase/firebase/Utils.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.LifecycleState;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import java.util.List;
@@ -151,7 +152,8 @@ public class Utils {
         appProcess.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
           && appProcess.processName.equals(packageName)
         ) {
-        return true;
+        ReactContext reactContext = (ReactContext) context;
+        return reactContext.getLifecycleState() == LifecycleState.RESUMED;
       }
     }
 


### PR DESCRIPTION
Prior to this change, this utility in some rare cases would return true that Activity was in the foreground, however, React Native was still in the process of resuming, this, for example, led to crashes in HeadlessJS Notification tasks: "Tried to start task RNFirebaseBackgroundMessage while in foreground, but this is not allowed."

---
Loving `react-native-firebase` and the support we provide? Please consider supporting us with any of the below:

  - 👉  Back financially via [Open Collective](https://opencollective.com/react-native-firebase/donate)  
  - 👉  Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter 
  - 👉  Star this repo on GitHub ⭐️