### PR TITLE
docs(perf): Add HTTP metric.start command to example

### DIFF
--- a/docs/perf/quick-start.md
+++ b/docs/perf/quick-start.md
@@ -80,13 +80,16 @@ async function getRequest(url) {
   // Define meta details
   metric.putAttribute('user', 'abcd');
 
+  // Start the metric
+  await metric.start();
+
   // Perform a HTTP request and provide response information
   const response = await fetch(url);
   metric.setHttpResponseCode(response.status);
   metric.setResponseContentType(response.headers.get('Content-Type'));
   metric.setResponsePayloadSize(response.headers.get('Content-Length'));
 
-  // Stop the trace
+  // Stop the metric
   await metric.stop();
 
   return response.json();


### PR DESCRIPTION
### Summary

#2886 and other users (including me!) copied and pasted the quick start example and started modifying away into my project, and then all my HTTP requests started throwing rejections. Turns out, I didn't read the module docs correctly - a metric must be started before you can use it!
This docfix should hopefully help prevent some frustrated googling.

Thanks for an amazing library :blue_heart:

### Checklist

N/A

### Test Plan

N/A

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[INTERNAL][minor] [perf] - Quick start documentation update for HTTP metrics

(I don't know if this is needed for doc updates!)
---

:fire: