### PR TITLE
[Android][IOS][Firestore] add arrayRemove and arrayUnion to FieldValue 

### DIFF
--- a/android/src/main/java/io/invertase/firebase/firestore/FirestoreSerialize.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/FirestoreSerialize.java
@@ -68,6 +68,10 @@ class FirestoreSerialize {
   private static final String TYPE_FIELDVALUE = "fieldvalue";
   private static final String TYPE_FIELDVALUE_DELETE = "delete";
   private static final String TYPE_FIELDVALUE_TIMESTAMP = "timestamp";
+  private static final String TYPE_FIELDVALUE_UNION = "union";
+  private static final String TYPE_FIELDVALUE_REMOVE = "remove";
+  private static final String TYPE_FIELDVALUE_TYPE = "type";
+  private static final String TYPE_FIELDVALUE_ELEMENTS = "elements";
 
   // Document Change Types
   private static final String CHANGE_ADDED = "added";
@@ -446,7 +450,9 @@ class FirestoreSerialize {
     }
 
     if (TYPE_FIELDVALUE.equals(type)) {
-      String fieldValueType = typeMap.getString(VALUE);
+      ReadableMap fieldValueMap = typeMap.getMap(VALUE);
+      String fieldValueType = fieldValueMap.getString(TYPE_FIELDVALUE_TYPE);
+
 
       if (TYPE_FIELDVALUE_TIMESTAMP.equals(fieldValueType)) {
         return FieldValue.serverTimestamp();
@@ -454,6 +460,16 @@ class FirestoreSerialize {
 
       if (TYPE_FIELDVALUE_DELETE.equals(fieldValueType)) {
         return FieldValue.delete();
+      }
+
+      if (TYPE_FIELDVALUE_UNION.equals(fieldValueType)) {
+        ReadableArray elements = fieldValueMap.getArray(TYPE_FIELDVALUE_ELEMENTS);
+        return FieldValue.arrayUnion(elements.toArrayList().toArray());
+      }
+
+      if (TYPE_FIELDVALUE_REMOVE.equals(fieldValueType)) {
+        ReadableArray elements = fieldValueMap.getArray(TYPE_FIELDVALUE_ELEMENTS);
+        return FieldValue.arrayRemove(elements.toArrayList().toArray());
       }
 
       Log.w(TAG, "Unknown FieldValue type: " + fieldValueType);

--- a/ios/RNFirebase/firestore/RNFirebaseFirestoreDocumentReference.m
+++ b/ios/RNFirebase/firestore/RNFirebaseFirestoreDocumentReference.m
@@ -37,6 +37,10 @@ static NSString *const typeTimestamp = @"timestamp";
 static NSString *const typeReference = @"reference";
 static NSString *const typeDocumentId = @"documentid";
 static NSString *const typeFieldValue = @"fieldvalue";
+static NSString *const typeFieldValueUnion = @"union";
+static NSString *const typeFieldValueRemove = @"remove";
+static NSString *const typeFieldValueType = @"type";
+static NSString *const typeFieldValueElements = @"elements";
 
 - (id)initWithPath:(RCTEventEmitter *)emitter
     appDisplayName:(NSString *)appDisplayName
@@ -408,14 +412,25 @@ static NSString *const typeFieldValue = @"fieldvalue";
   }
 
   if ([type isEqualToString:typeFieldValue]) {
-    NSString *string = (NSString *) value;
-
+    NSDictionary *fieldValueMap = (NSDictionary *) value;
+    NSString *string = (NSString *) fieldValueMap[typeFieldValueType];
+      
     if ([string isEqualToString:typeDelete]) {
       return [FIRFieldValue fieldValueForDelete];
     }
 
     if ([string isEqualToString:typeTimestamp]) {
       return [FIRFieldValue fieldValueForServerTimestamp];
+    }
+      
+    if ([string isEqualToString:typeFieldValueUnion]) {
+      NSDictionary *elements = (NSDictionary *) value[typeFieldValueElements];
+      return [FIRFieldValue fieldValueForArrayUnion:elements];
+    }
+      
+    if ([string isEqualToString:typeFieldValueRemove]) {
+      NSDictionary *elements = (NSDictionary *) value[typeFieldValueElements];
+      return [FIRFieldValue fieldValueForArrayRemove:elements];
     }
 
     DLog(@"RNFirebaseFirestore: Unsupported field-value sent to parseJSTypeMap - value is %@",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2404,10 +2404,16 @@ declare module 'react-native-firebase' {
         constructor(...segments: string[]);
       }
 
+      type AnyJs = null | undefined | boolean | number | string | object;
+
       class FieldValue {
         static delete(): FieldValue;
 
         static serverTimestamp(): FieldValue;
+
+        static arrayUnion(...elements: AnyJs[]): FieldValue;
+
+        static arrayRemove(...elements: AnyJs[]): FieldValue;
       }
 
       class GeoPoint {

--- a/src/modules/firestore/FieldValue.js
+++ b/src/modules/firestore/FieldValue.js
@@ -4,6 +4,14 @@
  */
 
 export default class FieldValue {
+  get elements() {
+    return this._elemenets;
+  }
+
+  set elements(elements) {
+    this._elemenets = elements;
+  }
+
   static delete(): FieldValue {
     return DELETE_FIELD_VALUE;
   }
@@ -11,7 +19,19 @@ export default class FieldValue {
   static serverTimestamp(): FieldValue {
     return SERVER_TIMESTAMP_FIELD_VALUE;
   }
+
+  static arrayUnion(...elements: any[]) {
+    ARRAY_UNION_FIELD_VALUE.elements = elements;
+    return ARRAY_UNION_FIELD_VALUE;
+  }
+
+  static arrayRemove(...elements: any[]) {
+    ARRAY_REMOVE_FIELD_VALUE.elements = elements;
+    return ARRAY_REMOVE_FIELD_VALUE;
+  }
 }
 
 export const DELETE_FIELD_VALUE = new FieldValue();
 export const SERVER_TIMESTAMP_FIELD_VALUE = new FieldValue();
+export const ARRAY_UNION_FIELD_VALUE = new FieldValue();
+export const ARRAY_REMOVE_FIELD_VALUE = new FieldValue();

--- a/src/modules/firestore/FieldValue.js
+++ b/src/modules/firestore/FieldValue.js
@@ -5,6 +5,10 @@
 import AnyJs from './utils/any';
 
 export default class FieldValue {
+  _type: string;
+
+  _elements: AnyJs[] | any;
+
   constructor(type: string, elements?: AnyJs[]) {
     this._type = type;
     this._elements = elements;

--- a/src/modules/firestore/FieldValue.js
+++ b/src/modules/firestore/FieldValue.js
@@ -5,7 +5,7 @@
 import AnyJs from './utils/any';
 
 export default class FieldValue {
-  constructor(type, elements?: AnyJs[]) {
+  constructor(type: string, elements?: AnyJs[]) {
     this._type = type;
     this._elements = elements;
   }

--- a/src/modules/firestore/FieldValue.js
+++ b/src/modules/firestore/FieldValue.js
@@ -4,6 +4,7 @@
  */
 import AnyJs from './utils/any';
 
+// TODO: Salakar: Refactor in v6
 export default class FieldValue {
   _type: string;
 

--- a/src/modules/firestore/FieldValue.js
+++ b/src/modules/firestore/FieldValue.js
@@ -5,36 +5,37 @@
 import AnyJs from './utils/any';
 
 export default class FieldValue {
-  _elements: AnyJs[];
+  constructor(type, elements?: AnyJs[]) {
+    this._type = type;
+    this._elements = elements;
+  }
+
+  get type(): string {
+    return this._type;
+  }
 
   get elements(): AnyJs[] {
     return this._elements;
   }
 
-  set elements(elements: AnyJs[]) {
-    this._elements = elements;
-  }
-
   static delete(): FieldValue {
-    return DELETE_FIELD_VALUE;
+    return new FieldValue(TypeFieldValueDelete);
   }
 
   static serverTimestamp(): FieldValue {
-    return SERVER_TIMESTAMP_FIELD_VALUE;
+    return new FieldValue(TypeFieldValueTimestamp);
   }
 
   static arrayUnion(...elements: AnyJs[]) {
-    ARRAY_UNION_FIELD_VALUE.elements = elements;
-    return ARRAY_UNION_FIELD_VALUE;
+    return new FieldValue(TypeFieldValueUnion, elements);
   }
 
   static arrayRemove(...elements: AnyJs[]) {
-    ARRAY_REMOVE_FIELD_VALUE.elements = elements;
-    return ARRAY_REMOVE_FIELD_VALUE;
+    return new FieldValue(TypeFieldValueRemove, elements);
   }
 }
 
-export const DELETE_FIELD_VALUE = new FieldValue();
-export const SERVER_TIMESTAMP_FIELD_VALUE = new FieldValue();
-export const ARRAY_UNION_FIELD_VALUE = new FieldValue();
-export const ARRAY_REMOVE_FIELD_VALUE = new FieldValue();
+export const TypeFieldValueDelete = 'delete';
+export const TypeFieldValueRemove = 'remove';
+export const TypeFieldValueUnion = 'union';
+export const TypeFieldValueTimestamp = 'timestamp';

--- a/src/modules/firestore/FieldValue.js
+++ b/src/modules/firestore/FieldValue.js
@@ -2,14 +2,17 @@
  * @flow
  * FieldValue representation wrapper
  */
+import AnyJs from './utils/any';
 
 export default class FieldValue {
-  get elements() {
-    return this._elemenets;
+  _elements: AnyJs[];
+
+  get elements(): AnyJs[] {
+    return this._elements;
   }
 
-  set elements(elements) {
-    this._elemenets = elements;
+  set elements(elements: AnyJs[]) {
+    this._elements = elements;
   }
 
   static delete(): FieldValue {
@@ -20,12 +23,12 @@ export default class FieldValue {
     return SERVER_TIMESTAMP_FIELD_VALUE;
   }
 
-  static arrayUnion(...elements: any[]) {
+  static arrayUnion(...elements: AnyJs[]) {
     ARRAY_UNION_FIELD_VALUE.elements = elements;
     return ARRAY_UNION_FIELD_VALUE;
   }
 
-  static arrayRemove(...elements: any[]) {
+  static arrayRemove(...elements: AnyJs[]) {
     ARRAY_REMOVE_FIELD_VALUE.elements = elements;
     return ARRAY_REMOVE_FIELD_VALUE;
   }

--- a/src/modules/firestore/utils/any.js
+++ b/src/modules/firestore/utils/any.js
@@ -1,0 +1,4 @@
+/**
+ *  @url https://github.com/firebase/firebase-js-sdk/blob/master/packages/firestore/src/util/misc.ts#L26
+ */
+export type AnyJs = null | undefined | boolean | number | string | object;

--- a/src/modules/firestore/utils/serialize.js
+++ b/src/modules/firestore/utils/serialize.js
@@ -5,12 +5,7 @@
 import DocumentReference from '../DocumentReference';
 import Blob from '../Blob';
 import { DOCUMENT_ID } from '../FieldPath';
-import {
-  DELETE_FIELD_VALUE,
-  SERVER_TIMESTAMP_FIELD_VALUE,
-  ARRAY_UNION_FIELD_VALUE,
-  ARRAY_REMOVE_FIELD_VALUE,
-} from '../FieldValue';
+import FieldValue from '../FieldValue';
 import GeoPoint from '../GeoPoint';
 import Path from '../Path';
 import { typeOf } from '../../../utils';
@@ -74,44 +69,6 @@ export const buildTypeMap = (value: any): NativeTypeMap | null => {
     };
   }
 
-  if (value === DELETE_FIELD_VALUE) {
-    return {
-      type: 'fieldvalue',
-      value: {
-        type: 'delete',
-      },
-    };
-  }
-
-  if (value === SERVER_TIMESTAMP_FIELD_VALUE) {
-    return {
-      type: 'fieldvalue',
-      value: {
-        type: 'timestamp',
-      },
-    };
-  }
-
-  if (value === ARRAY_UNION_FIELD_VALUE) {
-    return {
-      type: 'fieldvalue',
-      value: {
-        elements: value.elements,
-        type: 'union',
-      },
-    };
-  }
-
-  if (value === ARRAY_REMOVE_FIELD_VALUE) {
-    return {
-      type: 'fieldvalue',
-      value: {
-        elements: value.elements,
-        type: 'remove',
-      },
-    };
-  }
-
   if (value === DOCUMENT_ID) {
     return {
       type: 'documentid',
@@ -162,6 +119,16 @@ export const buildTypeMap = (value: any): NativeTypeMap | null => {
       return {
         type: 'blob',
         value: value.toBase64(),
+      };
+    }
+
+    if (value instanceof FieldValue) {
+      return {
+        type: 'fieldvalue',
+        value: {
+          elements: value.elements,
+          type: value.type,
+        },
       };
     }
 

--- a/src/modules/firestore/utils/serialize.js
+++ b/src/modules/firestore/utils/serialize.js
@@ -8,6 +8,8 @@ import { DOCUMENT_ID } from '../FieldPath';
 import {
   DELETE_FIELD_VALUE,
   SERVER_TIMESTAMP_FIELD_VALUE,
+  ARRAY_UNION_FIELD_VALUE,
+  ARRAY_REMOVE_FIELD_VALUE,
 } from '../FieldValue';
 import GeoPoint from '../GeoPoint';
 import Path from '../Path';
@@ -75,14 +77,38 @@ export const buildTypeMap = (value: any): NativeTypeMap | null => {
   if (value === DELETE_FIELD_VALUE) {
     return {
       type: 'fieldvalue',
-      value: 'delete',
+      value: {
+        type: 'delete',
+      },
     };
   }
 
   if (value === SERVER_TIMESTAMP_FIELD_VALUE) {
     return {
       type: 'fieldvalue',
-      value: 'timestamp',
+      value: {
+        type: 'timestamp',
+      },
+    };
+  }
+
+  if (value === ARRAY_UNION_FIELD_VALUE) {
+    return {
+      type: 'fieldvalue',
+      value: {
+        elements: value.elements,
+        type: 'union',
+      },
+    };
+  }
+
+  if (value === ARRAY_REMOVE_FIELD_VALUE) {
+    return {
+      type: 'fieldvalue',
+      value: {
+        elements: value.elements,
+        type: 'remove',
+      },
     };
   }
 

--- a/src/modules/firestore/utils/serialize.js
+++ b/src/modules/firestore/utils/serialize.js
@@ -122,6 +122,7 @@ export const buildTypeMap = (value: any): NativeTypeMap | null => {
       };
     }
 
+    // TODO: Salakar: Refactor in v6 - add internal `type` flag
     if (value instanceof FieldValue) {
       return {
         type: 'fieldvalue',

--- a/tests/e2e/firestore/fieldValue.e2e.js
+++ b/tests/e2e/firestore/fieldValue.e2e.js
@@ -53,6 +53,7 @@ describe('firestore()', () => {
 
         await testCollectionDoc(DOC_2_PATH).update({
           elements: firebase.firestore.FieldValue.arrayUnion('element 1'),
+          elements2: firebase.firestore.FieldValue.arrayUnion('element 2'),
         });
 
         const { data: dataAfterUpdate } = await testCollectionDoc(
@@ -60,6 +61,7 @@ describe('firestore()', () => {
         ).get();
 
         dataAfterUpdate().elements.should.containDeep(['element 1']);
+        dataAfterUpdate().elements2.should.containDeep(['element 2']);
       });
     });
     describe('arrayRemove()', () => {

--- a/tests/e2e/firestore/fieldValue.e2e.js
+++ b/tests/e2e/firestore/fieldValue.e2e.js
@@ -7,7 +7,7 @@ const {
 
 describe('firestore()', () => {
   describe('FieldValue', () => {
-    before(async () => {
+    beforeEach(async () => {
       await resetTestCollectionDoc(DOC_2_PATH, DOC_2);
     });
 
@@ -44,6 +44,41 @@ describe('firestore()', () => {
         dataAfterUpdate().creationDate.should.be.instanceof(
           jet.context.window.Date
         );
+      });
+    });
+    describe('arrayUnion()', () => {
+      it('should add new values to array field', async () => {
+        const { data } = await testCollectionDoc(DOC_2_PATH).get();
+        should.equal(data().elements, undefined);
+
+        await testCollectionDoc(DOC_2_PATH).update({
+          elements: firebase.firestore.FieldValue.arrayUnion('element 1'),
+        });
+
+        const { data: dataAfterUpdate } = await testCollectionDoc(
+          DOC_2_PATH
+        ).get();
+
+        dataAfterUpdate().elements.should.containDeep(['element 1']);
+      });
+    });
+    describe('arrayRemove()', () => {
+      it('should remove value from array', async () => {
+        await testCollectionDoc(DOC_2_PATH).set({
+          elements: ['element 1', 'element 2'],
+        });
+        const { data } = await testCollectionDoc(DOC_2_PATH).get();
+        data().elements.should.containDeep(['element 1', 'element 2']);
+
+        await testCollectionDoc(DOC_2_PATH).update({
+          elements: firebase.firestore.FieldValue.arrayRemove('element 2'),
+        });
+
+        const { data: dataAfterUpdate } = await testCollectionDoc(
+          DOC_2_PATH
+        ).get();
+
+        dataAfterUpdate().elements.should.not.containDeep(['element 2']);
       });
     });
   });


### PR DESCRIPTION
### Summary

Add methods arrayRemove and arrayUnion to work with arrays in firestore.

Fixes #1389

### Checklist
* [x]  Supports `Android`
* [x]  Supports `iOS`
* [x]  `e2e` tests added or updated in [/tests/e2e/*](/tests/e2e)
* [x]  Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)

https://github.com/invertase/react-native-firebase-docs/pull/134

* [x]  Flow types updated
* [x]  Typescript types updated

