### PR TITLE
Add JS in bug report for package.json/firebase.json

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -42,6 +42,23 @@ Describe your issue here
 
 <!-- ADD THE CONTENTS OF THE FILES IN THE PROVIDED CODE BLOCKS BELOW -->
 
+### Javascript
+
+<details><summary>Click To Expand</summary>
+<p>
+
+#### `package.json`:
+
+```json
+# N/A
+```
+
+#### `firebase.json` for react-native-firebase v6:
+
+```json
+# N/A
+```
+
 ### iOS
 
 <details><summary>Click To Expand</summary>


### PR DESCRIPTION
For v6 I really need to see firebase.json and package.json  or I don't know what versions people are running anymore as they aren't in the other files