### PR TITLE
Fixes default re-export syntax

### DIFF
--- a/packages/app/lib/index.js
+++ b/packages/app/lib/index.js
@@ -18,6 +18,6 @@
 import { getFirebaseRoot } from './internal/registry/namespace';
 
 export const firebase = getFirebaseRoot();
-export utils from './utils';
+export { default as utils } from './utils';
 
 export default firebase;


### PR DESCRIPTION
Same deal as https://github.com/invertase/react-native-firebase/pull/2975, don't know how I missed it