### PR TITLE
Move Firestore settings to share preferences

### DIFF
--- a/packages/app/android/src/main/java/io/invertase/firebase/common/UniversalFirebasePreferences.java
+++ b/packages/app/android/src/main/java/io/invertase/firebase/common/UniversalFirebasePreferences.java
@@ -36,6 +36,7 @@ public class UniversalFirebasePreferences {
     return getPreferences().contains(key);
   }
 
+  // Boolean
   public void setBooleanValue(String key, boolean value) {
     getPreferences().edit().putBoolean(key, value).apply();
   }
@@ -44,6 +45,16 @@ public class UniversalFirebasePreferences {
     return getPreferences().getBoolean(key, defaultValue);
   }
 
+  // Int
+  public void setIntValue(String key, int value) {
+    getPreferences().edit().putInt(key, value).apply();
+  }
+
+  public int getIntValue(String key, int defaultValue) {
+    return getPreferences().getInt(key, defaultValue);
+  }
+
+  // Long
   public void setLongValue(String key, long value) {
     getPreferences().edit().putLong(key, value).apply();
   }
@@ -52,6 +63,7 @@ public class UniversalFirebasePreferences {
     return getPreferences().getLong(key, defaultValue);
   }
 
+  // String
   public void setStringValue(String key, String value) {
     getPreferences().edit().putString(key, value).apply();
   }

--- a/packages/app/ios/RNFBApp/RNFBPreferences.m
+++ b/packages/app/ios/RNFBApp/RNFBPreferences.m
@@ -46,7 +46,7 @@ static RNFBPreferences *sharedInstance;
 }
 
 - (BOOL)getBooleanValue:(NSString *)key defaultValue:(BOOL)defaultValue {
-  if ([_userDefaults objectForKey:key] != nil) return defaultValue;
+  if ([_userDefaults objectForKey:key] == nil) return defaultValue;
   return [_userDefaults boolForKey:key];
 }
 
@@ -61,12 +61,12 @@ static RNFBPreferences *sharedInstance;
 }
 
 - (NSInteger *)getIntegerValue:(NSString *)key defaultValue:(NSInteger *)defaultValue {
-  if ([_userDefaults objectForKey:key] != nil) return defaultValue;
+  if ([_userDefaults objectForKey:key] == nil) return defaultValue;
   return (NSInteger *) [_userDefaults integerForKey:key];
 }
 
 - (NSString *)getStringValue:(NSString *)key defaultValue:(NSString *)defaultValue {
-  if ([_userDefaults objectForKey:key] != nil) return defaultValue;
+  if ([_userDefaults objectForKey:key] == nil) return defaultValue;
   return [_userDefaults stringForKey:key];
 }
 

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
@@ -20,13 +20,65 @@ package io.invertase.firebase.firestore;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.FirebaseFirestoreSettings;
 import com.google.firebase.firestore.Query;
 
