### PR TITLE
fixed, fieldPath:'__name__' should be added only once for queries with multiple cursors

### DIFF
--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -72,13 +72,14 @@ export default class FirestoreQuery {
 
       for (let i = 0; i < currentOrders.length; i++) {
         const order = currentOrders[i];
+        //skip if fieldPath is '__name__'
+        if (order.fieldPath === '__name__') continue;
+
         const value = documentSnapshot.get(order.fieldPath);
 
         if (value === undefined) {
           throw new Error(
-            `firebase.firestore().collection().${cursor}(*) You are trying to start or end a query using a document for which the field '${
-              order.fieldPath
-            }' (used as the orderBy) does not exist.`,
+            `firebase.firestore().collection().${cursor}(*) You are trying to start or end a query using a document for which the field '${order.fieldPath}' (used as the orderBy) does not exist.`,
           );
         }
 
@@ -87,10 +88,14 @@ export default class FirestoreQuery {
 
       // Based on https://github.com/invertase/react-native-firebase/issues/2854#issuecomment-552986650
       if (modifiers._orders.length) {
-        modifiers._orders.push({
-          fieldPath: '__name__',
-          direction: modifiers._orders[modifiers._orders.length - 1].direction,
-        });
+        const lastOrder = modifiers._orders[modifiers._orders.length - 1];
+        //push '__name__' field only if not present already
+        if (lastOrder.fieldPath !== '__name__') {
+          modifiers._orders.push({
+            fieldPath: '__name__',
+            direction: lastOrder.direction,
+          });
+        }
       } else {
         modifiers._orders.push({
           fieldPath: '__name__',

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -73,13 +73,17 @@ export default class FirestoreQuery {
       for (let i = 0; i < currentOrders.length; i++) {
         const order = currentOrders[i];
         //skip if fieldPath is '__name__'
-        if (order.fieldPath === '__name__') continue;
+        if (order.fieldPath === '__name__') {
+          continue;
+        }
 
         const value = documentSnapshot.get(order.fieldPath);
 
         if (value === undefined) {
           throw new Error(
-            `firebase.firestore().collection().${cursor}(*) You are trying to start or end a query using a document for which the field '${order.fieldPath}' (used as the orderBy) does not exist.`,
+            `firebase.firestore().collection().${cursor}(*) You are trying to start or end a query using a document for which the field '${
+              order.fieldPath
+            }' (used as the orderBy) does not exist.`,
           );
         }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


### Summary
Currently I was unable to add multiple query cursors to a firestore query.
For example adding both `startAfter` and `endBefore` to a query resulted in the following error:

> firebase.firestore().collection().${cursor}(*) You are trying to start or end a query using a document for which the field `'__name__`' (used as the orderBy) does not exist.

When I looked into the FirestoreQuery.js file, I found that the current code somewhat assumes that there will always going to be a single query cursor in the query. So the code was trying to get the `__name__` field from the `documentSnapshot` provided to the latter query cursor(s).
This PR handles this by allowing `__name__` field to be added to the `_orders` field only once as well as takes care to not let the code to get `__name__` field from the `documentSnapshot `provided to latter cursor(s).

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Checklist

- [*] Supports `Android`
- [*] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan
Testing was done manually. After the fix, the query no longer throws error and returns expected results.
The following logging result for the following query demonstrates this:
Query Code:

      const first = await firestore()
        .collection('orders')
        .doc('322aANRVXM0RTgM1BK6b')
        .get();

      const last = await firestore()
        .collection('orders')
        .doc('9iJaiA3ylpF2kLVDDDCy')
        .get();

      const query = firestore()
        .collection('orders')
        .orderBy('createdAt', 'desc')
        .startAfter(first)
        .endBefore(last);

      console.log(JSON.stringify(query._modifiers, null, 4));

Corresponding Logs:

```
{
    "_filters": [],
    "_orders": [
        {
            "fieldPath": "createdAt",
            "direction": "DESCENDING"
        },
        {
            "fieldPath": "__name__",
            "direction": "DESCENDING"
        }
    ],
    "_type": "collection",
    "_startAfter": [
        [
            13,
            [
                1578698717,
                160000000
            ]
        ],
        [
            8,
            "322aANRVXM0RTgM1BK6b"
        ]
    ],
    "_endBefore": [
        [
            13,
            [
                1578688673,
                0
            ]
        ],
        [
            8,
            "9iJaiA3ylpF2kLVDDDCy"
        ]
    ]
}
```
<!-- Demonstrate the code is solid. -->
<!-- Example: The exact testing commands you ran and their final output (e.g. screenshot of test summary). -->
<!-- Example: Screenshots / videos if the pull request changes UI related code such as Notifications or Admob -->

### Release Plan
[JS] [BUGFIX] [FIRESTORE] - Fixed bug when applying multiple query cursors to the same query
<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->
<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
