### PR TITLE
feat(ios): allow static_framework usage via Podfile global

### DIFF
--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -2,14 +2,10 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBAdMob: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAdMob"
+
   s.version             = package["version"]
   s.description         = package["description"]
   s.summary             = <<-DESC
@@ -22,11 +18,28 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  # Other dependencies
+  s.dependency          'PersonalizedAdConsent', '~> 1.0.4'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/AdMob', firebase_sdk_version
-  s.dependency          'PersonalizedAdConsent'
-  s.dependency          'RNFBApp'
-  s.static_framework    = true
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBAnalytics: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAnalytics"
@@ -22,8 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
-  s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
+  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/Analytics', firebase_sdk_version
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -3,11 +3,6 @@ require './firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBApp: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBApp"
@@ -23,7 +18,22 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = "ios/**/*.{h,m}"
+
+  # React Native dependencies
   s.dependency          'React'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBAuth: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAuth"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Auth', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -3,27 +3,12 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 # Firebase SDK Override
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBCrashlytics: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 # Fabric SDK Override
 fabric_sdk_version = '~> 1.10.2'
-using_custom_fabric_sdk_version = defined? $FabricSDKVersion
-if using_custom_fabric_sdk_version
-  Pod::UI.puts "RNFBCrashlytics: Using user specified Fabric SDK version '#{$FabricSDKVersion}'"
-  fabric_sdk_version = $FabricSDKVersion
-end
 
 # Crashlytics SDK Override
 crashlytics_sdk_version = '~> 3.14.0'
