### PR TITLE
[FEATURE][FIRESTORE][cacheSizeBytes]: expose SDK cacheSizeBytes prop

### DIFF
--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -463,9 +463,7 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
     if (settings.hasKey("ssl")) {
       firestoreSettings.setSslEnabled(settings.getBoolean("ssl"));
     } else {
-      firestoreSettings.setSslEnabled(firestore
-                                        .getFirestoreSettings()
-                                        .isSslEnabled());
+      firestoreSettings.setSslEnabled(firestore.getFirestoreSettings().isSslEnabled());
     }
 
     if (settings.hasKey("timestampsInSnapshots")) {

--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -444,9 +444,7 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
     if (settings.hasKey("persistence")) {
       firestoreSettings.setPersistenceEnabled(settings.getBoolean("persistence"));
     } else {
-      firestoreSettings.setPersistenceEnabled(firestore
-                                                .getFirestoreSettings()
-                                                .isPersistenceEnabled());
+      firestoreSettings.setPersistenceEnabled(firestore.getFirestoreSettings().isPersistenceEnabled());
     }
 
     if (settings.hasKey("cacheSizeBytes")) {

--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -437,9 +437,7 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
     if (settings.hasKey("host")) {
       firestoreSettings.setHost(settings.getString("host"));
     } else {
-      firestoreSettings.setHost(firestore
-                                  .getFirestoreSettings()
-                                  .getHost());
+      firestoreSettings.setHost(firestore.getFirestoreSettings().getHost());
     }
     if (settings.hasKey("persistence")) {
       firestoreSettings.setPersistenceEnabled(settings.getBoolean("persistence"));

--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -450,7 +450,6 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
     }
 
     if (settings.hasKey("cacheSizeBytes")) {
-      firestoreSettings.setCacheSizeBytes(settings.getInt("cacheSizeBytes"));
       int cacheSizeBytes = settings.getInt("cacheSizeBytes");
       if (cacheSizeBytes == -1) {
         firestoreSettings.setCacheSizeBytes(FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED);

--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -448,6 +448,13 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
                                                 .getFirestoreSettings()
                                                 .isPersistenceEnabled());
     }
+
+    if (settings.hasKey("cacheSizeBytes")) {
+      firestoreSettings.setCacheSizeBytes(settings.getInt("cacheSizeBytes"));
+    } else {
+      firestoreSettings.setCacheSizeBytes(firestore.getFirestoreSettings().getCacheSizeBytes());
+    }
+
     if (settings.hasKey("ssl")) {
       firestoreSettings.setSslEnabled(settings.getBoolean("ssl"));
     } else {

--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -434,11 +434,13 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
   public void settings(String appName, ReadableMap settings, final Promise promise) {
     FirebaseFirestore firestore = getFirestoreForApp(appName);
     FirebaseFirestoreSettings.Builder firestoreSettings = new FirebaseFirestoreSettings.Builder();
+    
     if (settings.hasKey("host")) {
       firestoreSettings.setHost(settings.getString("host"));
     } else {
       firestoreSettings.setHost(firestore.getFirestoreSettings().getHost());
     }
+    
     if (settings.hasKey("persistence")) {
       firestoreSettings.setPersistenceEnabled(settings.getBoolean("persistence"));
     } else {

--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -451,6 +451,12 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
 
     if (settings.hasKey("cacheSizeBytes")) {
       firestoreSettings.setCacheSizeBytes(settings.getInt("cacheSizeBytes"));
+      int cacheSizeBytes = settings.getInt("cacheSizeBytes");
+      if (cacheSizeBytes == -1) {
+        firestoreSettings.setCacheSizeBytes(FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED);
+      } else {
+        firestoreSettings.setCacheSizeBytes(cacheSizeBytes);
+      }
     } else {
       firestoreSettings.setCacheSizeBytes(firestore.getFirestoreSettings().getCacheSizeBytes());
     }

--- a/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
+++ b/android/src/main/java/io/invertase/firebase/firestore/RNFirebaseFirestore.java
@@ -449,6 +449,7 @@ public class RNFirebaseFirestore extends ReactContextBaseJavaModule {
 
     if (settings.hasKey("cacheSizeBytes")) {
       int cacheSizeBytes = settings.getInt("cacheSizeBytes");
+      
       if (cacheSizeBytes == -1) {
         firestoreSettings.setCacheSizeBytes(FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED);
       } else {

--- a/ios/RNFirebase/firestore/RNFirebaseFirestore.m
+++ b/ios/RNFirebase/firestore/RNFirebaseFirestore.m
@@ -378,6 +378,11 @@ RCT_EXPORT_METHOD(settings:(NSString *)appDisplayName
     } else {
         firestoreSettings.persistenceEnabled = firestore.settings.persistenceEnabled;
     }
+    if (settings[@"cacheSizeBytes"]) {
+        firestoreSettings.cacheSizeBytes = settings[@"cacheSizeBytes"];
+    } else {
+        firestoreSettings.cacheSizeBytes = firestore.settings.cacheSizeBytes;
+    }
     if (settings[@"ssl"]) {
         firestoreSettings.sslEnabled = settings[@"ssl"];
     } else {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2705,6 +2705,7 @@ declare module 'react-native-firebase' {
       interface Settings {
         host?: string;
         persistence?: boolean;
+        cacheSizeBytes?: number;
         ssl?: boolean;
         timestampsInSnapshots?: boolean;
       }

--- a/src/modules/firestore/index.js
+++ b/src/modules/firestore/index.js
@@ -24,6 +24,13 @@ import type DocumentSnapshot from './DocumentSnapshot';
 import type App from '../core/app';
 import type QuerySnapshot from './QuerySnapshot';
 
+// Flag firestore to use unlimited cache size
+const CACHE_SIZE_UNLIMITED = -1;
+
+// A constant indicating the the minimum cache size that
+// currently is 1MB
+const MIN_CACHE_SIZE = 1048576;
+
 type CollectionSyncEvent = {
   appName: string,
   querySnapshot?: QuerySnapshot,
@@ -42,7 +49,7 @@ type DocumentSyncEvent = {
 
 type Settings = {
   host?: string,
-  cacheSizeBytes?: number,
+  cacheSizeBytes?: CACHE_SIZE_UNLIMITED | number,
   persistence?: boolean,
   ssl?: boolean,
   timestampsInSnapshots?: boolean,
@@ -55,8 +62,6 @@ const NATIVE_EVENTS = [
 ];
 
 const LogLevels = ['debug', 'error', 'silent'];
-
-const MIN_CACHE_SIZE = 1048576;
 
 export const MODULE_NAME = 'RNFirebaseFirestore';
 export const NAMESPACE = 'firestore';
@@ -192,7 +197,10 @@ export default class Firestore extends ModuleBase {
           )
         );
       }
-      if (settings.cacheSizeBytes < MIN_CACHE_SIZE) {
+      if (
+        settings.cacheSizeBytes !== CACHE_SIZE_UNLIMITED &&
+        settings.cacheSizeBytes < MIN_CACHE_SIZE
+      ) {
         return Promise.reject(
           new Error(
             `Firestore.settings failed: settings.cacheSizeBytes must be set to ${MIN_CACHE_SIZE} at least bytes.`
@@ -293,6 +301,7 @@ export const statics = {
   FieldValue,
   GeoPoint,
   Timestamp,
+  CACHE_SIZE_UNLIMITED,
   enableLogging(enabled: boolean): void {
     // DEPRECATED: Remove method in v4.1.0
     console.warn(

--- a/src/modules/firestore/index.js
+++ b/src/modules/firestore/index.js
@@ -49,7 +49,7 @@ type DocumentSyncEvent = {
 
 type Settings = {
   host?: string,
-  cacheSizeBytes?: CACHE_SIZE_UNLIMITED | number,
+  cacheSizeBytes?: number,
   persistence?: boolean,
   ssl?: boolean,
   timestampsInSnapshots?: boolean,

--- a/src/modules/firestore/index.js
+++ b/src/modules/firestore/index.js
@@ -17,7 +17,7 @@ import WriteBatch from './WriteBatch';
 import TransactionHandler from './TransactionHandler';
 import Timestamp from './Timestamp';
 import Transaction from './Transaction';
-import { isBoolean, isObject, isString, hop } from '../../utils';
+import { isBoolean, isObject, isString, isNumber, hop } from '../../utils';
 import { getNativeModule } from '../../utils/native';
 
 import type DocumentSnapshot from './DocumentSnapshot';
@@ -42,6 +42,7 @@ type DocumentSyncEvent = {
 
 type Settings = {
   host?: string,
+  cacheSizeBytes?: number,
   persistence?: boolean,
   ssl?: boolean,
   timestampsInSnapshots?: boolean,
@@ -54,6 +55,8 @@ const NATIVE_EVENTS = [
 ];
 
 const LogLevels = ['debug', 'error', 'silent'];
+
+const MIN_CACHE_SIZE = 1048576;
 
 export const MODULE_NAME = 'RNFirebaseFirestore';
 export const NAMESPACE = 'firestore';
@@ -180,6 +183,32 @@ export default class Firestore extends ModuleBase {
         )
       );
     }
+
+    if (hop(settings, 'cacheSizeBytes')) {
+      if (!isNumber(settings.cacheSizeBytes)) {
+        return Promise.reject(
+          new Error(
+            'Firestore.settings failed: settings.cacheSizeBytes must be number.'
+          )
+        );
+      }
+      if (settings.cacheSizeBytes < MIN_CACHE_SIZE) {
+        return Promise.reject(
+          new Error(
+            `Firestore.settings failed: settings.cacheSizeBytes must be set to ${MIN_CACHE_SIZE} at least bytes.`
+          )
+        );
+      }
+    }
+
+    if (hop(settings, 'cacheSizeBytes') && !isNumber(settings.cacheSizeBytes)) {
+      return Promise.reject(
+        new Error(
+          'Firestore.settings failed: settings.cacheSizeBytes must be number.'
+        )
+      );
+    }
+
     if (hop(settings, 'ssl') && !isBoolean(settings.ssl)) {
       return Promise.reject(
         new Error('Firestore.settings failed: settings.ssl must be boolean.')

--- a/src/modules/firestore/index.js
+++ b/src/modules/firestore/index.js
@@ -24,11 +24,10 @@ import type DocumentSnapshot from './DocumentSnapshot';
 import type App from '../core/app';
 import type QuerySnapshot from './QuerySnapshot';
 
-// Flag firestore to use unlimited cache size
+// A constant indicating the unlimited cache size
 const CACHE_SIZE_UNLIMITED = -1;
 
-// A constant indicating the the minimum cache size that
-// currently is 1MB
+// A constant indicating the minimum cache size (currently 1MB)
 const MIN_CACHE_SIZE = 1048576;
 
 type CollectionSyncEvent = {

--- a/src/modules/firestore/index.js
+++ b/src/modules/firestore/index.js
@@ -24,10 +24,10 @@ import type DocumentSnapshot from './DocumentSnapshot';
 import type App from '../core/app';
 import type QuerySnapshot from './QuerySnapshot';
 
-// A constant indicating the unlimited cache size
+// A flag representing the unlimited cache size
 const CACHE_SIZE_UNLIMITED = -1;
 
-// A constant indicating the minimum cache size (currently 1MB)
+// The minimum cache size in the firebase SDK (currently 1MB)
 const MIN_CACHE_SIZE = 1048576;
 
 type CollectionSyncEvent = {

--- a/src/modules/firestore/index.js
+++ b/src/modules/firestore/index.js
@@ -209,14 +209,6 @@ export default class Firestore extends ModuleBase {
       }
     }
 
-    if (hop(settings, 'cacheSizeBytes') && !isNumber(settings.cacheSizeBytes)) {
-      return Promise.reject(
-        new Error(
-          'Firestore.settings failed: settings.cacheSizeBytes must be number.'
-        )
-      );
-    }
-
     if (hop(settings, 'ssl') && !isBoolean(settings.ssl)) {
       return Promise.reject(
         new Error('Firestore.settings failed: settings.ssl must be boolean.')

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -147,6 +147,15 @@ export function isString(value: mixed): boolean %checks {
 }
 
 /**
+ * Simple is number check
+ * @param value
+ * @return {boolean}
+ */
+export function isNumber(value: mixed): boolean %checks {
+  return typeof value === 'number';
+}
+
+/**
  * Simple is boolean check
  * @param value
  * @return {boolean}

--- a/tests/e2e/firestore/firestore.e2e.js
+++ b/tests/e2e/firestore/firestore.e2e.js
@@ -96,6 +96,30 @@ describe('firestore()', () => {
       );
     });
 
+    it('should reject invalid cache sizes', async () => {
+      try {
+        await firebase.firestore().settings({ cacheSizeBytes: '100' });
+      } catch (error) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject(
+        new Error('applied settings with cacheSizeBytes lower then minimal.')
+      );
+    });
+
+    it('should reject cache sizes lower then the minimum one', async () => {
+      try {
+        await firebase.firestore().settings({ cacheSizeBytes: 100 });
+      } catch (error) {
+        return Promise.resolve();
+      }
+
+      return Promise.reject(
+        new Error('applied settings with cacheSizeBytes lower then minimal.')
+      );
+    });
+
     it('should reject invalid ssl setting', async () => {
       try {
         await firebase.firestore().settings({ ssl: 'fail' });

--- a/tests/e2e/firestore/firestore.e2e.js
+++ b/tests/e2e/firestore/firestore.e2e.js
@@ -104,7 +104,9 @@ describe('firestore()', () => {
       }
 
       return Promise.reject(
-        new Error('applied settings with cacheSizeBytes lower then minimal.')
+        new Error(
+          'applied settings with cacheSizeBytes value passed as string.'
+        )
       );
     });
 


### PR DESCRIPTION
### Summary
The cacheSizeBytes prop could now be set from the client applications.
```jsx
firebase.firestore().settings({cacheSizeBytes: 10000000})
```

### Checklist

- [x] Supports `Android`
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [x] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **https://github.com/invertase/react-native-firebase-docs/pull/185**
- [x] Flow types updated
- [x] Typescript types updated