### PR TITLE
feat(ios): podspecs now utilize CoreOnly instead of Core

### DIFF
--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -32,8 +32,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
-  s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/AdMob', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/AdMob', firebase_sdk_version
 

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Analytics', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Auth', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Auth', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
 
   # Firebase dependencies
   s.dependency          'Fabric', fabric_sdk_version
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Crashlytics', crashlytics_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -46,7 +46,6 @@ Pod::Spec.new do |s|
 
   # Firebase dependencies
   s.dependency          'Fabric', fabric_sdk_version
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Crashlytics', crashlytics_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Database', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Database', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/DynamicLinks', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/DynamicLinks', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Firestore', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Firestore', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Functions', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Functions', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Messaging', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Messaging', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/MLNaturalLanguage', firebase_sdk_version
 
   if FirebaseJSON::Config.get_value_or_default('ml_natural_language_language_id_model', false)

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -29,7 +29,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/MLNaturalLanguage', firebase_sdk_version
 
   if FirebaseJSON::Config.get_value_or_default('ml_natural_language_language_id_model', false)

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -29,7 +29,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/MLVision', firebase_sdk_version
   if FirebaseJSON::Config.get_value_or_default('ml_vision_face_model', false)
     s.dependency          'Firebase/MLVisionFaceModel', firebase_sdk_version

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/MLVision', firebase_sdk_version
   if FirebaseJSON::Config.get_value_or_default('ml_vision_face_model', false)
     s.dependency          'Firebase/MLVisionFaceModel', firebase_sdk_version

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Performance', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Performance', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/RemoteConfig', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/RemoteConfig', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -28,7 +28,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Storage', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
   s.dependency          'Firebase/Storage', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)


### PR DESCRIPTION
…xcept Analytics which should continue to reference Core.

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

iOS does not allow applications in the Kids category to collect Firebase analytics. Firebase has refactored their libraries to utilize the CoreOnly module instead of Core to accommodate this. Currently RNFirebase pods rely on Firebase/Core. Pull request updates RNFirebase pod files to utilize CoreOnly instead of Core (except Analytics)

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #3570

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Ran e2e tests without errors. Tested libraries I use locally in my application (app, auth, database).
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
