### PR TITLE
fix(messaging): allow RNFirebaseMessagingHeadlessTask to run in foreground

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingHeadlessService.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingHeadlessService.java
@@ -25,7 +25,7 @@ public class ReactNativeFirebaseMessagingHeadlessService extends HeadlessJsTaskS
       TASK_KEY,
       ReactNativeFirebaseMessagingSerializer.remoteMessageToWritableMap(remoteMessage),
       ReactNativeFirebaseJSON.getSharedInstance().getLongValue(TIMEOUT_JSON_KEY, TIMEOUT_DEFAULT),
-      false
+      true /* allow to run foreground */
     );
   }
 }


### PR DESCRIPTION
### Summary

This PR fixes https://github.com/invertase/react-native-firebase/issues/2592

#2592 is caused by race condition. While current logic [only executes this code after checking app is not in foreground](https://github.com/invertase/react-native-firebase/blob/f429699990b6d521d996479f2bed96b52bbdb8d8/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingService.java#L72), it's possible that app gets foreground when execution reached [here](https://github.com/facebook/react-native/blob/b55146f7763e4e9d6cc2fd54dde62d4e4289721f/ReactAndroid/src/main/java/com/facebook/react/jstasks/HeadlessJsTaskContext.java#L103) 

(See also 
https://github.com/invertase/react-native-firebase/issues/2592#issuecomment-584190439 ) for how to reproduce.

Fix is rather simple, we just need to specify `allowedInForeground` flag to true (documentation - https://github.com/facebook/react-native/blob/722feeb02b5dbc8aeb5d975feb61ccedf4d9e07e/ReactAndroid/src/main/java/com/facebook/react/jstasks/HeadlessJsTaskConfig.java#L48 ). Now instead of crashing app, service would just run in UI thread (which is better than crash :))

### Checklist

- [ x ] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan

You can test this PR by:
1. close app
2. send notification
3. open app
if you're unlucky you'll get crash with this PR. With this PR you won't crash

### Release Plan

[Android][BUGFIX] [FirebaseMessaging] - Fix crash #2592
