### PR TITLE
docs(ads): replaces TestIds.BANNER with adUnitId in the Banner's props

### DIFF
--- a/docs/admob/displaying-ads.md
+++ b/docs/admob/displaying-ads.md
@@ -213,7 +213,7 @@ const adUnitId = __DEV__ ? TestIds.BANNER : 'ca-app-pub-xxxxxxxxxxxxx/yyyyyyyyyy
 function App() {
   return (
     <BannerAd
-      unitId={TestIds.BANNER}
+      unitId={adUnitId}
       size={BannerAdSize.FULL_BANNER}
       requestOptions={{
         requestNonPersonalizedAdsOnly: true,


### PR DESCRIPTION

### Description

The change is simple. I just found it right to propose a correction for the documentation. 
In the specific example the adUnitId variable is not used in the Banner's properties as it should be. So i replace the TestIds.BANNER with the unused variable adUnitId.

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- This is a breaking change;
  - [x] No