### PR TITLE
docs(database): added missing use of .push() type docs

### DIFF
--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -377,7 +377,7 @@ export namespace FirebaseDatabaseTypes {
      * #### Example
      *
      * ```js
-     * const newUserRef = firebase.database().ref('users');
+     * const newUserRef = firebase.database().ref('users').push();
      * console.log('New record key:', newUserRef.key);
      * await newUserRef.set({
      *   first: 'Ada',


### PR DESCRIPTION
There was formally no actual use of the .push method in it's documentation example snippet.