### PR TITLE
fix(functions): throw UNAVAILABLE code on network IO errors

### DIFF
--- a/packages/functions/android/src/reactnative/java/io/invertase/firebase/functions/ReactNativeFirebaseFunctionsModule.java
+++ b/packages/functions/android/src/reactnative/java/io/invertase/firebase/functions/ReactNativeFirebaseFunctionsModule.java
@@ -29,6 +29,8 @@ import com.google.firebase.functions.FirebaseFunctionsException;
 import io.invertase.firebase.common.RCTConvertFirebase;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
 
+import java.io.IOException;
+
 import static io.invertase.firebase.functions.UniversalFirebaseFunctionsModule.CODE_KEY;
 import static io.invertase.firebase.functions.UniversalFirebaseFunctionsModule.DATA_KEY;
 import static io.invertase.firebase.functions.UniversalFirebaseFunctionsModule.DETAILS_KEY;
@@ -76,6 +78,11 @@ public class ReactNativeFirebaseFunctionsModule extends ReactNativeFirebaseModul
         details = functionsException.getDetails();
         code = functionsException.getCode().name();
         message = functionsException.getMessage();
+        if (functionsException.getCause() instanceof IOException) {
+          // return UNAVAILABLE for network io errors, to match iOS
+          code = FirebaseFunctionsException.Code.UNAVAILABLE.name();
+          message = FirebaseFunctionsException.Code.UNAVAILABLE.name();
+        }
       }
       RCTConvertFirebase.mapPutValue(CODE_KEY, code, userInfo);
       RCTConvertFirebase.mapPutValue(MSG_KEY, message, userInfo);


### PR DESCRIPTION
Fixes #3326 

### Summary
Makes the error thrown by Functions when a network IO error occurs consistent between iOS and Android.

### Checklist

- [x] Supports `Android`
- [ ] Supports `iOS`
- [ ] `e2e` tests added or updated in packages/**/e2e
- [ ] Flow types updated
- [ ] Typescript types updated

### Test Plan
N/A

### Release Plan

<!-- Help reviewers and the release process by writing your own release notes. See below for examples. -->

[ANDROID][BUGFIX] [FirebaseFunctions] - change network IO errors to use code=UNAVAILABLE (matching iOS)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
