### PR TITLE
Fixes default re-export syntax

### DIFF
--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -23,8 +23,8 @@ export * from './path';
 export * from './promise';
 export * from './validate';
 
-export Base64 from './Base64';
-export ReferenceBase from './ReferenceBase';
+export { default as Base64 } from './Base64';
+export { default as ReferenceBase } from './ReferenceBase';
 
 export function getDataUrlParts(dataUrlString) {
   const isBase64 = dataUrlString.includes(';base64');


### PR DESCRIPTION
### Summary
This export is not valid when being parsed by typescript or webpack. The updated version is equivalent.
