### PR TITLE
docs(analytics): refined react-native-navigation setCurrentScreen example

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -27,6 +27,7 @@ Changelog
 CLI
 CocoaPods
 codebase
+componentDidAppear
 config
 Config
 Crashlytics

--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -27,7 +27,6 @@ Changelog
 CLI
 CocoaPods
 codebase
-componentDidAppear
 config
 Config
 Crashlytics

--- a/docs/analytics/screen-tracking.md
+++ b/docs/analytics/screen-tracking.md
@@ -13,7 +13,7 @@ therefore there is no "one fits all" solution to screen tracking.
 
 The [React Navigation](https://reactnavigation.org/) library allows for various navigation techniques such as
 Stack, Tab, Native or even custom navigation. The `NavigationController` component which the library exposes provides
-access to the current navigation state when a screen changes, allowing you to use the [`setCurrentScreen`](/reference/analytics#setcurrentscreen)
+access to the current navigation state when a screen changes, allowing you to use the [`setCurrentScreen`](/reference/analytics#setCurrentScreen)
 method the Analytics library provides:
 
 ```jsx
@@ -38,7 +38,7 @@ documentation on the React Navigation website.
 
 The [`wix/react-native-navigation`](https://github.com/wix/react-native-navigation) provides 100% native platform navigation
 for React Native apps. To manually track screens, you need to setup a componentDidAppear event listener and manually call the
-[`setCurrentScreen`](/reference/analytics#setcurrentscreen) method the Analytics library provides:
+[`setCurrentScreen`](/reference/analytics#setCurrentScreen) method the Analytics library provides:
 
 ```js
 import analytics from '@react-native-firebase/analytics';

--- a/docs/analytics/screen-tracking.md
+++ b/docs/analytics/screen-tracking.md
@@ -37,7 +37,7 @@ documentation on the React Navigation website.
 # React Native Navigation
 
 The [`wix/react-native-navigation`](https://github.com/wix/react-native-navigation) provides 100% native platform navigation
-for React Native apps. To manually track screens, you need to setup a componentDidAppear event listener and manually call the
+for React Native apps. To manually track screens, you need to setup a `componentDidAppear` event listener and manually call the
 [`setCurrentScreen`](/reference/analytics#setCurrentScreen) method the Analytics library provides:
 
 ```js

--- a/docs/analytics/screen-tracking.md
+++ b/docs/analytics/screen-tracking.md
@@ -37,19 +37,19 @@ documentation on the React Navigation website.
 # React Native Navigation
 
 The [`wix/react-native-navigation`](https://github.com/wix/react-native-navigation) provides 100% native platform navigation
-for React Native apps. To manually track screens, you need to setup a command listener and manually call the
+for React Native apps. To manually track screens, you need to setup a componentDidAppear event listener and manually call the
 [`setCurrentScreen`](/reference/analytics#setcurrentscreen) method the Analytics library provides:
 
 ```js
 import analytics from '@react-native-firebase/analytics';
 import { Navigation } from 'react-native-navigation';
 
-Navigation.events().registerCommandListener((name, params) => {
-  if (name === 'push') {
-    analytics().setCurrentScreen(params.componentId, params.componentId);
+Navigation.events().registerComponentDidAppearListener(({componentName, componentType}) => {
+  if (componentType === 'Component') {
+    analytics().setCurrentScreen(componentName, componentName);
   }
 });
 ```
 
-To learn more, view the [events documentation](https://wix.github.io/react-native-navigation/#/docs/events?id=registercommandlistener)
+To learn more, view the [events documentation](https://wix.github.io/react-native-navigation/api/events#componentdidappear)
 on the React Native Navigation website.


### PR DESCRIPTION
### Description

The `componentDidAppear` event is better suited than the `command` event, which doesn't fire when popping a screen natively (Android back button, iOS swipe back gesture) and in some other edge cases (e.g. `setRoot` with two components in the stack)

In addition, the componentId (usually auto-generated) is quite useless as a screen name, and componentName should be used instead.

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter