### PR TITLE
Fixes #1772

### DIFF
--- a/src/modules/notifications/IOSNotifications.js
+++ b/src/modules/notifications/IOSNotifications.js
@@ -21,7 +21,7 @@ export default class IOSNotifications {
     this._backgroundFetchResult = {
       noData: nativeModule.backgroundFetchResultNoData,
       newData: nativeModule.backgroundFetchResultNewData,
-      failure: nativeModule.backgroundFetchResultFailed
+      failure: nativeModule.backgroundFetchResultFailed,
     };
   }
 

--- a/src/modules/notifications/IOSNotifications.js
+++ b/src/modules/notifications/IOSNotifications.js
@@ -21,7 +21,7 @@ export default class IOSNotifications {
     this._backgroundFetchResult = {
       noData: nativeModule.backgroundFetchResultNoData,
       newData: nativeModule.backgroundFetchResultNewData,
-      failure: nativeModule.backgroundFetchResultFailure,
+      failure: nativeModule.backgroundFetchResultFailed
     };
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
<!-- Please esure you've also read the `/CONTRIBUTING.md` guide. -->

### Summary

There is a typo in IOSNotifications.backgroundFetchResult.failure which causes calling IOSNotification.complete with notifications.ios.backgroundFetchResult.failure to throw an error:
"Argument 1 () of RNFirebaseNotifications.complete could not be processed. Aborting method call."

Constant exposed from native module is backgroundFetchResultFailed and not backgroundFetchResultFailure.

### Checklist

- [ ] Supports `Android`
- [ x] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

NA

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[JS] [BUGFIX] [NOTIFICATIONS] - Fix backgroundFetchResult.failure

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
