### PR TITLE
Returning null as downloadUrl in upload task

### DIFF
--- a/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
+++ b/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
@@ -564,29 +564,20 @@ public class RNFirebaseStorage extends ReactContextBaseJavaModule {
       taskSnapshot
         .getStorage()
         .getDownloadUrl()
+        .addOnFailureListener(new OnFailureListener() {
+          @Override
+          public void onFailure(@Nonnull Exception e) {
+            int errorCode = ((StorageException) e).getErrorCode();
+            if (errorCode == StorageException.ERROR_NOT_AUTHORIZED) {
+              WritableMap resp = getRespAsMap(taskSnapshot, null);
+              listener.onSuccess(resp);
+            }
+          }
+        })
         .addOnSuccessListener(new OnSuccessListener<Uri>() {
           @Override
           public void onSuccess(Uri downloadUrl) {
-            WritableMap resp = Arguments.createMap();
-
-            resp.putDouble("bytesTransferred", taskSnapshot.getBytesTransferred());
-            resp.putString("downloadURL", downloadUrl.toString());
-
-            StorageMetadata d = taskSnapshot.getMetadata();
-            if (d != null) {
-              WritableMap metadata = getMetadataAsMap(d);
-              resp.putMap("metadata", metadata);
-            }
-
-            resp.putString(
-              "ref",
-              taskSnapshot
-                .getStorage()
-                .getPath()
-            );
-            resp.putString("state", RNFirebaseStorage.this.getTaskStatus(taskSnapshot.getTask()));
-            resp.putDouble("totalBytes", taskSnapshot.getTotalByteCount());
-
+            WritableMap resp = getRespAsMap(taskSnapshot, downloadUrl);
             listener.onSuccess(resp);
           }
         });
@@ -595,6 +586,29 @@ public class RNFirebaseStorage extends ReactContextBaseJavaModule {
     }
   }
 
+
+  private WritableMap getRespAsMap(final UploadTask.TaskSnapshot taskSnapshot, final Uri downloadUrl) {
+    WritableMap resp = Arguments.createMap();
+
+    resp.putDouble("bytesTransferred", taskSnapshot.getBytesTransferred());
+    resp.putString("downloadURL", downloadUrl.toString());
+
+    StorageMetadata d = taskSnapshot.getMetadata();
+    if (d != null) {
+      WritableMap metadata = getMetadataAsMap(d);
+      resp.putMap("metadata", metadata);
+    }
+
+    resp.putString(
+      "ref",
+      taskSnapshot
+        .getStorage()
+        .getPath()
+    );
+    resp.putString("state", RNFirebaseStorage.this.getTaskStatus(taskSnapshot.getTask()));
+    resp.putDouble("totalBytes", taskSnapshot.getTotalByteCount());
+    return resp;
+  }
   /**
    * Converts storageMetadata into a map
    *

--- a/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
+++ b/android/src/main/java/io/invertase/firebase/storage/RNFirebaseStorage.java
@@ -577,7 +577,7 @@ public class RNFirebaseStorage extends ReactContextBaseJavaModule {
         .addOnSuccessListener(new OnSuccessListener<Uri>() {
           @Override
           public void onSuccess(Uri downloadUrl) {
-            WritableMap resp = getRespAsMap(taskSnapshot, downloadUrl);
+            WritableMap resp = getRespAsMap(taskSnapshot, downloadUrl.toString());
             listener.onSuccess(resp);
           }
         });
@@ -587,11 +587,11 @@ public class RNFirebaseStorage extends ReactContextBaseJavaModule {
   }
 
 
-  private WritableMap getRespAsMap(final UploadTask.TaskSnapshot taskSnapshot, final Uri downloadUrl) {
+  private WritableMap getRespAsMap(final UploadTask.TaskSnapshot taskSnapshot, final String downloadUrl) {
     WritableMap resp = Arguments.createMap();
 
     resp.putDouble("bytesTransferred", taskSnapshot.getBytesTransferred());
-    resp.putString("downloadURL", downloadUrl.toString());
+    resp.putString("downloadURL", downloadUrl);
 
     StorageMetadata d = taskSnapshot.getMetadata();
     if (d != null) {

--- a/tests/e2e/storage/storage.e2e.js
+++ b/tests/e2e/storage/storage.e2e.js
@@ -108,6 +108,22 @@ describe('storage()', () => {
         uploadTaskSnapshot.metadata.should.be.an.Object();
         uploadTaskSnapshot.downloadURL.should.be.a.String();
       });
+
+      it('uploads a file without read permission', async () => {
+        const uploadTaskSnapshot = await firebase
+          .storage()
+          .ref('/ok.jpeg')
+          .putFile(
+            `${firebase.storage.Native.DOCUMENT_DIRECTORY_PATH}/notRead.jpeg`
+          );
+
+        uploadTaskSnapshot.state.should.eql(firebase.storage.TaskState.SUCCESS);
+        uploadTaskSnapshot.bytesTransferred.should.eql(
+          uploadTaskSnapshot.totalBytes
+        );
+        uploadTaskSnapshot.metadata.should.be.an.Object();
+        uploadTaskSnapshot.downloadURL.should.be.null();
+      });
     });
 
     describe('on()', () => {

--- a/tests/e2e/storage/storage.e2e.js
+++ b/tests/e2e/storage/storage.e2e.js
@@ -112,9 +112,9 @@ describe('storage()', () => {
       it('uploads a file without read permission', async () => {
         const uploadTaskSnapshot = await firebase
           .storage()
-          .ref('/ok.jpeg')
+          .ref('/writeOnly.jpeg')
           .putFile(
-            `${firebase.storage.Native.DOCUMENT_DIRECTORY_PATH}/notRead.jpeg`
+            `${firebase.storage.Native.DOCUMENT_DIRECTORY_PATH}/ok.jpeg`
           );
 
         uploadTaskSnapshot.state.should.eql(firebase.storage.TaskState.SUCCESS);
@@ -122,7 +122,7 @@ describe('storage()', () => {
           uploadTaskSnapshot.totalBytes
         );
         uploadTaskSnapshot.metadata.should.be.an.Object();
-        uploadTaskSnapshot.downloadURL.should.be.null();
+        should.not.exist(uploadTaskSnapshot.downloadURL);
       });
     });
 


### PR DESCRIPTION
solves: #1591 using the first solution:

> 1. Still consider the invocation a success, providing downloadURL as null.

Can some maintainer help me with the new test case? I need a file with permission to upload but not to download.