### PR TITLE
docs(functions): fix ios manual linking typo

### DIFF
--- a/docs/functions/ios.md
+++ b/docs/functions/ios.md
@@ -17,7 +17,7 @@ Add the `RNFBFunctions` Pod to your projects `/ios/Podfile`:
 ```ruby{3}
 target 'app' do
   ...
-  pod 'RNFBFirestore', :path => '../node_modules/@react-native-firebase/functions'
+  pod 'RNFBFunctions', :path => '../node_modules/@react-native-firebase/functions'
 end
 ```
 


### PR DESCRIPTION
### Summary

Fix naming conflict

### Checklist

- [x ] Supports `iOS`

[IOS][BUGFIX] [Pods]

