### PR TITLE
Upgrade iOS version to iOS9

### DIFF
--- a/ios/RNFirebase.xcodeproj/project.pbxproj
+++ b/ios/RNFirebase.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 					"${SRCROOT}/../../../ios/Firebase/**",
 					"${SRCROOT}/../../../ios/Pods/Headers/Public/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;
@@ -582,7 +582,7 @@
 					"${SRCROOT}/../../../ios/Firebase/**",
 					"${SRCROOT}/../../../ios/Pods/Headers/Public/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";


### PR DESCRIPTION
### Summary

React Native dropped support on iOS 8 since 0.56

Without this, it'll fail on Release with error:

`Could not build module 'Darwin'` etc

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
