### PR TITLE
docs(in-app-messaging): fix typo in doc ios manual install

### DIFF
--- a/docs/in-app-messaging/ios.md
+++ b/docs/in-app-messaging/ios.md
@@ -15,7 +15,7 @@ Add the `RNFBFiam` Pod to your projects `/ios/Podfile`:
 ```ruby{3}
 target 'app' do
   ...
-  pod 'RNFBFiam', :path => '../node_modules/@react-native-firebase/in-app-messaging'
+  pod 'RNFBInAppMessaging', :path => '../node_modules/@react-native-firebase/in-app-messaging'
 end
 ```
 

--- a/docs/in-app-messaging/ios.md
+++ b/docs/in-app-messaging/ios.md
@@ -8,9 +8,9 @@ description: Manually integrateFirebase In-App Messaging into your iOS applicati
 > The following steps are only required if your environment does not have access to React Native
 > auto-linking.
 
-### Add the RNFBFiam Pod
+### Add the RNFBInAppMessaging Pod
 
-Add the `RNFBFiam` Pod to your projects `/ios/Podfile`:
+Add the `RNFBInAppMessaging` Pod to your projects `/ios/Podfile`:
 
 ```ruby{3}
 target 'app' do
@@ -21,7 +21,7 @@ end
 
 ### Update Pods & rebuild the project
 
-You may need to update your local Pods in order for the `RNFBFiam` Pod to be installed in your project:
+You may need to update your local Pods in order for the `RNFBInAppMessaging` Pod to be installed in your project:
 
 ```bash
 $ cd /ios/


### PR DESCRIPTION
### Summary

replaced the correct podspec `RNFBInAppMessaging`
```
[!] No podspec found for `RNFBFiam` in `../node_modules/@react-native-firebase/in-app-messaging`
```

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
