### PR TITLE
feat(remote-config): implement updated APIs (v7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -545,6 +545,7 @@ typedoc.raw.json
 tests/ios/Firebase
 .tmp
 
+appPlaygrounds/
 google-services.json
 GoogleService-Info.plist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## remote-config 
  
-- removed `isDeveloperModeEnabled` from `remoteConfig().settings = { isDeveloperModeEnabled:true }` for both iOS & Android. Not in web spec.
-- removed `remoteConfig().setDefaults({})` & replaced with `remoteConfig().defaultConfig = {}` which is a web property.
-- removed `remoteConfig().setDefaultsFromResource({})`, not in the web spec.
-- removed `remoteConfig().setConfig({})` & replaced with `remoteConfig().settings = {}` which is a web property.
+- removed `isDeveloperModeEnabled` from `remoteConfig().setConfigSettings({ isDeveloperModeEnabled:true })` for both iOS & Android. Not in web spec.
 - removed `settings.minimumFetchInterval` in JS & changed it to `settings.minimumFetchIntervalMillis` as per web spec.
+- removed `remoteConfig().getValue(key).value` & `remoteConfig().getValue(key).source` has been removed. 
+- added `remoteConfig().getValue(key).asBoolean()`, `remoteConfig().getValue(key).asString()`, `remoteConfig().getValue(key).asNumber()` & `remoteConfig().getValue(key).getSource()` methods.
+- added `remoteConfig().defaultConfig = {}`, `remoteConfig().setLogLevel()` & `remoteConfig().settings = {}` console warning that we cannot use web spec implementation.
 - added `settings.fetchTimeMillis` as per web spec.
+- added `remoteConfig().ensureInitialized()` as per web spec.
+- added `setConfigSettingsAsync` API for Android.
+- added `fetchAndActivate` API for Android & iOS.
+- added `activateWithCompletionHandler` API for iOS.
+- added Multi-app support API for Android & iOS.
+
 
 # [6.1.0](https://github.com/invertase/react-native-firebase/compare/v6.0.4...v6.1.0) (2019-11-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-# [6.1.0](https://github.com/invertase/react-native-firebase/compare/v6.0.4...v6.1.0) (2019-11-26)
+# Next
 
+## remote-config 
+ 
+- removed `isDeveloperModeEnabled` from `remoteConfig().settings = { isDeveloperModeEnabled:true }` for both iOS & Android;
+
+# [6.1.0](https://github.com/invertase/react-native-firebase/compare/v6.0.4...v6.1.0) (2019-11-26)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## remote-config 
  
-- removed `isDeveloperModeEnabled` from `remoteConfig().settings = { isDeveloperModeEnabled:true }` for both iOS & Android;
+- removed `isDeveloperModeEnabled` from `remoteConfig().settings = { isDeveloperModeEnabled:true }` for both iOS & Android. Not in web spec.
+- removed `remoteConfig().setDefaults({})` & replaced with `remoteConfig().defaultConfig = {}` which is a web property.
+- removed `remoteConfig().setDefaultsFromResource({})`, not in the web spec.
 
 # [6.1.0](https://github.com/invertase/react-native-firebase/compare/v6.0.4...v6.1.0) (2019-11-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - removed `remoteConfig().setDefaults({})` & replaced with `remoteConfig().defaultConfig = {}` which is a web property.
 - removed `remoteConfig().setDefaultsFromResource({})`, not in the web spec.
 - removed `remoteConfig().setConfig({})` & replaced with `remoteConfig().settings = {}` which is a web property.
+- removed `settings.minimumFetchInterval` in JS & changed it to `settings.minimumFetchIntervalMillis` as per web spec.
+- added `settings.fetchTimeMillis` as per web spec.
 
 # [6.1.0](https://github.com/invertase/react-native-firebase/compare/v6.0.4...v6.1.0) (2019-11-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - removed `isDeveloperModeEnabled` from `remoteConfig().settings = { isDeveloperModeEnabled:true }` for both iOS & Android. Not in web spec.
 - removed `remoteConfig().setDefaults({})` & replaced with `remoteConfig().defaultConfig = {}` which is a web property.
 - removed `remoteConfig().setDefaultsFromResource({})`, not in the web spec.
+- removed `remoteConfig().setConfig({})` & replaced with `remoteConfig().settings = {}` which is a web property.
 
 # [6.1.0](https://github.com/invertase/react-native-firebase/compare/v6.0.4...v6.1.0) (2019-11-26)
 

--- a/docs/remote-config/quick-start.md
+++ b/docs/remote-config/quick-start.md
@@ -62,14 +62,14 @@ async function getValues() {
 
 In some cases you may want to fetch values from the console in the background without the process visibly impacting
 your application. To prevent any race conditions where values are being requested (i.e. via `getValue`) before they
-have been fetched and activated, it is recommended you set default values using the `defaultConfig` property:
+have been fetched and activated, it is recommended you set default values using the `setDefaults` property:
 
 ```js
 import remoteConfig from '@react-native-firebase/remote-config';
 async function bootstrap() {
-      firebase.remoteConfig().defaultConfig = {
-        experiment_enabled: false,
-      };
+  await remoteConfig().setDefaults({
+    experiment: false,
+  });
 }
 ```
 

--- a/docs/remote-config/quick-start.md
+++ b/docs/remote-config/quick-start.md
@@ -62,7 +62,7 @@ async function getValues() {
 
 In some cases you may want to fetch values from the console in the background without the process visibly impacting
 your application. To prevent any race conditions where values are being requested (i.e. via `getValue`) before they
-have been fetched and activated, it is recommended you set default values using the `setDefaults` property:
+have been fetched and activated, it is recommended you set default values using the `setDefaults` method:
 
 ```js
 import remoteConfig from '@react-native-firebase/remote-config';

--- a/docs/remote-config/quick-start.md
+++ b/docs/remote-config/quick-start.md
@@ -62,15 +62,14 @@ async function getValues() {
 
 In some cases you may want to fetch values from the console in the background without the process visibly impacting
 your application. To prevent any race conditions where values are being requested (i.e. via `getValue`) before they
-have been fetched and activated, it is recommended you set default values using `setDefaults`:
+have been fetched and activated, it is recommended you set default values using the `defaultConfig` property:
 
 ```js
 import remoteConfig from '@react-native-firebase/remote-config';
-
 async function bootstrap() {
-  await remoteConfig().setDefaults({
-    experiment: false,
-  });
+      firebase.remoteConfig().defaultConfig = {
+        experiment_enabled: false,
+      };
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "generate-changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -t -v -l",
     "tests:packager:chrome": "cd tests && node_modules/.bin/react-native start --platforms ios,android --reset-cache",
     "tests:packager:jet": "cd tests && cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start",
-    "tests:packager:jet-reset-cache": "cd tests & cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --reset-cache",
+    "tests:packager:jet-reset-cache": "cd tests && cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --reset-cache",
     "tests:android:build": "cd tests && ./node_modules/.bin/detox build --configuration android.emu.debug",
     "tests:android:build-release": "cd tests && ./node_modules/.bin/detox build --configuration android.emu.release",
     "tests:android:test": "cd tests && ./node_modules/.bin/detox test --configuration android.emu.debug",

--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBAdMob: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBAnalytics: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -2,7 +2,7 @@ require 'json'
 require './firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBApp: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBAuth: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -2,7 +2,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 # Firebase SDK Override
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBCrashlytics: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read('./package.json'))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBDatabase: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBDynamicLinks: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBDynamicLinks: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBFirestore: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBIid: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBInAppMessaging: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
   s.dependency          'React'
   s.dependency          'Firebase/Core', firebase_sdk_version
-  s.dependency          'Firebase/InAppMessagingDisplay', firebase_sdk_version
+  s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
   s.dependency          'RNFBApp'
   s.static_framework    = false
 end

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBMessaging: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -2,7 +2,7 @@ require 'json'
 require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBMLNaturalLanguage: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -2,7 +2,7 @@ require 'json'
 require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBMLVision: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBPerf: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBRemoteConfig: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -87,41 +87,10 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
     return FirebaseRemoteConfig.getInstance().setDefaultsAsync(defaults);
   }
 
-  Task<Void> ensureInitialized() {
-    FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
+  Task<FirebaseRemoteConfigInfo> ensureInitialized() {
     Task<FirebaseRemoteConfigInfo> ensureInitializedTask = config.ensureInitialized();
 
     return ensureInitializedTask;
-    // return ensureInitializedTask.onSuccessTask(() -> {
-      
-      /**
-       * Tried to build my own FirebaseRemoteConfigInfo abstract class to return within onSuccessTask event
-       */
-      // FirebaseRemoteConfigSettings.Builder configSettings = new FirebaseRemoteConfigSettings.Builder();
-      // FirebaseRemoteConfigInfo remoteConfigInfo = new FirebaseRemoteConfigInfo() {
-      //   @Override
-      //   public FirebaseRemoteConfigSettings getConfigSettings(){
-      //     return configSettings;
-      //   }
-      //   @Override
-      //   public FirebaseRemoteConfigSettings getFetchTimeMillis(){
-      //     return configSettings.getMinimumFetchIntervalInSeconds() * 1000;
-      //   }
-      //   @Override
-      //   public FirebaseRemoteConfigSettings getLastFetchStatus(){
-      //     return 
-      //   }
-      // }
-
-      /**
-       * Tried to build a config info object to return within onSuccessTask event
-       */
-      // FirebaseRemoteConfigInfo remoteConfigInfo = FirebaseRemoteConfig.getInstance(FirebaseApp.getInstance(appName))
-      //     .getInfo();
-
-      // return remoteConfigInfo;
-
-    });
   }
 
   Map<String, Object> getAllValuesForApp(String appName) {

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -68,10 +68,14 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
   Task<Void> setConfigSettings(Bundle configSettings) {
     return Tasks.call(getExecutor(), () -> {
       FirebaseRemoteConfigSettings.Builder configSettingsBuilder = new FirebaseRemoteConfigSettings.Builder();
-      configSettingsBuilder.setDeveloperModeEnabled(configSettings.getBoolean("isDeveloperModeEnabled"));
+
       if (configSettings.containsKey("minimumFetchInterval")) {
         double fetchInterval = configSettings.getDouble("minimumFetchInterval");
-        configSettingsBuilder.setMinimumFetchIntervalInSeconds((long)fetchInterval);
+        configSettingsBuilder.setMinimumFetchIntervalInSeconds((long) fetchInterval);
+      }
+      if (configSettings.containsKey("fetchTimeout")) {
+        double fetchTimeout = configSettings.getDouble("fetchTimeout");
+        configSettingsBuilder.setFetchTimeoutInSeconds((long) fetchTimeout);
       }
       FirebaseRemoteConfig.getInstance().setConfigSettings(configSettingsBuilder.build());
       return null;
@@ -176,7 +180,6 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
 
     appConstants.put("values", getAllValuesForApp(appName));
     appConstants.put("lastFetchTime", remoteConfigInfo.getFetchTimeMillis());
-    appConstants.put("isDeveloperModeEnabled", remoteConfigSettings.isDeveloperModeEnabled());
     appConstants.put("lastFetchStatus", lastFetchStatusToString(remoteConfigInfo.getLastFetchStatus()));
     appConstants.put("minimumFetchInterval", remoteConfigSettings.getMinimumFetchIntervalInSeconds());
 

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -88,6 +88,7 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
   }
 
   Task<FirebaseRemoteConfigInfo> ensureInitialized() {
+    FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
     Task<FirebaseRemoteConfigInfo> ensureInitializedTask = config.ensureInitialized();
 
     return ensureInitializedTask;

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -118,16 +118,17 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
     return FirebaseRemoteConfig.getInstance(firebaseApp).setDefaultsAsync(defaults);
   }
 
-  Task<FirebaseRemoteConfigInfo> ensureInitialized() {
-    FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
+  Task<FirebaseRemoteConfigInfo> ensureInitialized(String appName) {
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+
+    FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance(firebaseApp);
     Task<FirebaseRemoteConfigInfo> ensureInitializedTask = config.ensureInitialized();
 
     try {
-      Tasks.await(fetchAndActivate());
+      Tasks.await(fetchAndActivate(appName));
     } catch (Exception e) {
-      //do nothing
+      // do nothing
     }
-    
 
     return ensureInitializedTask;
   }
@@ -207,7 +208,7 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
 
     appConstants.put("values", getAllValuesForApp(appName));
     appConstants.put("lastFetchTime", remoteConfigInfo.getFetchTimeMillis());
-    appConstants.put("lastFetchStatus", lastFetchStatusToString(remoteConfigInfo.getLastFetchStatus()));
+    appConstants.put("lastFetchStatus", lastFetchStatusToString((remoteConfigInfo.getLastFetchStatus())));
     appConstants.put("minimumFetchInterval", remoteConfigSettings.getMinimumFetchIntervalInSeconds());
 
     return appConstants;

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -33,6 +33,7 @@ import io.invertase.firebase.common.UniversalFirebaseModule;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.*;
 
@@ -84,6 +85,42 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
 
   Task<Void> setDefaults(HashMap<String, Object> defaults) {
     return FirebaseRemoteConfig.getInstance().setDefaultsAsync(defaults);
+  }
+
+  Task<Void> ensureInitialized() {
+    FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
+    Task<FirebaseRemoteConfigInfo> ensureInitializedTask = config.ensureInitialized();
+    return ensureInitializedTask;
+    // return ensureInitializedTask.onSuccessTask(() -> {
+      
+      /**
+       * Tried to build my own FirebaseRemoteConfigInfo abstract class to return within onSuccessTask
+       */
+      // FirebaseRemoteConfigSettings.Builder configSettings = new FirebaseRemoteConfigSettings.Builder();
+      // FirebaseRemoteConfigInfo remoteConfigInfo = new FirebaseRemoteConfigInfo() {
+      //   @Override
+      //   public FirebaseRemoteConfigSettings getConfigSettings(){
+      //     return configSettings;
+      //   }
+      //   @Override
+      //   public FirebaseRemoteConfigSettings getFetchTimeMillis(){
+      //     return configSettings.getMinimumFetchIntervalInSeconds() * 1000;
+      //   }
+      //   @Override
+      //   public FirebaseRemoteConfigSettings getLastFetchStatus(){
+      //     return 
+      //   }
+      // }
+
+      /**
+       * Tried to build a config info object to return within onSuccessTask event
+       */
+      // FirebaseRemoteConfigInfo remoteConfigInfo = FirebaseRemoteConfig.getInstance(FirebaseApp.getInstance(appName))
+      //     .getInfo();
+
+      // return remoteConfigInfo;
+
+    });
   }
 
   Map<String, Object> getAllValuesForApp(String appName) {
@@ -155,7 +192,8 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
 
   public Map<String, Object> getConstantsForApp(String appName) {
     Map<String, Object> appConstants = new HashMap<>();
-    FirebaseRemoteConfigInfo remoteConfigInfo = FirebaseRemoteConfig.getInstance(FirebaseApp.getInstance(appName)).getInfo();
+    FirebaseRemoteConfigInfo remoteConfigInfo = FirebaseRemoteConfig.getInstance(FirebaseApp.getInstance(appName))
+        .getInfo();
     FirebaseRemoteConfigSettings remoteConfigSettings = remoteConfigInfo.getConfigSettings();
 
     appConstants.put("values", getAllValuesForApp(appName));

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -90,11 +90,12 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
   Task<Void> ensureInitialized() {
     FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance();
     Task<FirebaseRemoteConfigInfo> ensureInitializedTask = config.ensureInitialized();
+
     return ensureInitializedTask;
     // return ensureInitializedTask.onSuccessTask(() -> {
       
       /**
-       * Tried to build my own FirebaseRemoteConfigInfo abstract class to return within onSuccessTask
+       * Tried to build my own FirebaseRemoteConfigInfo abstract class to return within onSuccessTask event
        */
       // FirebaseRemoteConfigSettings.Builder configSettings = new FirebaseRemoteConfigSettings.Builder();
       // FirebaseRemoteConfigInfo remoteConfigInfo = new FirebaseRemoteConfigInfo() {

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -86,26 +86,6 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
     return FirebaseRemoteConfig.getInstance().setDefaultsAsync(defaults);
   }
 
-  Task<Void> setDefaultsFromResource(String resourceName) {
-    return Tasks.call(getExecutor(), () -> {
-      int resourceId = getXmlResourceIdByName(resourceName);
-      XmlResourceParser xmlResourceParser = null;
-
-      try {
-        xmlResourceParser = getApplicationContext().getResources().getXml(resourceId);
-      } catch (Resources.NotFoundException nfe) {
-        // do nothing
-      }
-
-      if (xmlResourceParser != null) {
-        FirebaseRemoteConfig.getInstance().setDefaults(resourceId);
-        return null;
-      }
-
-      throw new Exception("resource_not_found");
-    });
-  }
-
   Map<String, Object> getAllValuesForApp(String appName) {
     FirebaseRemoteConfig config = FirebaseRemoteConfig.getInstance(FirebaseApp.getInstance(appName));
     Map<String, FirebaseRemoteConfigValue> configValueMapRaw = config.getAll();

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -36,8 +36,8 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void activate(Promise promise) {
-    module.activate().addOnCompleteListener(task -> {
+  public void activate(String appName, Promise promise) {
+    module.activate(appName).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(task.getResult()));
       } else {
@@ -47,8 +47,8 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void fetch(double expirationDurationSeconds, Promise promise) {
-    module.fetch((long) expirationDurationSeconds).addOnCompleteListener(task -> {
+  public void fetch(String appName, double expirationDurationSeconds, Promise promise) {
+    module.fetch(appName, (long) expirationDurationSeconds).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(task.getResult()));
       } else {
@@ -58,8 +58,8 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void fetchAndActivate(Promise promise) {
-    module.fetchAndActivate().addOnCompleteListener(task -> {
+  public void fetchAndActivate(String appName, Promise promise) {
+    module.fetchAndActivate(appName).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(task.getResult()));
       } else {
@@ -69,8 +69,8 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void setConfigSettings(ReadableMap configSettings, Promise promise) {
-    module.setConfigSettings(Arguments.toBundle(configSettings)).addOnCompleteListener(task -> {
+  public void setConfigSettings(String appName, ReadableMap configSettings, Promise promise) {
+    module.setConfigSettings(Arguments.toBundle(appName, configSettings)).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(task.getResult()));
       } else {
@@ -80,8 +80,8 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void setDefaults(ReadableMap defaults, Promise promise) {
-    module.setDefaults(defaults.toHashMap()).addOnCompleteListener(task -> {
+  public void setDefaults(String appName, ReadableMap defaults, Promise promise) {
+    module.setDefaults(appName, defaults.toHashMap()).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(task.getResult()));
       } else {
@@ -91,8 +91,8 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void setDefaultsFromResource(String resourceName, Promise promise) {
-    module.setDefaultsFromResource(resourceName).addOnCompleteListener(task -> {
+  public void setDefaultsFromResource(String appName, String resourceName, Promise promise) {
+    module.setDefaultsFromResource(appName, resourceName).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(task.getResult()));
       } else {
@@ -106,7 +106,7 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void ensureInitialized(Promise promise) {
+  public void ensureInitialized(String appName, Promise promise) {
     module.ensureInitialized().addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(null));

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -90,25 +90,6 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
     });
   }
 
-  @ReactMethod
-  public void setDefaultsFromResource(String resourceName, Promise promise) {
-    module.setDefaultsFromResource(resourceName).addOnCompleteListener(task -> {
-      if (task.isSuccessful()) {
-        promise.resolve(resultWithConstants(task.getResult()));
-      } else {
-        Exception exception = task.getException();
-        if (exception != null && exception.getMessage().equals("resource_not_found")) {
-          rejectPromiseWithCodeAndMessage(
-            promise,
-            "resource_not_found",
-            "The specified resource name was not found."
-          );
-        }
-        rejectPromiseWithExceptionMap(promise, task.getException());
-      }
-    });
-  }
-
   private WritableMap resultWithConstants(Object result) {
     Map<String, Object> responseMap = new HashMap<>(2);
     responseMap.put("result", result);

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -70,7 +70,7 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
 
   @ReactMethod
   public void setConfigSettings(String appName, ReadableMap configSettings, Promise promise) {
-    module.setConfigSettings(Arguments.toBundle(appName, configSettings)).addOnCompleteListener(task -> {
+    module.setConfigSettings(appName, Arguments.toBundle(configSettings)).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(task.getResult()));
       } else {
@@ -107,7 +107,7 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
 
   @ReactMethod
   public void ensureInitialized(String appName, Promise promise) {
-    module.ensureInitialized().addOnCompleteListener(task -> {
+    module.ensureInitialized(appName).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(null));
       } else {

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -90,6 +90,17 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
     });
   }
 
+  @ReactMethod
+  public FirebaseRemoteConfigInfo ensureInitialized(Promise promise) {
+    module.ensureInitialized().addOnCompleteListener(task -> {
+      if (task.isSuccessful()) {
+        promise.resolve(resultWithConstants(null));
+      } else {
+        rejectPromiseWithExceptionMap(promise, task.getException());
+      }
+    });
+  }
+
   private WritableMap resultWithConstants(Object result) {
     Map<String, Object> responseMap = new HashMap<>(2);
     responseMap.put("result", result);

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -91,7 +91,7 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public FirebaseRemoteConfigInfo ensureInitialized(Promise promise) {
+  public void ensureInitialized(Promise promise) {
     module.ensureInitialized().addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(resultWithConstants(null));

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -91,6 +91,21 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
+  public void setDefaultsFromResource(String resourceName, Promise promise) {
+    module.setDefaultsFromResource(resourceName).addOnCompleteListener(task -> {
+      if (task.isSuccessful()) {
+        promise.resolve(resultWithConstants(task.getResult()));
+      } else {
+        Exception exception = task.getException();
+        if (exception != null && exception.getMessage().equals("resource_not_found")) {
+          rejectPromiseWithCodeAndMessage(promise, "resource_not_found", "The specified resource name was not found.");
+        }
+        rejectPromiseWithExceptionMap(promise, task.getException());
+      }
+    });
+  }
+
+  @ReactMethod
   public void ensureInitialized(Promise promise) {
     module.ensureInitialized().addOnCompleteListener(task -> {
       if (task.isSuccessful()) {

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -47,11 +47,11 @@ describe('remoteConfig()', () => {
 
       if (device.getPlatform() === 'android') {
         // TODO these tests fail
-      // iOS persists last fetch status so this test will fail sometimes
-        // firebase.remoteConfig().lastFetchTime.should.equal(0);
-        // firebase
-        //   .remoteConfig()
-        //   .lastFetchStatus.should.equal(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET);
+        // iOS persists last fetch status so this test will fail sometimes
+        firebase.remoteConfig().lastFetchTime.should.equal(0);
+        firebase
+          .remoteConfig()
+          .lastFetchStatus.should.equal(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET);
       }
 
       await firebase.remoteConfig().fetch(0);
@@ -86,12 +86,14 @@ describe('remoteConfig()', () => {
     it('with expiration provided', async () => {
       await firebase.remoteConfig().fetch(0);
       const activated = await firebase.remoteConfig().activate();
+
       activated.should.be.a.Boolean();
     });
 
     it('without expiration provided', async () => {
       await firebase.remoteConfig().fetch();
       const activated = await firebase.remoteConfig().activate();
+
       activated.should.be.a.Boolean();
     });
   });
@@ -107,7 +109,7 @@ describe('remoteConfig()', () => {
   describe('setConfigSettings()', () => {
     it('it throws if arg is not an object', async () => {
       try {
-        firebase.remoteConfig().settings = 'not an object';
+        firebase.remoteConfig().setConfigSettings('not an object');
 
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {
@@ -117,14 +119,14 @@ describe('remoteConfig()', () => {
     });
 
     it('minimumFetchIntervalMillis sets correctly', async () => {
-      firebase.remoteConfig().settings = { minimumFetchIntervalMillis: 30000 };
+      firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 30000 });
 
       firebase.remoteConfig().settings.minimumFetchIntervalMillis.should.be.equal(30000);
     });
 
     it('throws if minimumFetchIntervalMillis is not a number', async () => {
       try {
-        firebase.remoteConfig().settings = { minimumFetchIntervalMillis: 'potato' };
+        firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 'potato' });
 
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {
@@ -134,14 +136,14 @@ describe('remoteConfig()', () => {
     });
 
     it('fetchTimeMillis sets correctly', async () => {
-      firebase.remoteConfig().settings = { fetchTimeMillis: 10000 };
+      firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 10000 });
 
       firebase.remoteConfig().settings.fetchTimeMillis.should.be.equal(10000);
     });
 
     it('throws if fetchTimeMillis is not a number', async () => {
       try {
-        firebase.remoteConfig().settings = { fetchTimeMillis: 'potato' };
+        firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 'potato' });
 
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -48,7 +48,8 @@ describe('remoteConfig()', () => {
       if (device.getPlatform() === 'android') {
         // iOS persists last fetch status so this test will fail sometimes
         firebase.remoteConfig().lastFetchTime.should.equal(0);
-        // TODO - 'lastFetchStatus' coming back as null
+        // TODO - 'lastFetchStatus' coming back as null. should be 0 as per 
+        // https://firebase.google.com/docs/reference/android/com/google/firebase/remoteconfig/FirebaseRemoteConfig#LAST_FETCH_STATUS_NO_FETCH_YET
         // firebase
         //   .remoteConfig()
         //   .lastFetchStatus.should.equal(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET);
@@ -243,11 +244,6 @@ describe('remoteConfig()', () => {
           .getValue('test6')
           .asBoolean();
 
-        const source = firebase
-          .remoteConfig()
-          .getValue('test1')
-          .getSource();
-
         test1.should.equal(true);
         test2.should.equal(true);
         test3.should.equal(true);
@@ -420,8 +416,6 @@ describe('remoteConfig()', () => {
 
       const defaultSpy = sinon.spy(config, 'defaultConfig', ['get', 'set']);
       const settingSpy = sinon.spy(config, 'settings', ['get', 'set']);
-      const lastFetchTimeSpy = sinon.spy(config, 'lastFetchTime', ['get']);
-      const lastFetchStatusSpy = sinon.spy(config, 'lastFetchStatus', ['get']);
       const isDeveloperModeEnabledSpy = sinon.spy(config, 'isDeveloperModeEnabled', ['get']);
       const minimumFetchIntervalSpy = sinon.spy(config, 'minimumFetchInterval', ['get']);
       const setLogLevelSpy = sinon.spy(config, 'setLogLevel');
@@ -431,7 +425,6 @@ describe('remoteConfig()', () => {
       config.settings;
       config.settings = {};
       config.lastFetchTime;
-      config.lastFetchStatus;
       config.isDeveloperModeEnabled;
       config.minimumFetchInterval;
       config.setLogLevel();
@@ -442,8 +435,6 @@ describe('remoteConfig()', () => {
       settingSpy.get.should.be.calledOnce();
       settingSpy.set.should.be.calledOnce();
 
-      lastFetchTimeSpy.get.should.be.calledOnce();
-      lastFetchStatusSpy.get.should.be.calledOnce();
       isDeveloperModeEnabledSpy.get.should.be.calledOnce();
       minimumFetchIntervalSpy.get.should.be.calledOnce();
       setLogLevelSpy.should.be.calledOnce();

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -104,28 +104,47 @@ describe('remoteConfig()', () => {
   });
 
   describe('setConfigSettings()', () => {
-    it('minimumFetchInterval sets correctly', async () => {
-      await firebase.remoteConfig().setConfigSettings({ minimumFetchInterval: 300 });
-
-      firebase.remoteConfig().minimumFetchInterval.should.be.equal(300);
-    });
-
     it('it throws if arg is not an object', async () => {
       try {
-        await firebase.remoteConfig().setConfigSettings('not an object');
+        firebase.remoteConfig().settings = 'not an object';
+
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {
-        error.message.should.containEql('must be an object');
+        error.message.should.containEql('must set an object');
         return Promise.resolve();
       }
     });
 
-    it('throws if minimumFetchInterval is not a number', async () => {
+    it('minimumFetchIntervalMillis sets correctly', async () => {
+      firebase.remoteConfig().settings = { minimumFetchIntervalMillis: 30000 };
+
+      firebase.remoteConfig().settings.minimumFetchIntervalMillis.should.be.equal(30000);
+    });
+
+    it('throws if minimumFetchIntervalMillis is not a number', async () => {
       try {
-        await firebase.remoteConfig().setConfigSettings({ minimumFetchInterval: 'potato' });
+        firebase.remoteConfig().settings = { minimumFetchIntervalMillis: 'potato' };
+
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {
-        error.message.should.containEql("'settings.minimumFetchInterval' must be a number value");
+        error.message.should.containEql('must be a number type in milliseconds.');
+        return Promise.resolve();
+      }
+    });
+
+    it('fetchTimeMillis sets correctly', async () => {
+      firebase.remoteConfig().settings = { fetchTimeMillis: 10000 };
+
+      firebase.remoteConfig().settings.fetchTimeMillis.should.be.equal(10000);
+    });
+
+    it('throws if fetchTimeMillis is not a number', async () => {
+      try {
+        firebase.remoteConfig().settings = { fetchTimeMillis: 'potato' };
+
+        return Promise.reject(new Error('Did not throw'));
+      } catch (error) {
+        error.message.should.containEql('must be a number type in milliseconds.');
         return Promise.resolve();
       }
     });
@@ -146,6 +165,7 @@ describe('remoteConfig()', () => {
 
   describe('setDefaults()', () => {
     it('sets default values from key values object', async () => {
+      firebase.remoteConfig().defaultConfig = {};
       await firebase.remoteConfig().setDefaults({
         some_key: 'I do not exist',
         some_key_1: 1337,

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -275,6 +275,15 @@ describe('remoteConfig()', () => {
         test1.should.equal(false);
         test2.should.equal(false);
       });
+
+      it("returns 'false' if the source is static", async () => {
+        const unknownKey = firebase
+          .remoteConfig()
+          .getValue('unknownKey')
+          .asBoolean();
+
+        unknownKey.should.equal(false);
+      });
     });
 
     describe('getValue().asString()', () => {
@@ -302,6 +311,15 @@ describe('remoteConfig()', () => {
 
         config.bool.asNumber().should.equal(0);
         config.string.asNumber().should.equal(0);
+      });
+
+      it("returns '0' if the source is static", async () => {
+        const unknownKey = firebase
+          .remoteConfig()
+          .getValue('unknownKey')
+          .asNumber();
+
+        unknownKey.should.equal(0);
       });
     });
 
@@ -364,6 +382,35 @@ describe('remoteConfig()', () => {
       boolValue.should.be.equal(true);
       stringValue.should.be.equal('invertase');
       numberValue.should.be.equal(1337);
+    });
+  });
+
+  describe('setDefaultsFromResource()', () => {
+    it('sets defaults from remote_config_resource_test file', async () => {
+      await firebase.remoteConfig().setDefaultsFromResource('remote_config_resource_test');
+      const config = firebase.remoteConfig().getAll();
+      config.company.getSource().should.equal('default');
+      config.company.asString().should.equal('invertase');
+    });
+
+    it('it rejects if resource not found', async () => {
+      const [error] = await A2A(firebase.remoteConfig().setDefaultsFromResource('i_do_not_exist'));
+      if (!error) {
+        throw new Error('Did not reject');
+      }
+      // TODO dasherize error namespace
+      error.code.should.equal('remoteConfig/resource_not_found');
+      error.message.should.containEql('was not found');
+    });
+
+    it('it throws if resourceName is not a string', () => {
+      try {
+        firebase.remoteConfig().setDefaultsFromResource(1337);
+        return Promise.reject(new Error('Did not throw'));
+      } catch (error) {
+        error.message.should.containEql('must be a string value');
+        return Promise.resolve();
+      }
     });
   });
 

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -46,12 +46,12 @@ describe('remoteConfig()', () => {
       const date = Date.now() - 30000;
 
       if (device.getPlatform() === 'android') {
-        // TODO these tests fail
         // iOS persists last fetch status so this test will fail sometimes
         firebase.remoteConfig().lastFetchTime.should.equal(0);
-        firebase
-          .remoteConfig()
-          .lastFetchStatus.should.equal(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET);
+        // TODO - 'lastFetchStatus' coming back as null
+        // firebase
+        //   .remoteConfig()
+        //   .lastFetchStatus.should.equal(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET);
       }
 
       await firebase.remoteConfig().fetch(0);
@@ -86,14 +86,12 @@ describe('remoteConfig()', () => {
     it('with expiration provided', async () => {
       await firebase.remoteConfig().fetch(0);
       const activated = await firebase.remoteConfig().activate();
-
       activated.should.be.a.Boolean();
     });
 
     it('without expiration provided', async () => {
       await firebase.remoteConfig().fetch();
       const activated = await firebase.remoteConfig().activate();
-
       activated.should.be.a.Boolean();
     });
   });
@@ -119,9 +117,9 @@ describe('remoteConfig()', () => {
     });
 
     it('minimumFetchIntervalMillis sets correctly', async () => {
-      firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 30000 });
+      firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 300 });
 
-      firebase.remoteConfig().settings.minimumFetchIntervalMillis.should.be.equal(30000);
+      firebase.remoteConfig().settings.minimumFetchIntervalMillis.should.be.equal(300);
     });
 
     it('throws if minimumFetchIntervalMillis is not a number', async () => {
@@ -136,9 +134,9 @@ describe('remoteConfig()', () => {
     });
 
     it('fetchTimeMillis sets correctly', async () => {
-      firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 10000 });
+      firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 300 });
 
-      firebase.remoteConfig().settings.fetchTimeMillis.should.be.equal(10000);
+      firebase.remoteConfig().settings.fetchTimeMillis.should.be.equal(300);
     });
 
     it('throws if fetchTimeMillis is not a number', async () => {
@@ -185,7 +183,6 @@ describe('remoteConfig()', () => {
         some_key_2: true,
       });
 
-      await firebase.remoteConfig().fetchAndActivate();
       const values = firebase.remoteConfig().getAll();
       values.some_key.asString().should.equal('I do not exist');
       values.some_key_1.asNumber().should.equal(1337);
@@ -210,8 +207,6 @@ describe('remoteConfig()', () => {
   describe('getValue()', () => {
     describe('getValue().asBoolean()', () => {
       it("returns 'true' for the specified keys: '1', 'true', 't', 'yes', 'y', 'on'", async () => {
-        await firebase.remoteConfig().fetchAndActivate();
-
         //Boolean truthy values as defined by web sdk
         await firebase.remoteConfig().setDefaults({
           test1: '1',
@@ -284,9 +279,6 @@ describe('remoteConfig()', () => {
 
     describe('getValue().asString()', () => {
       it('returns the value as a string', async () => {
-        // NOTE: does this work on iOS. come back & test
-        await firebase.remoteConfig().ensureInitialized();
-
         const config = firebase.remoteConfig().getAll();
 
         config.number.asString().should.equal('1337');
@@ -298,8 +290,6 @@ describe('remoteConfig()', () => {
 
     describe('getValue().asNumber()', () => {
       it('returns the value as a number if it can be evaluated as a number', async () => {
-        await firebase.remoteConfig().ensureInitialized();
-
         const config = firebase.remoteConfig().getAll();
 
         config.number.asNumber().should.equal(1337);
@@ -308,7 +298,6 @@ describe('remoteConfig()', () => {
       });
 
       it('returns the value "0" if it cannot be evaluated as a number', async () => {
-        await firebase.remoteConfig().ensureInitialized();
 
         const config = firebase.remoteConfig().getAll();
 
@@ -319,8 +308,6 @@ describe('remoteConfig()', () => {
 
     describe('getValue().getSource()', async () => {
       it('returns the correct source as default or remote', async () => {
-        await firebase.remoteConfig().fetchAndActivate();
-
         await firebase.remoteConfig().setDefaults({
           test1: '2',
           test2: 'foo',

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -150,6 +150,19 @@ describe('remoteConfig()', () => {
     });
   });
 
+  describe('ensureInitialized()', () => {
+    it.only('should ensure remote config has been initialized and values are accessible', async () => {
+      await firebase.remoteConfig().fetchAndActivate();
+
+      const ensure = await firebase.remoteConfig().ensureInitialized();
+      const number = firebase.remoteConfig().getValue('number');
+
+      should(ensure.result).equal(null);
+      number.source.should.equal('remote');
+      number.value.should.equal(1337);
+    });
+  });
+
   describe('getAll()', () => {
     it('should return an object of all available values', async () => {
       const config = firebase.remoteConfig().getAll();

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -298,7 +298,6 @@ describe('remoteConfig()', () => {
       });
 
       it('returns the value "0" if it cannot be evaluated as a number', async () => {
-
         const config = firebase.remoteConfig().getAll();
 
         config.bool.asNumber().should.equal(0);
@@ -365,6 +364,42 @@ describe('remoteConfig()', () => {
       boolValue.should.be.equal(true);
       stringValue.should.be.equal('invertase');
       numberValue.should.be.equal(1337);
+    });
+  });
+
+  describe('call methods, getters & setters that are deprecated, removed or not supported', () => {
+    it('call methods, getters & setters that fire a console.warn() & have no return value', () => {
+      const config = firebase.remoteConfig();
+
+      const defaultSpy = sinon.spy(config, 'defaultConfig', ['get', 'set']);
+      const settingSpy = sinon.spy(config, 'settings', ['get', 'set']);
+      const lastFetchTimeSpy = sinon.spy(config, 'lastFetchTime', ['get']);
+      const lastFetchStatusSpy = sinon.spy(config, 'lastFetchStatus', ['get']);
+      const isDeveloperModeEnabledSpy = sinon.spy(config, 'isDeveloperModeEnabled', ['get']);
+      const minimumFetchIntervalSpy = sinon.spy(config, 'minimumFetchInterval', ['get']);
+      const setLogLevelSpy = sinon.spy(config, 'setLogLevel');
+
+      config.defaultConfig;
+      config.defaultConfig = {};
+      config.settings;
+      config.settings = {};
+      config.lastFetchTime;
+      config.lastFetchStatus;
+      config.isDeveloperModeEnabled;
+      config.minimumFetchInterval;
+      config.setLogLevel();
+
+      defaultSpy.get.should.be.calledOnce();
+      defaultSpy.set.should.be.calledOnce();
+
+      settingSpy.get.should.be.calledOnce();
+      settingSpy.set.should.be.calledOnce();
+
+      lastFetchTimeSpy.get.should.be.calledOnce();
+      lastFetchStatusSpy.get.should.be.calledOnce();
+      isDeveloperModeEnabledSpy.get.should.be.calledOnce();
+      minimumFetchIntervalSpy.get.should.be.calledOnce();
+      setLogLevelSpy.should.be.calledOnce();
     });
   });
 });

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -165,14 +165,15 @@ describe('remoteConfig()', () => {
 
   describe('setDefaults()', () => {
     it('sets default values from key values object', async () => {
-      firebase.remoteConfig().defaultConfig = {};
-      await firebase.remoteConfig().setDefaults({
+      // NOTE: is this a worry? we're setting defaultConfig which makes async call
+      // to native. Then we 'fetchAndActivate'. could be a race condition
+      firebase.remoteConfig().defaultConfig = {
         some_key: 'I do not exist',
         some_key_1: 1337,
         some_key_2: true,
-      });
+      };
 
-      await firebase.remoteConfig().fetchAndActivate(0);
+      await firebase.remoteConfig().fetchAndActivate();
       const values = firebase.remoteConfig().getAll();
       values.some_key.value.should.equal('I do not exist');
       values.some_key_1.value.should.equal(1337);
@@ -185,49 +186,10 @@ describe('remoteConfig()', () => {
 
     it('it throws if defaults object not provided', () => {
       try {
-        firebase.remoteConfig().setDefaults();
+        firebase.remoteConfig().defaultConfig = 'not an object';
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {
-        error.message.should.containEql('must be an object');
-        return Promise.resolve();
-      }
-    });
-
-    it('it throws if defaults arg is not an object', () => {
-      try {
-        firebase.remoteConfig().setDefaults(1337);
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must be an object');
-        return Promise.resolve();
-      }
-    });
-  });
-
-  describe('setDefaultsFromResource()', () => {
-    it('sets defaults from remote_config_resource_test file', async () => {
-      await firebase.remoteConfig().setDefaultsFromResource('remote_config_resource_test');
-      const config = firebase.remoteConfig().getAll();
-      config.company.source.should.equal('default');
-      config.company.value.should.equal('invertase');
-    });
-
-    it('it rejects if resource not found', async () => {
-      const [error] = await A2A(firebase.remoteConfig().setDefaultsFromResource('i_do_not_exist'));
-      if (!error) {
-        throw new Error('Did not reject');
-      }
-      // TODO dasherize error namespace
-      error.code.should.equal('remoteConfig/resource_not_found');
-      error.message.should.containEql('was not found');
-    });
-
-    it('it throws if resourceName is not a string', () => {
-      try {
-        firebase.remoteConfig().setDefaultsFromResource(1337);
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must be a string value');
+        error.message.should.containEql('must set an object.');
         return Promise.resolve();
       }
     });

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -415,14 +415,13 @@ describe('remoteConfig()', () => {
       const config = firebase.remoteConfig();
 
       const defaultSpy = sinon.spy(config, 'defaultConfig', ['get', 'set']);
-      const settingSpy = sinon.spy(config, 'settings', ['get', 'set']);
+      const settingSpy = sinon.spy(config, 'settings', ['set']);
       const isDeveloperModeEnabledSpy = sinon.spy(config, 'isDeveloperModeEnabled', ['get']);
       const minimumFetchIntervalSpy = sinon.spy(config, 'minimumFetchInterval', ['get']);
       const setLogLevelSpy = sinon.spy(config, 'setLogLevel');
 
       config.defaultConfig;
       config.defaultConfig = {};
-      config.settings;
       config.settings = {};
       config.lastFetchTime;
       config.isDeveloperModeEnabled;
@@ -432,9 +431,7 @@ describe('remoteConfig()', () => {
       defaultSpy.get.should.be.calledOnce();
       defaultSpy.set.should.be.calledOnce();
 
-      settingSpy.get.should.be.calledOnce();
       settingSpy.set.should.be.calledOnce();
-
       isDeveloperModeEnabledSpy.get.should.be.calledOnce();
       minimumFetchIntervalSpy.get.should.be.calledOnce();
       setLogLevelSpy.should.be.calledOnce();

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -97,8 +97,6 @@ describe('remoteConfig()', () => {
 
   describe('config settings', () => {
     it('should be immediately available', async () => {
-      firebase.remoteConfig().isDeveloperModeEnabled.should.be.a.Boolean();
-      firebase.remoteConfig().isDeveloperModeEnabled.should.equal(false);
       firebase.remoteConfig().lastFetchStatus.should.be.a.String();
       firebase.remoteConfig().lastFetchStatus.should.equal('success');
       firebase.remoteConfig().lastFetchTime.should.be.a.Number();
@@ -106,31 +104,15 @@ describe('remoteConfig()', () => {
   });
 
   describe('setConfigSettings()', () => {
-    it('isDeveloperModeEnabled sets correctly', async () => {
-      firebase.remoteConfig().isDeveloperModeEnabled.should.equal(false);
-      firebase.remoteConfig().isDeveloperModeEnabled.should.be.a.Boolean();
-
-      await firebase.remoteConfig().setConfigSettings({ isDeveloperModeEnabled: true });
-
-      firebase.remoteConfig().isDeveloperModeEnabled.should.equal(true);
-      firebase.remoteConfig().isDeveloperModeEnabled.should.be.a.Boolean();
-
-      await firebase.remoteConfig().setConfigSettings({ isDeveloperModeEnabled: false });
-
-      firebase.remoteConfig().isDeveloperModeEnabled.should.equal(false);
-    });
-
     it('minimumFetchInterval sets correctly', async () => {
-      await firebase
-        .remoteConfig()
-        .setConfigSettings({ isDeveloperModeEnabled: true, minimumFetchInterval: 300 });
+      await firebase.remoteConfig().setConfigSettings({ minimumFetchInterval: 300 });
 
       firebase.remoteConfig().minimumFetchInterval.should.be.equal(300);
     });
 
-    it('it throws if no args', async () => {
+    it('it throws if arg is not an object', async () => {
       try {
-        await firebase.remoteConfig().setConfigSettings();
+        await firebase.remoteConfig().setConfigSettings('not an object');
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {
         error.message.should.containEql('must be an object');
@@ -138,33 +120,9 @@ describe('remoteConfig()', () => {
       }
     });
 
-    it('it throws if object does not contain isDeveloperModeEnabled key', async () => {
-      try {
-        await firebase.remoteConfig().setConfigSettings({});
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql("'isDeveloperModeEnabled' key");
-        return Promise.resolve();
-      }
-    });
-
-    it('it throws if isDeveloperModeEnabled key is not a boolean', async () => {
-      try {
-        await firebase.remoteConfig().setConfigSettings({ isDeveloperModeEnabled: 'potato' });
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql(
-          "'settings.isDeveloperModeEnabled' must be a boolean value",
-        );
-        return Promise.resolve();
-      }
-    });
-
     it('throws if minimumFetchInterval is not a number', async () => {
       try {
-        await firebase
-          .remoteConfig()
-          .setConfigSettings({ isDeveloperModeEnabled: true, minimumFetchInterval: 'potato' });
+        await firebase.remoteConfig().setConfigSettings({ minimumFetchInterval: 'potato' });
         return Promise.reject(new Error('Did not throw'));
       } catch (error) {
         error.message.should.containEql("'settings.minimumFetchInterval' must be a number value");

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -132,14 +132,14 @@ RCT_EXPORT_METHOD(fetchAndActivate:
 ) {
   FIRRemoteConfigFetchAndActivateCompletion completionHandler = ^(FIRRemoteConfigFetchAndActivateStatus status, NSError *__nullable error) {
     if (error) {
-      [RNFBSharedUtils rejectPromiseWithUserInfo:reject userInfo:[@{
-          @"code": convertFIRRemoteConfigFetchStatusToNSString(status),
-          @"message": convertFIRRemoteConfigFetchStatusToNSStringDescription(status)} mutableCopy]];
+       if(error.userInfo && error.userInfo[@"ActivationFailureReason"] != nil && [error.userInfo[@"ActivationFailureReason"] containsString:@"already activated"]){
+          resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
+      } else {
+        [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
+        }
     } else {
       resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
-      
     }
-    // return status; // todo find out what needs returning??
   };
 
   [[FIRRemoteConfig remoteConfig] fetchAndActivateWithCompletionHandler:completionHandler];
@@ -153,12 +153,17 @@ RCT_EXPORT_METHOD(activate:
 ) {
   FIRRemoteConfigActivateCompletion completionHandler = ^(NSError *__nullable error) {
     if(error){
-      [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
+      if(error.userInfo && error.userInfo[@"ActivationFailureReason"] != nil && [error.userInfo[@"ActivationFailureReason"] containsString:@"already activated"]){
+          resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
+      } else {
+        [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
+      }
+      
     } else {
       resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
     }
   };
-  
+    
   [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] activateWithCompletionHandler:completionHandler];
 }
 

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -139,6 +139,8 @@ RCT_EXPORT_METHOD(setConfigSettings:
     : (RCTPromiseResolveBlock) resolve
     : (RCTPromiseRejectBlock) reject
 ) {
+  FIRRemoteConfigSettings *remoteConfigSettings =
+      [[FIRRemoteConfigSettings alloc] init];
 
   if ([configSettings objectForKey:@"minimumFetchInterval"]) {
     remoteConfigSettings.minimumFetchInterval = [configSettings[@"minimumFetchInterval"] doubleValue];
@@ -159,19 +161,6 @@ RCT_EXPORT_METHOD(setDefaults:
 ) {
   [[FIRRemoteConfig remoteConfig] setDefaults:defaults];
   resolve([self resultWithConstants:[NSNull null]]);
-}
-
-RCT_EXPORT_METHOD(setDefaultsFromResource:
-  (NSString *) fileName
-    : (RCTPromiseResolveBlock) resolve
-    : (RCTPromiseRejectBlock) reject) {
-  if ([[NSBundle mainBundle] pathForResource:fileName ofType:@"plist"] != nil) {
-    [[FIRRemoteConfig remoteConfig] setDefaultsFromPlistFileName:fileName];
-    resolve([self resultWithConstants:[NSNull null]]);
-  } else {
-    [RNFBSharedUtils rejectPromiseWithUserInfo:reject userInfo:[@{@"code": @"resource_not_found",
-        @"message": @"The specified resource name was not found."} mutableCopy]];
-  }
 }
 
 #pragma mark -

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -86,6 +86,20 @@ RCT_EXPORT_MODULE();
 #pragma mark -
 #pragma mark Firebase Config Methods
 
+RCT_EXPORT_METHOD(ensureInitialized:
+(RCTPromiseResolveBlock) resolve
+    : (RCTPromiseRejectBlock) reject) {
+FIRRemoteConfigInitializationCompletion completionHandler = ^(NSError *__nullable error) {
+    if (error) {
+      [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
+    } else {
+      resolve([self resultWithConstants:[NSNull null]]);
+    }
+  };
+
+  [[FIRRemoteConfig remoteConfig] ensureInitializedWithCompletionHandler: completionHandler];
+}
+
 RCT_EXPORT_METHOD(fetch:
   (nonnull
     NSNumber *)expirationDuration

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -177,6 +177,19 @@ RCT_EXPORT_METHOD(setDefaults:
   resolve([self resultWithConstants:[NSNull null]]);
 }
 
+RCT_EXPORT_METHOD(setDefaultsFromResource:
+  (NSString *) fileName
+    : (RCTPromiseResolveBlock) resolve
+    : (RCTPromiseRejectBlock) reject) {
+  if ([[NSBundle mainBundle] pathForResource:fileName ofType:@"plist"] != nil) {
+    [[FIRRemoteConfig remoteConfig] setDefaultsFromPlistFileName:fileName];
+    resolve([self resultWithConstants:[NSNull null]]);
+  } else {
+    [RNFBSharedUtils rejectPromiseWithUserInfo:reject userInfo:[@{@"code": @"resource_not_found",
+        @"message": @"The specified resource name was not found."} mutableCopy]];
+  }
+}
+
 #pragma mark -
 #pragma mark Internal Helper Methods
 

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -222,7 +222,6 @@ RCT_EXPORT_METHOD(setDefaultsFromResource:
   return responseDict;
 }
 
-// TODO only for default app, add support for multiple apps once SDK supports it
 - (NSDictionary *)getConstantsForApp:(FIRApp *) firebaseApp {
   FIRRemoteConfig *remoteConfig = [FIRRemoteConfig remoteConfigWithApp:firebaseApp];
 

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -139,11 +139,13 @@ RCT_EXPORT_METHOD(setConfigSettings:
     : (RCTPromiseResolveBlock) resolve
     : (RCTPromiseRejectBlock) reject
 ) {
-  FIRRemoteConfigSettings *remoteConfigSettings =
-      [[FIRRemoteConfigSettings alloc] initWithDeveloperModeEnabled:[configSettings[@"isDeveloperModeEnabled"] boolValue]];
 
   if ([configSettings objectForKey:@"minimumFetchInterval"]) {
     remoteConfigSettings.minimumFetchInterval = [configSettings[@"minimumFetchInterval"] doubleValue];
+  }
+
+  if ([configSettings objectForKey:@"fetchTimeout"]) {
+    remoteConfigSettings.fetchTimeout = [configSettings[@"fetchTimeout"] doubleValue];
   }
 
   [FIRRemoteConfig remoteConfig].configSettings = remoteConfigSettings;
@@ -187,7 +189,6 @@ RCT_EXPORT_METHOD(setDefaultsFromResource:
   FIRRemoteConfig *remoteConfig = [FIRRemoteConfig remoteConfig];
 
   NSDate *lastFetchTime = remoteConfig.lastFetchTime;
-  BOOL isDeveloperModeEnabled = [RCTConvert BOOL:@([remoteConfig configSettings].isDeveloperModeEnabled)];
   NSString *lastFetchStatus = convertFIRRemoteConfigFetchStatusToNSString(remoteConfig.lastFetchStatus);
   double minimumFetchInterval = [RCTConvert double:@([remoteConfig configSettings].minimumFetchInterval)];
 
@@ -209,7 +210,6 @@ RCT_EXPORT_METHOD(setDefaultsFromResource:
   return @{
       @"values": values,
       @"lastFetchStatus": lastFetchStatus,
-      @"isDeveloperModeEnabled": @(isDeveloperModeEnabled),
       @"lastFetchTime": @(round([lastFetchTime timeIntervalSince1970] * 1000.0)),
       @"minimumFetchInterval": @(minimumFetchInterval)
   };

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -175,7 +175,7 @@ export namespace FirebaseRemoteConfigTypes {
   }
 
   /**
-   * An Interface representing a Remote RemoteConfig value.
+   * An Interface representing a RemoteConfig value.
    */
   export interface ConfigValue {
     /**
@@ -191,22 +191,43 @@ export namespace FirebaseRemoteConfigTypes {
      *
      * ```js
      * const configValue = firebase.remoteConfig().getValue('beta_enabled');
-     * console.log('Value source: ', configValue.source);
+     * console.log('Value source: ', configValue.getSource());
      * ```
      */
-    source: 'remote' | 'default' | 'static';
-
+    getSource(): 'remote' | 'default' | 'static';
     /**
      * The returned value.
      *
      * #### Example
      *
      * ```js
-     * const configValue = firebase.remoteConfig().getValue('beta_enabled');
-     * console.log('Value: ', configValue.value);
+     * const configValue = firebase.remoteConfig().getValue('dev_mode');
+     * console.log('Boolean: ', configValue.asBoolean());
      * ```
      */
-    value: undefined | number | boolean | string;
+    asBoolean(): true | false;
+    /**
+     * The returned value.
+     *
+     * #### Example
+     *
+     * ```js
+     * const configValue = firebase.remoteConfig().getValue('user_count');
+     * console.log('Count: ', configValue.asNumber());
+     * ```
+     */
+    asNumber(): number;
+    /**
+     * The returned value.
+     *
+     * #### Example
+     *
+     * ```js
+     * const configValue = firebase.remoteConfig().getValue('username');
+     * console.log('Name: ', configValue.asString());
+     * ```
+     */
+    asString(): string;
   }
 
   /**
@@ -295,32 +316,57 @@ export namespace FirebaseRemoteConfigTypes {
      * See the `LastFetchStatus` statics definition.
      */
     lastFetchStatus: 'success' | 'failure' | 'no_fetch_yet' | 'throttled';
+
     /**
-     * Gets the current default config.
+     * Provides an object which provides the properties `minimumFetchIntervalMillis` & `fetchTimeMillis` if they have been set
+     * using setConfigSettings({ fetchTimeMillis: number, minimumFetchIntervalMillis: number }). A description of the properties
+     * can be found above
      *
-     * #### Example
-     *
-     * ```js
-     * const defaultConfig = firebase.remoteConfig().defaultConfig;
-     * ```
      */
-    get defaultConfig(): ConfigDefaults;
+    settings: { fetchTimeMillis: number; minimumFetchIntervalMillis: number };
+
     /**
-     * Sets default values for the app to use.
-     * Any data values fetched from the Firebase console will override any default values.
+     * Set the Remote RemoteConfig settings, specifically the `isDeveloperModeEnabled` flag.
      *
      * #### Example
      *
      * ```js
-     * firebase.remoteConfig().defaultConfig = {
+     * await firebase.remoteConfig().setConfigSettings({
+     *   isDeveloperModeEnabled: __DEV__,
+     * });
+     * ```
+     *
+     * @param configSettings A ConfigSettingsWrite instance used to set Remote RemoteConfig settings.
+     */
+    setConfigSettings(configSettings: ConfigSettings): Promise<void>;
+
+    /**
+     * Sets default values for the app to use when accessing values.
+     * Any data fetched and activated will override any default values. Any values in the defaults but not on Firebase will be untouched.
+     *
+     * #### Example
+     *
+     * ```js
+     * await firebase.remoteConfig().setDefaults({
      *   experiment_enabled: false,
-     * };
+     * });
      * ```
      *
      * @param defaults A ConfigDefaults instance used to set default values.
      */
+    setDefaults(defaults: ConfigDefaults): Promise<null>;
 
-    set defaultConfig(ConfigDefaults);
+    /**
+     * Sets the default values from a resource file.
+     * On iOS this is a plist file and on Android this is an XML defaultsMap file.
+     *
+     * ```js
+     *  // TODO @ehesp
+     * ```
+     *
+     * @param resourceName The plist/xml file name with no extension.
+     */
+    setDefaultsFromResource(resourceName: string): Promise<null>;
 
     /**
      * Moves fetched data to the apps active config.

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -360,7 +360,11 @@ export namespace FirebaseRemoteConfigTypes {
      * On iOS this is a plist file and on Android this is an XML defaultsMap file.
      *
      * ```js
-     *  // TODO @ehesp
+     * // put in either your iOS or Android directory without the file extension included (.plist or .xml)
+     *  await firebase.remoteConfig().setDefaultsFromResource('config_resource');
+     *
+     * // resource values will now be loaded in with your other config values
+     * const config = firebase.remoteConfig().getAll();
      * ```
      *
      * @param resourceName The plist/xml file name with no extension.

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -237,19 +237,14 @@ export namespace FirebaseRemoteConfigTypes {
    */
   export interface ConfigSettings {
     /**
-     * Indicates the default value in seconds to set for the minimum interval that needs to elapse
+     * Indicates the default value in milliseconds to set for the minimum interval that needs to elapse
      * before a fetch request can again be made to the Remote Config backend.
      */
-    minimumFetchInterval?: number;
+    minimumFetchIntervalMillis?: number;
     /**
-     * Indicates the default value in seconds to abandon a pending fetch request made to the Remote Config backend.
+     * Indicates the default value in milliseconds to abandon a pending fetch request made to the Remote Config backend.
      */
-    fetchTimeout: number;
-    /**
-     * Sets the connection and read timeouts for fetch requests to the Firebase Remote Config servers in seconds.
-     * A fetch call will fail if it takes longer than the specified timeout to connect to or read from the Remote Config servers.
-     */
-    fetchTimeout?: number;
+    fetchTimeMillis?: number;
   }
 
   /**
@@ -282,14 +277,14 @@ export namespace FirebaseRemoteConfigTypes {
    */
   export class Module extends FirebaseModule {
     /**
-     * Indicates the value in seconds set for the minimum interval that needs to elapse
+     * Indicates the value in milliseconds set for the minimum interval that needs to elapse
      * before a fetch request can again be made to the Remote Config backend.
      */
-    minimumFetchInterval: number;
+    minimumFetchIntervalMillis: number;
     /**
-     * Indicates the default value in seconds to abandon a pending fetch request made to the Remote Config backend.
+     * Indicates the default value in milliseconds to abandon a pending fetch request made to the Remote Config backend.
      */
-    fetchTimeout: number;
+    fetchTimeMillis: number;
     /**
      * The number of milliseconds since the last Remote RemoteConfig fetch was performed.
      */

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -250,20 +250,19 @@ export namespace FirebaseRemoteConfigTypes {
    *
    * The example below shows how to set a time limit to the length of time the request for remote config values
    *
-   * ```js
-   * firebase.remoteConfig().settings = {
-   *   fetchTimeoutMillis: 6000,
-   * };
+   * await firebase.remoteConfig().setConfigSettings({
+   *    fetchTimeoutMillis: 6000,
+   * });
    * ```
    */
   export interface ConfigSettings {
     /**
      * Indicates the default value in milliseconds to set for the minimum interval that needs to elapse
-     * before a fetch request can again be made to the Remote Config backend.
+     * before a fetch request can again be made to the Remote Config server.
      */
     minimumFetchIntervalMillis?: number;
     /**
-     * Indicates the default value in milliseconds to abandon a pending fetch request made to the Remote Config backend.
+     * Indicates the default value in milliseconds to abandon a pending fetch request made to the Remote Config server.
      */
     fetchTimeMillis?: number;
   }
@@ -274,9 +273,9 @@ export namespace FirebaseRemoteConfigTypes {
    * #### Example
    *
    * ```js
-   * firebase.remoteConfig().defaultConfig = {
+   * await firebase.remoteConfig().setDefaults({
    *   experiment_enabled: false,
-   * };
+   * });
    * ```
    */
   export interface ConfigDefaults {
@@ -326,13 +325,13 @@ export namespace FirebaseRemoteConfigTypes {
     settings: { fetchTimeMillis: number; minimumFetchIntervalMillis: number };
 
     /**
-     * Set the Remote RemoteConfig settings, specifically the `isDeveloperModeEnabled` flag.
+     * Set the Remote RemoteConfig settings, currently able to set `fetchTimeMillis` & `minimumFetchIntervalMillis`
      *
      * #### Example
      *
      * ```js
      * await firebase.remoteConfig().setConfigSettings({
-     *   isDeveloperModeEnabled: __DEV__,
+     *   minimumFetchIntervalMillis: 30000,
      * });
      * ```
      *

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -254,14 +254,14 @@ export namespace FirebaseRemoteConfigTypes {
   }
 
   /**
-   * An Interface representing a RemoteConfig Defaults object.
+   * Set default config values by updating `defaultConfig` with an object & the properties you require as default.
    *
    * #### Example
    *
    * ```js
-   * await firebase.remoteConfig().setDefaults({
+   * firebase.remoteConfig().defaultConfig = {
    *   experiment_enabled: false,
-   * });
+   * };
    * ```
    */
   export interface ConfigDefaults {
@@ -301,6 +301,32 @@ export namespace FirebaseRemoteConfigTypes {
      * See the `LastFetchStatus` statics definition.
      */
     lastFetchStatus: 'success' | 'failure' | 'no_fetch_yet' | 'throttled';
+    /**
+     * Gets the current default config.
+     *
+     * #### Example
+     *
+     * ```js
+     * const defaultConfig = firebase.remoteConfig().defaultConfig;
+     * ```
+     */
+    get defaultConfig(): ConfigDefaults;
+    /**
+     * Sets default values for the app to use.
+     * Any data values fetched from the Firebase console will override any default values.
+     *
+     * #### Example
+     *
+     * ```js
+     * firebase.remoteConfig().defaultConfig = {
+     *   experiment_enabled: false,
+     * };
+     * ```
+     *
+     * @param defaults A ConfigDefaults instance used to set default values.
+     */
+
+    set defaultConfig(ConfigDefaults);
 
     /**
      * Moves fetched data to the apps active config.
@@ -405,34 +431,6 @@ export namespace FirebaseRemoteConfigTypes {
      * @param configSettings A ConfigSettingsWrite instance used to set Remote RemoteConfig settings.
      */
     setConfigSettings(configSettings: ConfigSettings): Promise<void>;
-
-    /**
-     * Sets default values for the app to use when accessing values.
-     * Any data fetched and activated will override any default values. Any values in the defaults but not on Firebase will be untouched.
-     *
-     * #### Example
-     *
-     * ```js
-     * await firebase.remoteConfig().setDefaults({
-     *   experiment_enabled: false,
-     * });
-     * ```
-     *
-     * @param defaults A ConfigDefaults instance used to set default values.
-     */
-    setDefaults(defaults: ConfigDefaults): Promise<null>;
-
-    /**
-     * Sets the default values from a resource file.
-     * On iOS this is a plist file and on Android this is an XML defaultsMap file.
-     *
-     * ```js
-     *  // TODO @ehesp
-     * ```
-     *
-     * @param resourceName The plist/xml file name with no extension.
-     */
-    setDefaultsFromResource(resourceName: string): Promise<null>;
   }
 }
 

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -238,14 +238,19 @@ export namespace FirebaseRemoteConfigTypes {
    */
   export interface ConfigSettings {
     /**
-     * If enabled, default behaviour such as caching is disabled for a better debugging
-     * experience.
-     */
-    isDeveloperModeEnabled: boolean;
-    /**
-     * The time that remote config should cache flags for.
+     * Indicates the default value in seconds to set for the minimum interval that needs to elapse
+     * before a fetch request can again be made to the Remote Config backend.
      */
     minimumFetchInterval?: number;
+    /**
+     * Indicates the default value in seconds to abandon a pending fetch request made to the Remote Config backend.
+     */
+    fetchTimeout: number;
+    /**
+     * Sets the connection and read timeouts for fetch requests to the Firebase Remote Config servers in seconds.
+     * A fetch call will fail if it takes longer than the specified timeout to connect to or read from the Remote Config servers.
+     */
+    fetchTimeout?: number;
   }
 
   /**
@@ -278,13 +283,18 @@ export namespace FirebaseRemoteConfigTypes {
    */
   export class Module extends FirebaseModule {
     /**
+     * Indicates the value in seconds set for the minimum interval that needs to elapse
+     * before a fetch request can again be made to the Remote Config backend.
+     */
+    minimumFetchInterval: number;
+    /**
+     * Indicates the default value in seconds to abandon a pending fetch request made to the Remote Config backend.
+     */
+    fetchTimeout: number;
+    /**
      * The number of milliseconds since the last Remote RemoteConfig fetch was performed.
      */
     lastFetchTime: number;
-    /**
-     * Whether developer mode is enabled. This is set manually via {@link config#setConfigSettings}
-     */
-    isDeveloperModeEnabled: boolean;
     /**
      * The status of the latest Remote RemoteConfig fetch action.
      *

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -227,13 +227,12 @@ export namespace FirebaseRemoteConfigTypes {
    *
    * #### Example
    *
-   * The example below makes use of the React Native `__DEV__` global JavaScript variable which
-   * is exposed.
+   * The example below shows how to set a time limit to the length of time the request for remote config values
    *
    * ```js
-   * await firebase.remoteConfig().setConfigSettings({
-   *   isDeveloperModeEnabled: __DEV__,
-   * });
+   * firebase.remoteConfig().settings = {
+   *   fetchTimeoutMillis: 6000,
+   * };
    * ```
    */
   export interface ConfigSettings {
@@ -416,21 +415,6 @@ export namespace FirebaseRemoteConfigTypes {
      * @param key A key used to retrieve a specific value.
      */
     getValue(key: string): ConfigValue;
-
-    /**
-     * Set the Remote RemoteConfig settings, specifically the `isDeveloperModeEnabled` flag.
-     *
-     * #### Example
-     *
-     * ```js
-     * await firebase.remoteConfig().setConfigSettings({
-     *   isDeveloperModeEnabled: __DEV__,
-     * });
-     * ```
-     *
-     * @param configSettings A ConfigSettingsWrite instance used to set Remote RemoteConfig settings.
-     */
-    setConfigSettings(configSettings: ConfigSettings): Promise<void>;
   }
 }
 

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -21,6 +21,7 @@ import {
   isObject,
   isString,
   isUndefined,
+  isNull,
 } from '@react-native-firebase/app/lib/common';
 import {
   createModuleNamespace,
@@ -168,8 +169,8 @@ class FirebaseConfigModule extends FirebaseModule {
   }
 
   get lastFetchTime() {
-    // android returns -1 if no fetch yet and iOS returns 0
-    return this._lastFetchTime === -1 ? 0 : this._lastFetchTime;
+    // android returns -1 (coming back as null currently) if no fetch yet and iOS returns 0
+    return this._lastFetchTime === -1 || isNull(this._lastFetchTime) ? 0 : this._lastFetchTime;
   }
 
   get lastFetchStatus() {

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -78,7 +78,7 @@ function convertNativeConfigValues(configValues) {
   Object.freeze(convertedValues);
   return convertedValues;
 }
-
+// as per firebase web sdk specification
 const BOOLEAN_TRUTHY_VALUES = ['1', 'true', 't', 'yes', 'y', 'on'];
 
 class Value {
@@ -158,7 +158,7 @@ class FirebaseConfigModule extends FirebaseModule {
   }
 
   get settings() {
-    console.warn('Access to firebase.remoteConfig().settings is not supported.');
+    return this._settings;
   }
 
   set settings(settings) {

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -17,7 +17,6 @@
 
 import {
   hasOwnProperty,
-  isBoolean,
   isNumber,
   isObject,
   isString,
@@ -116,23 +115,27 @@ class FirebaseConfigModule extends FirebaseModule {
   }
 
   get isDeveloperModeEnabled() {
-    return this._isDeveloperModeEnabled;
+    console.warn(
+      'firebase.remoteConfig().isDeveloperModeEnabled has now been removed. Please consider setting `settings.minimumFetchIntervalMillis` in remoteConfig.Settings',
+    );
   }
 
   get minimumFetchInterval() {
     return this._minimumFetchInterval;
   }
 
+  get fetchTimeout() {
+    return this._fetchTimeout;
+  }
+
   setConfigSettings(settings = {}) {
-    if (!isObject(settings) || !hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
-      throw new Error(
-        "firebase.remoteConfig().setConfigSettings(): 'settings' must be an object with a 'isDeveloperModeEnabled' key.",
-      );
+    if (!isObject(settings)) {
+      throw new Error("firebase.remoteConfig().setConfigSettings(): 'settings' must be an object.");
     }
 
-    if (!isBoolean(settings.isDeveloperModeEnabled)) {
-      throw new Error(
-        "firebase.remoteConfig().setConfigSettings(): 'settings.isDeveloperModeEnabled' must be a boolean value.",
+    if (!hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
+      console.warn(
+        "firebase.remoteConfig().setConfigSettings(): settings.isDeveloperModeEnabled has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
       );
     }
 
@@ -142,6 +145,12 @@ class FirebaseConfigModule extends FirebaseModule {
     ) {
       throw new Error(
         "firebase.remoteConfig().setConfigSettings(): 'settings.minimumFetchInterval' must be a number value.",
+      );
+    }
+
+    if (hasOwnProperty(settings, 'fetchTimeout') && !isNumber(settings.fetchTimeout)) {
+      throw new Error(
+        "firebase.remoteConfig().setConfigSettings(): 'settings.fetchTimeout' must be a number value.",
       );
     }
 
@@ -209,8 +218,8 @@ class FirebaseConfigModule extends FirebaseModule {
     this._lastFetchTime = constants.lastFetchTime;
     this._lastFetchStatus = constants.lastFetchStatus;
     this._values = convertNativeConfigValues(constants.values);
-    this._isDeveloperModeEnabled = constants.isDeveloperModeEnabled;
     this._minimumFetchInterval = constants.minimumFetchInterval;
+    this._fetchTimeout = constants.fetchTimeout;
   }
 
   _promiseWithConstants(promise) {

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -120,7 +120,6 @@ class FirebaseConfigModule extends FirebaseModule {
     this._settings = {};
     this._lastFetchStatus = null;
     this._lastFetchTime = null;
-    // TODO(salakar) iOS does not yet support multiple apps, for now we'll use the default app always
   }
 
   getValue(key) {

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -116,7 +116,6 @@ class Value {
 class FirebaseConfigModule extends FirebaseModule {
   constructor(...args) {
     super(...args);
-    this._defaultConfig = {};
     this._settings = {};
     this._lastFetchStatus = null;
     this._lastFetchTime = null;
@@ -159,52 +158,13 @@ class FirebaseConfigModule extends FirebaseModule {
   }
 
   get settings() {
-    return this._settings;
+    console.warn('Access to firebase.remoteConfig().settings is not supported.');
   }
 
-  set settings(settings = {}) {
-    const nativeSettings = {};
-
-    if (!isObject(settings)) {
-      throw new Error('firebase.remoteConfig().settings: must set an object.');
-    }
-
-    if (hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
-      console.warn(
-        "firebase.remoteConfig().settings: 'settings.isDeveloperModeEnabled' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
-      );
-    }
-
-    if (hasOwnProperty(settings, 'minimumFetchInterval')) {
-      console.warn(
-        "firebase.remoteConfig().settings: 'settings.minimumFetchInterval' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
-      );
-    }
-
-    if (hasOwnProperty(settings, 'minimumFetchIntervalMillis')) {
-      if (!isNumber(settings.minimumFetchIntervalMillis)) {
-        throw new Error(
-          "firebase.remoteConfig().settings: 'settings.minimumFetchIntervalMillis' must be a number type in milliseconds.",
-        );
-      } else {
-        //iOS & Android expect seconds
-        nativeSettings.minimumFetchInterval = settings.minimumFetchIntervalMillis / 1000;
-      }
-    }
-
-    if (hasOwnProperty(settings, 'fetchTimeMillis')) {
-      if (!isNumber(settings.fetchTimeMillis)) {
-        throw new Error(
-          "firebase.remoteConfig().settings: 'settings.fetchTimeMillis' must be a number type in milliseconds.",
-        );
-      } else {
-        //iOS & Android expect seconds
-        nativeSettings.fetchTimeout = settings.fetchTimeMillis / 1000;
-      }
-    }
-
-    this._settings = settings;
-    this._promiseWithConstants(this.native.setConfigSettings(nativeSettings));
+  set settings(settings) {
+    console.warn(
+      "firebase.remoteConfig().settings = { [key]: string }; is not supported. Please use 'firebase.remoteConfig().settings = { ...[key]: string, }' instead'",
+    );
   }
 
   get lastFetchTime() {
@@ -228,10 +188,49 @@ class FirebaseConfigModule extends FirebaseModule {
     );
   }
 
-  setConfigSettings() {
-    console.warn(
-      "firebase.remoteConfig().setConfigSettings({ [key]: string}) has now been removed. Please use 'firebase.remoteConfig().settings = { ...[key]: string, }' instead'",
-    );
+  setConfigSettings(settings = {}) {
+    const nativeSettings = {};
+
+    if (!isObject(settings)) {
+      throw new Error('firebase.remoteConfig().settings: must set an object.');
+    }
+
+    if (hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
+      console.warn(
+        "firebase.remoteConfig().setConfigSettings(): 'settings.isDeveloperModeEnabled' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
+      );
+    }
+
+    if (hasOwnProperty(settings, 'minimumFetchInterval')) {
+      console.warn(
+        "firebase.remoteConfig().setConfigSettings(): 'settings.minimumFetchInterval' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
+      );
+    }
+
+    if (hasOwnProperty(settings, 'minimumFetchIntervalMillis')) {
+      if (!isNumber(settings.minimumFetchIntervalMillis)) {
+        throw new Error(
+          "firebase.remoteConfig().setConfigSettings(): 'settings.minimumFetchIntervalMillis' must be a number type in milliseconds.",
+        );
+      } else {
+        //iOS & Android expect seconds
+        nativeSettings.minimumFetchInterval = settings.minimumFetchIntervalMillis / 1000;
+      }
+    }
+
+    if (hasOwnProperty(settings, 'fetchTimeMillis')) {
+      if (!isNumber(settings.fetchTimeMillis)) {
+        throw new Error(
+          "firebase.remoteConfig().setConfigSettings(): 'settings.fetchTimeMillis' must be a number type in milliseconds.",
+        );
+      } else {
+        //iOS & Android expect seconds
+        nativeSettings.fetchTimeout = settings.fetchTimeMillis / 1000;
+      }
+    }
+
+    this._settings = settings;
+    return this._promiseWithConstants(this.native.setConfigSettings(nativeSettings));
   }
 
   /**
@@ -323,7 +322,7 @@ export default createModuleNamespace({
   namespace,
   nativeModuleName,
   nativeEvents: false,
-  hasMultiAppSupport: false,
+  hasMultiAppSupport: true,
   hasCustomUrlOrRegionSupport: false,
   ModuleClass: FirebaseConfigModule,
 });

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -83,6 +83,7 @@ class FirebaseConfigModule extends FirebaseModule {
   constructor(...args) {
     super(...args);
     this._defaultConfig = {};
+    this._settings = {};
     this._lastFetchStatus = null;
     this._lastFetchTime = null;
     // TODO(salakar) iOS does not yet support multiple apps, for now we'll use the default app always
@@ -114,11 +115,44 @@ class FirebaseConfigModule extends FirebaseModule {
 
   set defaultConfig(defaults) {
     if (!isObject(defaults)) {
-      throw new Error("'firebase.remoteConfig().defaultConfig = {}'  must set an object.");
+      throw new Error('firebase.remoteConfig().defaultConfig: must set an object.');
     }
 
     this._defaultConfig = defaults;
     this._promiseWithConstants(this.native.setDefaults(defaults));
+  }
+
+  get settings() {
+    return this._settings;
+  }
+
+  set settings(settings = {}) {
+    if (!isObject(settings)) {
+      throw new Error('firebase.remoteConfig().settings: must set an object.');
+    }
+
+    if (!hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
+      console.warn(
+        "firebase.remoteConfig().settings: 'settings.isDeveloperModeEnabled' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
+      );
+    }
+
+    if (
+      hasOwnProperty(settings, 'minimumFetchInterval') &&
+      !isNumber(settings.minimumFetchInterval)
+    ) {
+      throw new Error(
+        "firebase.remoteConfig().settings: 'settings.minimumFetchInterval' must be a number value.",
+      );
+    }
+
+    if (hasOwnProperty(settings, 'fetchTimeout') && !isNumber(settings.fetchTimeout)) {
+      throw new Error(
+        "firebase.remoteConfig().settings: 'settings.fetchTimeout' must be a number value.",
+      );
+    }
+    this._settings = settings;
+    this._promiseWithConstants(this.native.setConfigSettings(settings));
   }
 
   get lastFetchTime() {
@@ -144,33 +178,10 @@ class FirebaseConfigModule extends FirebaseModule {
     return this._fetchTimeout;
   }
 
-  setConfigSettings(settings = {}) {
-    if (!isObject(settings)) {
-      throw new Error("firebase.remoteConfig().setConfigSettings(): 'settings' must be an object.");
-    }
-
-    if (!hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
-      console.warn(
-        "firebase.remoteConfig().setConfigSettings(): settings.isDeveloperModeEnabled has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
-      );
-    }
-
-    if (
-      hasOwnProperty(settings, 'minimumFetchInterval') &&
-      !isNumber(settings.minimumFetchInterval)
-    ) {
-      throw new Error(
-        "firebase.remoteConfig().setConfigSettings(): 'settings.minimumFetchInterval' must be a number value.",
-      );
-    }
-
-    if (hasOwnProperty(settings, 'fetchTimeout') && !isNumber(settings.fetchTimeout)) {
-      throw new Error(
-        "firebase.remoteConfig().setConfigSettings(): 'settings.fetchTimeout' must be a number value.",
-      );
-    }
-
-    return this._promiseWithConstants(this.native.setConfigSettings(settings));
+  setConfigSettings() {
+    console.warn(
+      "firebase.remoteConfig().setConfigSettings({ [key]: string}) has now been removed. Please use 'firebase.remoteConfig().settings = { ...[key]: string, }' instead'",
+    );
   }
 
   /**

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -294,6 +294,7 @@ class FirebaseConfigModule extends FirebaseModule {
 
     return this._promiseWithConstants(this.native.setDefaultsFromResource(resourceName));
   }
+
   setLogLevel() {
     console.warn('firebase.remoteConfig().setLogLevel() is not supported natively.');
   }

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -141,17 +141,38 @@ class FirebaseConfigModule extends FirebaseModule {
       hasOwnProperty(settings, 'minimumFetchInterval') &&
       !isNumber(settings.minimumFetchInterval)
     ) {
-      throw new Error(
-        "firebase.remoteConfig().settings: 'settings.minimumFetchInterval' must be a number value.",
+      console.warn(
+        "firebase.remoteConfig().settings: 'settings.minimumFetchInterval' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
       );
     }
 
-    if (hasOwnProperty(settings, 'fetchTimeout') && !isNumber(settings.fetchTimeout)) {
-      throw new Error(
-        "firebase.remoteConfig().settings: 'settings.fetchTimeout' must be a number value.",
-      );
+    if (hasOwnProperty(settings, 'minimumFetchIntervalMillis')) {
+      if (!isNumber(settings.minimumFetchIntervalMillis)) {
+        throw new Error(
+          "firebase.remoteConfig().settings: 'settings.minimumFetchIntervalMillis' must be a number type in milliseconds.",
+        );
+      } else {
+        //iOS & Android expect seconds
+        settings.minimumFetchInterval = settings.minimumFetchIntervalMillis / 1000;
+      }
     }
+
+    if (hasOwnProperty(settings, 'fetchTimeMillis')) {
+      if (!isNumber(settings.fetchTimeMillis)) {
+        throw new Error(
+          "firebase.remoteConfig().settings: 'settings.fetchTimeMillis' must be a number type in milliseconds.",
+        );
+      } else {
+        //iOS & Android expect seconds
+        settings.fetchTimeout = settings.fetchTimeMillis / 1000;
+      }
+    }
+
     this._settings = settings;
+
+    delete settings.minimumFetchIntervalMillis;
+    delete settings.fetchTimeMillis;
+
     this._promiseWithConstants(this.native.setConfigSettings(settings));
   }
 
@@ -171,11 +192,9 @@ class FirebaseConfigModule extends FirebaseModule {
   }
 
   get minimumFetchInterval() {
-    return this._minimumFetchInterval;
-  }
-
-  get fetchTimeout() {
-    return this._fetchTimeout;
+    console.warn(
+      'firebase.remoteConfig().minimumFetchInterval has now been removed. Please consider setting `settings.minimumFetchIntervalMillis` in remoteConfig.Settings',
+    );
   }
 
   setConfigSettings() {
@@ -236,8 +255,6 @@ class FirebaseConfigModule extends FirebaseModule {
     this._lastFetchTime = constants.lastFetchTime;
     this._lastFetchStatus = constants.lastFetchStatus;
     this._values = convertNativeConfigValues(constants.values);
-    this._minimumFetchInterval = constants.minimumFetchInterval;
-    this._fetchTimeout = constants.fetchTimeout;
   }
 
   _promiseWithConstants(promise) {

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -82,6 +82,9 @@ function convertNativeConfigValues(configValues) {
 class FirebaseConfigModule extends FirebaseModule {
   constructor(...args) {
     super(...args);
+    this._defaultConfig = {};
+    this._lastFetchStatus = null;
+    this._lastFetchTime = null;
     // TODO(salakar) iOS does not yet support multiple apps, for now we'll use the default app always
     this._updateFromConstants(this.native.REMOTE_CONFIG_APP_CONSTANTS['[DEFAULT]']);
   }
@@ -103,6 +106,19 @@ class FirebaseConfigModule extends FirebaseModule {
 
   getAll() {
     return Object.assign({}, this._values);
+  }
+
+  get defaultConfig() {
+    return this._defaultConfig;
+  }
+
+  set defaultConfig(defaults) {
+    if (!isObject(defaults)) {
+      throw new Error("'firebase.remoteConfig().defaultConfig = {}'  must set an object.");
+    }
+
+    this._defaultConfig = defaults;
+    this._promiseWithConstants(this.native.setDefaults(defaults));
   }
 
   get lastFetchTime() {
@@ -188,30 +204,21 @@ class FirebaseConfigModule extends FirebaseModule {
   }
 
   /**
-   * Sets defaults.
-   *
-   * @param {object} defaults
+   * Removed. Use defaultConfig instead to get/set default values
    */
-  setDefaults(defaults) {
-    if (!isObject(defaults)) {
-      throw new Error("firebase.remoteConfig().setDefaults(): 'defaults' must be an object.");
-    }
-
-    return this._promiseWithConstants(this.native.setDefaults(defaults));
+  setDefaults() {
+    console.warn(
+      "firebase.remoteConfig().setDefaults({ [key]: string}) has now been removed. Please use 'firebase.remoteConfig().defaultConfig = { ...[key]: string, }' instead",
+    );
   }
 
   /**
-   * Sets defaults based on resource.
-   * @param {string} resourceName
+   * Removed. Use defaultConfig instead to get/set default values
    */
-  setDefaultsFromResource(resourceName) {
-    if (!isString(resourceName)) {
-      throw new Error(
-        "firebase.remoteConfig().setDefaultsFromResource(): 'resourceName' must be a string value.",
-      );
-    }
-
-    return this._promiseWithConstants(this.native.setDefaultsFromResource(resourceName));
+  setDefaultsFromResource() {
+    console.warn(
+      "firebase.remoteConfig().setDefaultsFromResource('resourceName') has now been removed. Please use 'firebase.remoteConfig().defaultConfig = { ...[key]: string, }' instead",
+    );
   }
 
   _updateFromConstants(constants) {

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -127,20 +127,19 @@ class FirebaseConfigModule extends FirebaseModule {
   }
 
   set settings(settings = {}) {
+    const nativeSettings = {};
+
     if (!isObject(settings)) {
       throw new Error('firebase.remoteConfig().settings: must set an object.');
     }
 
-    if (!hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
+    if (hasOwnProperty(settings, 'isDeveloperModeEnabled')) {
       console.warn(
         "firebase.remoteConfig().settings: 'settings.isDeveloperModeEnabled' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
       );
     }
 
-    if (
-      hasOwnProperty(settings, 'minimumFetchInterval') &&
-      !isNumber(settings.minimumFetchInterval)
-    ) {
+    if (hasOwnProperty(settings, 'minimumFetchInterval')) {
       console.warn(
         "firebase.remoteConfig().settings: 'settings.minimumFetchInterval' has now been removed. Please consider setting 'settings.minimumFetchIntervalMillis'",
       );
@@ -153,7 +152,7 @@ class FirebaseConfigModule extends FirebaseModule {
         );
       } else {
         //iOS & Android expect seconds
-        settings.minimumFetchInterval = settings.minimumFetchIntervalMillis / 1000;
+        nativeSettings.minimumFetchInterval = settings.minimumFetchIntervalMillis / 1000;
       }
     }
 
@@ -164,16 +163,12 @@ class FirebaseConfigModule extends FirebaseModule {
         );
       } else {
         //iOS & Android expect seconds
-        settings.fetchTimeout = settings.fetchTimeMillis / 1000;
+        nativeSettings.fetchTimeout = settings.fetchTimeMillis / 1000;
       }
     }
 
     this._settings = settings;
-
-    delete settings.minimumFetchIntervalMillis;
-    delete settings.fetchTimeMillis;
-
-    this._promiseWithConstants(this.native.setConfigSettings(settings));
+    this._promiseWithConstants(this.native.setConfigSettings(nativeSettings));
   }
 
   get lastFetchTime() {

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -88,6 +88,14 @@ class Value {
     this._source = source;
   }
 
+  get value() {
+    console.warn('firebase.remoteConfig().getValue().value has been removed');
+  }
+
+  get source() {
+    console.warn('firebase.remoteConfig().getValue().source has been removed');
+  }
+
   asBoolean() {
     if (this._source === 'static') {
       return false;

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -228,6 +228,10 @@ class FirebaseConfigModule extends FirebaseModule {
     return this._promiseWithConstants(this.native.fetchAndActivate());
   }
 
+  ensureInitialized() {
+    return this.native.ensureInitialized();
+  }
+
   /**
    * Removed. Use defaultConfig instead to get/set default values
    */

--- a/packages/remote-config/type-test.ts
+++ b/packages/remote-config/type-test.ts
@@ -33,7 +33,3 @@ firebase
   .fetch(123)
   .then();
 firebase.remoteConfig().getAll();
-firebase
-  .remoteConfig()
-  .setConfigSettings({ isDeveloperModeEnabled: true })
-  .then();

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -1,7 +1,7 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = '~> 6.19.0'
 using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
 if using_custom_firebase_sdk_version
   Pod::UI.puts "RNFBStorage: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -169,114 +169,114 @@ PODS:
     - Fabric (~> 1.10.2)
   - DoubleConversion (1.1.6)
   - Fabric (1.10.2)
-  - Firebase/AdMob (6.13.0):
+  - Firebase/AdMob (6.19.0):
     - Firebase/CoreOnly
     - Google-Mobile-Ads-SDK (~> 7.50)
-  - Firebase/Analytics (6.13.0):
+  - Firebase/Analytics (6.19.0):
     - Firebase/Core
-  - Firebase/Auth (6.13.0):
+  - Firebase/Auth (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 6.4.0)
-  - Firebase/Core (6.13.0):
+    - FirebaseAuth (~> 6.4.3)
+  - Firebase/Core (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.1.6)
-  - Firebase/CoreOnly (6.13.0):
-    - FirebaseCore (= 6.4.0)
-  - Firebase/Database (6.13.0):
+    - FirebaseAnalytics (= 6.3.1)
+  - Firebase/CoreOnly (6.19.0):
+    - FirebaseCore (= 6.6.4)
+  - Firebase/Database (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 6.1.2)
-  - Firebase/DynamicLinks (6.13.0):
+    - FirebaseDatabase (~> 6.1.4)
+  - Firebase/DynamicLinks (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 4.0.5)
-  - Firebase/Firestore (6.13.0):
+    - FirebaseDynamicLinks (~> 4.0.7)
+  - Firebase/Firestore (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 1.8.0)
-  - Firebase/Functions (6.13.0):
+    - FirebaseFirestore (~> 1.11.1)
+  - Firebase/Functions (6.19.0):
     - Firebase/CoreOnly
     - FirebaseFunctions (~> 2.5.1)
-  - Firebase/InAppMessagingDisplay (6.13.0):
+  - Firebase/InAppMessaging (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessagingDisplay (~> 0.15.5)
-  - Firebase/Messaging (6.13.0):
+    - FirebaseInAppMessaging (~> 0.19.0)
+  - Firebase/Messaging (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 4.1.9)
-  - Firebase/MLCommon (6.13.0):
+    - FirebaseMessaging (~> 4.3.0)
+  - Firebase/MLCommon (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLCommon (~> 0.19.0)
-  - Firebase/MLNaturalLanguage (6.13.0):
+  - Firebase/MLNaturalLanguage (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLNaturalLanguage (~> 0.17.0)
-  - Firebase/MLNLLanguageID (6.13.0):
+  - Firebase/MLNLLanguageID (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLNLLanguageID (~> 0.17.0)
-  - Firebase/MLNLSmartReply (6.13.0):
+  - Firebase/MLNLSmartReply (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLNLSmartReply (~> 0.17.0)
-  - Firebase/MLVision (6.13.0):
+  - Firebase/MLVision (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLVision (~> 0.19.0)
-  - Firebase/MLVisionBarcodeModel (6.13.0):
+  - Firebase/MLVisionBarcodeModel (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionBarcodeModel (~> 0.19.0)
-  - Firebase/MLVisionFaceModel (6.13.0):
+  - Firebase/MLVisionFaceModel (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionFaceModel (~> 0.19.0)
-  - Firebase/MLVisionLabelModel (6.13.0):
+  - Firebase/MLVisionLabelModel (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionLabelModel (~> 0.19.0)
-  - Firebase/MLVisionTextModel (6.13.0):
+  - Firebase/MLVisionTextModel (6.19.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionTextModel (~> 0.19.0)
-  - Firebase/Performance (6.13.0):
+  - Firebase/Performance (6.19.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 3.1.7)
-  - Firebase/RemoteConfig (6.13.0):
+    - FirebasePerformance (~> 3.1.10)
+  - Firebase/RemoteConfig (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 4.4.5)
-  - Firebase/Storage (6.13.0):
+    - FirebaseRemoteConfig (~> 4.4.9)
+  - Firebase/Storage (6.19.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 3.4.2)
-  - FirebaseABTesting (3.1.2):
+    - FirebaseStorage (~> 3.6.0)
+  - FirebaseABTesting (3.2.0):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.1)
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseAnalytics (6.1.6):
-    - FirebaseCore (~> 6.4)
-    - FirebaseInstanceID (~> 4.2)
-    - GoogleAppMeasurement (= 6.1.6)
+  - FirebaseAnalytics (6.3.1):
+    - FirebaseCore (~> 6.6)
+    - FirebaseInstallations (~> 1.1)
+    - GoogleAppMeasurement (= 6.3.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (= 0.3.9011)
-  - FirebaseAnalyticsInterop (1.4.0)
-  - FirebaseAuth (6.4.0):
+  - FirebaseAnalyticsInterop (1.5.0)
+  - FirebaseAuth (6.4.3):
     - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.2)
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.2)
-    - GoogleUtilities/Environment (~> 6.2)
+    - FirebaseCore (~> 6.6)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
+    - GoogleUtilities/Environment (~> 6.5)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseAuthInterop (1.0.0)
-  - FirebaseCore (6.4.0):
-    - FirebaseCoreDiagnostics (~> 1.0)
-    - FirebaseCoreDiagnosticsInterop (~> 1.0)
-    - GoogleUtilities/Environment (~> 6.2)
-    - GoogleUtilities/Logger (~> 6.2)
-  - FirebaseCoreDiagnostics (1.1.2):
-    - FirebaseCoreDiagnosticsInterop (~> 1.0)
-    - GoogleDataTransportCCTSupport (~> 1.0)
-    - GoogleUtilities/Environment (~> 6.2)
-    - GoogleUtilities/Logger (~> 6.2)
+  - FirebaseAuthInterop (1.1.0)
+  - FirebaseCore (6.6.4):
+    - FirebaseCoreDiagnostics (~> 1.2)
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
+  - FirebaseCoreDiagnostics (1.2.2):
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleDataTransportCCTSupport (~> 2.0)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
     - nanopb (~> 0.3.901)
-  - FirebaseCoreDiagnosticsInterop (1.1.0)
-  - FirebaseDatabase (6.1.2):
+  - FirebaseCoreDiagnosticsInterop (1.2.0)
+  - FirebaseDatabase (6.1.4):
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (4.0.5):
+  - FirebaseDynamicLinks (4.0.7):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.2)
-  - FirebaseFirestore (1.8.1):
+  - FirebaseFirestore (1.11.2):
     - abseil/algorithm (= 0.20190808)
     - abseil/base (= 0.20190808)
     - abseil/memory (= 0.20190808)
@@ -293,26 +293,29 @@ PODS:
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseInAppMessaging (0.15.5):
+  - FirebaseInAppMessaging (0.19.0):
+    - FirebaseABTesting (~> 3.2)
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.2)
     - FirebaseInstanceID (~> 4.0)
-    - GoogleDataTransportCCTSupport (~> 1.0)
-  - FirebaseInAppMessagingDisplay (0.15.5):
-    - FirebaseCore (~> 6.2)
-    - FirebaseInAppMessaging (>= 0.15.0)
-  - FirebaseInstanceID (4.2.7):
-    - FirebaseCore (~> 6.0)
-    - GoogleUtilities/Environment (~> 6.0)
-    - GoogleUtilities/UserDefaults (~> 6.0)
-  - FirebaseMessaging (4.1.9):
-    - FirebaseAnalyticsInterop (~> 1.3)
-    - FirebaseCore (~> 6.2)
-    - FirebaseInstanceID (~> 4.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.2)
-    - GoogleUtilities/Environment (~> 6.2)
-    - GoogleUtilities/Reachability (~> 6.2)
-    - GoogleUtilities/UserDefaults (~> 6.2)
+    - GoogleDataTransportCCTSupport (~> 2.0)
+  - FirebaseInstallations (1.1.0):
+    - FirebaseCore (~> 6.6)
+    - GoogleUtilities/UserDefaults (~> 6.5)
+    - PromisesObjC (~> 1.2)
+  - FirebaseInstanceID (4.3.2):
+    - FirebaseCore (~> 6.6)
+    - FirebaseInstallations (~> 1.0)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/UserDefaults (~> 6.5)
+  - FirebaseMessaging (4.3.0):
+    - FirebaseAnalyticsInterop (~> 1.5)
+    - FirebaseCore (~> 6.6)
+    - FirebaseInstanceID (~> 4.3)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Reachability (~> 6.5)
+    - GoogleUtilities/UserDefaults (~> 6.5)
     - Protobuf (>= 3.9.2, ~> 3.9)
   - FirebaseMLCommon (0.19.0):
     - FirebaseCore (~> 6.3)
@@ -356,9 +359,9 @@ PODS:
     - FirebaseMLVision (~> 0.19)
   - FirebaseMLVisionTextModel (0.19.0):
     - FirebaseMLVision (~> 0.19)
-  - FirebasePerformance (3.1.7):
-    - FirebaseCore (~> 6.4)
-    - FirebaseInstanceID (~> 4.2)
+  - FirebasePerformance (3.1.10):
+    - FirebaseCore (~> 6.6)
+    - FirebaseInstanceID (~> 4.3)
     - FirebaseRemoteConfig (~> 4.4)
     - GoogleToolboxForMac/Logger (~> 2.1)
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
@@ -367,7 +370,7 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 6.2)
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.9)
-  - FirebaseRemoteConfig (4.4.5):
+  - FirebaseRemoteConfig (4.4.9):
     - FirebaseABTesting (~> 3.1)
     - FirebaseAnalyticsInterop (~> 1.4)
     - FirebaseCore (~> 6.2)
@@ -375,9 +378,9 @@ PODS:
     - GoogleUtilities/Environment (~> 6.2)
     - "GoogleUtilities/NSData+zlib (~> 6.2)"
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseStorage (3.4.2):
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.0)
+  - FirebaseStorage (3.6.0):
+    - FirebaseAuthInterop (~> 1.1)
+    - FirebaseCore (~> 6.6)
     - GTMSessionFetcher/Core (~> 1.1)
   - Folly (2018.10.22.00):
     - boost-for-react-native
@@ -389,22 +392,22 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Google-Mobile-Ads-SDK (7.52.0):
+  - Google-Mobile-Ads-SDK (7.56.0):
     - GoogleAppMeasurement (~> 6.0)
-  - GoogleAPIClientForREST/Core (1.3.10):
+  - GoogleAPIClientForREST/Core (1.3.11):
     - GTMSessionFetcher (>= 1.1.7)
-  - GoogleAPIClientForREST/Vision (1.3.10):
+  - GoogleAPIClientForREST/Vision (1.3.11):
     - GoogleAPIClientForREST/Core
     - GTMSessionFetcher (>= 1.1.7)
-  - GoogleAppMeasurement (6.1.6):
+  - GoogleAppMeasurement (6.3.1):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (= 0.3.9011)
-  - GoogleDataTransport (3.2.0)
-  - GoogleDataTransportCCTSupport (1.2.2):
-    - GoogleDataTransport (~> 3.2)
+  - GoogleDataTransport (5.0.0)
+  - GoogleDataTransportCCTSupport (2.0.0):
+    - GoogleDataTransport (~> 5.0)
     - nanopb (~> 0.3.901)
   - GoogleToolboxForMac/DebugUtils (2.2.2):
     - GoogleToolboxForMac/Defines (= 2.2.2)
@@ -418,24 +421,24 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
-  - GoogleUtilities/AppDelegateSwizzler (6.3.2):
+  - GoogleUtilities/AppDelegateSwizzler (6.5.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.3.2)
-  - GoogleUtilities/ISASwizzler (6.3.2)
-  - GoogleUtilities/Logger (6.3.2):
+  - GoogleUtilities/Environment (6.5.1)
+  - GoogleUtilities/ISASwizzler (6.5.1)
+  - GoogleUtilities/Logger (6.5.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (6.3.2):
+  - GoogleUtilities/MethodSwizzler (6.5.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (6.3.2):
+  - GoogleUtilities/Network (6.5.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.3.2)"
-  - GoogleUtilities/Reachability (6.3.2):
+  - "GoogleUtilities/NSData+zlib (6.5.1)"
+  - GoogleUtilities/Reachability (6.5.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (6.3.2):
+  - GoogleUtilities/UserDefaults (6.5.1):
     - GoogleUtilities/Logger
   - "gRPC-C++ (0.0.9)":
     - "gRPC-C++/Implementation (= 0.0.9)"
@@ -453,11 +456,11 @@ PODS:
     - gRPC-Core/Interface (= 1.21.0)
     - nanopb (~> 0.3)
   - gRPC-Core/Interface (1.21.0)
-  - GTMSessionFetcher (1.3.0):
-    - GTMSessionFetcher/Full (= 1.3.0)
-  - GTMSessionFetcher/Core (1.3.0)
-  - GTMSessionFetcher/Full (1.3.0):
-    - GTMSessionFetcher/Core (= 1.3.0)
+  - GTMSessionFetcher (1.3.1):
+    - GTMSessionFetcher/Full (= 1.3.1)
+  - GTMSessionFetcher/Core (1.3.1)
+  - GTMSessionFetcher/Full (1.3.1):
+    - GTMSessionFetcher/Core (= 1.3.1)
   - Jet (0.4.4):
     - React
   - leveldb-library (1.22)
@@ -466,8 +469,9 @@ PODS:
     - nanopb/encode (= 0.3.9011)
   - nanopb/decode (0.3.9011)
   - nanopb/encode (0.3.9011)
-  - PersonalizedAdConsent (1.0.3)
-  - Protobuf (3.10.0)
+  - PersonalizedAdConsent (1.0.5)
+  - PromisesObjC (1.2.8)
+  - Protobuf (3.11.4)
   - React (0.60.5):
     - React-Core (= 0.60.5)
     - React-DevSupport (= 0.60.5)
@@ -537,92 +541,92 @@ PODS:
   - React-RCTWebSocket (0.60.5):
     - React-Core (= 0.60.5)
   - RNFBAdMob (6.3.4):
-    - Firebase/AdMob (~> 6.13.0)
-    - Firebase/Analytics (~> 6.13.0)
-    - Firebase/Core (~> 6.13.0)
+    - Firebase/AdMob (~> 6.19.0)
+    - Firebase/Analytics (~> 6.19.0)
+    - Firebase/Core (~> 6.19.0)
     - PersonalizedAdConsent
     - React
     - RNFBApp
   - RNFBAnalytics (6.3.4):
-    - Firebase/Core (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBApp (6.3.4):
-    - Firebase/Core (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
     - React
   - RNFBAuth (6.3.4):
-    - Firebase/Auth (~> 6.13.0)
-    - Firebase/Core (~> 6.13.0)
+    - Firebase/Auth (~> 6.19.0)
+    - Firebase/Core (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBCrashlytics (6.3.4):
     - Crashlytics (~> 3.14.0)
     - Fabric (~> 1.10.2)
-    - Firebase/Core (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBDatabase (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/Database (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/Database (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBDynamicLinks (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/DynamicLinks (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/DynamicLinks (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBFirestore (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/Firestore (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/Firestore (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBFunctions (6.3.4):
-    - Firebase/Functions (~> 6.13.0)
+    - Firebase/Functions (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBIid (6.3.4):
-    - Firebase/Core (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBInAppMessaging (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/InAppMessagingDisplay (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/InAppMessaging (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBMessaging (6.3.4):
-    - Firebase/Messaging (~> 6.13.0)
+    - Firebase/Messaging (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBMLNaturalLanguage (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/MLCommon (~> 6.13.0)
-    - Firebase/MLNaturalLanguage (~> 6.13.0)
-    - Firebase/MLNLLanguageID (~> 6.13.0)
-    - Firebase/MLNLSmartReply (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/MLCommon (~> 6.19.0)
+    - Firebase/MLNaturalLanguage (~> 6.19.0)
+    - Firebase/MLNLLanguageID (~> 6.19.0)
+    - Firebase/MLNLSmartReply (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBMLVision (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/MLVision (~> 6.13.0)
-    - Firebase/MLVisionBarcodeModel (~> 6.13.0)
-    - Firebase/MLVisionFaceModel (~> 6.13.0)
-    - Firebase/MLVisionLabelModel (~> 6.13.0)
-    - Firebase/MLVisionTextModel (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/MLVision (~> 6.19.0)
+    - Firebase/MLVisionBarcodeModel (~> 6.19.0)
+    - Firebase/MLVisionFaceModel (~> 6.19.0)
+    - Firebase/MLVisionLabelModel (~> 6.19.0)
+    - Firebase/MLVisionTextModel (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBPerf (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/Performance (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/Performance (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBRemoteConfig (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/RemoteConfig (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/RemoteConfig (~> 6.19.0)
     - React
     - RNFBApp
   - RNFBStorage (6.3.4):
-    - Firebase/Core (~> 6.13.0)
-    - Firebase/Storage (~> 6.13.0)
+    - Firebase/Core (~> 6.19.0)
+    - Firebase/Storage (~> 6.19.0)
     - React
     - RNFBApp
   - yoga (0.60.5.React)
@@ -689,7 +693,7 @@ SPEC REPOS:
     - FirebaseFirestore
     - FirebaseFunctions
     - FirebaseInAppMessaging
-    - FirebaseInAppMessagingDisplay
+    - FirebaseInstallations
     - FirebaseInstanceID
     - FirebaseMessaging
     - FirebaseMLCommon
@@ -717,6 +721,7 @@ SPEC REPOS:
     - leveldb-library
     - nanopb
     - PersonalizedAdConsent
+    - PromisesObjC
     - Protobuf
 
 EXTERNAL SOURCES:
@@ -806,23 +811,23 @@ SPEC CHECKSUMS:
   Crashlytics: 540b7e5f5da5a042647227a5e3ac51d85eed06df
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
-  Firebase: 458d109512200d1aca2e1b9b6cf7d68a869a4a46
-  FirebaseABTesting: 0d10f3cdc3fa00f3f175b5b56c1003c8e888299f
-  FirebaseAnalytics: 45f36d9c429fc91d206283900ab75390cd05ee8a
-  FirebaseAnalyticsInterop: d48b6ab67bcf016a05e55b71fc39c61c0cb6b7f3
-  FirebaseAuth: 7d0f84873926f6648bbd1391a318dfb1a26b5e4f
-  FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
-  FirebaseCore: 307ea2508df730c5865334e41965bd9ea344b0e5
-  FirebaseCoreDiagnostics: 511f4f3ed7d440bb69127e8b97c2bc8befae639e
-  FirebaseCoreDiagnosticsInterop: e9b1b023157e3a2fc6418b5cb601e79b9af7b3a0
-  FirebaseDatabase: 963515d232ded06f36f6ce830507c94551866170
-  FirebaseDynamicLinks: db62e9da4788f9c5ebce2028dab933a0c158cfe2
-  FirebaseFirestore: 2e92e977280d63ecbf3fd58bdbfaf9145abb880f
+  Firebase: d55ddb0e0bb3207166cddc028647833d8a1b5b6f
+  FirebaseABTesting: 821a3a3e4a145987e80fee3657c4de1cb9adf693
+  FirebaseAnalytics: 572e467f3d977825266e8ccd52674aa3e6f47eac
+  FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
+  FirebaseAuth: 5ce2b03a3d7fe56b7a6e4c5ec7ff1522890b1d6f
+  FirebaseAuthInterop: a0f37ae05833af156e72028f648d313f7e7592e9
+  FirebaseCore: ed0a24c758a57c2b88c5efa8e6a8195e868af589
+  FirebaseCoreDiagnostics: e9b4cd8ba60dee0f2d13347332e4b7898cca5b61
+  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
+  FirebaseDatabase: 0144e0706a4761f1b0e8679572eba8095ddb59be
+  FirebaseDynamicLinks: b3338d0c0423ee3d409f5ecc0fb774a9baa6537b
+  FirebaseFirestore: 71925e62a5d1cbfaff46aa4d5107e525cc48356a
   FirebaseFunctions: 5af7c35d1c5e41608fecbb667eb6c4e672e318d0
-  FirebaseInAppMessaging: acbfa8c5582b11ccc0366511d29ef1d288f302fc
-  FirebaseInAppMessagingDisplay: 60a65c8277f17675a8a5b92e9a97cd914b45d4ff
-  FirebaseInstanceID: ebd2ea79ee38db0cb5f5167b17a0d387e1cc7b6e
-  FirebaseMessaging: e8d71368a5c579083da02203146c953f3386d503
+  FirebaseInAppMessaging: f12e34645ab7b32c97dcd1578bf24a4a1c894b33
+  FirebaseInstallations: 575cd32f2aec0feeb0e44f5d0110a09e5e60b47b
+  FirebaseInstanceID: 7ee0d6777013bb952f377b41965bf132b6a075be
+  FirebaseMessaging: 4ec33842d36b3319e062e51fb8b35a74f726950d
   FirebaseMLCommon: 074a67e05122b1c9f6401a4e33b2cea3b4efd224
   FirebaseMLNaturalLanguage: 9d38301a41b1201d248588bf66937b975391e8f4
   FirebaseMLNLLanguageID: afd2e97dfc8ff215f7527acc7e4cd56d4f537737
@@ -832,26 +837,27 @@ SPEC CHECKSUMS:
   FirebaseMLVisionFaceModel: d6ba42000f263df52187aee936262bc2002b3389
   FirebaseMLVisionLabelModel: 7638a20d27219d5baa4b534a62375fc1d5bd077d
   FirebaseMLVisionTextModel: c264caa3100ca804580bf2a7c1cb9ff390d1f471
-  FirebasePerformance: 22273a775eaed4cd3e072c9b88396a5e4b285c3f
-  FirebaseRemoteConfig: 6ad68503c04701b8d9d709240711bc0bf6edaf94
-  FirebaseStorage: 046abe9ac4e2a1a0e47d72f536490ffa50896632
+  FirebasePerformance: a9b0985f80d2a5cf780cf9bd4db920b45c200507
+  FirebaseRemoteConfig: 47abf7a04a9082091955ea555aa79cfdd249b19c
+  FirebaseStorage: b43ee271294227e1a3225544b073f3b49b427f46
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Google-Mobile-Ads-SDK: 62f6244637306cb60a1b4adda067f53224c7a860
-  GoogleAPIClientForREST: 4acfffd77f1c3c8741b6be9eaed0e603278efbde
-  GoogleAppMeasurement: dfe55efa543e899d906309eaaac6ca26d249862f
-  GoogleDataTransport: 8e9b210c97d55fbff306cc5468ff91b9cb32dcf5
-  GoogleDataTransportCCTSupport: ef79a4728b864946a8aafdbab770d5294faf3b5f
+  Google-Mobile-Ads-SDK: 65e335fadc97c5a91a9d4546214bfd3a2fb11047
+  GoogleAPIClientForREST: 0f19a8280dfe6471f76016645d26eb5dae305101
+  GoogleAppMeasurement: c29d405ff76e18551b5d158eaba6753fda8c7542
+  GoogleDataTransport: a857c6a002d201b524dd4bc2ed7e7355ed07e785
+  GoogleDataTransportCCTSupport: 32f75fbe904c82772fcbb6b6bd4525bfb6f2a862
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
-  GoogleUtilities: 547a86735c6f0ee30ad17e94df4fc21f616b71cb
+  GoogleUtilities: 06eb53bb579efe7099152735900dd04bf09e7275
   "gRPC-C++": 9dfe7b44821e7b3e44aacad2af29d2c21f7cde83
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
-  GTMSessionFetcher: 43b8b64263023d4f32caa0b40f4c8bfa3c5f36d8
+  GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   Jet: 28e2deb607658bd5c5d24e3fcb926bb3f7daf59e
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
-  PersonalizedAdConsent: b50a8a5d6065b6db23121e8fcc0dce2ae983f6ea
-  Protobuf: a4dc852ad69c027ca2166ed287b856697814375b
+  PersonalizedAdConsent: dbecabb3467df967c16d9cebc2ef4a8890e4bbd8
+  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
+  Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
   React: 53c53c4d99097af47cf60594b8706b4e3321e722
   React-Core: ba421f6b4f4cbe2fb17c0b6fc675f87622e78a64
   React-cxxreact: 8384287780c4999351ad9b6e7a149d9ed10a2395
@@ -869,23 +875,23 @@ SPEC CHECKSUMS:
   React-RCTText: b074d89033583d4f2eb5faf7ea2db3a13c7553a2
   React-RCTVibration: 2105b2e0e2b66a6408fc69a46c8a7fb5b2fdade0
   React-RCTWebSocket: cd932a16b7214898b6b7f788c8bddb3637246ac4
-  RNFBAdMob: 220fc6f8db48fc824ebbb6704f3887a2c779254e
-  RNFBAnalytics: b8bad44e6653af73219b1a7af24bf3452cb02c1b
-  RNFBApp: 7d4006751de8bb5cafa2e8d2e7d94ee250df81db
-  RNFBAuth: ed8b865db45f7ded9dbf535e390cba2ba672aede
-  RNFBCrashlytics: 93e1cc09a93aa4bb1e9b5a07af0efb2702db5a39
-  RNFBDatabase: 1201eb94eff3ab457d3e898fb5c347ddc67e00db
-  RNFBDynamicLinks: e0d320b2bd02dee6ed1f0a7d8deecdf3469db461
-  RNFBFirestore: 04c1eb90463c208ee072988d463c74bec09d08c1
-  RNFBFunctions: 6975565f0abcc68d9731d05b78778f003db0eca5
-  RNFBIid: 4aa2f4fb218fd4effff8c6f947a6cfa44557d16f
-  RNFBInAppMessaging: b27609b776f16fc327b86119d745b7877df59c0f
-  RNFBMessaging: 51cc7f6beaf4c4feac6f18ea941bba5854e3d9c6
-  RNFBMLNaturalLanguage: 4aacf1c4f339a5733054e69fc8d680272d38f50c
-  RNFBMLVision: 352b94db5c5521c222217bfdb4d3f43ab0b2f9ea
-  RNFBPerf: d5c9efa43b61bdcff5ac949932055b5e5a5c132f
-  RNFBRemoteConfig: acfef78587e8d544b53338c07ecbc172fae1b781
-  RNFBStorage: 3628afb1f3dd0b3395fc15c95967b9f080897aec
+  RNFBAdMob: c116c065214d5c19d995d9b29f53903c8aa701ab
+  RNFBAnalytics: 69c95a649c2ffdc450af0b19b46a5c4cafae6f99
+  RNFBApp: d4ac641cee39213ea304d3c0db92e619fc117b5f
+  RNFBAuth: 7ad30e61145c04b84f895ef5abd762fbe90113d4
+  RNFBCrashlytics: 32fa88037ab46cd115ec213b013e60e21eaa954d
+  RNFBDatabase: f1c78d6f9a59dd8cd8954fc033b80ce10ae4a58e
+  RNFBDynamicLinks: 6c03c64ae7d18e39441bea6f5492c8465a33f5d0
+  RNFBFirestore: 4be53bbf375ea278e1584df3447a092467d42fdc
+  RNFBFunctions: ee73c17af5ebbe1c04f8e5a91e678d0439d73e47
+  RNFBIid: a9071b998e5b2574858c2e97480ef95818dfc11b
+  RNFBInAppMessaging: b3a9a402a5476f545fb109bba9054a798702294d
+  RNFBMessaging: 6a68d9e70862bd5bea8665512444642e505b66c9
+  RNFBMLNaturalLanguage: 66952511a2672ad435f5fb8a7cd5677bdd90b8c3
+  RNFBMLVision: 01adfe1663d4911dc7ae5b90702ca6b25b42e000
+  RNFBPerf: 06191d46685db01e5900133df9de9e2ec873060f
+  RNFBRemoteConfig: c269552c9515b05878c6181d0b3850c9bc4f11a2
+  RNFBStorage: 350b89c86d6b2a9721da40cb63c3ebb9ba8503ae
   yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
 
 PODFILE CHECKSUM: 4ceb34e93fa1dd96bcca7e61934b407531c8e96e

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -536,64 +536,64 @@ PODS:
     - React-Core (= 0.60.5)
   - React-RCTWebSocket (0.60.5):
     - React-Core (= 0.60.5)
-  - RNFBAdMob (6.3.3):
+  - RNFBAdMob (6.3.4):
     - Firebase/AdMob (~> 6.13.0)
     - Firebase/Analytics (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
     - PersonalizedAdConsent
     - React
     - RNFBApp
-  - RNFBAnalytics (6.3.3):
+  - RNFBAnalytics (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBApp (6.3.3):
+  - RNFBApp (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - React
-  - RNFBAuth (6.3.3):
+  - RNFBAuth (6.3.4):
     - Firebase/Auth (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBCrashlytics (6.3.3):
+  - RNFBCrashlytics (6.3.4):
     - Crashlytics (~> 3.14.0)
     - Fabric (~> 1.10.2)
     - Firebase/Core (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBDatabase (6.3.3):
+  - RNFBDatabase (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Database (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBDynamicLinks (6.3.3):
+  - RNFBDynamicLinks (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/DynamicLinks (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBFirestore (6.3.3):
+  - RNFBFirestore (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Firestore (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBFunctions (6.3.3):
+  - RNFBFunctions (6.3.4):
     - Firebase/Functions (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBIid (6.3.3):
+  - RNFBIid (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBInAppMessaging (6.3.3):
+  - RNFBInAppMessaging (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/InAppMessagingDisplay (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBMessaging (6.3.3):
+  - RNFBMessaging (6.3.4):
     - Firebase/Messaging (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBMLNaturalLanguage (6.3.3):
+  - RNFBMLNaturalLanguage (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/MLCommon (~> 6.13.0)
     - Firebase/MLNaturalLanguage (~> 6.13.0)
@@ -601,7 +601,7 @@ PODS:
     - Firebase/MLNLSmartReply (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBMLVision (6.3.3):
+  - RNFBMLVision (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/MLVision (~> 6.13.0)
     - Firebase/MLVisionBarcodeModel (~> 6.13.0)
@@ -610,17 +610,17 @@ PODS:
     - Firebase/MLVisionTextModel (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBPerf (6.3.3):
+  - RNFBPerf (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Performance (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBRemoteConfig (6.3.3):
+  - RNFBRemoteConfig (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/RemoteConfig (~> 6.13.0)
     - React
     - RNFBApp
-  - RNFBStorage (6.3.3):
+  - RNFBStorage (6.3.4):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Storage (~> 6.13.0)
     - React
@@ -869,23 +869,23 @@ SPEC CHECKSUMS:
   React-RCTText: b074d89033583d4f2eb5faf7ea2db3a13c7553a2
   React-RCTVibration: 2105b2e0e2b66a6408fc69a46c8a7fb5b2fdade0
   React-RCTWebSocket: cd932a16b7214898b6b7f788c8bddb3637246ac4
-  RNFBAdMob: 10e291334160a7b3a94deb0a06acb30b9e4f1866
-  RNFBAnalytics: f58606fa9288800fff933bdc1cd998dd0446f876
-  RNFBApp: 887ccc5840f93abad3202ff23eb0faf7bee4ac12
-  RNFBAuth: 9c6a6ad1435eeff2aca7bbb335123e25b5781e65
-  RNFBCrashlytics: 22dada190d23a867127a541d7175d6160640f089
-  RNFBDatabase: d1b7a7295f193e627c842b28132a9cf3d3e6d81a
-  RNFBDynamicLinks: 80662576b218aa4925e09363339232d89efd9dc0
-  RNFBFirestore: c03f496b934c498fea94f17b739c6dcb2309f8cc
-  RNFBFunctions: fa9bdeca6bbf80ce74b8656d594ac14d0384b5e5
-  RNFBIid: 609a7c47d2f597d99fb138bbcf8cfcd41700c867
-  RNFBInAppMessaging: 659b4df0ed1977bc1aadda816ece954d53ec7bc4
-  RNFBMessaging: 591a196b643d913bfad6492fab292b7da037bf78
-  RNFBMLNaturalLanguage: 4eee88bda3b4f4161b59fceaf6009235e61b40ef
-  RNFBMLVision: a950c0a6702a4daa8a755802b783db59fa531897
-  RNFBPerf: aa9a6b9568afcfdbefdcf5b26eee392573126e3d
-  RNFBRemoteConfig: a6cefa426cd0f3286e1b8cc7f671bf621071f28c
-  RNFBStorage: 7e692e25f23faf05889a779b0a9a5ae7655f0b98
+  RNFBAdMob: 220fc6f8db48fc824ebbb6704f3887a2c779254e
+  RNFBAnalytics: b8bad44e6653af73219b1a7af24bf3452cb02c1b
+  RNFBApp: 7d4006751de8bb5cafa2e8d2e7d94ee250df81db
+  RNFBAuth: ed8b865db45f7ded9dbf535e390cba2ba672aede
+  RNFBCrashlytics: 93e1cc09a93aa4bb1e9b5a07af0efb2702db5a39
+  RNFBDatabase: 1201eb94eff3ab457d3e898fb5c347ddc67e00db
+  RNFBDynamicLinks: e0d320b2bd02dee6ed1f0a7d8deecdf3469db461
+  RNFBFirestore: 04c1eb90463c208ee072988d463c74bec09d08c1
+  RNFBFunctions: 6975565f0abcc68d9731d05b78778f003db0eca5
+  RNFBIid: 4aa2f4fb218fd4effff8c6f947a6cfa44557d16f
+  RNFBInAppMessaging: b27609b776f16fc327b86119d745b7877df59c0f
+  RNFBMessaging: 51cc7f6beaf4c4feac6f18ea941bba5854e3d9c6
+  RNFBMLNaturalLanguage: 4aacf1c4f339a5733054e69fc8d680272d38f50c
+  RNFBMLVision: 352b94db5c5521c222217bfdb4d3f43ab0b2f9ea
+  RNFBPerf: d5c9efa43b61bdcff5ac949932055b5e5a5c132f
+  RNFBRemoteConfig: acfef78587e8d544b53338c07ecbc172fae1b781
+  RNFBStorage: 3628afb1f3dd0b3395fc15c95967b9f080897aec
   yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
 
 PODFILE CHECKSUM: 4ceb34e93fa1dd96bcca7e61934b407531c8e96e


### PR DESCRIPTION
## RemoteConfig Module
```js
const remoteConfig = firebase.remoteConfig();
```
### Updates
-  added `ensureInitialized ` API.
- `console.warn()` if user tries to set `defaultConfig` which is part of web sdk.
- `console.warn()` if user tries to set `settings` which is part of web sdk.
- `console.warn()` if user tries to set `setLogLevel` which is part of web sdk.

## RemoteConfig.setConfigSettings()
```js
const remoteConfig = firebase.remoteConfig().setConfigSettings({});
```
### Updates
- can set 'minimumFetchIntervalMillis' in `setConfigSettings` to match web sdk.
- can set 'fetchTimeMillis' in `setConfigSettings` to match web sdk.

### Removed
- `isDeveloperModeEnabled` from config settings and console.warn() if tried to set.
- `minimumFetchInterval ` config setting and console.warn() if tried to set.

## RemoteConfig.getValue(key)
```js
const remoteConfig = firebase.remoteConfig().getValue('key');
```
### Updates
- `asBoolean()` resolves value to a boolean.
- `asNumber()` resolves value to a number.
- `asString()` resolves value to a string.
- `getSource()` source of the property.

### Removed
- `value` removed property. Not sure how to warn users it is no longer available
- `source` removed property. Again, not sure how to warn users.

## Internal Changes
- Switched to `setConfigSettingsAsync ` for Android, nothing similar for iOS.
- Switched to `fetchAndActivate` API for both platforms.
- Switched to async `activate` API for iOS. No changes needed for Android.
- Switched to multi-app support for both platforms.


## Comments
- I had to comment out a test for `lastFetchStatus` as it is coming back as `null` oddly enough as it should be 0 according to: https://firebase.google.com/docs/reference/android/com/google/firebase/remoteconfig/FirebaseRemoteConfig#LAST_FETCH_STATUS_NO_FETCH_YET
- Also had to update JS code for `lastFetchTime` as it was also coming back as `null` if no previous fetch had been made. 
- Test coverage is almost 100%. Not mocking the `console.warn()` calls is stopping full coverage.