### PR TITLE
feat(auth): add initial support for Apple auth provider

### DIFF
--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -878,6 +878,8 @@ RCT_EXPORT_METHOD(verifyPasswordResetCode:
     credential = [FIRFacebookAuthProvider credentialWithAccessToken:authToken];
   } else if ([provider compare:@"google.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIRGoogleAuthProvider credentialWithIDToken:authToken accessToken:authTokenSecret];
+  } else if ([provider compare:@"apple.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+    credential = [FIROAuthProvider credentialWithProviderID:provider IDToken:authToken rawNonce:authTokenSecret];
   } else if ([provider compare:@"password" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIREmailAuthProvider credentialWithEmail:authToken password:authTokenSecret];
   } else if ([provider compare:@"emailLink" options:NSCaseInsensitiveSearch] == NSOrderedSame) {

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -214,6 +214,16 @@ export namespace FirebaseAuthTypes {
      */
     GoogleAuthProvider: AuthProvider;
     /**
+     * Apple auth provider implementation.
+     *
+     * #### Example
+     *
+     * ```js
+     * firebase.auth.AppleAuthProvider;
+     * ```
+     */
+    AppleAuthProvider: AuthProvider;
+    /**
      * Github auth provider implementation.
      *
      * #### Example

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -30,11 +30,13 @@ import GoogleAuthProvider from './providers/GoogleAuthProvider';
 import OAuthProvider from './providers/OAuthProvider';
 import PhoneAuthProvider from './providers/PhoneAuthProvider';
 import TwitterAuthProvider from './providers/TwitterAuthProvider';
+import AppleAuthProvider from './providers/AppleAuthProvider';
 import Settings from './Settings';
 import User from './User';
 import version from './version';
 
 const statics = {
+  AppleAuthProvider,
   EmailAuthProvider,
   PhoneAuthProvider,
   GoogleAuthProvider,

--- a/packages/auth/lib/providers/AppleAuthProvider.js
+++ b/packages/auth/lib/providers/AppleAuthProvider.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const providerId = 'apple.com';
+
+export default class AppleAuthProvider {
+  constructor() {
+    throw new Error('`new AppleAuthProvider()` is not supported on the native Firebase SDKs.');
+  }
+
+  static get PROVIDER_ID() {
+    return providerId;
+  }
+
+  static credential(token, secret) {
+    return {
+      token,
+      secret,
+      providerId,
+    };
+  }
+}


### PR DESCRIPTION
### Summary

Implements Apple Authentication support for Firebase Authentication, tested usage via our [`@invertase/react-native-apple-authentication`](https://github.com/invertase/react-native-apple-authentication) package.

Fixes #2884.

### Checklist

- [x] Supports `iOS`
- [x] Typescript types updated

### Test Plan

Test code:
```js
import appleAuth from '@invertase/react-native-apple-authentication';
import { firebase } from '@react-native-firebase/auth';

// ...

const appleAuthRequestResponse = await auth.performRequest({
  requestedScopes: [
    AppleAuthRequestScope.EMAIL, 
    AppleAuthRequestScope.FULL_NAME
  ],
});

const { nonce, identityToken } = appleAuthRequestResponse;

if (identityToken) {
  const appleCredential = firebase.auth.AppleAuthProvider.credential(identityToken, nonce);
  const userCredential = await firebase.auth().signInWithCredential(appleCredential);

  console.warn(`Firebase authenticated via Apple, UID: ${userCredential.user.uid}`);
}
```

Output:
![image](https://user-images.githubusercontent.com/5347038/70381427-dd06cb00-1941-11ea-98c6-7c92fb164452.png)