-using_custom_crashlytics_sdk_version = defined? $CrashlyticsSDKVersion
-if using_custom_crashlytics_sdk_version
-  Pod::UI.puts "RNFBCrashlytics: Using user specified Crashlytics SDK version '#{$CrashlyticsSDKVersion}'"
-  crashlytics_sdk_version = $CrashlyticsSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBCrashlytics"
@@ -39,10 +24,36 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  if defined?($CrashlyticsSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Crashlytics SDK version '#{$CrashlyticsSDKVersion}'"
+    crashlytics_sdk_version = $CrashlyticsSDKVersion
+  end
+
+  if defined?($FabricSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Fabric SDK version '#{$FabricSDKVersion}'"
+    fabric_sdk_version = $FabricSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Fabric', fabric_sdk_version
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Crashlytics', crashlytics_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
+
 end

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read('./package.json'))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBDatabase: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBDatabase"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Database', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBDynamicLinks: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBDynamicLinks"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/DynamicLinks', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBDynamicLinks: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBFirestore"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Firestore', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBFirestore: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBFunctions"
@@ -22,8 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
-  s.dependency          'Firebase/Functions', firebase_sdk_version
   s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
+  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/Functions', firebase_sdk_version
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBIid: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBIid"
@@ -22,8 +17,23 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
-  s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
+  s.dependency          'Firebase/Core', firebase_sdk_version
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBInAppMessaging: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBInAppMessaging"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBMessaging: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBMessaging"
@@ -22,8 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
-  s.dependency          'Firebase/Messaging', firebase_sdk_version
   s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
+  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/Messaging', firebase_sdk_version
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -3,11 +3,6 @@ require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBMLNaturalLanguage: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBMLNaturalLanguage"
@@ -23,12 +18,21 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
-  s.dependency          'RNFBApp'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/MLNaturalLanguage', firebase_sdk_version
 
   if FirebaseJSON::Config.get_value_or_default('ml_natural_language_language_id_model', false)
-    s.dependency          'Firebase/MLNaturalLanguage', firebase_sdk_version
     s.dependency          'Firebase/MLNLLanguageID', firebase_sdk_version
   end
 
@@ -42,5 +46,10 @@ Pod::Spec.new do |s|
     s.dependency          'Firebase/MLNLSmartReply', firebase_sdk_version
   end
 
-  s.static_framework    = false
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -3,11 +3,6 @@ require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBMLVision: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBMLVision"
@@ -23,26 +18,36 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
-  s.dependency          'RNFBApp'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/MLVision', firebase_sdk_version
-
   if FirebaseJSON::Config.get_value_or_default('ml_vision_face_model', false)
     s.dependency          'Firebase/MLVisionFaceModel', firebase_sdk_version
   end
-
   if FirebaseJSON::Config.get_value_or_default('ml_vision_ocr_model', false)
     s.dependency          'Firebase/MLVisionTextModel', firebase_sdk_version
   end
-
   if FirebaseJSON::Config.get_value_or_default('ml_vision_barcode_model', false)
     s.dependency          'Firebase/MLVisionBarcodeModel', firebase_sdk_version
   end
-
   if FirebaseJSON::Config.get_value_or_default('ml_vision_image_label_model', false)
     s.dependency          'Firebase/MLVisionLabelModel', firebase_sdk_version
   end
 
-  s.static_framework    = false
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBPerf: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBPerf"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Performance', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBRemoteConfig: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBRemoteConfig"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/RemoteConfig', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -2,11 +2,6 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 firebase_sdk_version = '~> 6.13.0'
-using_custom_firebase_sdk_version = defined? $FirebaseSDKVersion
-if using_custom_firebase_sdk_version
-  Pod::UI.puts "RNFBStorage: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBStorage"
@@ -22,9 +17,24 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
+
+  # React Native dependencies
   s.dependency          'React'
+  s.dependency          'RNFBApp'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  end
+
+  # Firebase dependencies
   s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Storage', firebase_sdk_version
-  s.dependency          'RNFBApp'
-  s.static_framework    = false
+
+  if defined?($RNFirebaseAsStaticFramework)
+    Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
+    s.static_framework = $RNFirebaseAsStaticFramework
+  else
+    s.static_framework = false
+  end
 end

--- a/packages/template/project/ios/Podfile
+++ b/packages/template/project/ios/Podfile
@@ -6,6 +6,9 @@ require_relative '../node_modules/@react-native-community/cli-platform-ios/nativ
 # $FabricSDKVersion = '1.6.0'
 # $CrashlyticsSDKVersion = '3.1.0'
 
+# To use RNFirebase packages as static frameworks uncomment the below line
+# $RNFirebaseAsStaticFramework = true
+
 target 'HelloWorld' do
   # Pods for HelloWorld
   pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -1,7 +1,10 @@
 platform :ios, '9.0'
 
+# Allow using RNFirebase as static frameworks
+$RNFirebaseAsStaticFramework = true
+
 # Version override testing
-# $FirebaseSDKVersion = '6.8.1'
+# $FirebaseSDKVersion = '6.15.0'
 # $FabricSDKVersion = '1.6.0'
 # $CrashlyticsSDKVersion = '3.1.0'
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -249,8 +249,8 @@ PODS:
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (= 0.3.9011)
-  - FirebaseAnalyticsInterop (1.4.0)
-  - FirebaseAuth (6.4.0):
+  - FirebaseAnalyticsInterop (1.5.0)
+  - FirebaseAuth (6.4.2):
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.2)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.2)
@@ -262,21 +262,21 @@ PODS:
     - FirebaseCoreDiagnosticsInterop (~> 1.0)
     - GoogleUtilities/Environment (~> 6.2)
     - GoogleUtilities/Logger (~> 6.2)
-  - FirebaseCoreDiagnostics (1.1.2):
-    - FirebaseCoreDiagnosticsInterop (~> 1.0)
-    - GoogleDataTransportCCTSupport (~> 1.0)
-    - GoogleUtilities/Environment (~> 6.2)
-    - GoogleUtilities/Logger (~> 6.2)
+  - FirebaseCoreDiagnostics (1.2.0):
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleDataTransportCCTSupport (~> 1.3)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
     - nanopb (~> 0.3.901)
-  - FirebaseCoreDiagnosticsInterop (1.1.0)
-  - FirebaseDatabase (6.1.2):
+  - FirebaseCoreDiagnosticsInterop (1.2.0)
+  - FirebaseDatabase (6.1.4):
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (4.0.5):
+  - FirebaseDynamicLinks (4.0.6):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.2)
-  - FirebaseFirestore (1.8.1):
+  - FirebaseFirestore (1.8.3):
     - abseil/algorithm (= 0.20190808)
     - abseil/base (= 0.20190808)
     - abseil/memory (= 0.20190808)
