### PR TITLE
[BUGFIX][Notifications][Android] - fix false negative getInitialNotification call

### DIFF
--- a/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
+++ b/android/src/main/java/io/invertase/firebase/notifications/RNFirebaseNotifications.java
@@ -13,6 +13,7 @@ import android.util.Log;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -95,11 +96,32 @@ public class RNFirebaseNotifications extends ReactContextBaseJavaModule implemen
 
   @ReactMethod
   public void getInitialNotification(Promise promise) {
-    WritableMap notificationOpenMap = null;
     if (getCurrentActivity() != null) {
-      notificationOpenMap = parseIntentForNotification(getCurrentActivity().getIntent());
+      WritableMap notificationOpenMap = parseIntentForNotification(getCurrentActivity().getIntent());
+      promise.resolve(notificationOpenMap);
+    } else {
+      ReactApplicationContext ctx = getReactApplicationContext();
+      LifecycleEventListener lifecycleEventListener = new LifecycleEventListener() {
+        @Override
+        public void onHostResume() {
+          WritableMap notificationOpenMap = null;
+          if (getCurrentActivity() != null) {
+            notificationOpenMap = parseIntentForNotification(getCurrentActivity().getIntent());
+          }
+          promise.resolve(notificationOpenMap);
+          ctx.removeLifecycleEventListener(this);
+        }
+
+        @Override
+        public void onHostPause() {
+        }
+
+        @Override
+        public void onHostDestroy() {
+        }
+      };
+      ctx.addLifecycleEventListener(lifecycleEventListener);
     }
-    promise.resolve(notificationOpenMap);
   }
 
   @ReactMethod


### PR DESCRIPTION
[BUGFIX][Notifications][Android] - fix false negative getInitialNotification call

Fixes the situation when `getInitialNotification` fires with an empty `notificationOpen` object even if the app was opened via notification press. It happens because in the native method implementation `getCurrentActivity` returns null. Under the hood mCurrentActivity is set on `Activity.onResume` event, so the fix is to wait for this event and try to reach the notification data once again.