### PR TITLE
[Utils] Fix TypeError is not a function

### DIFF
--- a/src/utils/apps.js
+++ b/src/utils/apps.js
@@ -4,7 +4,7 @@
 import { NativeModules } from 'react-native';
 import App from '../modules/core/app';
 import INTERNALS from './internals';
-import { isAndroid, isObject, isString } from '.';
+import { isAndroid, isObject, isString } from './index';
 
 import type {
   FirebaseModule,


### PR DESCRIPTION
`react-native-firebase` -> 5.0.0
`react-native` -> 0.57.1
`Mac OS` -> 10.13.6

Fix error when we want to init an app: `firebase.initializeApp(options, name);`

```
ExceptionsManager.js:84 TypeError: (0 , _.isString) is not a function
    at Object.initializeApp (apps.js:101)
    at Firebase.initializeApp (firebase.js:60)
    at _default (firestack.js:12)
    at _default (index.js:6)
    at runCallEffect (proc.js:514)
    at runEffect (proc.js:436)
    at next (proc.js:317)
    at proc (proc.js:272)
    at runForkEffect (proc.js:555)
    at runEffect (proc.js:436)
```