### PR TITLE
[RELEASE][VERSIONS][DOCS] - bump versions to 5.4.3, document release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ tests/android/app/.project
 tests/android/app/.classpath
 **/*.xcworkspace/**
 tests/functions/firebase-debug.log
+yarn.lock

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -17,7 +17,6 @@ This document is an attempt to write down all the steps in the release process f
 1. Update the firebase registration version numbers to match the next version number
    - iOS here: <https://github.com/invertase/react-native-firebase/blob/v5.x.x/ios/RNFirebase/RNFirebase.m#L20>
    - Android here: <https://github.com/invertase/react-native-firebase/blob/v5.x.x/android/src/main/java/io/invertase/firebase/ReactNativeFirebaseAppRegistrar.java#L36>
-1. Update package.json (need guidance here)
 
 ## Package and Deploy
 

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -29,6 +29,6 @@ This document is an attempt to write down all the steps in the release process f
 
 ## Release notification
 
-1. discord announcements: invertase / react-native?
+1. Discord announcement: Invertase OSS > React Native Firebase > Announcements (use `@here` in the announcement to notify anyone watching the channel)
 1. twitter?
 1. anyone else?

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,34 @@
+# Introduction
+
+This document is an attempt to write down all the steps in the release process for the v5 branch.
+
+## Testing
+
+- Make sure android and ios e2e tests work locally. **THIS IS VITAL** as android does not run e2e in CI, and it caught a problem just before 5.4.3 release for instance
+- Make sure full CI runs complete successfully
+
+## Documentation
+
+- Make sure there is an entry in docs for the new release: <https://github.com/invertase/react-native-firebase-docs/tree/v5.x.x/docs/releases>
+- Traditionally the new minor versions get a new page (e.g. v5.4.x.md)
+
+## SDK Version numbers
+
+1. Update the firebase registration version numbers to match the next version number
+   - iOS here: <https://github.com/invertase/react-native-firebase/blob/v5.x.x/ios/RNFirebase/RNFirebase.m#L20>
+   - Android here: <https://github.com/invertase/react-native-firebase/blob/v5.x.x/android/src/main/java/io/invertase/firebase/ReactNativeFirebaseAppRegistrar.java#L36>
+1. Update package.json (need guidance here)
+
+## Package and Deploy
+
+1. Create git tag and alter package.json with `npm version 5.x.x` (e.g. `npm version 5.4.3`)
+1. Publish with `npm publish`
+1. Commit changes with `git add -A && git commit -a`
+1. Push changes back to repo with `git push --follow-tags upstream` (substitute your remote ref for `upstream` if the main repository has a different reference name in your local repo)
+1. For new minor versions make an entry github releases page pointing to the new v5.5.x (or v5.6.x etc) releases page on rnfirebase.io
+
+## Release notification
+
+1. discord announcements: invertase / react-native?
+1. twitter?
+1. anyone else?

--- a/android/src/main/java/io/invertase/firebase/ReactNativeFirebaseAppRegistrar.java
+++ b/android/src/main/java/io/invertase/firebase/ReactNativeFirebaseAppRegistrar.java
@@ -33,7 +33,7 @@ public class ReactNativeFirebaseAppRegistrar implements ComponentRegistrar {
     return Collections.singletonList(
       LibraryVersionComponent.create(
         "react-native-firebase",
-        "5.3.0"
+        "5.4.3"
       )
     );
   }

--- a/ios/RNFirebase/RNFirebase.m
+++ b/ios/RNFirebase/RNFirebase.m
@@ -17,7 +17,7 @@ RCT_EXPORT_MODULE(RNFirebase);
     if (self != nil) {
       DLog(@"Setting up RNFirebase instance");
 #ifdef REGISTER_LIB
-      [FIRApp registerLibrary:@"react-native-firebase" withVersion:@"5.3.0"];
+      [FIRApp registerLibrary:@"react-native-firebase" withVersion:@"5.4.3"];
 #endif
     }
     return self;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prepare": "yarn run clean && yarn run build && yarn run build-flow",
     "precommit": "lint-staged",
     "postinstall": "opencollective-postinstall && echo 'WARNING: react-native-firebase v5 will allow breaking changes in minor versions starting from v5.5.x, this is in order to continue supporting it prior to v6. Info: https://rnfirebase.io/docs/v5.x.x/releases/v5.4.x' || exit 0",
-    "prepublishOnly": "yarn run validate-ts-declarations && yarn run validate-flow-declarations"
+    "prepublishOnly": "yarn run validate:all:ts && yarn run validate:all:flow && yarn run validate:all:js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION

This one needs more than review, it needs collaboration or I'm lost :-) - you might want to do this (assuming my commands are correct, in an attempt to make this copy-pastable):

```shell
git remote add mikehardy git@github.com:mikehardy/react-native-firebase.git
git fetch mikehardy
git co mikehardy/release-process-5.4.3
```

...so it is easy to edit and just type away then push to this branch in my repo, I'm fine rebasing etc to collaborate and that way you/we just type once?

The idea is:

* bump the versions as requested
* figure out how to actually turn the crank on this thing

I did not edit package.json or anything as I'm not sure what release machinery you've already built

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
