### PR TITLE
docs: update usage of secondary app

### DIFF
--- a/docs/app/usage.md
+++ b/docs/app/usage.md
@@ -65,19 +65,26 @@ console.log(firebase.apps);
 
 ## Switching app instance
 
-You can switch app instances at any time whilst developing by calling the `app` method:
+You can switch app instances at any time whilst developing by calling the `app` method with the name of the secondary app:
 
 ```js
 import firebase from '@react-native-firebase/app';
+import '@react-native-firebase/auth';
 
 // Example using auth
 firebase.app('SECONDARY_APP').auth().currentUser;
 ```
 
-The `firebase` instance is also exported on modules for added convenience, for example:
-
+Or pass the secondary app instance you created above directly to the desired module, for example:
 ```js
-import auth, { firebase } from '@react-native-firebase/auth';
+import firebase from '@react-native-firebase/app';
+import auth from '@react-native-firebase/auth';
+
+// create secondary app as described above
+const secondaryApp = await firebase.initalizeApp(credentials, config);
+
+// Example using auth with passing the secondary app instance
+auth(secondaryApp).currentUser;
 ```
 
 ## Deleting instances


### PR DESCRIPTION
### Summary
I struggled a lot with simply switching the database URL within the [DEFAULT] app instance during run time.
I documented my solution in this ticket: https://github.com/invertase/react-native-firebase/issues/3049

This PR shall reflect my further findings when switching app instances.

### Checklist

It's a documentation update.

- [x] Supports `Android`
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in packages/\*\*/e2e
- [x] Flow types updated
- [x] Typescript types updated