@@ -293,7 +293,7 @@ PODS:
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseInAppMessaging (0.15.5):
+  - FirebaseInAppMessaging (0.15.6):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.2)
     - FirebaseInstanceID (~> 4.0)
@@ -302,7 +302,7 @@ PODS:
     - FirebaseCore (~> 6.0)
     - GoogleUtilities/Environment (~> 6.0)
     - GoogleUtilities/UserDefaults (~> 6.0)
-  - FirebaseMessaging (4.1.9):
+  - FirebaseMessaging (4.1.10):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.2)
     - FirebaseInstanceID (~> 4.1)
@@ -364,7 +364,7 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 6.2)
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.9)
-  - FirebaseRemoteConfig (4.4.5):
+  - FirebaseRemoteConfig (4.4.6):
     - FirebaseABTesting (~> 3.1)
     - FirebaseAnalyticsInterop (~> 1.4)
     - FirebaseCore (~> 6.2)
@@ -372,7 +372,7 @@ PODS:
     - GoogleUtilities/Environment (~> 6.2)
     - "GoogleUtilities/NSData+zlib (~> 6.2)"
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseStorage (3.4.2):
+  - FirebaseStorage (3.4.3):
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - GTMSessionFetcher/Core (~> 1.1)
@@ -386,11 +386,11 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Google-Mobile-Ads-SDK (7.52.0):
+  - Google-Mobile-Ads-SDK (7.54.0):
     - GoogleAppMeasurement (~> 6.0)
-  - GoogleAPIClientForREST/Core (1.3.10):
+  - GoogleAPIClientForREST/Core (1.3.11):
     - GTMSessionFetcher (>= 1.1.7)
-  - GoogleAPIClientForREST/Vision (1.3.10):
+  - GoogleAPIClientForREST/Vision (1.3.11):
     - GoogleAPIClientForREST/Core
     - GTMSessionFetcher (>= 1.1.7)
   - GoogleAppMeasurement (6.1.6):
@@ -399,9 +399,9 @@ PODS:
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (= 0.3.9011)
-  - GoogleDataTransport (3.2.0)
-  - GoogleDataTransportCCTSupport (1.2.2):
-    - GoogleDataTransport (~> 3.2)
+  - GoogleDataTransport (3.3.1)
+  - GoogleDataTransportCCTSupport (1.3.1):
+    - GoogleDataTransport (~> 3.3)
     - nanopb (~> 0.3.901)
   - GoogleToolboxForMac/DebugUtils (2.2.2):
     - GoogleToolboxForMac/Defines (= 2.2.2)
