### PR TITLE
Fix timestampToUTC timezone handling

### DIFF
--- a/android/src/main/java/io/invertase/firebase/Utils.java
+++ b/android/src/main/java/io/invertase/firebase/Utils.java
@@ -28,8 +28,7 @@ public class Utils {
   private static final String TAG = "Utils";
 
   public static String timestampToUTC(long timestamp) {
-    Calendar calendar = Calendar.getInstance();
-    Date date = new Date((timestamp + calendar.getTimeZone().getOffset(timestamp)) * 1000);
+    Date date = new Date(timestamp * 1000);
     SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
     format.setTimeZone(TimeZone.getTimeZone("UTC"));
     return format.format(date);


### PR DESCRIPTION
TimeZone.getOffset() is in milliseconds, so it should be added to milliseconds, not to seconds.

`Date(long date)` this constructor accepts milliseconds from unix epoch, which considered to be in UTC time. So, there should not be any extra timezone handle.

### Summary

I found this bug in GMT+3, all dates were shifted to coulple of months to future. With this fix all dates becomes correct.

Please note, that I am originally is not java/android developer, I just used the debugger to find this. So, plz, check carefully.