### PR TITLE
Update links() to dynamicLinks() in Typescript in v6

### DIFF
--- a/packages/dynamic-links/lib/index.d.ts
+++ b/packages/dynamic-links/lib/index.d.ts
@@ -551,11 +551,11 @@ declare module '@react-native-firebase/app' {
     import FirebaseModuleWithStatics = ReactNativeFirebase.FirebaseModuleWithStatics;
 
     interface Module {
-      links: FirebaseModuleWithStatics<DynamicLinks.Module, DynamicLinks.Statics>;
+      dynamicLinks: FirebaseModuleWithStatics<DynamicLinks.Module, DynamicLinks.Statics>;
     }
 
     interface FirebaseApp {
-      links(): DynamicLinks.Module;
+      dynamicLinks(): DynamicLinks.Module;
     }
   }
 }


### PR DESCRIPTION
The type declarations had been updated for flow to reflect the updated file, but not in Typescript

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


<!-- 🚨 PLEASE SEND PRs TO THE v5.x.x BRANCH AND NOT MASTER - THANKS 🚨 -->

### Summary

Typings are incorrect for v6 dynamic-links

### Checklist

- [ ] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [ ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [X] Typescript types updated

### Test Plan

In a Typescript React Native project
```
yarn add @react-native-firebase/app @react-native-firebase/dynamic-links
```

Add code to a file with
```
import { firebase } from '@react-native-firebase/app';

firebase.dynamicLinks();
```

Run `tsc` or build that single file

### Release Plan

N/A

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
