### PR TITLE
docs(auth): fixed google sign-in with correct webClientId

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -212,13 +212,13 @@ documentation.
 Ensure the "Google" sign-in provider is enabled on the [Firebase Console](https://console.firebase.google.com/project/_/authentication/providers).
 
 Before triggering a sign-in request, you must initialize the Google SDK using your any required scopes and the
-`webClientId`, which can be found in `google-services.json`, under `client/oauth_client/client_id`.
+`webClientId`, which can be found in the `android/app/google-services.json` file as the `client/oauth_client/client_id` property (the id ends with `.apps.googleusercontent.com`).
 
 ```js
 import { GoogleSignin } from '@react-native-community/google-signin';
 
 GoogleSignin.configure({
-  webClientId: '', // From google-services.json, ends with .apps.googleusercontent.com
+  webClientId: '', 
 });
 ```
 

--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -212,13 +212,13 @@ documentation.
 Ensure the "Google" sign-in provider is enabled on the [Firebase Console](https://console.firebase.google.com/project/_/authentication/providers).
 
 Before triggering a sign-in request, you must initialize the Google SDK using your any required scopes and the
-`webClientId`, which can be found on the Firebase Console Settings, as "Web API Key".
+`webClientId`, which can be found in `google-services.json`, under `client/oauth_client/client_id`.
 
 ```js
 import { GoogleSignin } from '@react-native-community/google-signin';
 
 GoogleSignin.configure({
-  webClientId: '', // From Firebase Console Settings
+  webClientId: '', // From google-services.json, ends with .apps.googleusercontent.com
 });
 ```
 


### PR DESCRIPTION
### Description

I was receiving developer_error with the instructions here. Following this suggestion fixed it: https://github.com/react-native-community/google-signin/issues/224#issuecomment-599171322 . In that video at this time the correct webClientId is visible on the top of the screen and it would not work otherwise for me: https://youtu.be/AHVaxhcoY98?t=2557

### Related issues

Could not find any here. This is relevant, however: https://github.com/react-native-community/google-signin/issues/224

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ x] Yes
- My change supports the following platforms;
  - [ x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
