### PR TITLE
Allows react-native-firebase to be used via Podfile with use_frameworks!

### DIFF
--- a/ios/RNFirebase.podspec
+++ b/ios/RNFirebase.podspec
@@ -21,4 +21,10 @@ Pod::Spec.new do |s|
     cs.dependency 'Fabric'
     cs.dependency 'Crashlytics'
   end
+  # allow this package to be used with use_frameworks!
+  s.static_framework = true
+  # fix recursive header flag being skipped by cocoapods when using this as a framework
+  s.xcconfig = {
+    'HEADER_SEARCH_PATHS' => '${PODS_ROOT}/Headers/Public/**'
+  }
 end


### PR DESCRIPTION
Ref https://github.com/invertase/react-native-firebase/issues/252#issuecomment-501692286

### Checklist

- [ ] Supports `Android`
- [x] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

I tested this  like that:

- installed rnfirebase v5 via yarn
- modified podspec in `node_modules/react-native-firebase/ios` after install (as in the pr)
- run `pod install` (cocoapods read the podspec)
- I can build my app without the 3 tricks mentionned in https://github.com/invertase/react-native-firebase/issues/252#issuecomment-501692286

### Release Plan

[IOS][BUGFIX] [ios/RNFirebase.podspec] - Allows react-native-firebase to be used via Podfile with use_frameworks!

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
