### PR TITLE
Load Android Gradle Plugin conditionally

### DIFF
--- a/packages/admob/android/build.gradle
+++ b/packages/admob/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/database/android/build.gradle
+++ b/packages/database/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/dynamic-links/android/build.gradle
+++ b/packages/dynamic-links/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.3.0'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/iid/android/build.gradle
+++ b/packages/iid/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/invites/android/build.gradle
+++ b/packages/invites/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/ml-natural-language/android/build.gradle
+++ b/packages/ml-natural-language/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/ml-vision/android/build.gradle
+++ b/packages/ml-vision/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -1,10 +1,16 @@
 buildscript {
-  repositories {
-    google()
-    jcenter()
-  }
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+  // The Android Gradle plugin is only required when opening the android folder stand-alone.
+  // This avoids unnecessary downloads and potential conflicts when the library is included as a
+  // module dependency in an application project.
+  if (project == rootProject) {
+    repositories {
+      google()
+      jcenter()
+    }
+
+    dependencies {
+      classpath("com.android.tools.build:gradle:3.5.2")
+    }
   }
 }
 

--- a/packages/template/project/android/build.gradle
+++ b/packages/template/project/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath 'com.google.gms:google-services:4.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.4.2'
+    classpath 'com.android.tools.build:gradle:3.5.2'
     classpath 'com.google.gms:google-services:4.3.0'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.3.0'


### PR DESCRIPTION
### Summary

This wraps the Android Gradle plugin dependency in the buildscripts section of android/build.gradle in a conditional:

```
if (project == rootProject) {
    // ... (dependency here)
}
```

The Android Gradle plugin is only required when opening the project stand-alone, not when it is included as a dependency. By doing this, the project opens correctly in Android Studio, and it can also be consumed as a native module dependency from an application project without affecting the app project (avoiding unnecessary downloads/conflicts/etc).

for more info, you can refer to [this thread](https://github.com/facebook/react-native/pull/25569) and especially [this comment.](https://github.com/facebook/react-native/pull/25569#issuecomment-532504277)

### Checklist

- [x] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

### Release Plan

[INTERNAL] [ENHANCEMENT] [ALL MODULES] - Load Android Gradle Plugin only when the android projects of each module opened as a stand-alone project in Android Studio.