### PR TITLE
@russell/cloud functions timeout v7 implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -545,6 +545,7 @@ typedoc.raw.json
 tests/ios/Firebase
 .tmp
 
+appPlaygrounds/
 google-services.json
 GoogleService-Info.plist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# [6.1.0](https://github.com/invertase/react-native-firebase/compare/v6.0.4...v6.1.0) (2019-11-26)
+# Next
+
+
+## Cloud Functions
+
+- added `HttpsCallableOptions` to `firebase.functions().httpsCallable` method which allows user to set timeout on cloud function call.
 
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "generate-changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -t -v -l",
     "tests:packager:chrome": "cd tests && node_modules/.bin/react-native start --platforms ios,android --reset-cache",
     "tests:packager:jet": "cd tests && cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start",
-    "tests:packager:jet-reset-cache": "cd tests & cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --reset-cache",
+    "tests:packager:jet-reset-cache": "cd tests && cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --reset-cache",
     "tests:android:build": "cd tests && ./node_modules/.bin/detox build --configuration android.emu.debug",
     "tests:android:build-release": "cd tests && ./node_modules/.bin/detox build --configuration android.emu.release",
     "tests:android:test": "cd tests && ./node_modules/.bin/detox test --configuration android.emu.debug",

--- a/packages/functions/android/src/main/java/io/invertase/firebase/functions/UniversalFirebaseFunctionsModule.java
+++ b/packages/functions/android/src/main/java/io/invertase/firebase/functions/UniversalFirebaseFunctionsModule.java
@@ -19,10 +19,14 @@ package io.invertase.firebase.functions;
 
 import android.content.Context;
 
+import com.facebook.react.bridge.ReadableMap;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.functions.FirebaseFunctions;
+import com.google.firebase.functions.HttpsCallableReference;
+
+import java.util.concurrent.TimeUnit;
 
 import io.invertase.firebase.common.UniversalFirebaseModule;
 
@@ -42,17 +46,23 @@ public class UniversalFirebaseFunctionsModule extends UniversalFirebaseModule {
     String region,
     String origin,
     String name,
-    Object data
+    Object data,
+    ReadableMap options
   ) {
     return Tasks.call(getExecutor(), () -> {
       FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
       FirebaseFunctions functionsInstance = FirebaseFunctions.getInstance(firebaseApp, region);
-
+      HttpsCallableReference httpReference = functionsInstance.getHttpsCallable(name);
+      
+      if (options.hasKey("timeout")) {
+        httpReference.setTimeout((long) options.getInt("timeout") , TimeUnit.SECONDS);
+      }
+      
       if (origin != null) {
         functionsInstance.useFunctionsEmulator(origin);
       }
 
-      return Tasks.await(functionsInstance.getHttpsCallable(name).call(data)).getData();
+      return Tasks.await(httpReference.call(data)).getData();
     });
   }
 

--- a/packages/functions/android/src/reactnative/java/io/invertase/firebase/functions/ReactNativeFirebaseFunctionsModule.java
+++ b/packages/functions/android/src/reactnative/java/io/invertase/firebase/functions/ReactNativeFirebaseFunctionsModule.java
@@ -50,6 +50,7 @@ public class ReactNativeFirebaseFunctionsModule extends ReactNativeFirebaseModul
     String origin,
     String name,
     ReadableMap wrapper,
+    ReadableMap options,
     Promise promise
   ) {
     Task<Object> callMethodTask = module.httpsCallable(
@@ -57,7 +58,8 @@ public class ReactNativeFirebaseFunctionsModule extends ReactNativeFirebaseModul
       region,
       origin,
       name,
-      wrapper.toHashMap().get(DATA_KEY)
+      wrapper.toHashMap().get(DATA_KEY),
+      options
     );
 
     // resolve

--- a/packages/functions/e2e/functions.e2e.js
+++ b/packages/functions/e2e/functions.e2e.js
@@ -286,5 +286,21 @@ describe('functions()', () => {
 
       return Promise.resolve();
     });
+
+    it('HttpsCallableOptions.timeout will error when timeout is exceeded', async () => {
+      const fnName = 'invertaseReactNativeFirebaseFunctionsEmulator';
+      const region = 'europe-west2';
+
+      const functions = firebase.app().functions(region);
+      functions.useFunctionsEmulator('http://api.rnfirebase.io');
+
+      try {
+        await functions.httpsCallable(fnName, { timeout: 1000 })({ testTimeout: 3000 });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql('DEADLINE_EXCEEDED');
+        return Promise.resolve();
+      }
+    });
   });
 });

