### PR TITLE
Fix daily notifications to respect fireDate day

### DIFF
--- a/ios/RNFirebase/notifications/RNFirebaseNotifications.m
+++ b/ios/RNFirebase/notifications/RNFirebaseNotifications.m
@@ -222,7 +222,7 @@ didReceiveNotificationResponse:(UNNotificationResponse *)response
          withCompletionHandler:(void(^)())completionHandler NS_AVAILABLE_IOS(10_0) {
 #endif
      NSDictionary *message = [self parseUNNotificationResponse:response];
-           
+
      NSString *handlerKey = message[@"notification"][@"notificationId"];
 
      [self sendJSEvent:self name:NOTIFICATIONS_NOTIFICATION_OPENED body:message];
@@ -577,7 +577,7 @@ RCT_EXPORT_METHOD(jsInitialised:(RCTPromiseResolveBlock)resolve rejecter:(RCTPro
             } else if ([interval isEqualToString:@"hour"]) {
                 calendarUnit = NSCalendarUnitMinute | NSCalendarUnitSecond;
             } else if ([interval isEqualToString:@"day"]) {
-                calendarUnit = NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
+                calendarUnit = NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
             } else if ([interval isEqualToString:@"week"]) {
                 calendarUnit = NSCalendarUnitWeekday | NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond;
             } else {


### PR DESCRIPTION
Fixes #2490 

### Summary

This solves the fact that daily local notifications do not respect the day of the fireDate.
For example, when setting up a daily scheduled local notification starting tomorrow, it ignores the day and starts today.

### Checklist

- [ ] Supports `Android`
- [X] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

I did not make or update any test as there doesn't seem to have any for this logic. 

### Release Plan

[IOS][BUGFIX] [NOTIFICATIONS] - Fixes daily scheduled notification ignoring fireDate's day

---
