### PR TITLE
docs(remote-config): fix a typo in doc RNFBRemoteConfig manual install

### DIFF
--- a/docs/remote-config/ios.md
+++ b/docs/remote-config/ios.md
@@ -8,20 +8,20 @@ description: Manually integrate Remote Config into your iOS application.
 > The following steps are only required if your environment does not have access to React Native
 > auto-linking.
 
-### Add the RNFBConfig Pod
+### Add the RNFBRemoteConfig Pod
 
-Add the `RNFBConfig` Pod to your projects `/ios/Podfile`:
+Add the `RNFBRemoteConfig` Pod to your projects `/ios/Podfile`:
 
 ```ruby{3}
 target 'app' do
   ...
-  pod 'RNFBConfig', :path => '../node_modules/@react-native-firebase/remote-config'
+  pod 'RNFBRemoteConfig', :path => '../node_modules/@react-native-firebase/remote-config'
 end
 ```
 
 ### Update Pods & rebuild the project
 
-You may need to update your local Pods in order for the `RNFBConfig` Pod to be installed in your project:
+You may need to update your local Pods in order for the `RNFBRemoteConfig` Pod to be installed in your project:
 
 ```bash
 $ cd /ios/


### PR DESCRIPTION
### Summary

replaced the correct podspec `RNFBRemoteConfig`

```
[!] No podspec found for `RNFBConfig` in `../node_modules/@react-native-firebase/remote-config`
```

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
