### PR TITLE
[TYPES][BUGFIX][AUTHENTICATION] - Change type PhoneAuthSnapshot.Error to NativeError

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -928,11 +928,18 @@ declare module 'react-native-firebase' {
       verificationId: string | null;
     }
 
+    interface NativeError extends Error {
+      code: string;
+      message: string;
+      nativeErrorCode?: string;
+      nativeErrorMessage?: string;
+    }
+
     type PhoneAuthSnapshot = {
       state: 'sent' | 'timeout' | 'verified' | 'error';
       verificationId: string;
       code: string | null;
-      error: Error | null;
+      error: NativeError | null;
     };
 
     type PhoneAuthError = {

--- a/src/modules/auth/phone/PhoneAuthListener.js
+++ b/src/modules/auth/phone/PhoneAuthListener.js
@@ -11,13 +11,13 @@ import {
 } from '../../../utils';
 import { getNativeModule } from '../../../utils/native';
 
-import type Auth from '..';
+import type { NativeErrorInterface } from '../../../common/commonTypes.flow';
 
 type PhoneAuthSnapshot = {
   state: 'sent' | 'timeout' | 'verified' | 'error',
   verificationId: string,
   code: string | null,
-  error: NativeError | null,
+  error: NativeErrorInterface | null,
 };
 
 type PhoneAuthError = {

--- a/src/modules/auth/phone/PhoneAuthListener.js
+++ b/src/modules/auth/phone/PhoneAuthListener.js
@@ -17,7 +17,7 @@ type PhoneAuthSnapshot = {
   state: 'sent' | 'timeout' | 'verified' | 'error',
   verificationId: string,
   code: string | null,
-  error: Error | null,
+  error: NativeError | null,
 };
 
 type PhoneAuthError = {

--- a/src/modules/auth/phone/PhoneAuthListener.js
+++ b/src/modules/auth/phone/PhoneAuthListener.js
@@ -11,6 +11,7 @@ import {
 } from '../../../utils';
 import { getNativeModule } from '../../../utils/native';
 
+import type Auth from '..';
 import type { NativeErrorInterface } from '../../../common/commonTypes.flow';
 
 type PhoneAuthSnapshot = {


### PR DESCRIPTION
Fixes #2041

### Summary

As mentioned in #2041 I *believe* there is a type error in PhoneAuthSnapshot.

I wasn't able to successfully use Typescript to extract the phone auth error code until I started using this patch (via patch-package)

I've been using it in production for a few weeks now so I could do i18n on phone auth messages by using the code as an i18n lookup key

I do not know or use Flow. I am not sure if flow types are affected but it stands to reason they would be?

I am not pleased that the NativeError type already existed in a deeper hierarchy and I copied it up here, but it does work. If I were better at creating type definitions I'd generalize it

### Checklist

- [x] Supports `Android`
- [x] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [x] Flow types updated
- [x] Typescript types updated

### Test Plan

The linked bug has all the data that led me to this conclusion, and using this patch in production with standard toolchain (well, standard for typescript of Visual Studio Code + Typescript) now validates correctly and I get nice error message data objects from phone auth

I also validated with `npm run validate-ts-declarations` (and it helped me improve the patch actually)

### Release Plan

[TYPES][BUGFIX][AUTHENTICATION] - Change type PhoneAuthSnapshot.Error to NativeError

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
