### PR TITLE
fix(messaging) fix typescript signature for setBackgroundMessageHandler

### DIFF
--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -497,7 +497,7 @@ export namespace FirebaseMessagingTypes {
      *
      * @android
      */
-    setBackgroundMessageHandler(handler: (message: RemoteMessage) => any);
+    setBackgroundMessageHandler(handler: (message: RemoteMessage) => Promise<any>);
 
     /**
      * Send a new `RemoteMessage` to the FCM server.

--- a/packages/messaging/type-test.ts
+++ b/packages/messaging/type-test.ts
@@ -42,4 +42,5 @@ firebase
   .then();
 firebase.messaging().setBackgroundMessageHandler(msg => {
   console.log(msg.data);
+  return Promise.resolve();
 });


### PR DESCRIPTION
It wasn't specified that it should actually return a promise.
If it doesn't return a promise, you start to get `cannot resolve .then of undefined` errors.