### PR TITLE
Update Fabric gradle plugin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.2.0'
-    classpath 'io.fabric.tools:gradle:1.25.4'
+    classpath 'io.fabric.tools:gradle:1.26.1'
   }
 }
 


### PR DESCRIPTION
CI build was failing on this error

```
* What went wrong:
A problem occurred configuring project ':react-native-firebase'.
> Could not resolve all files for configuration ':react-native-firebase:classpath'.
   > Could not resolve io.fabric.tools:gradle:1.25.4.
     Required by:
         project :react-native-firebase
      > Could not resolve io.fabric.tools:gradle:1.25.4.
         > Could not get resource 'https://jcenter.bintray.com/io/fabric/tools/gradle/1.25.4/gradle-1.25.4.pom'.
            > Could not GET 'https://jcenter.bintray.com/io/fabric/tools/gradle/1.25.4/gradle-1.25.4.pom'.
               > Read timed out
```

https://docs.fabric.io/android/changelog.html#fabric-gradle-plugin