### PR TITLE
fix(auth): Fix exception in PhoneAuthListener

### DIFF
--- a/packages/auth/lib/PhoneAuthListener.js
+++ b/packages/auth/lib/PhoneAuthListener.js
@@ -112,7 +112,10 @@ export default class PhoneAuthListener {
 
   _promiseDeferred() {
     if (!this._promise) {
-      this._promise = promiseDefer();
+      const { promise, resolve, reject } = promiseDefer();
+      this._promise = promise;
+      this._resolve = resolve;
+      this._reject = reject;
     }
   }
 


### PR DESCRIPTION
Fixes #2639

### Summary
promiseDefer was incorrectly used in PhoneAuthListener, causing an error reported by https://github.com/invertase/react-native-firebase/issues/2639#issuecomment-539963660

### Checklist

- [x ] Supports `Android`
- [ x] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated
