### PR TITLE
docs: add breaking change notice to postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:assets": "prettier --ignore-path .gitignore --write \"**/*.{json,md}\"",
     "prepare": "yarn run clean && yarn run build && yarn run build-flow",
     "precommit": "lint-staged",
-    "postinstall": "opencollective-postinstall || exit 0",
+    "postinstall": "opencollective-postinstall && echo 'FIREBASE WARNING: react-native-firebase v5 will allow breaking change in minor versions starting v5.5.x. Info: https://rnfirebase.io/docs/v5.x.x/releases/v5.4.x' || exit 0",
     "prepublishOnly": "yarn run validate-ts-declarations && yarn run validate-flow-declarations"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:assets": "prettier --ignore-path .gitignore --write \"**/*.{json,md}\"",
     "prepare": "yarn run clean && yarn run build && yarn run build-flow",
     "precommit": "lint-staged",
-    "postinstall": "opencollective-postinstall && echo 'FIREBASE WARNING: react-native-firebase v5 will allow breaking change in minor versions starting v5.5.x. Info: https://rnfirebase.io/docs/v5.x.x/releases/v5.4.x' || exit 0",
+    "postinstall": "opencollective-postinstall && echo 'WARNING: react-native-firebase v5 will allow breaking changes in minor versions starting from v5.5.x, this is in order to continue supporting it prior to v6. Info: https://rnfirebase.io/docs/v5.x.x/releases/v5.4.x' || exit 0",
     "prepublishOnly": "yarn run validate-ts-declarations && yarn run validate-flow-declarations"
   },
   "repository": {


### PR DESCRIPTION
As discussed with you guys, and paired with the docs PR here https://github.com/invertase/react-native-firebase-docs/pull/187 - I want to give the installed base a big heads-up that we may issue breaking releases in v5 minor releases during the transition to v6

I don't intend to propose anything crazy but sometimes maintenance requires a break when you are dependent on underlying libraries out of your control, and this gives us the space to break if we need to

This completes the effort to notify - we notify on package install, in the install docs, and in the release notes now, no one can say we didn't try, and the community should be able to self-resolve issues so it doesn't cause a support burden

### Checklist

- [x] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)

### Test Plan


I worked on it until it displayed correctly on install, it looks like this:

![Screenshot from 2019-06-07 15-39-58](https://user-images.githubusercontent.com/782704/59132949-21d28a80-893c-11e9-876b-68e0d55b9397.png)




### Release Plan

This can be merged any time I believe, assuming consensus on the plan to allow breaking change in the minor version semver space

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 🟟 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 🟟 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 🟟 Star this repo on GitHub ⭐️
- 🟟 Contribute; see our [contributing guide](/CONTRIBUTING.md)
