### PR TITLE
Fix exception caused by a race condition in the database module on iOS

### DIFF
--- a/ios/RNFirebase/database/RNFirebaseDatabase.m
+++ b/ios/RNFirebase/database/RNFirebaseDatabase.m
@@ -96,11 +96,11 @@ RCT_EXPORT_METHOD(transactionStart:(NSString *)appDisplayName
                   path:(NSString *)path
                   transactionId:(nonnull NSNumber *)transactionId
                   applyLocally:(BOOL)applyLocally) {
+    FIRDatabaseReference *ref = [self getReferenceForAppPath:appDisplayName dbURL:dbURL path:path];
     dispatch_async(_transactionQueue, ^{
         NSMutableDictionary *transactionState = [NSMutableDictionary new];
         dispatch_semaphore_t sema = dispatch_semaphore_create(0);
         transactionState[@"semaphore"] = sema;
-        FIRDatabaseReference *ref = [self getReferenceForAppPath:appDisplayName dbURL:dbURL path:path];
 
         [ref runTransactionBlock:^FIRTransactionResult *_Nonnull (FIRMutableData *_Nonnull currentData) {
             dispatch_barrier_async(_transactionQueue, ^{


### PR DESCRIPTION
### Summary

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

I came across a race condition while working on our app: https://github.com/celo-org/celo-monorepo/tree/master/packages/mobile

The exception raised is `createRepo called for Repo that already exists.` in `FRepoManager.m`

It happens when using a transaction and db listener at the same time after initializing firebase.
https://github.com/celo-org/celo-monorepo/blob/833c2d3d2341185dc141aec901c9b2828e776de6/packages/mobile/src/firebase/firebase.ts#L21

<details>
<summary>Exception stacktrace</summary>
<pre>
Exception 'createRepo called for Repo that already exists.' was thrown while invoking on on target RNFirebaseDatabase with params (
    "[DEFAULT]",
    "https://celo-org-mobile-int.firebaseio.com/",
        {
        appName = "[DEFAULT]";
        eventType = value;
        hasCancellationCallback = 0;
        key = "$https://celo-org-mobile-int.firebaseio.com/$/.info/serverTimeOffset${}";
        modifiers =         (
        );
        path = ".info/serverTimeOffset";
        registration =         {
            eventRegistrationKey = "$https://celo-org-mobile-int.firebaseio.com/$/.info/serverTimeOffset${}$0$value";
            key = "$https://celo-org-mobile-int.firebaseio.com/$/.info/serverTimeOffset${}";
            registrationCancellationKey = "$https://celo-org-mobile-int.firebaseio.com/$/.info/serverTimeOffset${}$0$value$cancelled";
        };
    }
)
callstack: (
  0   CoreFoundation                      0x0000000108c058db __exceptionPreprocess + 331
  1   libobjc.A.dylib                     0x0000000107d6aac5 objc_exception_throw + 48
  2   CoreFoundation                      0x0000000108c05735 +[NSException raise:format:] + 197
  3   celo                                0x0000000101d0782e +[FRepoManager createRepo:config:database:] + 878
  4   celo                                0x0000000101cba88c -[FIRDatabase ensureRepo] + 188
  5   celo                                0x0000000101cb9c78 -[FIRDatabase reference] + 40
  6   celo                                0x0000000101e5c740 -[RNFirebaseDatabaseReference buildQueryAtPathWithModifiers:modifiers:] + 208
  7   celo                                0x0000000101e5b129 -[RNFirebaseDatabaseReference initWithPathAndModifiers:appDisplayName:dbURL:key:refPath:modifiers:] + 521
  8   celo                                0x0000000101e59979 -[RNFirebaseDatabase getCachedInternalReferenceForApp:dbURL:props:] + 393
  9   celo                                0x0000000101e58f4b -[RNFirebaseDatabase on:dbURL:props:] + 155
  10  CoreFoundation                      0x0000000108c0c6ac __invoking___ + 140
  11  CoreFoundation                      0x0000000108c09c25 -[NSInvocation invoke] + 325
  12  CoreFoundation                      0x0000000108c0a076 -[NSInvocation invokeWithTarget:] + 54
  13  React                               0x0000000106f7283a -[RCTModuleMethod invokeWithBridge:module:arguments:] + 2810
  14  React                               0x0000000106f7f026 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 790
  15  React                               0x0000000106f7eb33 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 131
  16  React                               0x0000000106f7eaa9 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 25
  17  libdispatch.dylib                   0x000000010a34fd7f _dispatch_call_block_and_release + 12
  18  libdispatch.dylib                   0x000000010a350db5 _dispatch_client_callout + 8
  19  libdispatch.dylib                   0x000000010a358225 _dispatch_lane_serial_drain + 778
  20  libdispatch.dylib                   0x000000010a358e9c _dispatch_lane_invoke + 425
  21  libdispatch.dylib                   0x000000010a362ea3 _dispatch_workloop_worker_thread + 733
  22  libsystem_pthread.dylib             0x000000010a739611 _pthread_wqthread + 421
  23  libsystem_pthread.dylib             0x000000010a7393fd start_wqthread + 13
</pre>
</details>

It looks like we have to get the firebase database reference from the same
thread/queue otherwise we have a race condition leading to that exception.

Here are screenshots showing the race condition captured while debugging the app.
You can see the 2 different code paths calling `createRepo:` from 2 different threads racing to cause the exception.

**first the transaction**
![Screenshot 2019-10-15 at 15 55 15](https://user-images.githubusercontent.com/57791/66861492-6546a080-ef8f-11e9-99ec-39b271526d03.png)
**second the db listener**
![Screenshot 2019-10-15 at 15 55 48](https://user-images.githubusercontent.com/57791/66848210-f65c4e00-ef74-11e9-814d-b9747a1145a2.png)

This might affect v6 but we haven't upgraded yet.

### Checklist

- [ ] Supports `Android`
- [x] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

Ran our app without this patch -> the exception is raised.
Ran our app with this patch -> no exception is raised and the app behaves correctly.

### Release Plan

[IOS] [BUGFIX] [DATABASE] - Fix race condition causing exception 'createRepo called for Repo that already exists.' to be raised when using transaction and db listener at roughly the same time.
