### PR TITLE
[BREAKING CHANGE][TYPES][Firestore] Document id can't be null

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2437,7 +2437,7 @@ declare module 'react-native-firebase' {
 
       interface DocumentReference {
         readonly firestore: Firestore;
-        readonly id: string | null;
+        readonly id: string;
         readonly parent: CollectionReference;
         readonly path: string;
 
@@ -2526,7 +2526,7 @@ declare module 'react-native-firebase' {
 
       interface DocumentSnapshot {
         readonly exists: boolean;
-        readonly id: string | null;
+        readonly id: string;
         readonly metadata: Types.SnapshotMetadata;
         readonly ref: DocumentReference;
 


### PR DESCRIPTION
### Summary

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
I looked in all the official firebase SDKs for different platforms and they all say that ID is guarranteed to be as string. Also, it seems that when the typescript definitions were added, they followed the flow types which also said id could be null, but the flow types have since changed to correctly reflect the official SDKs, while the TS types remained as they were.

Links to SDKs:
https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentReference.html#id
https://firebase.google.com/docs/reference/js/firebase.firestore.DocumentSnapshot.html#id
https://firebase.google.com/docs/reference/swift/firebasefirestore/api/reference/Classes/DocumentReference#/c:objc(cs)FIRDocumentReference(py)documentID
https://firebase.google.com/docs/reference/swift/firebasefirestore/api/reference/Classes/DocumentSnapshot#/c:objc(cs)FIRDocumentSnapshot(py)documentID
https://firebase.google.com/docs/reference/android/com/google/firebase/firestore/DocumentReference.html#getId()
https://firebase.google.com/docs/reference/android/com/google/firebase/firestore/DocumentSnapshot.html#getId()

### Checklist

- [x] Supports `Android`
- [x] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [x] Typescript types updated

[TYPES][BUGFIX][Firestore] - Document id is no longer possibly null in typescript

:fire: