### PR TITLE
[links] Add ability to specify domainUriPrefix instead of dynamicLinkDomain

### DIFF
--- a/android/src/main/java/io/invertase/firebase/links/RNFirebaseLinks.java
+++ b/android/src/main/java/io/invertase/firebase/links/RNFirebaseLinks.java
@@ -219,7 +219,16 @@ public class RNFirebaseLinks extends ReactContextBaseJavaModule implements Activ
       .createDynamicLink();
     try {
       builder.setLink(Uri.parse(linkData.getString("link")));
-      builder.setDomainUriPrefix(linkData.getString("dynamicLinkDomain"));
+
+      if (linkData.hasKey("dynamicLinkDomain")) {
+        builder.setDynamicLinkDomain(linkData.getString("dynamicLinkDomain"));
+        Log.w(TAG, "dynamicLinkDomain is deprecated, use domainUriPrefix instead, see API docs for usage");
+      } else {
+        if (!linkData.hasKey("domainUriPrefix")) {
+          throw new RuntimeException("linkData did not contain domainUriPrefix or deprecated dynamicLinkDomain");
+        }
+        builder.setDomainUriPrefix(linkData.getString("domainUriPrefix"));
+      }
       setAnalyticsParameters(linkData.getMap("analytics"), builder);
       setAndroidParameters(linkData.getMap("android"), builder);
       setIosParameters(linkData.getMap("ios"), builder);

--- a/android/src/main/java/io/invertase/firebase/links/RNFirebaseLinks.java
+++ b/android/src/main/java/io/invertase/firebase/links/RNFirebaseLinks.java
@@ -219,7 +219,7 @@ public class RNFirebaseLinks extends ReactContextBaseJavaModule implements Activ
       .createDynamicLink();
     try {
       builder.setLink(Uri.parse(linkData.getString("link")));
-      builder.setDynamicLinkDomain(linkData.getString("dynamicLinkDomain"));
+      builder.setDomainUriPrefix(linkData.getString("dynamicLinkDomain"));
       setAnalyticsParameters(linkData.getMap("analytics"), builder);
       setAndroidParameters(linkData.getMap("android"), builder);
       setIosParameters(linkData.getMap("ios"), builder);

--- a/ios/RNFirebase/links/RNFirebaseLinks.m
+++ b/ios/RNFirebase/links/RNFirebaseLinks.m
@@ -197,7 +197,17 @@ RCT_EXPORT_METHOD(jsInitialised:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 - (FIRDynamicLinkComponents *)buildDynamicLink:(NSDictionary *)linkData {
     @try {
         NSURL *link = [NSURL URLWithString:linkData[@"link"]];
-        FIRDynamicLinkComponents *components = [FIRDynamicLinkComponents componentsWithLink:link domain:linkData[@"dynamicLinkDomain"]];
+        if (linkData[@"dynamicLinkDomain"]) {
+          FIRDynamicLinkComponents *components = [FIRDynamicLinkComponents componentsWithLink:link domain:linkData[@"dynamicLinkDomain"]];
+          DLog(@"dynamicLinkDomain is deprecated, use domainUriPrefix instead, see API docs for usage")
+        } else {
+          if (!linkData[@"domainUriPrefix"]) {
+              @throw [[NSException alloc] initWithName:@"Exception" reason@"linkData did not contain domainUriPrefix or deprecated dynamicLinkDomain"];
+          }
+          FIRDynamicLinkComponents *components = [[FIRDynamicLinkComponents alloc]
+                                         initWithLink:link
+                                         domainURIPrefix:linkData[@"domainUriPrefix"]];
+        }
         
         [self setAnalyticsParameters:linkData[@"analytics"] components:components];
         [self setAndroidParameters:linkData[@"android"] components:components];

--- a/ios/RNFirebase/links/RNFirebaseLinks.m
+++ b/ios/RNFirebase/links/RNFirebaseLinks.m
@@ -197,16 +197,18 @@ RCT_EXPORT_METHOD(jsInitialised:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
 - (FIRDynamicLinkComponents *)buildDynamicLink:(NSDictionary *)linkData {
     @try {
         NSURL *link = [NSURL URLWithString:linkData[@"link"]];
+        FIRDynamicLinkComponents *components;
         if (linkData[@"dynamicLinkDomain"]) {
-          FIRDynamicLinkComponents *components = [FIRDynamicLinkComponents componentsWithLink:link domain:linkData[@"dynamicLinkDomain"]];
+          components = [FIRDynamicLinkComponents componentsWithLink:link domain:linkData[@"dynamicLinkDomain"]];
           DLog(@"dynamicLinkDomain is deprecated, use domainUriPrefix instead, see API docs for usage")
         } else {
           if (!linkData[@"domainUriPrefix"]) {
-              @throw [[NSException alloc] initWithName:@"Exception" reason@"linkData did not contain domainUriPrefix or deprecated dynamicLinkDomain"];
+              @throw [[NSException alloc]
+                      initWithName:@"Exception"
+                      reason:@"neither domainUriPrefix or deprecated dynamicLinkDomain specified"
+                      userInfo:nil];
           }
-          FIRDynamicLinkComponents *components = [[FIRDynamicLinkComponents alloc]
-                                         initWithLink:link
-                                         domainURIPrefix:linkData[@"domainUriPrefix"]];
+          components = [[FIRDynamicLinkComponents alloc] initWithLink:link domainURIPrefix:linkData[@"domainUriPrefix"]];
         }
         
         [self setAnalyticsParameters:linkData[@"analytics"] components:components];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2111,7 +2111,7 @@ declare module 'react-native-firebase' {
         navigation: NavigationParameters;
         social: SocialParameters;
 
-        constructor(link: string, dynamicLinkDomain: string);
+        constructor(link: string, dynamicLinkDomainOrDomainUriPrefix: string);
       }
 
       interface AnalyticsParameters {

--- a/src/modules/links/DynamicLink.js
+++ b/src/modules/links/DynamicLink.js
@@ -18,6 +18,8 @@ export default class DynamicLink {
 
   _dynamicLinkDomain: string;
 
+  _domainUriPrefix: string;
+
   _ios: IOSParameters;
 
   _itunes: ITunesParameters;
@@ -28,10 +30,15 @@ export default class DynamicLink {
 
   _social: SocialParameters;
 
-  constructor(link: string, dynamicLinkDomain: string) {
+  constructor(link: string, dynamicLinkDomainOrDomainUriPrefix: string) {
     this._analytics = new AnalyticsParameters(this);
     this._android = new AndroidParameters(this);
-    this._dynamicLinkDomain = dynamicLinkDomain;
+
+    if (dynamicLinkDomainOrDomainUriPrefix.startsWith('http')) {
+      this._domainUriPrefix = dynamicLinkDomainOrDomainUriPrefix;
+    } else {
+      this._dynamicLinkDomain = dynamicLinkDomainOrDomainUriPrefix;
+    }
     this._ios = new IOSParameters(this);
     this._itunes = new ITunesParameters(this);
     this._link = link;
@@ -75,6 +82,7 @@ export default class DynamicLink {
     return {
       analytics: this._analytics.build(),
       android: this._android.build(),
+      domainUriPrefix: this._domainUriPrefix,
       dynamicLinkDomain: this._dynamicLinkDomain,
       ios: this._ios.build(),
       itunes: this._itunes.build(),

--- a/src/modules/links/types.js
+++ b/src/modules/links/types.js
@@ -44,7 +44,8 @@ export type NativeSocialParameters = {|
 export type NativeDynamicLink = {|
   analytics: NativeAnalyticsParameters,
   android: NativeAndroidParameters,
-  dynamicLinkDomain: string,
+  domainUriPrefix?: string,
+  dynamicLinkDomain?: string,
   ios: NativeIOSParameters,
   itunes: NativeITunesParameters,
   link: string,


### PR DESCRIPTION
Made a change for the custom links.
If you make a link with customization(eg>abc.com/link), package throws an error.

> Error: Use setDomainUriPrefix() instead, setDynamicLinkDomain() is only applicable for *.page.link and *.app.goo.gl domains.

So, I changed the v5.3.1 code just one line.
One thing to consider, setDomainUriPrefix must provided with 'https://' or 'http://'.
```js
const link = new firebase.links.DynamicLink(
          `https://abc.com/link/?invitedby=${String(Name)},
           "abc.com/link" // Wrong
          "https://abc.com/link" // Right
```
 

### Checklist

- [x] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan
<!-- Made links with no problem. -->

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[CATEGORY][type] [LOCATION] - Message

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

[ANDROID][ENHANCEMENT][android/src/main/java/io/invertase/firebase/links/RNFirebaseLinks.java // line 222] - Modified code for enabling custom domain.
---
