### PR TITLE
docs(remote-config): remove unnecessary await in example

### DIFF
--- a/docs/remote-config/quick-start.md
+++ b/docs/remote-config/quick-start.md
@@ -48,7 +48,7 @@ async function getValues() {
     const activated = await remoteConfig().fetchAndActivate();
 
     if (activated) {
-      const experimentalFeatureEnabled = await remoteConfig().getValue('experiment');
+      const experimentalFeatureEnabled = remoteConfig().getValue('experiment');
       console.log('Experimental source: ', experimentalFeatureEnabled.source);
       console.log('Experimental value: ', experimentalFeatureEnabled.value);
     }


### PR DESCRIPTION
In the quick start section of the Remote Config docs, getValue is called as if it's asynchronous, which I don't believe it is. 