### PR TITLE
docs: update database usage with switching database URL

### DIFF
--- a/docs/database/usage/index.md
+++ b/docs/database/usage/index.md
@@ -320,9 +320,7 @@ Please follow the firebase Realtime Database documentation on [security](https:/
 
 # Using a secondary database
 
-## Switch the database URL of the default app
-
-If the default installed firebase instance needs to address a different database within the same project, call the database method on the default app with passing the database URL.
+If the default installed Firebase instance needs to address a different database within the same project, call the database method on the default app with passing the database URL.
 For example:
 
 ```js

--- a/docs/database/usage/index.md
+++ b/docs/database/usage/index.md
@@ -318,30 +318,12 @@ database and the new [`DataSnapshot`](/reference/database/datasnapshot) containi
 It is important that you understand how to write rules in your firebase console to ensure that your data is secure.
 Please follow the firebase Realtime Database documentation on [security](https://firebase.google.com/docs/database/security)
 
-# firebase.json
-
-## Disabling persistence
-
-By default the Realtime Database persists data on the user application, and is used by the SDKs for offline usage
-and caching. To disable this functionality, update the `database_persistence_enabled` key in the `firebase.json` file:
-
-```json
-// <project-root>/firebase.json
-{
-  "react-native": {
-    "database_persistence_enabled": false
-  }
-}
-```
-
-To enable persistence, view the [Offline Support](/database/offline-support) documentation.
-
 # Change the database URL
 
 ## Switch the database URL of the default app
 
-If the default installed firebase instance needs to address a different database within the same project, call the database method on the default app with passing the database URL. 
-For example: 
+If the default installed firebase instance needs to address a different database within the same project, call the database method on the default app with passing the database URL.
+For example:
 
 ```js
 import firebase from '@react-native-firebase/app';
@@ -370,3 +352,21 @@ const secondaryDatabase = database(secondaryApp);
 
 secondaryDatabase.ref();
 ```
+
+# firebase.json
+
+## Disabling persistence
+
+By default the Realtime Database persists data on the user application, and is used by the SDKs for offline usage
+and caching. To disable this functionality, update the `database_persistence_enabled` key in the `firebase.json` file:
+
+```json
+// <project-root>/firebase.json
+{
+  "react-native": {
+    "database_persistence_enabled": false
+  }
+}
+```
+
+To enable persistence, view the [Offline Support](/database/offline-support) documentation.

--- a/docs/database/usage/index.md
+++ b/docs/database/usage/index.md
@@ -324,8 +324,7 @@ If the default installed Firebase instance needs to address a different database
 For example:
 
 ```js
-import firebase from '@react-native-firebase/app';
-import '@react-native-firebase/database';
+import { firebase } from '@react-native-firebase/database';
 
 const database = firebase.app().database('https://path-to-database.firebaseio.com');
 
@@ -339,8 +338,7 @@ If you want to address a database from a different Firebase project, you will ne
 For example:
 
 ```js
-import firebase from '@react-native-firebase/app';
-import database from '@react-native-firebase/database';
+import database, { firebase } from '@react-native-firebase/database';
 
 // create a secondary app
 const secondaryApp = await firebase.initalizeApp(credentials, config);

--- a/docs/database/usage/index.md
+++ b/docs/database/usage/index.md
@@ -335,3 +335,38 @@ and caching. To disable this functionality, update the `database_persistence_ena
 ```
 
 To enable persistence, view the [Offline Support](/database/offline-support) documentation.
+
+# Change the database URL
+
+## Switch the database URL of the default app
+
+If the default installed firebase instance needs to address a different database within the same project, call the database method on the default app with passing the database URL. 
+For example: 
+
+```js
+import firebase from '@react-native-firebase/app';
+import '@react-native-firebase/database';
+
+const database = firebase.app().database('https://path-to-database.firebaseio.com');
+
+database.ref();
+```
+
+## Connect to a database of a secondary app
+
+If you want to address a database from a different firebase project, you will need to create a secondary app first
+(Read more on creating a secondary app here: https://rnfirebase.io/app/usage).
+For example:
+
+```js
+import firebase from '@react-native-firebase/app';
+import database from '@react-native-firebase/database';
+
+// create a secondary app
+const secondaryApp = await firebase.initalizeApp(credentials, config);
+
+// pass the secondary app instance to the database module
+const secondaryDatabase = database(secondaryApp);
+
+secondaryDatabase.ref();
+```

--- a/docs/database/usage/index.md
+++ b/docs/database/usage/index.md
@@ -318,7 +318,7 @@ database and the new [`DataSnapshot`](/reference/database/datasnapshot) containi
 It is important that you understand how to write rules in your firebase console to ensure that your data is secure.
 Please follow the firebase Realtime Database documentation on [security](https://firebase.google.com/docs/database/security)
 
-# Change the database URL
+# Using a secondary database
 
 ## Switch the database URL of the default app
 

--- a/docs/database/usage/index.md
+++ b/docs/database/usage/index.md
@@ -334,7 +334,7 @@ database.ref();
 
 ## Connect to a database of a secondary app
 
-If you want to address a database from a different firebase project, you will need to create a secondary app first
+If you want to address a database from a different Firebase project, you will need to create a secondary app first
 (Read more on creating a secondary app here: https://rnfirebase.io/app/usage).
 For example:
 


### PR DESCRIPTION
### Summary
I struggled a while with finding out how to switch the database URL for the [DEFAULT] firebase instance during runtime.
With version 5 it was very easy with simply passing the databaseURL to the database module.

The docs did not help unfortunately, so I tried a lot of ways which are documented in this ticket:
https://github.com/invertase/react-native-firebase/issues/3049

This PR shall help other people with the same situation too.

Furthermore, I hope to get valid feedback if the proposed implementation documented in this PR is actually correct.

### Checklist

It's a documentation update

- [x] Supports `Android`
- [x] Supports `iOS`
- [x] `e2e` tests added or updated in packages/\*\*/e2e
- [x] Flow types updated
- [x] Typescript types updated