### PR TITLE
docs(crashlytics): improve Crashlytics docs in response to #2724

### DIFF
--- a/docs/crashlytics/quick-start.md
+++ b/docs/crashlytics/quick-start.md
@@ -121,6 +121,6 @@ await firebase.crashlytics().setCrashlyticsCollectionEnabled(true);
 
 
 ### Enabling Debug Reports
-By defualt, Crashlytics won't report crashes and logs from builds in debug mode. To enable it, set the `crashlytics_debug_enabled` option to true in the `firebase.json` file.
+By default, Crashlytics won't report crashes and logs from builds in debug mode. To enable it, set the `crashlytics_debug_enabled` option to `true` in the `react-native` section of your `firebase.json` config file.
 
 To learn more about all the `firebase.json` options, view the <Anchor version group="app" href="/reference/firebasejsonconfig">documentation here</Anchor>. 

--- a/docs/crashlytics/quick-start.md
+++ b/docs/crashlytics/quick-start.md
@@ -119,4 +119,8 @@ Once your user has consented, enable Crashlytics collection via the JavaScript A
 await firebase.crashlytics().setCrashlyticsCollectionEnabled(true);
 ```
 
-To learn more about all the `firebase.json` options, view the <Anchor version group="app" href="/reference/firebasejsonconfig">documentation here</Anchor>.
+
+### Enabling Debug Reports
+By defualt, Crashlytics won't report crashes and logs from builds in debug mode. To enable it, set the `crashlytics_debug_enabled` option to true in the `firebase.json` file.
+
+To learn more about all the `firebase.json` options, view the <Anchor version group="app" href="/reference/firebasejsonconfig">documentation here</Anchor>. 


### PR DESCRIPTION
I believe there should also be a place in the documentation that should explicitly explain that the firebase.json file is and where it should go.
Any idea where I should put that?