### PR TITLE
[IOS][BUGFIX][ADMOB] - add new iOS framework search path (release)

### DIFF
--- a/ios/RNFirebase.xcodeproj/project.pbxproj
+++ b/ios/RNFirebase.xcodeproj/project.pbxproj
@@ -559,6 +559,7 @@
 					"$(SRCROOT)/../../../ios/Pods/FirebaseRemoteConfig/Frameworks",
 					"$(SRCROOT)/../../../ios/Pods/FirebaseStorage/Frameworks",
 					"$(SRCROOT)/../../../ios/Pods/Google-Mobile-Ads-SDK/Frameworks/frameworks",
+					"$(SRCROOT)/../../../ios/Pods/Google-Mobile-Ads-SDK/Frameworks/GoogleMobileAdsFramework-Current",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Do the same as https://github.com/invertase/react-native-firebase/pull/2414 for Release search paths

### Summary

Add new iOS framework search path for Release build

### Checklist

- [ ] Supports `Android`
- [x] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan
The same as https://github.com/invertase/react-native-firebase/pull/2414 but with Release builds

### Release Plan

[IOS][BUGFIX][ADMOB] - Add new iOS code path to Xcode project

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)