### PR TITLE
fix(database): Fix crash when removing listeners at RN reload

### DIFF
--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseQuery.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseQuery.m
@@ -130,7 +130,7 @@
 }
 
 - (void)removeAllEventListeners {
-  NSDictionary *listeners = [_listeners copy];
+  NSArray *listeners = [_listeners allKeys];
 
   for (NSString *eventRegistrationKey in listeners) {
     [self removeEventListener:eventRegistrationKey];

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseQuery.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseQuery.m
@@ -130,7 +130,9 @@
 }
 
 - (void)removeAllEventListeners {
-  for (NSString * eventRegistrationKey in _listeners) {
+  NSDictionary *listeners = [_listeners copy];
+
+  for (NSString *eventRegistrationKey in listeners) {
     [self removeEventListener:eventRegistrationKey];
   }
 }


### PR DESCRIPTION
### Summary
An exception is raised when removing listeners on iOS, for example onAuthChanged listener. This causes a crash when reloading application using the built-in reloading feature in React Native. The issue has been traced down to the following method: -[RNFBDatabaseQuery removeAllEventListeners]. Currently, this is what the code looks like:

```Objective-C
@interface RNFBDatabaseQuery
@property NSMutableDictionary *listeners;
/* ... */
@implementation RNFBDatabaseQuery

- (void)removeEventListener:(NSString *)eventRegistrationKey {
  FIRDatabaseHandle handle = (FIRDatabaseHandle)[_listeners[eventRegistrationKey] integerValue];
  if (handle) {
    [_query removeObserverWithHandle:handle];
    [_listeners removeObjectForKey:eventRegistrationKey]; // <= removes the value while still being in the 'for loop' in -[RNFBDatabaseQuery removeAllEventListeners]

  }
}

- (void)removeAllEventListeners {
  for (NSString* eventRegistrationKey in _listeners) {
    [self removeEventListener:eventRegistrationKey]; // <= call to remove value from dictionary
  }
}

/* ... */
@end

```

When -[RNFBDatabaseQuery removeAllEventListeners] is called, it enumerates through an NSDictionary object, and at the same time removes values from it when -[RNFBDatabaseQuery removeEventListener:] is called. This raises the following exception:

```
2019-10-23 21:24:25.969117+0200 TestApp[71196:231603] *** Terminating app due to uncaught exception 'NSGenericException', reason: '*** Collection <__NSDictionaryM: 0x600000eb1940> was mutated while being enumerated.'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff23b98bde __exceptionPreprocess + 350
	1   libobjc.A.dylib                     0x00007fff503b5b20 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff23b95ab0 +[__NSFastEnumerationEnumerator allocWithZone:] + 0
	3   TestApp                        0x000000010cb031f3 -[RNFBDatabaseQuery removeAllEventListeners] + 275
	4   TestApp                        0x000000010cb038c0 -[RNFBDatabaseQueryModule invalidate] + 400
	5   TestApp                        0x000000010cbbd3be
```

The issue was fixed by creating a copy of the keys of the dictionary before modifying it.
