### PR TITLE
docs(*): change `@import Firebase` to `#import <Firebase.h>`

### DIFF
--- a/pages/quick-start/ios-firebase-credentials.md
+++ b/pages/quick-start/ios-firebase-credentials.md
@@ -39,7 +39,7 @@ Next we need to initialize the Firebase service manually. To do this, open the A
 At the top of the file import the Firebase module:
 
 ```objectivec
-@import Firebase;
+#import <Firebase.h>
 ```
 
 Within the `didFinishLaunchingWithOptions` method, add the `configure` method:


### PR DESCRIPTION
`@import Firebase` requires enabling Modules in Xcode. By using this syntax `#import <Firebase.h>` it would save some time for people not to google why `@import` is not working.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
