### PR TITLE
docs: noted iOS pod needed for iOS audience stats

### DIFF
--- a/docs/analytics/ios.md
+++ b/docs/analytics/ios.md
@@ -7,9 +7,10 @@ description: Manually integrate Analytics into your iOS application.
 
 ## Device Identification
 
-If you would like to enable Firebase Analytics to generate automatic audience metrics for iOS (as it does by default in Android), you must link additional iOS libraries, [as documented by the Google Firebase team](https://support.google.com/firebase/answer/6318039). Specifically you need libAdIdAccess.a and AdSupport.framework
+If you would like to enable Firebase Analytics to generate automatic audience metrics for iOS (as it does by default in Android), you must link additional iOS libraries, [as documented by the Google Firebase team](https://support.google.com/firebase/answer/6318039). Specifically you need `libAdIdAccess.a` and `AdSupport.framework`.
 
 The way to do this using Cocoapods is to add this to your Podfile (though please use [the most current Pod version](https://cocoapods.org/pods/GoogleIDFASupport) supported by react-native-firebase):
+
 ```ruby
   pod 'GoogleIDFASupport', '~> 3.14.0'
 ```

--- a/docs/analytics/ios.md
+++ b/docs/analytics/ios.md
@@ -5,6 +5,15 @@ description: Manually integrate Analytics into your iOS application.
 
 # iOS Setup
 
+## Device Identification
+
+If you would like to enable Firebase Analytics to generate automatic audience metrics for iOS (as it does by default in Android), you must link additional iOS libraries, [as documented by the Google Firebase team](https://support.google.com/firebase/answer/6318039). Specifically you need libAdIdAccess.a and AdSupport.framework
+
+The way to do this using Cocoapods is to add this to your Podfile (though please use [the most current Pod version](https://cocoapods.org/pods/GoogleIDFASupport) supported by react-native-firebase):
+```ruby
+  pod 'GoogleIDFASupport', '~> 3.14.0'
+```
+
 > The following steps are only required if your environment does not have access to React Native
 auto-linking. 
 


### PR DESCRIPTION
Per discussion on #2071 - added a note about the cocoapod required for automatic audience metric collection on iOS

I will send a separate one to v5

I am skipping the template, this is a docs change as discussed already, please don't shoot me :pray: 
