### PR TITLE
Fix 2657 error getting remote notifications tokens

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingAppDelegateInterceptor.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingAppDelegateInterceptor.m
@@ -44,6 +44,7 @@
 
 // called when `registerForRemoteNotifications` completes successfully
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+  [FIRMessaging messaging].APNSToken = deviceToken;
   if (_registerPromiseResolver != nil) {
     _registerPromiseResolver(@([RCTConvert BOOL:@([UIApplication sharedApplication].isRegisteredForRemoteNotifications)]));
     _registerPromiseResolver = nil;

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -181,10 +181,6 @@ RCT_EXPORT_METHOD(registerForRemoteNotifications:
   (RCTPromiseResolveBlock) resolve
     : (RCTPromiseRejectBlock) reject
 ) {
-  if ([UIApplication sharedApplication].isRegisteredForRemoteNotifications == YES) {
-    return resolve(@([RCTConvert BOOL:@(YES)]));
-  }
-
   [[RNFBMessagingAppDelegateInterceptor sharedInstance] setPromiseResolve:resolve andPromiseReject:reject];
   [[UIApplication sharedApplication] registerForRemoteNotifications];
 }


### PR DESCRIPTION
### Summary

This PR fixes the logic on `registerForRemoteNotifications` and a race condition that caused issue #2657.

#### Explanation

##### Change registerForRemoteNotifications in RNFirebase to skip the check on `isRegisteredForRemoteNotifications` 

The native call to `registerForRemoteNotifications` shouldn't be aborted even if `isRegisteredForRemoteNotifications` returns `true`. This is because after successful registration on the first boot, on successive boots the app `isRegisteredForRemoteNotifications` will return true, and then `registerForRemoteNotifications` won't be called again and therefore the APNSToken will never be set (because it is only set on the `didRegisterForRemoteNotificationsWithDeviceToken` swizzled by the `FIRMessagingRemoteNotificationsProxy`). If the APNSToken is null when calling getTokens, then the call to `[[FIRInstanceID instanceID] tokenWithAuthorizedEntity] ` on `getToken` fails.

##### Change RNFBMessagingAppDelegateInterceptor to set [FIRMessaging messaging].APNSToken

This is what the `FIRMessagingRemoteNotificationsProxy` does, and doing it here seems to avoid a race condition that happens when the `registerForRemoteNotification` method is resolved but the APNSToken is not yet set because the swizzling done by `RNFirebase` finishes first than the one done by the `FirebaseMessaging` library. Even though this race condition only seems to happen on iOS 12, It doesn't do any damage anyway to do it here first anyway.

### Checklist

- [x] Supports `Android`: *This change doesn't affect `Android`*
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in packages/**/e2e: *can only be tested on actual devices*.
- [x] Flow types updated: *doesn't require type changes*
- [x] Typescript types updated: *doesn't require type changes*

### Test Plan

Tested on iOS 12 device by calling `registerForRemoteNotifications` followed by `getToken` on app start and restarting multiple times.

### Release Plan

[IOS][BUGFIX] [Messaging] - Fix race condition that prevented getting APNSToken and Firebase Token on iOS after first boot, and on iOS 12.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
