### PR TITLE
fix(v5-messaging): registerForRemoteNotifications when has permission

### DIFF
--- a/ios/RNFirebase/messaging/RNFirebaseMessaging.m
+++ b/ios/RNFirebase/messaging/RNFirebaseMessaging.m
@@ -195,14 +195,22 @@ RCT_EXPORT_METHOD(registerForRemoteNotifications:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(hasPermission:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_9_x_Max) {
         dispatch_async(dispatch_get_main_queue(), ^{
-          BOOL hasPermission = [RCTConvert BOOL:@([RCTSharedApplication() currentUserNotificationSettings].types != UIUserNotificationTypeNone)];
-          resolve(@(hasPermission));
+            BOOL hasPermission = [RCTConvert BOOL:@([RCTSharedApplication() currentUserNotificationSettings].types != UIUserNotificationTypeNone)];
+            if(hasPermission){
+                [RCTSharedApplication() registerForRemoteNotifications];
+            }
+            resolve(@(hasPermission));
         });
     } else {
         if (@available(iOS 10.0, *)) {
             [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-              BOOL hasPermission = [RCTConvert BOOL:@(settings.alertSetting == UNNotificationSettingEnabled)];
-              resolve(@(hasPermission));
+                BOOL hasPermission = [RCTConvert BOOL:@(settings.alertSetting == UNNotificationSettingEnabled)];
+                if(hasPermission){
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [RCTSharedApplication() registerForRemoteNotifications];
+                    });
+                }
+                resolve(@(hasPermission));
             }];
         }
     }


### PR DESCRIPTION
## Common Scenario
```js
const permission = await firebase.messaging().hasPermission();
if(permission){
  console.log('user has permissions! Maybe I have nothing to do!);
  // But actually we have to do this one
  // firebase.messaging().ios.registerForRemoteNotification();
} else {
  console.log('oh... user doesn't have permission, ok let's request permission!');
  firebase.messaging().requestPermission();
}
```
**requestPermission** includes **registerForRemoteNotifications** that trigger below

`didRegisterForRemoteNotificationsWithDeviceToken -> [FIRMessaging messaging] setAPNSToken:deviceToken` or `Swizzling APNS token mapping`


But **hasPermission** is not calling above flow, so user can't receive **silent-notification**(Background onMessage) or any APNs notifications

---

Usually, we think we don't have to do anything with permission.
related with #3067, resolve #3275