### PR TITLE
Update ios-setup.md

### DIFF
--- a/docs/crashlytics/ios-setup.md
+++ b/docs/crashlytics/ios-setup.md
@@ -7,26 +7,8 @@ description: Additional iOS steps for Crashlytics integration.
 
 ## Additional Installation Steps
 
-### Add the Crashlytics run script
+Get into the `ios` folder and run `pod install`.
 
-Crashlytics for iOS requires an additional manual step once the NPM package has been installed.
-You'll need XCode for the following steps.
-
-Open your project in XCode, and select the project file in the Navigator. Select the 'Build Phases' tab &
-add a 'New Run Script Phase':
-
-![Run Script](https://prismic-io.s3.amazonaws.com/invertase%2F96f32c96-0aca-4054-bf30-bd2448ca2462_new+project.png)
-
-In the new build phase, add a new script into the text box:
-
-```
-"${PODS_ROOT}/Fabric/run"
-```
-
-![Script](https://prismic-io.s3.amazonaws.com/invertase%2Ff06cf5b3-884e-4cbc-8c3d-81072a254f1d_new+project+%281%29.png)
-
-Once added, rebuild your project:
-
-```bash
-npx react-native run-ios
-```
+This will create appropriate script in your Target Build Phases:
+- [CP-User] [RNFB] Core Configuration
+- [CP-User] [RNFB] Crashlytics Configuration


### PR DESCRIPTION
### Summary

Currently the documentation ask to add a custom build phase, but pod install currently do this using:
```
pod install
Adding a custom script phase for Pod RNFBApp: [RNFB] Core Configuration
Adding a custom script phase for Pod RNFBCrashlytics: [RNFB] Crashlytics Configuration
Detected React Native module pods for RNCMaskedView, RNFBApp, RNFBCrashlytics, RNGestureHandler, RNReanimated, RNScreens, and react-native-safe-area-context
```

So I updated the documentation accordingly. :)

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[GENERAL][ENHANCEMENT] [DOCUMENTATION] - Improved IOS documentation for Crashlytics with IOS.

---
