### PR TITLE
docs(auth): fix typo in Phone Auth description

### DIFF
--- a/docs/auth/phone-auth.md
+++ b/docs/auth/phone-auth.md
@@ -1,6 +1,6 @@
 ---
 title: Phone Authentication
-description: Sign-in with users with their phone number.
+description: Sign-in users with their phone number.
 next: /firestore/usage
 previous: /auth/social-auth
 ---


### PR DESCRIPTION
### Description

Fixes a typo in the documentation for Phone Auth

:fire:

### Release Summary

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
