### PR TITLE
docs(auth): fixes wrong signOut method call in types

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1288,7 +1288,7 @@ export namespace FirebaseAuthTypes {
      * #### Example
      *
      * ```js
-     * await firebase.auth().currentUser.signOut();
+     * await firebase.auth().signOut();
      * ```
      *
      */


### PR DESCRIPTION
In the docs for auth the signOut() function is called by doing `firebase.auth().currentUser.signOut()`

This is supposed to be ` firebase.auth().signOut()` 
I think the docs on the websites are based on these comments so I fixed it here. 