### PR TITLE
fix(messaging,ios): hasPermission checks authorizationStatus

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -187,7 +187,7 @@ RCT_EXPORT_METHOD(hasPermission:
 ) {
   if (@available(iOS 10.0, *)) {
     [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *_Nonnull settings) {
-      BOOL hasPermission = [RCTConvert BOOL:@(settings.alertSetting == UNNotificationSettingEnabled)];
+      BOOL hasPermission = [RCTConvert BOOL:@(settings.authorizationStatus >= UNAuthorizationStatusAuthorized)];
       resolve(@(hasPermission));
     }];
   } else {


### PR DESCRIPTION
### Summary

hasPermission checked if alert notification enabled and returned false on iOS 12 and up when provisional permission granted or Notification Center is enabled. This PR changes hasPermission to check authorizationStatus is equal to or above UNAuthorizationStatusAuthorized (value is 2), because it might be a UNAuthorizationStatusProvisional(value is 3).

Previously, on iOS 12 requestPermission would return true, but hasPermission returned false. This PR fixes it, and both return true.

See https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications

### Checklist

- [ ] Supports `Android`
- [x] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

<!-- Demonstrate the code is solid. -->
<!-- Example: The exact testing commands you ran and their final output (e.g. screenshot of test summary). -->
<!-- Example: Screenshots / videos if the pull request changes UI related code such as Notifications or Admob -->

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[CATEGORY][type] [LOCATION] - Message

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
