### PR TITLE
fix(types): remove types in ConfirmationResult.js

### DIFF
--- a/packages/auth/lib/ConfirmationResult.js
+++ b/packages/auth/lib/ConfirmationResult.js
@@ -27,7 +27,7 @@ export default class ConfirmationResult {
       .then(user => this._auth._setUser(user));
   }
 
-  get verificationId(): string | null {
+  get verificationId() {
     return this._verificationId;
   }
 }

--- a/packages/auth/lib/providers/OAuthProvider.js
+++ b/packages/auth/lib/providers/OAuthProvider.js
@@ -26,7 +26,7 @@ export default class OAuthProvider {
     return providerId;
   }
 
-  static credential(idToken, accessToken): AuthCredential {
+  static credential(idToken, accessToken) {
     return {
       token: idToken,
       secret: accessToken,


### PR DESCRIPTION
'types' can only be used in a .ts file.