+import java.util.HashMap;
+
+import io.invertase.firebase.common.UniversalFirebasePreferences;
+
 public class UniversalFirebaseFirestoreCommon {
+  private static HashMap<String, Boolean> settingsLock = new HashMap<>();
 
   static FirebaseFirestore getFirestoreForApp(String appName) {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
-    return FirebaseFirestore.getInstance(firebaseApp);
+
+    FirebaseFirestore instance = FirebaseFirestore.getInstance(firebaseApp);
+    setFirestoreSettings(instance, appName);
+
+    return instance;
+  }
+
+  private static void setFirestoreSettings(FirebaseFirestore firebaseFirestore, String appName) {
+    // Ensure not already been set
+    if (settingsLock.containsKey(appName)) return;
+
+    UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
+    FirebaseFirestoreSettings.Builder firestoreSettings = new FirebaseFirestoreSettings.Builder();
+
+    int cacheSizeBytes = preferences.getIntValue(
+      UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + appName,
+      (int) firebaseFirestore.getFirestoreSettings().getCacheSizeBytes()
+    );
+
+    String host = preferences.getStringValue(
+      UniversalFirebaseFirestoreStatics.FIRESTORE_HOST + "_" + appName,
+      firebaseFirestore.getFirestoreSettings().getHost()
+    );
+
+    boolean persistence = preferences.getBooleanValue(
+      UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + appName,
+      firebaseFirestore.getFirestoreSettings().isPersistenceEnabled()
+    );
+
+    boolean ssl = preferences.getBooleanValue(
+      UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + appName,
+      firebaseFirestore.getFirestoreSettings().isSslEnabled()
+    );
+
+    firestoreSettings.setCacheSizeBytes(cacheSizeBytes);
+    firestoreSettings.setHost(host);
+    firestoreSettings.setPersistenceEnabled(persistence);
+    firestoreSettings.setSslEnabled(ssl);
+
+    try {
+      firebaseFirestore.setFirestoreSettings(firestoreSettings.build());
+    } catch (Exception exception) {
+      throw exception;
+    }
+
+    settingsLock.put(appName, true);
   }
 
   static Query getQueryForFirestore(

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
@@ -67,16 +67,17 @@ public class UniversalFirebaseFirestoreCommon {
       firebaseFirestore.getFirestoreSettings().isSslEnabled()
     );
 
-    firestoreSettings.setCacheSizeBytes(cacheSizeBytes);
+    if (cacheSizeBytes == -1) {
+      firestoreSettings.setCacheSizeBytes(FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED);
+    } else {
+      firestoreSettings.setCacheSizeBytes((long) cacheSizeBytes);
+    }
+
     firestoreSettings.setHost(host);
     firestoreSettings.setPersistenceEnabled(persistence);
     firestoreSettings.setSslEnabled(ssl);
 
-    try {
-      firebaseFirestore.setFirestoreSettings(firestoreSettings.build());
-    } catch (Exception exception) {
-      throw exception;
-    }
+    firebaseFirestore.setFirestoreSettings(firestoreSettings.build());
 
     settingsLock.put(appName, true);
   }

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
@@ -23,6 +23,7 @@ import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
 import io.invertase.firebase.common.UniversalFirebaseModule;
+import io.invertase.firebase.common.UniversalFirebasePreferences;
 
 import java.util.Map;
 import java.util.Objects;
@@ -45,45 +46,40 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
 
   Task<Void> settings(String appName, Map<String, Object> settings) {
     return Tasks.call(getExecutor(), () -> {
-      FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
-      FirebaseFirestoreSettings.Builder firestoreSettings = new FirebaseFirestoreSettings.Builder();
-
       // settings.cacheSizeBytes
       if (settings.containsKey("cacheSizeBytes")) {
         Double cacheSizeBytesDouble = (Double) settings.get("cacheSizeBytes");
-        int cacheSizeBytes = cacheSizeBytesDouble.intValue();
 
-        if (cacheSizeBytes == -1) {
-          firestoreSettings.setCacheSizeBytes(FirebaseFirestoreSettings.CACHE_SIZE_UNLIMITED);
-        } else {
-          firestoreSettings.setCacheSizeBytes(cacheSizeBytes);
-        }
-      } else {
-        firestoreSettings.setCacheSizeBytes(firebaseFirestore.getFirestoreSettings().getCacheSizeBytes());
+        UniversalFirebasePreferences.getSharedInstance().setIntValue(
+          UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + appName,
+          Objects.requireNonNull(cacheSizeBytesDouble).intValue()
+        );
       }
 
       // settings.host
       if (settings.containsKey("host")) {
-        firestoreSettings.setHost((String) Objects.requireNonNull(settings.get("host")));
-      } else {
-        firestoreSettings.setHost(firebaseFirestore.getFirestoreSettings().getHost());
+        UniversalFirebasePreferences.getSharedInstance().setStringValue(
+          UniversalFirebaseFirestoreStatics.FIRESTORE_HOST + "_" + appName,
+          (String) settings.get("host")
+        );
       }
 
       // settings.persistence
       if (settings.containsKey("persistence")) {
-        firestoreSettings.setPersistenceEnabled((boolean) settings.get("persistence"));
-      } else {
-        firestoreSettings.setPersistenceEnabled(firebaseFirestore.getFirestoreSettings().isPersistenceEnabled());
+        UniversalFirebasePreferences.getSharedInstance().setBooleanValue(
+          UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + appName,
+          (boolean) settings.get("persistence")
+        );
       }
 
       // settings.ssl
       if (settings.containsKey("ssl")) {
-        firestoreSettings.setSslEnabled((boolean) settings.get("ssl"));
-      } else {
-        firestoreSettings.setSslEnabled(firebaseFirestore.getFirestoreSettings().isSslEnabled());
+        UniversalFirebasePreferences.getSharedInstance().setBooleanValue(
+          UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + appName,
+          (boolean) settings.get("ssl")
+        );
       }
 
-      firebaseFirestore.setFirestoreSettings(firestoreSettings.build());
       return null;
     });
   }

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreStatics.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreStatics.java
@@ -1,0 +1,25 @@
+package io.invertase.firebase.firestore;
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+public class UniversalFirebaseFirestoreStatics {
+  public static String FIRESTORE_CACHE_SIZE = "firebase_firestore_cache_size";
+  public static String FIRESTORE_HOST = "firebase_firestore_host";
+  public static String FIRESTORE_PERSISTENCE = "firebase_firestore_persistence";
+  public static String FIRESTORE_SSL = "firebase_firestore_ssl";
+}

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
@@ -20,8 +20,8 @@
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <React/RCTBridgeModule.h>
 #import <RNFBFirestoreQuery.h>
-#import <RNFBFirestoreCommon.h>
-#import <RNFBFirestoreSerialize.h>
+#import "RNFBFirestoreCommon.h"
+#import "RNFBFirestoreSerialize.h"
 
 static NSString *const KEY_INCLUDE_METADATA_CHANGES = @"includeMetadataChanges";
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -30,7 +30,7 @@ static NSString *const RNFB_FIRESTORE_COLLECTION_SYNC = @"firestore_collection_s
 RCT_EXPORT_MODULE();
 
 - (dispatch_queue_t)methodQueue {
-  return dispatch_queue_create("io.invertase.firebase.firestore", DISPATCH_QUEUE_SERIAL);
+  return [RNFBFirestoreCommon getFirestoreQueue];
 }
 
 + (BOOL)requiresMainQueueSetup {

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
@@ -21,7 +21,11 @@
 
 @interface RNFBFirestoreCommon : NSObject
 
++ (dispatch_queue_t)getFirestoreQueue;
+
 + (FIRFirestore *)getFirestoreForApp:(FIRApp *)firebaseApp;
+
++ (void)setFirestoreSettings:(FIRFirestore *)firestore appName:(NSString *)appName;
 
 + (FIRDocumentReference *)getDocumentForFirestore:(FIRFirestore *)firestore path:(NSString *)path;
 
@@ -32,3 +36,8 @@
 + (NSArray *)getCodeAndMessage:(NSError *)error;
 
 @end
+
+extern NSString *const FIRESTORE_CACHE_SIZE;
+extern NSString *const FIRESTORE_HOST;
+extern NSString *const FIRESTORE_PERSISTENCE;
+extern NSString *const FIRESTORE_SSL;

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.h
@@ -19,8 +19,8 @@
 #import <Firebase/Firebase.h>
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <React/RCTBridgeModule.h>
-#import <RNFBFirestoreCommon.h>
-#import <RNFBFirestoreSerialize.h>
+#import "RNFBFirestoreCommon.h"
+#import "RNFBFirestoreSerialize.h"
 
 @interface RNFBFirestoreDocumentModule : NSObject <RCTBridgeModule>
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -30,7 +30,7 @@ static NSString *const RNFB_FIRESTORE_DOCUMENT_SYNC = @"firestore_document_sync_
 RCT_EXPORT_MODULE();
 
 - (dispatch_queue_t)methodQueue {
-  return dispatch_queue_create("io.invertase.firebase.firestore", DISPATCH_QUEUE_SERIAL);
+  return [RNFBFirestoreCommon getFirestoreQueue];
 }
 
 + (BOOL)requiresMainQueueSetup {

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.h
@@ -20,8 +20,8 @@
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <React/RCTBridgeModule.h>
 #import <RNFBFirestoreQuery.h>
-#import <RNFBFirestoreCommon.h>
-#import <RNFBFirestoreSerialize.h>
+#import "RNFBFirestoreSerialize.h"
+#import "RNFBFirestoreCommon.h"
 
 @interface RNFBFirestoreTransactionModule : NSObject <RCTBridgeModule>
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -44,7 +44,7 @@ RCT_EXPORT_MODULE();
 }
 
 - (dispatch_queue_t)methodQueue {
-  return dispatch_queue_create("io.invertase.firebase.firestore", DISPATCH_QUEUE_SERIAL);
+  return [RNFBFirestoreCommon getFirestoreQueue];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
Currently calling settings multiple times or after usage throws an error/warning. This moves it off to shared prefs and sets the latest settings the first time the app is requested.