### PR TITLE
[ANDROID][BUGFIX][link] - react-native@0.59 still needs rnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,13 @@
     "opencollective-postinstall": "^2.0.0",
     "prop-types": "^15.7.2"
   },
+  "rnpm": {
+    "android": {
+      "buildPatch": "    implementation project(':react-native-firebase')",
+      "packageImportPath": "import io.invertase.firebase.RNFirebasePackage;",
+      "packageInstance": "new RNFirebasePackage()"
+    }
+  },
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/react-native-firebase"


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


<!-- 🚨 PLEASE SEND PRs TO THE v5.x.x BRANCH AND NOT MASTER - THANKS 🚨 -->

### Summary

This partially reverts #2335 so that link works on react-native 0.59

Someone mentioned they were having problems and when I checked my demonstrator app I noticed the same thing. New react-native-firebase links on react-native 0.59 fail now

They generate an import of `io.invertase.firebase.RNFirebaseAdMobPackage` (which does not exist) instead of the RNFirebasePackage, so the build then fails

There must be an underlying reason but I haven't investigated, as a partial revert so that the rnpm block is there works for now

### Checklist

- [x] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

<!-- Demonstrate the code is solid. -->
<!-- Example: The exact testing commands you ran and their final output (e.g. screenshot of test summary). -->
<!-- Example: Screenshots / videos if the pull request changes UI related code such as Notifications or Admob -->

My demonstrator app fails if I just use react-native-firebase@5.5.5 directly, but if I add 5.5.4, do the link, then add '5' (which brings in 5.5.5) the link works. 

I further tested it locally by doing 5.5.5 directly, adding this patch, then doing the link, and it worked fine.

https://github.com/mikehardy/rnfbdemo/blob/master/make-demo-rn59.sh#L12

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[ANDROID][BUGFIX][linking] - fix react-native@0.59 linking

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
