### PR TITLE
fix(admob): add null checks for getCurrentActivity() usages

### DIFF
--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
@@ -63,6 +63,13 @@ public class ReactNativeFirebaseAdMobInterstitialModule extends ReactNativeFireb
 
   @ReactMethod
   public void interstitialLoad(int requestId, String adUnitId, ReadableMap adRequestOptions) {
+    if (getCurrentActivity() == null) {
+      WritableMap error = Arguments.createMap();
+      error.putString("code", "null-activity");
+      error.putString("message", "Interstitial ad attempted to load but the current Activity was null.");
+      sendInterstitialEvent(AD_ERROR, requestId, adUnitId, error);
+      return;
+    }
     getCurrentActivity().runOnUiThread(() -> {
       InterstitialAd interstitialAd = new InterstitialAd(getApplicationContext());
       interstitialAd.setAdUnitId(adUnitId);
@@ -112,6 +119,10 @@ public class ReactNativeFirebaseAdMobInterstitialModule extends ReactNativeFireb
 
   @ReactMethod
   public void interstitialShow(int requestId, ReadableMap showOptions, Promise promise) {
+    if (getCurrentActivity() == null) {
+      rejectPromiseWithCodeAndMessage(promise, "null-activity", "Interstitial ad attempted to show but the current Activity was null.");
+      return;
+    }
     getCurrentActivity().runOnUiThread(() -> {
       InterstitialAd interstitialAd = interstitialAdArray.get(requestId);
 

--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
@@ -50,6 +50,13 @@ public class ReactNativeFirebaseAdMobRewardedModule extends ReactNativeFirebaseM
 
   @ReactMethod
   public void rewardedLoad(int requestId, String adUnitId, ReadableMap adRequestOptions) {
+    if (getCurrentActivity() == null) {
+      WritableMap error = Arguments.createMap();
+      error.putString("code", "null-activity");
+      error.putString("message", "Rewarded ad attempted to load but the current Activity was null.");
+      sendRewardedEvent(AD_ERROR, requestId, adUnitId, error, null);
+      return;
+    }
     getCurrentActivity().runOnUiThread(() -> {
       RewardedAd rewardedAd = new RewardedAd(getApplicationContext(), adUnitId);
 
@@ -80,6 +87,10 @@ public class ReactNativeFirebaseAdMobRewardedModule extends ReactNativeFirebaseM
 
   @ReactMethod
   public void rewardedShow(int requestId, String adUnitId, ReadableMap showOptions, Promise promise) {
+    if (getCurrentActivity() == null) {
+      rejectPromiseWithCodeAndMessage(promise, "null-activity", "Rewarded ad attempted to show but the current Activity was null.");
+      return;
+    }
     getCurrentActivity().runOnUiThread(() -> {
       RewardedAd rewardedAd = rewardedAdArray.get(requestId);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


### Summary

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This fixes issue #2912 
Ideally, `interstitialLoad()` and `rewardedLoad()` would return a promise that can be rejected in case that the Activity is null (or any other required condition is not met). I did not want to make any API changes though, so, for now, I've resorted to dispatching an error event with a custom message when the Activity is null.

I've already tested the code and it's being used in a production app. If `getCurrentActivity()` returns null, both "load" calls send the error event correctly, and both "show" calls reject the promise correctly and then exit the method.

### Checklist

- [x] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

<!-- Demonstrate the code is solid. -->
<!-- Example: The exact testing commands you ran and their final output (e.g. screenshot of test summary). -->
<!-- Example: Screenshots / videos if the pull request changes UI related code such as Notifications or Admob -->

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[CATEGORY][type] [LOCATION] - Message

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
