### PR TITLE
Fix notification data type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1443,7 +1443,7 @@ declare module 'react-native-firebase' {
         android: AndroidNotification;
         ios: IOSNotification;
         body: string;
-        data: any;
+        data: { [key: string]: string };
         notificationId: string;
         sound?: string;
         subtitle?: string;


### PR DESCRIPTION
### Summary

Fix notification data TypeScript type to `{ [key: string]: string }`
 instead of `any` matching the flow type https://github.com/invertase/react-native-firebase/blob/e411598315a395d339c9a80cdc58538942277329/src/modules/notifications/types.js#L219

Documentation should also be updated here

https://rnfirebase.io/docs/v5.x.x/notifications/reference/Notification#data

### Checklist

- [ ] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [x] Typescript types updated

### Test Plan

N/A

### Release Plan

[TYPES] [BUGFIX] [NOTIFICATIONS] - Change notification data type definition to `{ [key: string]: string }`
