### PR TITLE
[JS][FEATURE][FIRESTORE] - Implement isEqual in Query

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2592,6 +2592,8 @@ declare module 'react-native-firebase' {
 
         get(options?: Types.GetOptions): Promise<QuerySnapshot>;
 
+        isEqual(otherQuery: Query): boolean;
+
         limit(limit: number): Query;
 
         onSnapshot(

--- a/src/modules/firestore/Query.js
+++ b/src/modules/firestore/Query.js
@@ -181,6 +181,73 @@ export default class Query {
       .then(nativeData => new QuerySnapshot(this._firestore, this, nativeData));
   }
 
+  isEqual(otherQuery: Query): boolean {
+    if (!(otherQuery instanceof Query)) {
+      throw new Error(
+        'firebase.firestore.Query.isEqual(*) expects an instance of Query.'
+      );
+    }
+
+    if (this._firestore.app.name !== otherQuery._firestore.app.name) {
+      return false;
+    }
+
+    if (
+      this._firestore.app.options.projectId !==
+      otherQuery._firestore.app.options.projectId
+    ) {
+      return false;
+    }
+
+    if (this._fieldFilters.length !== otherQuery._fieldFilters.length) {
+      return false;
+    }
+
+    for (let i = 0; i < this._fieldFilters.length; i++) {
+      const thisFieldFilter = this._fieldFilters[i];
+      const otherFieldFilter = otherQuery._fieldFilters[i];
+      if (
+        thisFieldFilter.fieldPath.string !== otherFieldFilter.fieldPath.string
+      ) {
+        return false;
+      }
+      if (thisFieldFilter.fieldPath.type !== otherFieldFilter.fieldPath.type) {
+        return false;
+      }
+      if (thisFieldFilter.value.type !== otherFieldFilter.value.type) {
+        return false;
+      }
+      if (thisFieldFilter.value.value !== otherFieldFilter.value.value) {
+        return false;
+      }
+      if (thisFieldFilter.operator !== otherFieldFilter.operator) {
+        return false;
+      }
+    }
+
+    if (this._fieldOrders.length !== otherQuery._fieldOrders.length) {
+      return false;
+    }
+
+    for (let i = 0; i < this._fieldOrders.length; i++) {
+      const thisFieldOrder = this._fieldOrders[i];
+      const otherFieldOrder = otherQuery._fieldOrders[i];
+      if (thisFieldOrder.direction !== otherFieldOrder.direction) {
+        return false;
+      }
+      if (
+        thisFieldOrder.fieldPath.string !== otherFieldOrder.fieldPath.string
+      ) {
+        return false;
+      }
+      if (thisFieldOrder.fieldPath.type !== otherFieldOrder.fieldPath.type) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   limit(limit: number): Query {
     // TODO: Validation
     // validate.isInteger('n', n);

--- a/tests/e2e/firestore/query.e2e.js
+++ b/tests/e2e/firestore/query.e2e.js
@@ -1,0 +1,90 @@
+describe('firestore()', () => {
+  describe('Query', () => {
+    describe('isEqual()', () => {
+      it(`returns true if two Queries have the same .where and .orderBy calls`, () => {
+        const ref1 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true)
+          .where('baz', '!=', false)
+          .orderBy('date', 'DESC');
+        const ref2 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true)
+          .where('baz', '!=', false)
+          .orderBy('date', 'DESC');
+        should.equal(ref1.isEqual(ref2), true);
+      });
+
+      it(`returns false if two Queries have different number of .where calls`, () => {
+        const ref1 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true);
+        const ref2 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true)
+          .where('baz', '!=', false);
+        should.equal(ref1.isEqual(ref2), false);
+      });
+
+      it(`returns false if two Queries have different .where calls`, () => {
+        const ref1 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true);
+        const ref2 = firebase
+          .firestore()
+          .collection('foo')
+          .where('biz', '==', true);
+        should.equal(ref1.isEqual(ref2), false);
+      });
+
+      it(`returns false if two Queries have different number of .orderBy calls`, () => {
+        const ref1 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true)
+          .orderBy('baz', 'DESC');
+        const ref2 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true)
+          .orderBy('baz', 'DESC')
+          .orderBy('biz', 'ASC');
+        should.equal(ref1.isEqual(ref2), false);
+      });
+
+      it(`returns false if two Queries have different .orderBy calls`, () => {
+        const ref1 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true)
+          .orderBy('baz', 'DESC');
+        const ref2 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true)
+          .orderBy('baz', 'ASC');
+        should.equal(ref1.isEqual(ref2), false);
+      });
+
+      it(`throws if arg is not an instance of Query`, () => {
+        const ref1 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true);
+        const maybeRef2 = 'nope';
+        try {
+          ref1.isEqual(maybeRef2);
+          return Promise.reject(new Error('Did not throw'));
+        } catch (error) {
+          error.message.should.containEql('expects an instance of Query');
+          return Promise.resolve();
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


<!-- 🚨 PLEASE SEND PRs TO THE v5.x.x BRANCH AND NOT MASTER - THANKS 🚨 -->

### Summary

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Added `.isEqual` method to Query instances so that `useCollection` from `react-firebase-hooks/firestore` works with firestore queries, as it does on web. This is PR is in the same vein as #2077.

### Checklist

- [x] Supports `Android`
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
- [x] Flow types updated
- [x] Typescript types updated


I ran my newly-added tests on iOS and Android and they're passing when I run them as the only tests using `.only`. For some reason when running all of the tests it is failing at the crashlytics tests, even before applying my changes:

```
  1) crashlytics()
       log()
         should set a string value:
     You attempted to use a firebase module that's not installed natively on your iOS project by calling firebase.crashlytics().

Ensure you have the required Firebase iOS SDK pod for this module included in your Podfile, in this instance confirm you've added "pod 'undefined'" to your Podfile

See http://invertase.link/ios for full setup instructions.
```

:fire: