### PR TITLE
Fix typings to for `createShortDynamicLink`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1969,7 +1969,7 @@ declare module 'react-native-firebase' {
         createDynamicLink(dynamicLink: DynamicLink): Promise<string>;
 
         /** Creates a short dynamic link. */
-        createShortDynamicLink(type: 'SHORT' | 'UNGUESSABLE'): Promise<string>;
+        createShortDynamicLink(dynamicLink: DynamicLink, type: 'SHORT' | 'UNGUESSABLE'): Promise<string>;
 
         /**
          * Returns the URL that the app has been launched from. If the app was


### PR DESCRIPTION
'createShortDynamicLink' should accept a link as well as a type parameter, similar to 'createDynamicLink'. 
See documentation here: https://rnfirebase.io/docs/v4.3.x/links/reference/links#createShortDynamicLink