### PR TITLE
docs(ios): extra Pod repo update step incase 'cli init' fails

### DIFF
--- a/pages/quick-start/new-project.md
+++ b/pages/quick-start/new-project.md
@@ -14,11 +14,11 @@ The following npx command will create a new directory on your machine with the `
 ```bash
 npx @react-native-community/cli init --template=@react-native-firebase/template <name>
 ```
-> If the `cli init` script fails while performing the `pod install` phase (fails with `could not find spec` or similar), try the following step:
->```bash
->$ cd ./<name>/ios
->$ pod update (or pod install --repo-update)
->```
+If the `cli init` script fails while performing the `pod install` phase (fails with `could not find spec` or similar), try the following step:
+```bash
+$ cd ./<name>/ios
+$ pod update (or pod install --repo-update)
+```
 
 For example, to install a new `TodoApp` on your machine and start the Android app:
 

--- a/pages/quick-start/new-project.md
+++ b/pages/quick-start/new-project.md
@@ -14,6 +14,11 @@ The following npx command will create a new directory on your machine with the `
 ```bash
 npx @react-native-community/cli init --template=@react-native-firebase/template <name>
 ```
+> In case `cli init` script fails while performing `pod install`, follow next step:
+>```bash
+>$ cd ./<name>/ios
+>$ pod update (or pod install --repo-update)
+>```
 
 For example, to install a new `TodoApp` on your machine and start the Android app:
 

--- a/pages/quick-start/new-project.md
+++ b/pages/quick-start/new-project.md
@@ -14,7 +14,7 @@ The following npx command will create a new directory on your machine with the `
 ```bash
 npx @react-native-community/cli init --template=@react-native-firebase/template <name>
 ```
-> In case `cli init` script fails while performing `pod install`, follow next step:
+> If the `cli init` script fails while performing the `pod install` phase (fails with `could not find spec` or similar), try the following step:
 >```bash
 >$ cd ./<name>/ios
 >$ pod update (or pod install --repo-update)


### PR DESCRIPTION
Getting started guide claims one can start new RN project with react-native-firebase integrated with next template:
`npx @react-native-community/cli init --template=@react-native-firebase/template <name>`

Latest react-native cli init will try running pod install automatically.

In case user performing install has not updated cocoapods repo index for a while, pod install will fail due to latest Firebase modules version are not found in current cocoapods repo.

@mikehardy filed an issue  to _cli_ repo https://github.com/react-native-community/cli/issues/752
until its resolved, we can update docs with extra step that solves the issue.

Solution is to run 'pod update' or 'pod install --repo-update' manually after 'cli init' fails

### Checklist

- [ ] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in [/tests/e2e/\*](/tests/e2e)
- [x ] Updated the documentation in the [docs repo](https://github.com/invertase/react-native-firebase-docs)
  - **LINK TO DOCS PR HERE**
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan


### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[CATEGORY][type] [LOCATION] - Message

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
