### PR TITLE
docs(auth): fix incorrect auth credential example

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -64,7 +64,7 @@ export namespace FirebaseAuthTypes {
    * const provider = firebase.auth.EmailAuthProvider;
    * const authCredential = provider.credential('foo@bar.com', '123456');
    *
-   * await firebase.auth().linkWithCredential(authCredential);
+   * await firebase.auth().signInWithCredential(authCredential);
    * ```
    */
   export interface AuthCredential {


### PR DESCRIPTION
This one had me confused for quite a bit myself.