### PR TITLE
Fix v5.x.x build.gradle fallback

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -189,7 +189,7 @@ dependencies {
   def supportLibVersion = safeExtGet('supportLibVersion', '28.0.0')
   def supportLibMajorVersion = supportLibVersion.split('\\.')[0] as int
   def supportV4LibName =  (supportLibMajorVersion < 20) ? "androidx.legacy:legacy-support-v4" : "com.android.support:support-v4"
-  def supportV4Version = safeExtGet('supportV4Version', safeExtGet('supportLibVersion', '$supportVersion'))
+  def supportV4Version = safeExtGet('supportV4Version', supportLibVersion)
   api "$supportV4LibName:$supportV4Version"
 
   // For React Native Firebase Notifications


### PR DESCRIPTION
I'm not too familiar with Gradle/Groovy, but this line was giving me errors when I tried to leave both `supportLibVersion` and `supportV4Version` unspecified.  I think there were multiple issues with the way it's written:

1. It refers to `supportVersion` which isn't specified anywhere (probably meant `supportLibVersion`?)
2. No need for a `safeExtGet` for that value as it's already done a few lines above.
3. The fallback value is getting recognised as literally `$supportVersion`, without substitution, because it's wrapped in single quotes rather than double.