### PR TITLE
Notification constructor flow type fix

### DIFF
--- a/src/modules/notifications/IOSNotification.js
+++ b/src/modules/notifications/IOSNotification.js
@@ -43,9 +43,11 @@ export default class IOSNotification {
 
   constructor(
     notification: Notification,
-    notifications: Notifications,
+    notifications?: Notifications,
     data?: NativeIOSNotification
   ) {
+    const iosNotifications =
+      isIOS && notifications && notifications.ios && notifications;
     this._notification = notification;
 
     if (data) {
@@ -58,26 +60,26 @@ export default class IOSNotification {
       this._threadIdentifier = data.threadIdentifier;
     }
 
-    if (isIOS && notifications && notifications.ios) {
-      const complete = (fetchResult: BackgroundFetchResultValue) => {
-        const { notificationId } = notification;
-        if (notificationId) {
-          getLogger(notifications).debug(
-            `Completion handler called for notificationId=${notificationId}`
-          );
-          getNativeModule(notifications).complete(notificationId, fetchResult);
-        }
-      };
-
-      if (notifications.ios.shouldAutoComplete) {
-        complete(notifications.ios.backgroundFetchResult.noData);
-      } else {
-        this._complete = complete;
-      }
-    }
-
     // Defaults
     this._attachments = this._attachments || [];
+
+    if (!iosNotifications) return;
+
+    const complete = (fetchResult: BackgroundFetchResultValue) => {
+      const { notificationId } = notification;
+      if (notificationId) {
+        getLogger(iosNotifications).debug(
+          `Completion handler called for notificationId=${notificationId}`
+        );
+        getNativeModule(iosNotifications).complete(notificationId, fetchResult);
+      }
+    };
+
+    if (iosNotifications.ios.shouldAutoComplete) {
+      complete(iosNotifications.ios.backgroundFetchResult.noData);
+    } else {
+      this._complete = complete;
+    }
   }
 
   get alertAction(): ?string {

--- a/src/modules/notifications/Notification.js
+++ b/src/modules/notifications/Notification.js
@@ -40,7 +40,7 @@ export default class Notification {
 
   constructor(
     nativeNotification?: NativeNotification,
-    notifications: Notifications
+    notifications?: Notifications
   ) {
     if (nativeNotification) {
       this._body = nativeNotification.body;


### PR DESCRIPTION
### Summary

The `notifications` parameter for `Notification` and `IOSNotification` are optional, however their flow types perviously marked these parameters as required. This might have been because the previous `IOSNotification` constructor implementation triggered a flow refinement invalidation, causing flow to throw errors at various places if `notifications` was marked as optional. In support of the `notifications` changes, this too has been fixed.

Fixes #1558 but should not result in any Notification / IOSNotification behavior changes.

### Checklist

- [x] Supports `Android`
- [x] Supports `iOS`
- [x] ~`e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)~ N/A
- [x] ~Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)~ N/A
- [x] Flow types updated
- [x] ~Typescript types updated~ N/A

### Test Plan

> $ ./node_modules/.bin/flow ./
> No errors!

### Release Plan

[TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Marks `notifications` constructor param for `IOSNotification` and `Notification` as optional.