### PR TITLE
Update flow type for analytics.setCurrentScreen()

### DIFF
--- a/packages/analytics/lib/index.js.flow
+++ b/packages/analytics/lib/index.js.flow
@@ -48,7 +48,7 @@ export interface Module extends ReactNativeFirebaseModule {
    * @param screenName
    * @param screenClassOverride
    */
-  setCurrentScreen(screenName: string, screenClassOverride: string): Promise<void>;
+  setCurrentScreen(screenName: string, screenClassOverride?: string): Promise<void>;
 
   /**
    * Sets the minimum engagement time required before starting a session.


### PR DESCRIPTION
### Summary
Does not match the documentation and reality https://rnfirebase.io/docs/v5.x.x/analytics/reference/analytics#setCurrentScreen

### Checklist
- [x] Flow types updated

### Test Plan
```js
// @flow
import firebase from 'react-native-firebase';

firebase.analytics().setCurrentScreen('test') // error currently
```

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[TYPES] [ENHANCEMENT] [ANALYTICS] - Make second argument for `.setCurrentScreen(screenName, screenClassOverride)` optional (Flow.js)