--- a/packages/functions/ios/RNFBFunctions/RNFBFunctionsModule.m
+++ b/packages/functions/ios/RNFBFunctions/RNFBFunctionsModule.m
@@ -41,6 +41,8 @@
         (NSString *) name
         wrapper:
         (NSDictionary *) wrapper
+        options:
+        (NSDictionary *) options
         resolver:
         (RCTPromiseResolveBlock) resolve
         rejecter:
@@ -53,6 +55,10 @@
     }
 
     FIRHTTPSCallable *callable = [functions HTTPSCallableWithName:name];
+
+    if(options[@"timeout"]){
+      callable.timeoutInterval = [options[@"timeout"] doubleValue];
+    }
 
     [callable callWithObject:[wrapper valueForKey:@"data"] completion:^(FIRHTTPSCallableResult *_Nullable result, NSError *_Nullable error) {
       if (error) {

--- a/packages/functions/lib/index.d.ts
+++ b/packages/functions/lib/index.d.ts
@@ -145,6 +145,24 @@ export namespace FirebaseFunctionsTypes {
   }
 
   /**
+   * An HttpsCallableOptions object that can be passed as the second argument to `firebase.functions().httpsCallable(name, HttpsCallableOptions)`.
+   * It allows you to control how long the application will wait for the cloud function to respond in milliseconds.
+   *
+   * const instance = firebase.functions().httpsCallable('order', { timeout: 7000 });
+   * // The below will wait 7 seconds for a response from the cloud function before an error is thrown
+   * try {
+   *  const response = await instance({
+   *    id: '12345',
+   *  });
+   * } catch (e) {
+   *  console.log(e);
+   * }
+   */
+  export interface HttpsCallableOptions {
+    timeout?: Number;
+  }
+
+  /**
    * An HttpsError wraps a single error from a function call.
    *
    * #### Example

--- a/packages/functions/lib/index.js
+++ b/packages/functions/lib/index.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { isAndroid } from '@react-native-firebase/app/lib/common';
+import { isAndroid, isNumber } from '@react-native-firebase/app/lib/common';
 import {
   createModuleNamespace,
   FirebaseModule,
@@ -60,6 +60,14 @@ class FirebaseFunctionsModule extends FirebaseModule {
   }
 
   httpsCallable(name, options = {}) {
+    if (options.timeout) {
+      if (isNumber(options.timeout)) {
+        options.timeout = options.timeout / 1000;
+      } else {
+        throw new Error('HttpsCallableOptions.timeout expected a Number in milliseconds');
+      }
+    }
+
     return data => {
       const nativePromise = this.native.httpsCallable(
         this._useFunctionsEmulatorOrigin,

--- a/packages/functions/lib/index.js
+++ b/packages/functions/lib/index.js
@@ -59,11 +59,16 @@ class FirebaseFunctionsModule extends FirebaseModule {
     this._useFunctionsEmulatorOrigin = null;
   }
 
-  httpsCallable(name) {
+  httpsCallable(name, options = {}) {
     return data => {
-      const nativePromise = this.native.httpsCallable(this._useFunctionsEmulatorOrigin, name, {
-        data,
-      });
+      const nativePromise = this.native.httpsCallable(
+        this._useFunctionsEmulatorOrigin,
+        name,
+        {
+          data,
+        },
+        options,
+      );
       return nativePromise.catch(nativeError => {
         const { code, message, details } = nativeError.userInfo || {};
         return Promise.reject(

--- a/tests/index.android.js
+++ b/tests/index.android.js
@@ -1,2 +1,3 @@
 require('./app');
+// require('./appPlaygrounds/functions');
 //require('./app.admob');


### PR DESCRIPTION
cloud functions timeout v7 implementation

- added `timeout` option property to functions which allows you to set the timeout response from a cloud function in milliseconds (native timeout is seconds for both platforms).