@@ -415,24 +415,24 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
-  - GoogleUtilities/AppDelegateSwizzler (6.3.2):
+  - GoogleUtilities/AppDelegateSwizzler (6.5.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.3.2)
-  - GoogleUtilities/ISASwizzler (6.3.2)
-  - GoogleUtilities/Logger (6.3.2):
+  - GoogleUtilities/Environment (6.5.1)
+  - GoogleUtilities/ISASwizzler (6.5.1)
+  - GoogleUtilities/Logger (6.5.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (6.3.2):
+  - GoogleUtilities/MethodSwizzler (6.5.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (6.3.2):
+  - GoogleUtilities/Network (6.5.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.3.2)"
-  - GoogleUtilities/Reachability (6.3.2):
+  - "GoogleUtilities/NSData+zlib (6.5.1)"
+  - GoogleUtilities/Reachability (6.5.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (6.3.2):
+  - GoogleUtilities/UserDefaults (6.5.1):
     - GoogleUtilities/Logger
   - "gRPC-C++ (0.0.9)":
     - "gRPC-C++/Implementation (= 0.0.9)"
@@ -450,11 +450,11 @@ PODS:
     - gRPC-Core/Interface (= 1.21.0)
     - nanopb (~> 0.3)
   - gRPC-Core/Interface (1.21.0)
-  - GTMSessionFetcher (1.3.0):
-    - GTMSessionFetcher/Full (= 1.3.0)
-  - GTMSessionFetcher/Core (1.3.0)
-  - GTMSessionFetcher/Full (1.3.0):
-    - GTMSessionFetcher/Core (= 1.3.0)
+  - GTMSessionFetcher (1.3.1):
+    - GTMSessionFetcher/Full (= 1.3.1)
+  - GTMSessionFetcher/Core (1.3.1)
+  - GTMSessionFetcher/Full (1.3.1):
+    - GTMSessionFetcher/Core (= 1.3.1)
   - Jet (0.4.4):
     - React
   - leveldb-library (1.22)
@@ -463,8 +463,8 @@ PODS:
     - nanopb/encode (= 0.3.9011)
   - nanopb/decode (0.3.9011)
   - nanopb/encode (0.3.9011)
-  - PersonalizedAdConsent (1.0.3)
-  - Protobuf (3.10.0)
+  - PersonalizedAdConsent (1.0.4)
+  - Protobuf (3.11.2)
   - React (0.60.5):
     - React-Core (= 0.60.5)
     - React-DevSupport (= 0.60.5)
@@ -537,10 +537,11 @@ PODS:
     - Firebase/AdMob (~> 6.13.0)
     - Firebase/Analytics (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
-    - PersonalizedAdConsent
+    - PersonalizedAdConsent (~> 1.0.4)
     - React
     - RNFBApp
   - RNFBAnalytics (6.3.4):
+    - Firebase/Analytics (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
     - React
     - RNFBApp
@@ -574,6 +575,7 @@ PODS:
     - React
     - RNFBApp
   - RNFBFunctions (6.3.4):
+    - Firebase/Core (~> 6.13.0)
     - Firebase/Functions (~> 6.13.0)
     - React
     - RNFBApp
@@ -587,6 +589,7 @@ PODS:
     - React
     - RNFBApp
   - RNFBMessaging (6.3.4):
+    - Firebase/Core (~> 6.13.0)
     - Firebase/Messaging (~> 6.13.0)
     - React
     - RNFBApp
@@ -805,19 +808,19 @@ SPEC CHECKSUMS:
   Firebase: 458d109512200d1aca2e1b9b6cf7d68a869a4a46
   FirebaseABTesting: 0d10f3cdc3fa00f3f175b5b56c1003c8e888299f
   FirebaseAnalytics: 45f36d9c429fc91d206283900ab75390cd05ee8a
-  FirebaseAnalyticsInterop: d48b6ab67bcf016a05e55b71fc39c61c0cb6b7f3
-  FirebaseAuth: 7d0f84873926f6648bbd1391a318dfb1a26b5e4f
+  FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
+  FirebaseAuth: ce45d7c5d46bed90159f3a73b6efbe8976ed3573
   FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
   FirebaseCore: 307ea2508df730c5865334e41965bd9ea344b0e5
-  FirebaseCoreDiagnostics: 511f4f3ed7d440bb69127e8b97c2bc8befae639e
-  FirebaseCoreDiagnosticsInterop: e9b1b023157e3a2fc6418b5cb601e79b9af7b3a0
-  FirebaseDatabase: 963515d232ded06f36f6ce830507c94551866170
-  FirebaseDynamicLinks: db62e9da4788f9c5ebce2028dab933a0c158cfe2
-  FirebaseFirestore: 2e92e977280d63ecbf3fd58bdbfaf9145abb880f
+  FirebaseCoreDiagnostics: 5e78803ab276bc5b50340e3c539c06c3de35c649
+  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
+  FirebaseDatabase: 0144e0706a4761f1b0e8679572eba8095ddb59be
+  FirebaseDynamicLinks: 5ba2a0d46ba1615c6c08819fc964c495ca1d0845
+  FirebaseFirestore: 52120e2833f804a874ba1a9f59aab864a8ae2286
   FirebaseFunctions: 5af7c35d1c5e41608fecbb667eb6c4e672e318d0
-  FirebaseInAppMessaging: acbfa8c5582b11ccc0366511d29ef1d288f302fc
+  FirebaseInAppMessaging: 8e1190f8d8cf6f1fcfc8f82f99e0ecce522fc02b
   FirebaseInstanceID: ebd2ea79ee38db0cb5f5167b17a0d387e1cc7b6e
-  FirebaseMessaging: e8d71368a5c579083da02203146c953f3386d503
+  FirebaseMessaging: 089b7a4991425783384acc8bcefcd78c0af913bd
   FirebaseMLCommon: 074a67e05122b1c9f6401a4e33b2cea3b4efd224
   FirebaseMLNaturalLanguage: 9d38301a41b1201d248588bf66937b975391e8f4
   FirebaseMLNLLanguageID: afd2e97dfc8ff215f7527acc7e4cd56d4f537737
@@ -828,25 +831,25 @@ SPEC CHECKSUMS:
   FirebaseMLVisionLabelModel: 7638a20d27219d5baa4b534a62375fc1d5bd077d
   FirebaseMLVisionTextModel: c264caa3100ca804580bf2a7c1cb9ff390d1f471
   FirebasePerformance: 22273a775eaed4cd3e072c9b88396a5e4b285c3f
-  FirebaseRemoteConfig: 6ad68503c04701b8d9d709240711bc0bf6edaf94
-  FirebaseStorage: 046abe9ac4e2a1a0e47d72f536490ffa50896632
+  FirebaseRemoteConfig: c11d74d8b1ff8463b587fc8899d92ee089f9a691
+  FirebaseStorage: 93fe2f8190a01bfb2b2c4932df7d679744c4ef1d
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Google-Mobile-Ads-SDK: 62f6244637306cb60a1b4adda067f53224c7a860
-  GoogleAPIClientForREST: 4acfffd77f1c3c8741b6be9eaed0e603278efbde
+  Google-Mobile-Ads-SDK: 8241b4bd0f11b4f03f5dcd4affccb04ca938f050
+  GoogleAPIClientForREST: 0f19a8280dfe6471f76016645d26eb5dae305101
   GoogleAppMeasurement: dfe55efa543e899d906309eaaac6ca26d249862f
-  GoogleDataTransport: 8e9b210c97d55fbff306cc5468ff91b9cb32dcf5
-  GoogleDataTransportCCTSupport: ef79a4728b864946a8aafdbab770d5294faf3b5f
+  GoogleDataTransport: 0048df6388dab1c254799f2a30365b1dffe20422
+  GoogleDataTransportCCTSupport: f880d70972efa2ed1be4e9173a0f4c5f3dc2d176
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
-  GoogleUtilities: 547a86735c6f0ee30ad17e94df4fc21f616b71cb
+  GoogleUtilities: 06eb53bb579efe7099152735900dd04bf09e7275
   "gRPC-C++": 9dfe7b44821e7b3e44aacad2af29d2c21f7cde83
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
-  GTMSessionFetcher: 43b8b64263023d4f32caa0b40f4c8bfa3c5f36d8
+  GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
   Jet: 28e2deb607658bd5c5d24e3fcb926bb3f7daf59e
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
-  PersonalizedAdConsent: b50a8a5d6065b6db23121e8fcc0dce2ae983f6ea
-  Protobuf: a4dc852ad69c027ca2166ed287b856697814375b
+  PersonalizedAdConsent: 4b87320b7a0f22576bec530ae3b7adba88a24c78
+  Protobuf: dd1aaea7140debfe4dd0683fb8ef208e527ae153
   React: 53c53c4d99097af47cf60594b8706b4e3321e722
   React-Core: ba421f6b4f4cbe2fb17c0b6fc675f87622e78a64
   React-cxxreact: 8384287780c4999351ad9b6e7a149d9ed10a2395
@@ -864,25 +867,25 @@ SPEC CHECKSUMS:
   React-RCTText: b074d89033583d4f2eb5faf7ea2db3a13c7553a2
   React-RCTVibration: 2105b2e0e2b66a6408fc69a46c8a7fb5b2fdade0
   React-RCTWebSocket: cd932a16b7214898b6b7f788c8bddb3637246ac4
-  RNFBAdMob: 220fc6f8db48fc824ebbb6704f3887a2c779254e
-  RNFBAnalytics: b8bad44e6653af73219b1a7af24bf3452cb02c1b
-  RNFBApp: 7d4006751de8bb5cafa2e8d2e7d94ee250df81db
-  RNFBAuth: ed8b865db45f7ded9dbf535e390cba2ba672aede
-  RNFBCrashlytics: 93e1cc09a93aa4bb1e9b5a07af0efb2702db5a39
-  RNFBDatabase: 1201eb94eff3ab457d3e898fb5c347ddc67e00db
-  RNFBDynamicLinks: e0d320b2bd02dee6ed1f0a7d8deecdf3469db461
-  RNFBFirestore: 04c1eb90463c208ee072988d463c74bec09d08c1
-  RNFBFunctions: 6975565f0abcc68d9731d05b78778f003db0eca5
-  RNFBIid: 4aa2f4fb218fd4effff8c6f947a6cfa44557d16f
-  RNFBInAppMessaging: 956fa7fe24e213218bb67ef2fb5db0e0aee4d091
-  RNFBMessaging: 51cc7f6beaf4c4feac6f18ea941bba5854e3d9c6
-  RNFBMLNaturalLanguage: 4aacf1c4f339a5733054e69fc8d680272d38f50c
-  RNFBMLVision: 352b94db5c5521c222217bfdb4d3f43ab0b2f9ea
-  RNFBPerf: d5c9efa43b61bdcff5ac949932055b5e5a5c132f
-  RNFBRemoteConfig: acfef78587e8d544b53338c07ecbc172fae1b781
-  RNFBStorage: 3628afb1f3dd0b3395fc15c95967b9f080897aec
+  RNFBAdMob: 2bdf07ebb9ddfbb6ec858ca041266b2d7f9ac51c
+  RNFBAnalytics: b7790bae8f0f8a66b710e9d2960c4d1dd48fa40f
+  RNFBApp: 1c7191cf7f511a34db037ef50e60a6e2d38fe999
+  RNFBAuth: 7d89f872de916d58cdb0b1d8dde7d9f382ae69af
+  RNFBCrashlytics: c20569ceca8e2cd4db09f83c92b4d1ea916abd11
+  RNFBDatabase: e4e0c03580fb961c117766b30ba77491597df44f
+  RNFBDynamicLinks: ae773a828764b2481f0a7055a544d0c84c7665ff
+  RNFBFirestore: 4773e8a450042d76913b289a765ec8df529be8b3
+  RNFBFunctions: d7f499e79f9359aa17f62a75ce1a29149f321844
+  RNFBIid: debbd57bef80b12b68f2cf90e6845229c9e94d85
+  RNFBInAppMessaging: c8c00a14d3e2c0a7b885c62ba9107ef1f024eb02
+  RNFBMessaging: 6f8ff04a11ce65431077934df584d6e347de11f8
+  RNFBMLNaturalLanguage: 693379689bc4a894b27b68b96266f697692cd49b
+  RNFBMLVision: df125d0532dad3b0ac4c6fa4f1590f7641a7c98e
+  RNFBPerf: 082209095bde50dcd10fcfed63834c3777a73cc2
+  RNFBRemoteConfig: c1fa18051e115e315a1cda548b43212f2faabdaf
+  RNFBStorage: ab31641a2c25f90d68d9e23e28b2ad72270c3074
   yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
 
-PODFILE CHECKSUM: 4ceb34e93fa1dd96bcca7e61934b407531c8e96e
+PODFILE CHECKSUM: 173a64b0d2329c21a9d76d9c8a34c95c8f057ba8
 
 COCOAPODS: 1.8.4


### PR DESCRIPTION
### Summary

First pass at addressing #3253 to allow release in 6.4.0 - there is no breaking changes as the default is currently `false`

For v7.0.0 we should make the default value `true` along with the RN min version set to 0.61.x +

### Checklist

- [x] Supports `iOS`

### Test Plan

`pod install` logs show flag being detected and used correctly;

![image](https://user-images.githubusercontent.com/5347038/78248396-7acf6880-74e4-11ea-9475-d89ea4bc6b62.png)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Donate via [Open Collective](https://opencollective.com/react-native-firebase/donate)
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
- 👉 Star this repo on GitHub ⭐️
- 👉 Contribute; see our [contributing guide](/CONTRIBUTING.md)
