### PR TITLE
fixed UploadTaskSnapshot ref type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -423,7 +423,7 @@ declare module 'react-native-firebase' {
         bytesTransferred: number;
         downloadURL: string | null;
         metadata: FullMetadata;
-        ref: Reference;
+        ref: string;
         state: TaskState;
         task: StorageTask<UploadTaskSnapshot>;
         totalBytes: number;


### PR DESCRIPTION
I noticed that `ref` in `UploadTaskSnapshot` was of type string and not actually `Reference`