### PR TITLE
[v5] Check paths in Query.isEqual

### DIFF
--- a/src/modules/firestore/Query.js
+++ b/src/modules/firestore/Query.js
@@ -199,6 +199,13 @@ export default class Query {
       return false;
     }
 
+    if (
+      this._referencePath.relativeName !==
+      otherQuery._referencePath.relativeName
+    ) {
+      return false;
+    }
+
     if (this._fieldFilters.length !== otherQuery._fieldFilters.length) {
       return false;
     }

--- a/tests/e2e/firestore/query.e2e.js
+++ b/tests/e2e/firestore/query.e2e.js
@@ -1,7 +1,7 @@
 describe('firestore()', () => {
   describe('Query', () => {
     describe('isEqual()', () => {
-      it(`returns true if two Queries have the same .where and .orderBy calls`, () => {
+      it(`returns true if two Queries for the same collection have the same .where and .orderBy calls`, () => {
         const ref1 = firebase
           .firestore()
           .collection('foo')
@@ -15,6 +15,18 @@ describe('firestore()', () => {
           .where('baz', '!=', false)
           .orderBy('date', 'DESC');
         should.equal(ref1.isEqual(ref2), true);
+      });
+
+      it(`returns false if the two Queries are for different collections`, () => {
+        const ref1 = firebase
+          .firestore()
+          .collection('foo')
+          .where('bar', '==', true);
+        const ref2 = firebase
+          .firestore()
+          .collection('baz')
+          .where('bar', '==', true);
+        should.equal(ref1.isEqual(ref2), false);
       });
 
       it(`returns false if two Queries have different number of .where calls`, () => {


### PR DESCRIPTION
### Summary

`Query.isEqual` should return false when you compare two queries on different collections.

### Checklist

- [x] Supports `Android`
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

The plan is to wait and see if CI accepts the PR.

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[JS][BUGFIX] [firestore] - Query.isEqual now takes the collection path into consideration

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
