### PR TITLE
iOS Manual Linking for RNFBMessaging

### DIFF
--- a/docs/messaging/ios.md
+++ b/docs/messaging/ios.md
@@ -44,4 +44,29 @@ To integrate FCM for iOS, the following integration steps must be followed;
 > The following steps are only required if your environment does not have access to React Native
 > auto-linking.
 
-> TODO
+### Add the RNFBMessaging Pod
+
+Add the `RNFBMessaging` Pod to your projects `/ios/Podfile`:
+
+```ruby{3}
+target 'app' do
+  ...
+  pod 'RNFBMessaging', :path => '../node_modules/@react-native-firebase/messaging'
+end
+```
+
+### Update Pods & rebuild the project
+
+You may need to update your local Pods in order for the `RNFBMessaging` Pod to be installed in your project:
+
+```bash
+$ cd /ios/
+$ pod install --repo-update
+```
+
+Once the Pods have installed locally, rebuild your iOS project:
+
+```bash
+npx react-native run-ios
+```
+


### PR DESCRIPTION
### Summary

iOS Manual Linking for RNFBMessaging
Was missing

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
