### PR TITLE
Use Firebase/InAppMessaging only per upstream 6.16.0 release notes

### DIFF
--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
   s.dependency          'React'
   s.dependency          'Firebase/Core', firebase_sdk_version
-  s.dependency          'Firebase/InAppMessagingDisplay', firebase_sdk_version
+  s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
   s.dependency          'RNFBApp'
   s.static_framework    = false
 end


### PR DESCRIPTION
https://firebase.google.com/support/release-notes/ios#firebase-in-app-messaging

> Consolidated backend and UI SDKs under FirebaseInAppMessaging. Developers should remove pod Firebase/InAppMessagingDisplay and only use pod Firebase/InAppMessaging in their Podfile.

I believe this is a breaking change as it removes support for Firebase iOS SDK releases < 6.16.0?

Maybe it is possible to make this backwards compatible if there was ruby-podfile-magic where you could see what Firebase iOS SDK version the consuming project was on, and switch which pod you use based on that?

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- If this PR fixes an issue, type "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->


### Summary

<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Checklist

- [ ] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

<!-- Demonstrate the code is solid. -->
<!-- Example: The exact testing commands you ran and their final output (e.g. screenshot of test summary). -->
<!-- Example: Screenshots / videos if the pull request changes UI related code such as Notifications or Admob -->

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[CATEGORY][type] [LOCATION] - Message

<!--
  **INTERNAL tagged notes will not be included in the next version's release notes.**

    CATEGORY
  [----------]      TYPE
  [ TYPES    ] [-------------]       LOCATION
  [ JS       ] [ BREAKING    ] [------------------]
  [ GENERAL  ] [ BUGFIX      ] [ {FirebaseModule} ]
  [ INTERNAL ] [ ENHANCEMENT ] [ {Filename}       ]
  [ IOS      ] [ FEATURE     ] [ {Directory}      ]   |-----------|
  [ ANDROID  ] [ MINOR       ] [ {Framework}      ] - | {Message} |
  [----------] [-------------] [------------------]   |-----------|

 EXAMPLES:

 [IOS] [ANDROID] [BREAKING] [AUTHENTICATION] - Change a thing that breaks other things
 [ANDROID] [BUGFIX] [FIRESTORE] - Did a thing to fix a thing with a Firestore thing
 [JS] [BREAKING] - Remove a deprecated thing
 [TYPES] [ENHANCEMENT] [NOTIFICATIONS] - Update flow types for a thing in notifications
 [JS] [ENHANCEMENT] - Expose export of a internal thing utility for public usage
 [INTERNAL] [FEATURE] [./utils] - Added an internal util to make doing a thing easier
-->

[IOS][BREAKING][InAppMessaging] - track upstream Pod name change

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
