### PR TITLE
feat(messaging:) use prominent iOS push notification permission

### DIFF
--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -319,6 +319,19 @@ export namespace FirebaseMessagingTypes {
     requestPermission(): Promise<boolean>;
 
     /**
+     * Same as `requestPermission()` but leaves out the `UNAuthorizationOptionProvisional` auth option when requesting permission, showing the native permission alert to the user.
+     *
+     * #### Example
+     *
+     * ```js
+     * const permissionGranted = await firebase.messaging().requestPermissionWithoutProvisional();
+     * ```
+     *
+     * @ios
+     */
+    requestPermissionWithoutProvisional(): Promise<boolean>;
+
+    /**
      * On iOS, if your app wants to receive remote messages from FCM (via APNS), you must explicitly register
      * this request with APNS. For example if you want to display alerts, play sounds
      * or perform other user-facing actions (via the Notification library), you must call this method.

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -159,6 +159,16 @@ class FirebaseMessagingModule extends FirebaseModule {
   /**
    * @platform ios
    */
+  requestPermissionWithoutProvisional() {
+    if (isAndroid) {
+      return Promise.resolve(true);
+    }
+    return this.native.requestPermissionWithoutProvisional();
+  }
+
+  /**
+   * @platform ios
+   */
   registerForRemoteNotifications() {
     if (isAndroid) {
       return Promise.resolve();


### PR DESCRIPTION
This PR solves the "Provisional push authorization should be optional on iOS" post on the Feedback site: https://invertase.io/oss/react-native-firebase/feedback/

The `requestPermissionWithoutProvisional()` requests push permission for iOS without the `UNAuthorizationOptionProvisional` auth option set, showing the native permission alert to the user.
The current `requestPermission()` has no option for leaving out the provisional auth option. 

### Summary
It is currently not possible to explicitly ask for push permission for iOS 12+, because the `UNAuthorizationOptionProvisional` flag is set making push notifications silent for the user until the user actively accepts prominent permission (more info on Provisional Authorization [here](http://info.localytics.com/blog/ios-12-brings-new-power-to-push-notifications)). In some cases, e.g. the commercial app I am currently working on, it is a requirement to explicitly ask for push permission. 
This PR adds the possibility to explicitly ask for push permission with `requestPermissionWithoutProvisional()` without changing the current functionality of `requestPermission()`.

### Checklist

- [x] Supports `Android` (doesn't affect Android)
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in packages/**/e2e
- [x] Flow types updated
- [x] Typescript types updated

### Test Plan
The "\<app name\> Would Like To Send You Notifications" permission alert is shown on iOS when calling `requestPermissionWithoutProvisional()`. When calling `requestPermission()` instead no alert is shown on iOS 12+ since it has the `UNAuthorizationOptionProvisional` auth option set.

### Release Plan

 [IOS] [ENHANCEMENT] {Messaging} - Add prominent push notification permission option to Messaging
