### PR TITLE
signInWithEmailAndPassword(): Add missing check for empty email, password

### DIFF
--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -214,6 +214,14 @@ class FirebaseAuthModule extends FirebaseModule {
   }
 
   signInWithEmailAndPassword(email, password) {
+    // Cases not handled in the Android SDK, causing a native error
+    if (!email) {
+      throw new Error('Error: The email address is badly formatted.');
+    }
+    if (!password) {
+      throw new Error('Error: The password is invalid or the user does not have a password.');
+    }
+
     return this.native
       .signInWithEmailAndPassword(email, password)
       .then(userCredential => this._setUserCredential(userCredential));


### PR DESCRIPTION
`auth().signInWithEmailAndPassword()` does not check for empty or null values for the email or password on the Android SDK, causing an uncatchable Java error to crash the app. I repeated the two cases on the web SDK to obtain the proper exceptions and created JS side validation for the arguments.

Fixes #3290 