### PR TITLE
[ANDROID][BUGFIX][ADMOB] Fix Admob crash from UnityAds with Admob Mediation

### DIFF
--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobRewardedVideo.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobRewardedVideo.java
@@ -25,9 +25,14 @@ public class RNFirebaseAdMobRewardedVideo implements RewardedVideoAdListener {
     adUnit = adUnitString;
     adMob = adMobInstance;
 
-    rewardedVideo = MobileAds.getRewardedVideoAdInstance(adMob.getContext());
-
     Activity activity = adMob.getActivity();
+    // Some ads won't work without passing activity, but it is better than make the app crash
+    if (activity == null) {
+      rewardedVideo = MobileAds.getRewardedVideoAdInstance(adMob.getContext());
+    } else {
+      rewardedVideo = MobileAds.getRewardedVideoAdInstance(activity);
+    }
+
     final RNFirebaseAdMobRewardedVideo _this = this;
 
     if (activity != null) {

--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobRewardedVideo.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdMobRewardedVideo.java
@@ -26,7 +26,7 @@ public class RNFirebaseAdMobRewardedVideo implements RewardedVideoAdListener {
     adMob = adMobInstance;
 
     Activity activity = adMob.getActivity();
-    // Some ads won't work without passing activity, but it is better than make the app crash
+    // Some ads won't work without passing activity, or the app will crash
     if (activity == null) {
       rewardedVideo = MobileAds.getRewardedVideoAdInstance(adMob.getContext());
     } else {

--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdmobInterstitial.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdmobInterstitial.java
@@ -24,7 +24,7 @@ class RNFirebaseAdmobInterstitial {
     adMob = adMobInstance;
 
     Activity activity = adMob.getActivity();
-    // Some ads won't work without passing activity, but it is better than make the app crash
+    // Some ads won't work without passing activity, or the app will crash
     if (activity == null) {
       interstitialAd = new InterstitialAd(adMob.getContext());
     } else {

--- a/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdmobInterstitial.java
+++ b/android/src/main/java/io/invertase/firebase/admob/RNFirebaseAdmobInterstitial.java
@@ -22,7 +22,14 @@ class RNFirebaseAdmobInterstitial {
   RNFirebaseAdmobInterstitial(final String adUnitString, final RNFirebaseAdMob adMobInstance) {
     adUnit = adUnitString;
     adMob = adMobInstance;
-    interstitialAd = new InterstitialAd(adMob.getContext());
+
+    Activity activity = adMob.getActivity();
+    // Some ads won't work without passing activity, but it is better than make the app crash
+    if (activity == null) {
+      interstitialAd = new InterstitialAd(adMob.getContext());
+    } else {
+      interstitialAd = new InterstitialAd(activity);
+    }
     interstitialAd.setAdUnitId(adUnit);
 
     AdListener adListener = new AdListener() {


### PR DESCRIPTION
Fixes #1792

### Summary
There is a problem that UnityAds does not work with Admob Mediation.
It seems some mediation adapters such as UnityAds, adcolony, appodeal require ActivityContext.
This PR fixes the issue.

### Checklist
* [ x] Supports `Android`
* [x]  Supports `iOS`
* [ ]  `e2e` tests added or updated in [/tests/e2e/*](/tests/e2e)
* [ ]  Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  
  * **LINK TO DOCS PR HERE**
* [ ]  Flow types updated
* [ ]  Typescript types updated

### Test Plan
My fork is already released for my games in production.
I started seeing getting a traffic to UnityAds via AdmobMediation which used to be zero.
So far I am not seeing any obvious bug due to this change, but I have no idea how to make sure this change won't introduce any regression.

### Release Plan
[ANDROID][BUGFIX][ADMOB] - Fixed an issue UnityAds wasn't working with Admob Mediation due to the lack of ActivityContext