### PR TITLE
fix(vision): Improve null checks on iOS #2744

### DIFF
--- a/packages/ml-vision/ios/RNFBMLVision/RNFBMLVisionBarcodeDetectorModule.m
+++ b/packages/ml-vision/ios/RNFBMLVision/RNFBMLVisionBarcodeDetectorModule.m
@@ -116,38 +116,38 @@ RCT_EXPORT_METHOD(barcodeDetectorProcessImage:
 
 - (NSDictionary *)getEmailMap:(FIRVisionBarcodeEmail *)email {
   return @{
-      @"address": email.address,
-      @"body": email.body,
-      @"subject": email.subject,
+      @"address": email.address ?: (id) [NSNull null],
+      @"body": email.body ?: (id) [NSNull null],
+      @"subject": email.subject ?: (id) [NSNull null],
   };
 }
 
 - (NSDictionary *)getPhoneMap:(FIRVisionBarcodePhone *)phone {
   return @{
-      @"number": phone.number,
+      @"number": phone.number ?: (id) [NSNull null],
       @"type": @(phone.type),
   };
 }
 
 - (NSDictionary *)getSMSMap:(FIRVisionBarcodeSMS *)sms {
   return @{
-      @"message": sms.message,
-      @"phoneNumber": sms.phoneNumber,
+      @"message": sms.message ?: (id) [NSNull null],
+      @"phoneNumber": sms.phoneNumber ?: (id) [NSNull null],
   };
 }
 
 - (NSDictionary *)getURLMap:(FIRVisionBarcodeURLBookmark *)url {
   return @{
-      @"title": url.title,
-      @"url": url.url,
+      @"title": url.title ?: (id) [NSNull null],
+      @"url": url.url ?: (id) [NSNull null],
   };
 }
 
 - (NSDictionary *)getWiFiMap:(FIRVisionBarcodeWiFi *)wifi {
   return @{
       @"encryptionType": @(wifi.type),
-      @"password": wifi.password,
-      @"ssid": wifi.ssid,
+      @"password": wifi.password ?: (id) [NSNull null],
+      @"ssid": wifi.ssid ?: (id) [NSNull null],
   };
 }
 
@@ -157,27 +157,27 @@ RCT_EXPORT_METHOD(barcodeDetectorProcessImage:
 
 - (NSDictionary *)getPersonNameMap:(FIRVisionBarcodePersonName *)name {
   return @{
-      @"first": name.first,
-      @"formatted": name.formattedName,
-      @"last": name.last,
-      @"middle": name.middle,
-      @"prefix": name.prefix,
-      @"pronunciation": name.pronounciation,
-      @"suffix": name.suffix,
+      @"first": name.first ?: (id) [NSNull null],
+      @"formatted": name.formattedName ?: (id) [NSNull null],
+      @"last": name.last ?: (id) [NSNull null],
+      @"middle": name.middle ?: (id) [NSNull null],
+      @"prefix": name.prefix ?: (id) [NSNull null],
+      @"pronunciation": name.pronounciation ?: (id) [NSNull null],
+      @"suffix": name.suffix ?: (id) [NSNull null],
   };
 }
 
 - (NSDictionary *)getAddressMap:(FIRVisionBarcodeAddress *)address {
   return @{
-      @"lines": address.addressLines,
+      @"lines": address.addressLines ?: @[],
       @"type": @(address.type),
   };
 }
 
 - (NSDictionary *)getContactInfoMap:(FIRVisionBarcodeContactInfo *)contactInfo {
   NSMutableDictionary *contactInfoFormatted = [@{
-      @"title": contactInfo.jobTitle,
-      @"organisation": contactInfo.organization,
+      @"title": contactInfo.jobTitle ?: (id) [NSNull null],
+      @"organisation": contactInfo.organization ?: (id) [NSNull null],
   } mutableCopy];
 
   // Name
@@ -226,31 +226,31 @@ RCT_EXPORT_METHOD(barcodeDetectorProcessImage:
 
 - (NSDictionary *)getCalendarEventMap:(FIRVisionBarcodeCalendarEvent *)event {
   return @{
-      @"description": event.description,
-      @"end": [RNFBSharedUtils getISO8601String:event.end],
-      @"location": event.location,
-      @"organizer": event.organizer,
-      @"start": [RNFBSharedUtils getISO8601String:event.start],
-      @"status": event.status,
-      @"summary": event.summary,
+      @"description": event.description ?: (id) [NSNull null],
+      @"end": event.end ? [RNFBSharedUtils getISO8601String:event.end] : (id) [NSNull null],
+      @"location": event.location ?: (id) [NSNull null],
+      @"organizer": event.organizer ?: (id) [NSNull null],
+      @"start": event.start ? [RNFBSharedUtils getISO8601String:event.start] : (id) [NSNull null],
+      @"status": event.status ?: (id) [NSNull null],
+      @"summary": event.summary ?: (id) [NSNull null],
   };
 }
 
 - (NSDictionary *)getDriverLicenseMap:(FIRVisionBarcodeDriverLicense *)license {
   return @{
-      @"addressCity": license.addressCity,
-      @"addressState": license.addressState,
-      @"addressZip": license.addressZip,
-      @"birthDate": license.birthDate,
-      @"documentType": license.documentType,
-      @"expiryDate": license.expiryDate,
-      @"firstName": license.firstName,
-      @"gender": license.gender,
-      @"issueDate": license.issuingDate,
-      @"issuingCountry": license.issuingCountry,
-      @"lastName": license.lastName,
-      @"licenseNumber": license.licenseNumber,
-      @"middleName": license.middleName,
+      @"addressCity": license.addressCity ?: (id) [NSNull null],
+      @"addressState": license.addressState ?: (id) [NSNull null],
+      @"addressZip": license.addressZip ?: (id) [NSNull null],
+      @"birthDate": license.birthDate ?: (id) [NSNull null],
+      @"documentType": license.documentType ?: (id) [NSNull null],
+      @"expiryDate": license.expiryDate ?: (id) [NSNull null],
+      @"firstName": license.firstName ?: (id) [NSNull null],
+      @"gender": license.gender ?: (id) [NSNull null],
+      @"issueDate": license.issuingDate ?: (id) [NSNull null],
+      @"issuingCountry": license.issuingCountry ?: (id) [NSNull null],
+      @"lastName": license.lastName ?: (id) [NSNull null],
+      @"licenseNumber": license.licenseNumber ?: (id) [NSNull null],
+      @"middleName": license.middleName ?: (id) [NSNull null],
   };
 }
 


### PR DESCRIPTION
Most of the barcode types have nullable properties, which were returning as `nil`, causing the app to crash if it hit them. This PR forces a check and returns `null` if they do not exist.