### PR TITLE
fix(analytics): Use correct add_to_cart event name

### DIFF
--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -223,7 +223,7 @@ class FirebaseAnalyticsModule extends FirebaseModule {
     validateCompound(object, 'value', 'currency', 'firebase.analytics().logAddToCart(*):');
 
     return this.logEvent(
-      'add_payment_info',
+      'add_to_cart',
       validateStruct(object, structs.AddToCart, 'firebase.analytics().logAddToCart(*):'),
     );
   }


### PR DESCRIPTION
triggering analytics().logAddToCart firebase event resulted in sending "addPaymentInfo" event to firebase analytics

### Summary

After inspecting source code its clear this was almost a "typo"  as "add_payment_info" is defined few lines above and it was probably a simple omission.

This is a simple bug - but crucial for anyone who tries to use more advanced ecommerce pre-defined firebase events (like adding/removing from cart etc. ecommerce funnels etc.).

Tested on Android - with my fix I can now send correct add_to_cart events which are then successfully registered in Firebase Analytics

### Checklist

- [X] Supports `Android`
- [X] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

-

### Release Plan

-

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
