### PR TITLE
Fix incorrect pod name in documentation.

### DIFF
--- a/docs/crashlytics/ios.md
+++ b/docs/crashlytics/ios.md
@@ -9,7 +9,7 @@ The following steps are only required if your environment does not have access t
 
 ## CocoaPods Installation
 
-### Add the RNFBFirestore Pod
+### Add the RNFBCrashlytics Pod
 
 Add the `RNFBCrashlytics`, `Fabric` & `Crashlytics` Pod to your projects `/ios/Podfile`:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


### Summary

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Changed the name of a Pod that the Crashlytics iOS installation guide references to be the correct one. I assume this was caused by copy-and-pasting.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
