### PR TITLE
[Messaging] Add null check to acquire WakeLock on Android

### DIFF
--- a/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessagingService.java
+++ b/android/src/main/java/io/invertase/firebase/messaging/RNFirebaseMessagingService.java
@@ -1,6 +1,7 @@
 package io.invertase.firebase.messaging;
 
 import android.content.Intent;
+import android.content.ComponentName;
 import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
@@ -58,10 +59,10 @@ public class RNFirebaseMessagingService extends FirebaseMessagingService {
             RNFirebaseBackgroundMessagingService.class
           );
           headlessIntent.putExtra("message", message);
-          this
-            .getApplicationContext()
-            .startService(headlessIntent);
-          HeadlessJsTaskService.acquireWakeLockNow(this.getApplicationContext());
+          ComponentName name = this.getApplicationContext().startService(headlessIntent);
+          if (name != null) {
+            HeadlessJsTaskService.acquireWakeLockNow(this.getApplicationContext());
+          }
         } catch (IllegalStateException ex) {
           Log.e(
             TAG,

--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseBackgroundNotificationActionReceiver.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseBackgroundNotificationActionReceiver.java
@@ -3,6 +3,7 @@ package io.invertase.firebase.notifications;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.ComponentName;
 import android.os.Bundle;
 import android.support.v4.app.RemoteInput;
 
@@ -62,8 +63,10 @@ public class RNFirebaseBackgroundNotificationActionReceiver extends BroadcastRec
       if (remoteInput != null) {
         serviceIntent.putExtra("results", remoteInput);
       }
-      context.startService(serviceIntent);
-      HeadlessJsTaskService.acquireWakeLockNow(context);
+      ComponentName name = context.startService(serviceIntent);
+      if (name != null) {
+        HeadlessJsTaskService.acquireWakeLockNow(context);
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


<!-- 🚨 PLEASE SEND PRs TO THE v5.x.x BRANCH AND NOT MASTER - THANKS 🚨 -->

### Summary

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

The Message module and Notification module will accidentally acquire a `PARTIAL_WAKE_LOCK` by calling `HeadlessJsTaskService.acquireWakeLockNow()`, and this lock will always hold if no js tasks to consume it. This will drain off user phones' battery.

This happens when you init the Message module without the optional step of adding `RNFirebaseBackgroundMessagingService` to the `AndroidManifest.xml`.

The `context.startService()` will not throw on unregistered service, [it just `return null`](https://developer.android.com/reference/android/content/Context.html#startService(android.content.Intent)). Adding a null check will handle the cases.

On the Notification module, the service is undocumented, should have fewer people using it.

### Checklist

- [x] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

<!-- Demonstrate the code is solid. -->
<!-- Example: The exact testing commands you ran and their final output (e.g. screenshot of test summary). -->
<!-- Example: Screenshots / videos if the pull request changes UI related code such as Notifications or Admob -->

Tested on a private production app.

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[ANDROID][BUGFIX] [Messaging] - Add null checks to avoid accidentally acquiring wakelocks on Android.

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
