### PR TITLE
docs(messaging): code typo on docs/messaging/usage/index.md

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -177,7 +177,7 @@ any custom data via the `data` property. To learn more, view the [`RemoteMessage
 API reference.
 
 If the `RemoteMessage` payload contains a `notification` property when sent to the `setBackgroundMessageHandler` handler, the device
-will have displayed a [notification](/messaging/notififications) to the user.
+will have displayed a [notification](/messaging/notifications) to the user.
 
 #### Data-only messages
 


### PR DESCRIPTION
### Description

Fix typo on [docs/messaging/usage/index.md](https://github.com/invertase/react-native-firebase/blob/master/docs/messaging/usage/index.md)

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
