### PR TITLE
Messaging. FIX: issue with removeToken on ios.

### DIFF
--- a/ios/RNFirebase/messaging/RNFirebaseMessaging.m
+++ b/ios/RNFirebase/messaging/RNFirebaseMessaging.m
@@ -108,9 +108,7 @@ didReceiveMessage:(nonnull FIRMessagingRemoteMessage *)remoteMessage {
 
 // ** Start React Module methods **
 RCT_EXPORT_METHOD(getToken:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    if (initialToken) {
-        resolve(initialToken);
-    } else if ([[FIRInstanceID instanceID] token]) {
+    if ([[FIRInstanceID instanceID] token]) {
         resolve([[FIRInstanceID instanceID] token]);
     } else {
         NSString * senderId = [[FIRApp defaultApp] options].GCMSenderID;


### PR DESCRIPTION
Its related to this issue https://github.com/invertase/react-native-firebase/issues/1510

### Summary
Currently on iOS if we remove token by `firebase.messaging().deleteToken();` and try to get new one after that - it returns previous. 

### Checklist

- [ ] Supports `Android`
- [x] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan
```
const oldToken = await firebase.messaging().getToken();
await firebase.messaging().deleteToken();
const newToken = await firebase.messaging().getToken();
if (oldToken === newToken) {
    console.error('Token has not been refreshed');
} else {
     console.log('Token has refreshed successfully!');
}
```

This code must output `Token has refreshed successfully!'`

### Release Plan

[IOS][BUGFIX] [MESSAGING] - fixed bug with removeToken on ios.


