### PR TITLE
docs(iam): fix gradle settings path in manual linking docs

### DIFF
--- a/docs/in-app-messaging/android.md
+++ b/docs/in-app-messaging/android.md
@@ -13,8 +13,8 @@ description: Manually integrate Firebase In-App Messaging into your Android appl
 Add the following to your projects `/android/settings.gradle` file:
 
 ```groovy
-include ':@react-native-firebase_inAppMessaging'
-project(':@react-native-firebase_inAppMessaging').projectDir = new File(rootProject.projectDir, './../node_modules/@react-native-firebase/in-app-messaging/android')
+include ':@react-native-firebase_in-app-messaging'
+project(':@react-native-firebase_in-app-messaging').projectDir = new File(rootProject.projectDir, './../node_modules/@react-native-firebase/in-app-messaging/android')
 ```
 
 #### Update Gradle Dependencies


### PR DESCRIPTION
# Summary
In build, error occurred below.
```
* What went wrong:
A problem occurred evaluating project ':app'.
> Project with path ':@react-native-firebase_in-app-messaging' could not be found in project ':app'.
```

So, I fixed document.

### Checklist

- [x] Supports `Android`
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in packages/**/e2e
- [x] Flow types updated
- [x] Typescript types updated
