### PR TITLE
feat!: all packages should depend on core

### DIFF
--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   # Other dependencies
   s.dependency          'PersonalizedAdConsent', '~> 1.0.4'

--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAdMob"
@@ -21,7 +31,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   # Other dependencies
   s.dependency          'PersonalizedAdConsent', '~> 1.0.4'

--- a/packages/admob/android/build.gradle
+++ b/packages/admob/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -52,7 +53,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0"
+        bom: firebaseBomVersion
       ],
 
       ads     : [

--- a/packages/admob/android/build.gradle
+++ b/packages/admob/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -18,10 +20,29 @@ plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
 
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 project.ext {
   set('react-native', [
     versions: [
-      android           : [
+      android : [
         minSdk    : 16,
         targetSdk : 28,
         compileSdk: 28,
@@ -30,11 +51,11 @@ project.ext {
         buildTools: "28.0.3"
       ],
 
-      firebase          : [
+      firebase: [
         bom: "24.1.0"
       ],
 
-      ads          : [
+      ads     : [
         consent: "1.0.6"
       ],
     ],
@@ -59,7 +80,7 @@ android {
   defaultConfig {
     multiDexEnabled true
     manifestPlaceholders = [
-      firebaseJSONAdmobAppID: firebaseJSONAdmobAppIDString,
+      firebaseJSONAdmobAppID                  : firebaseJSONAdmobAppIDString,
       firebaseJSONAdmobDelayAppMeasurementInit: firebaseJSONAdmobDelayAppMeasurementInitBool
     ]
   }
@@ -79,13 +100,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-ads"
   implementation "com.google.android.ads.consent:consent-library:${ReactNative.ext.getVersion("ads", "consent")}"

--- a/packages/admob/package.json
+++ b/packages/admob/package.json
@@ -27,7 +27,7 @@
     "ad consent"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAnalytics"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase          : [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-analytics"
 }

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -22,7 +22,7 @@
     "analytics"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -1,8 +1,7 @@
 require 'json'
 require './firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
-
-firebase_sdk_version = '~> 6.13.0'
+firebase_sdk_version = package['sdkVersions']['ios']['firebase'] || '~> 6.13.0'
 
 Pod::Spec.new do |s|
   s.name                = "RNFBApp"

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -18,6 +20,9 @@ plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
 
+def packageJson = PackageJson.getForProject(project)
+def firebaseBomVersion = packageJson['sdkVersions']['android']['firebase']
+
 project.ext {
   set('react-native', [
     versions: [
@@ -31,7 +36,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -63,5 +63,13 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "sdkVersions": {
+    "ios" : {
+      "firebase": "~> 6.13.0"
+    },
+    "android": {
+      "firebase": "24.1.0"
+    }
   }
 }

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAuth"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -52,7 +53,7 @@ project.ext {
         buildTools: "28.0.3"
       ],
       firebase          : [
-        bom : "24.1.0",
+        bom : firebaseBomVersion,
       ],
     ],
   ])
@@ -78,13 +79,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-auth"
 }

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -22,7 +22,7 @@
     "auth"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -1,8 +1,18 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
 # Firebase SDK Override
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 # Fabric SDK Override
 fabric_sdk_version = '~> 1.10.2'
@@ -27,7 +37,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -3,15 +3,15 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
 # Firebase SDK Override
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 # Fabric SDK Override

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -11,7 +11,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 # Fabric SDK Override
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -80,13 +81,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   // don't use firebase bom here as crashlytics-ndk is not included in the bom, trying to partially use bom here fails
   implementation "com.crashlytics.sdk.android:crashlytics:${ReactNative.ext.getVersion("firebase", "crashlytics")}"
   // ndk not in Firebase BoM

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -27,7 +27,7 @@
     "crashlytics"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "dependencies": {
     "stacktrace-js": "^2.0.0"

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -1,7 +1,17 @@
 require 'json'
-package = JSON.parse(File.read('./package.json'))
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBDatabase"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/database/android/build.gradle
+++ b/packages/database/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/database/android/build.gradle
+++ b/packages/database/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-database"
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -25,7 +25,7 @@
     "realtome database"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBDynamicLinks"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/dynamic-links/android/build.gradle
+++ b/packages/dynamic-links/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/dynamic-links/android/build.gradle
+++ b/packages/dynamic-links/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -79,13 +80,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-dynamic-links"
 }

--- a/packages/dynamic-links/package.json
+++ b/packages/dynamic-links/package.json
@@ -23,7 +23,7 @@
     "dynamic link"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBFirestore"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-firestore"
 }

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -27,7 +27,7 @@
     "firestore"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBFunctions"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-functions"
 }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -24,7 +24,7 @@
     "functions"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "devDependencies": {
     "@react-native-firebase/private-tests-firebase-functions": "^0.0.1"

--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBIid"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/iid/android/build.gradle
+++ b/packages/iid/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/iid/android/build.gradle
+++ b/packages/iid/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-iid"
 }

--- a/packages/iid/package.json
+++ b/packages/iid/package.json
@@ -24,7 +24,7 @@
     "iid"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBInAppMessaging"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-inappmessaging-display"
 }

--- a/packages/in-app-messaging/package.json
+++ b/packages/in-app-messaging/package.json
@@ -27,7 +27,7 @@
     "inAppMessaging"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBMessaging"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -100,13 +101,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-messaging"
 }

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -22,7 +22,7 @@
     "messaging"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -1,8 +1,18 @@
 require 'json'
 require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBMLNaturalLanguage"
@@ -21,7 +31,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -3,15 +3,15 @@ require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -11,7 +11,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/ml-natural-language/android/build.gradle
+++ b/packages/ml-natural-language/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/ml-natural-language/android/build.gradle
+++ b/packages/ml-natural-language/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -88,13 +89,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-ml-natural-language"
 }

--- a/packages/ml-natural-language/package.json
+++ b/packages/ml-natural-language/package.json
@@ -30,7 +30,7 @@
     "vision"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -3,15 +3,15 @@ require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -11,7 +11,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -1,8 +1,18 @@
 require 'json'
 require '../app/firebase_json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBMLVision"
@@ -21,7 +31,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/ml-vision/android/build.gradle
+++ b/packages/ml-vision/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-ml-vision"
 }

--- a/packages/ml-vision/android/build.gradle
+++ b/packages/ml-vision/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/ml-vision/package.json
+++ b/packages/ml-vision/package.json
@@ -32,7 +32,7 @@
     "vision"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBPerf"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-perf"
 }

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -27,7 +27,7 @@
     "performance monitoring"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBRemoteConfig"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase          : [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -84,13 +85,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-config"
 }

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -24,7 +24,7 @@
     "remote-config"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -2,15 +2,15 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-core_version_detected = appPackage['version']
-core_version_required = package['peerDependencies'][appPackage['name']]
+coreVersionDetected = appPackage['version']
+coreVersionRequired = package['peerDependencies'][appPackage['name']]
 if appPackage['sdkVersions']
   firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
 else
   firebase_sdk_version = '~> 6.13.0'
 end
-if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
+if coreVersionDetected != coreVersionRequired
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{coreVersionRequired} but found v#{coreVersionDetected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -1,7 +1,17 @@
 require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
-firebase_sdk_version = '~> 6.13.0'
+core_version_detected = appPackage['version']
+core_version_required = package['peerDependencies'][appPackage['name']]
+if appPackage['sdkVersions']
+  firebase_sdk_version = appPackage['sdkVersions']['ios']['firebase']
+else
+  firebase_sdk_version = '~> 6.13.0'
+end
+if core_version_detected != core_version_required
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+end
 
 Pod::Spec.new do |s|
   s.name                = "RNFBStorage"
@@ -20,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp'
+  s.dependency          'RNFBApp', "~> #{core_version_required}"
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -10,7 +10,7 @@ else
   firebase_sdk_version = '~> 6.13.0'
 end
 if core_version_detected != core_version_required
-  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this may cause build issues."
+  Pod::UI.warn "NPM package '#{package['name']}' depends on '#{appPackage['name']}' v#{core_version_required} but found v#{core_version_detected}, this might cause build issues or runtime crashes."
 end
 
 Pod::Spec.new do |s|
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
   # React Native dependencies
   s.dependency          'React'
-  s.dependency          'RNFBApp', "~> #{core_version_required}"
+  s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -1,3 +1,5 @@
+import io.invertase.gradle.common.PackageJson
+
 buildscript {
   // The Android Gradle plugin is only required when opening the android folder stand-alone.
   // This avoids unnecessary downloads and potential conflicts when the library is included as a
@@ -17,6 +19,26 @@ buildscript {
 plugins {
   id "io.invertase.gradle.build" version "1.4"
 }
+
+def appProject
+if (findProject(':@react-native-firebase_app')) {
+  appProject = project(':@react-native-firebase_app')
+} else if (findProject(':react-native-firebase_app')) {
+  appProject = project(':react-native-firebase_app')
+} else {
+  throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
+}
+def packageJson = PackageJson.getForProject(project)
+def appPackageJson = PackageJson.getForProject(appProject)
+def core_version_detected = appPackageJson['version']
+def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+// Only log after build completed so log warning appears at the end
+if (core_version_detected != core_version_required) {
+  gradle.buildFinished {
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+  }
+}
+
 
 project.ext {
   set('react-native', [

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -30,12 +30,13 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def core_version_detected = appPackageJson['version']
-def core_version_required = packageJson['peerDependencies'][appPackageJson['name']]
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "24.1.0"
+def coreVersionDetected = appPackageJson['version']
+def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
-if (core_version_detected != core_version_required) {
+if (coreVersionDetected != coreVersionRequired) {
   gradle.buildFinished {
-    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${core_version_required} but found v${core_version_detected}, this might cause build issues or runtime crashes.")
+    project.logger.warn("ReactNativeFirebase WARNING: NPM package '${packageJson['name']}' depends on '${appPackageJson['name']}' v${coreVersionRequired} but found v${coreVersionDetected}, this might cause build issues or runtime crashes.")
   }
 }
 
@@ -53,7 +54,7 @@ project.ext {
       ],
 
       firebase: [
-        bom: "24.1.0",
+        bom: firebaseBomVersion,
       ],
     ],
   ])
@@ -79,13 +80,7 @@ repositories {
 }
 
 dependencies {
-  if (findProject(':@react-native-firebase_app')) {
-    api project(':@react-native-firebase_app')
-  } else if (findProject(':react-native-firebase_app')) {
-    api project(':react-native-firebase_app')
-  } else {
-    throw new GradleException('Could not find the react-native-firebase/app package, have you installed it?')
-  }
+  api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-storage"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,7 +29,7 @@
     "download"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "*"
+    "@react-native-firebase/app": "6.7.1"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -703,60 +703,60 @@ PODS:
     - Firebase/Core (~> 6.13.0)
     - PersonalizedAdConsent (~> 1.0.4)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBAnalytics (6.7.2):
     - Firebase/Analytics (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
-  - RNFBApp (6.7.1):
+    - RNFBApp
+  - RNFBApp (6.7.2):
     - Firebase/Core (~> 6.13.0)
     - React
   - RNFBAuth (6.7.1):
     - Firebase/Auth (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBCrashlytics (6.7.1):
     - Crashlytics (~> 3.14.0)
     - Fabric (~> 1.10.2)
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBDatabase (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Database (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBDynamicLinks (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/DynamicLinks (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBFirestore (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Firestore (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBFunctions (6.8.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Functions (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBIid (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBInAppMessaging (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/InAppMessaging (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBMessaging (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Messaging (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBMLNaturalLanguage (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/MLCommon (~> 6.13.0)
@@ -764,7 +764,7 @@ PODS:
     - Firebase/MLNLLanguageID (~> 6.13.0)
     - Firebase/MLNLSmartReply (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBMLVision (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/MLVision (~> 6.13.0)
@@ -773,22 +773,22 @@ PODS:
     - Firebase/MLVisionLabelModel (~> 6.13.0)
     - Firebase/MLVisionTextModel (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBPerf (6.7.3):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Performance (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBRemoteConfig (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/RemoteConfig (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - RNFBStorage (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Storage (~> 6.13.0)
     - React
-    - RNFBApp (~> 6.7.1)
+    - RNFBApp
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1052,23 +1052,23 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNFBAdMob: b94ddc34d0efe999c5a709685140ab90182ce928
-  RNFBAnalytics: 28b48ab2ca2280cda809f6665fdfa0299c7a4af2
-  RNFBApp: 7b539bb25520fa73d6a240f5c6ea569e27683645
-  RNFBAuth: 2b8cdb9f70c102de4877eeeb532797780dabbea7
-  RNFBCrashlytics: 9391ec620f3127c5ad0e65ec48e8c6b25043b2d9
-  RNFBDatabase: c11c57cb14b88de4d3bf7b86238f6b89e5cb7c48
-  RNFBDynamicLinks: 2b5d023bf04a6cdc956cb84e10be9e598ce9cf81
-  RNFBFirestore: f4e42d79185ae6cee82ea2fd3bb5ecbfec200e60
-  RNFBFunctions: 8b724780b8df1ab25d9cb31ab4dc2f1161560d3b
-  RNFBIid: d05c0c556a44e54c548494d981665c09faeb0a41
-  RNFBInAppMessaging: e0be1c085186ba15b8943417250952f4d1fc2997
-  RNFBMessaging: 0f62a7bb03b01396561a3d7847b70cf34e275995
-  RNFBMLNaturalLanguage: 70e61b247ddf0961b16dc736ee4c5910e2aae3a1
-  RNFBMLVision: fb3330b61635500548e69217c5da6911883e009a
-  RNFBPerf: 3771f4474828c3a419bfa513f6503b2c1d0342f8
-  RNFBRemoteConfig: fee15c5c98ba508fc3e22cbb9c19c0644a9867fa
-  RNFBStorage: 52edf50893588acc292332c3e311c53de5df8621
+  RNFBAdMob: 8e6fd1d00c34ed743ccd11b823ed78a224492d00
+  RNFBAnalytics: 29bc4baf70da8dc04238d2e1c050367264d2f440
+  RNFBApp: c6f875472200b8894f19c44fe66545bdb5251b1d
+  RNFBAuth: c292603069a09065a1b4d3336148beff83e4c897
+  RNFBCrashlytics: b34063b906dd0c57a5d286dd743a40c90c8326c7
+  RNFBDatabase: 2737d8e87c20246cd91e95743c514e08c791ebe1
+  RNFBDynamicLinks: 9dd4895eda7b597a8dbce706cfd3f79fbfc783b2
+  RNFBFirestore: 23757ad7c33d81587a5d7d7d77f3ea22a1103372
+  RNFBFunctions: 095a760299c21f413e5fed53f5251d914d07b69c
+  RNFBIid: 8f673a41f45f04273d0759c5df0aef113b580822
+  RNFBInAppMessaging: 5154a6ffe88bce8464e9cc16a15c8335ed7070a9
+  RNFBMessaging: c55142d3b2d34d706bf12bd5eef9ef35254c2df1
+  RNFBMLNaturalLanguage: 534356c4d906d4b88430231f251d3ffd8366477c
+  RNFBMLVision: a7056ed3c940eb72be6a4442c5a8a2dc013fdacb
+  RNFBPerf: 1fbcd5833bd74cfb99f4a7ec967d53005d96e3b0
+  RNFBRemoteConfig: 59818c5933149b5a6b7fe5159e3d4df09199e858
+  RNFBStorage: 0087dec3c49fcd4c805e9455239d684d8f61a6b0
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
 
 PODFILE CHECKSUM: 4f83b6fd6809baac1e594bc2699f79e47652b797

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -244,7 +244,7 @@ PODS:
   - Firebase/Storage (6.13.0):
     - Firebase/CoreOnly
     - FirebaseStorage (~> 3.4.2)
-  - FirebaseABTesting (3.1.2):
+  - FirebaseABTesting (3.2.0):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.1)
     - Protobuf (>= 3.9.2, ~> 3.9)
@@ -264,13 +264,13 @@ PODS:
     - GoogleUtilities/AppDelegateSwizzler (~> 6.2)
     - GoogleUtilities/Environment (~> 6.2)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseAuthInterop (1.0.0)
+  - FirebaseAuthInterop (1.1.0)
   - FirebaseCore (6.4.0):
     - FirebaseCoreDiagnostics (~> 1.0)
     - FirebaseCoreDiagnosticsInterop (~> 1.0)
     - GoogleUtilities/Environment (~> 6.2)
     - GoogleUtilities/Logger (~> 6.2)
-  - FirebaseCoreDiagnostics (1.2.0):
+  - FirebaseCoreDiagnostics (1.2.1):
     - FirebaseCoreDiagnosticsInterop (~> 1.2)
     - GoogleDataTransportCCTSupport (~> 1.3)
     - GoogleUtilities/Environment (~> 6.5)
@@ -281,7 +281,7 @@ PODS:
     - FirebaseAuthInterop (~> 1.0)
     - FirebaseCore (~> 6.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (4.0.6):
+  - FirebaseDynamicLinks (4.0.8):
     - FirebaseAnalyticsInterop (~> 1.3)
     - FirebaseCore (~> 6.2)
   - FirebaseFirestore (1.8.3):
@@ -372,7 +372,7 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 6.2)
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.9)
-  - FirebaseRemoteConfig (4.4.6):
+  - FirebaseRemoteConfig (4.4.9):
     - FirebaseABTesting (~> 3.1)
     - FirebaseAnalyticsInterop (~> 1.4)
     - FirebaseCore (~> 6.2)
@@ -394,7 +394,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Google-Mobile-Ads-SDK (7.54.0):
+  - Google-Mobile-Ads-SDK (7.58.0):
     - GoogleAppMeasurement (~> 6.0)
   - GoogleAPIClientForREST/Core (1.3.11):
     - GTMSessionFetcher (>= 1.1.7)
@@ -407,9 +407,9 @@ PODS:
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (= 0.3.9011)
-  - GoogleDataTransport (3.3.1)
-  - GoogleDataTransportCCTSupport (1.3.1):
-    - GoogleDataTransport (~> 3.3)
+  - GoogleDataTransport (4.0.1)
+  - GoogleDataTransportCCTSupport (1.4.1):
+    - GoogleDataTransport (~> 4.0)
     - nanopb (~> 0.3.901)
   - GoogleToolboxForMac/DebugUtils (2.2.2):
     - GoogleToolboxForMac/Defines (= 2.2.2)
@@ -423,24 +423,25 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.2)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.2)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.2)"
-  - GoogleUtilities/AppDelegateSwizzler (6.5.1):
+  - GoogleUtilities/AppDelegateSwizzler (6.6.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.5.1)
-  - GoogleUtilities/ISASwizzler (6.5.1)
-  - GoogleUtilities/Logger (6.5.1):
+  - GoogleUtilities/Environment (6.6.0):
+    - PromisesObjC (~> 1.2)
+  - GoogleUtilities/ISASwizzler (6.6.0)
+  - GoogleUtilities/Logger (6.6.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (6.5.1):
+  - GoogleUtilities/MethodSwizzler (6.6.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (6.5.1):
+  - GoogleUtilities/Network (6.6.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.5.1)"
-  - GoogleUtilities/Reachability (6.5.1):
+  - "GoogleUtilities/NSData+zlib (6.6.0)"
+  - GoogleUtilities/Reachability (6.6.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (6.5.1):
+  - GoogleUtilities/UserDefaults (6.6.0):
     - GoogleUtilities/Logger
   - "gRPC-C++ (0.0.9)":
     - "gRPC-C++/Implementation (= 0.0.9)"
@@ -458,11 +459,11 @@ PODS:
     - gRPC-Core/Interface (= 1.21.0)
     - nanopb (~> 0.3)
   - gRPC-Core/Interface (1.21.0)
-  - GTMSessionFetcher (1.3.1):
-    - GTMSessionFetcher/Full (= 1.3.1)
-  - GTMSessionFetcher/Core (1.3.1)
-  - GTMSessionFetcher/Full (1.3.1):
-    - GTMSessionFetcher/Core (= 1.3.1)
+  - GTMSessionFetcher (1.4.0):
+    - GTMSessionFetcher/Full (= 1.4.0)
+  - GTMSessionFetcher/Core (1.4.0)
+  - GTMSessionFetcher/Full (1.4.0):
+    - GTMSessionFetcher/Core (= 1.4.0)
   - Jet (0.6.6-0):
     - React
   - leveldb-library (1.22)
@@ -471,8 +472,9 @@ PODS:
     - nanopb/encode (= 0.3.9011)
   - nanopb/decode (0.3.9011)
   - nanopb/encode (0.3.9011)
-  - PersonalizedAdConsent (1.0.4)
-  - Protobuf (3.11.2)
+  - PersonalizedAdConsent (1.0.5)
+  - PromisesObjC (1.2.8)
+  - Protobuf (3.11.4)
   - RCTRequired (0.62.2)
   - RCTTypeSafety (0.62.2):
     - FBLazyVector (= 0.62.2)
@@ -701,12 +703,12 @@ PODS:
     - Firebase/Core (~> 6.13.0)
     - PersonalizedAdConsent (~> 1.0.4)
     - React
-    - RNFBApp
-  - RNFBAnalytics (6.7.1):
+    - RNFBApp (~> 6.7.1)
+  - RNFBAnalytics (6.7.2):
     - Firebase/Analytics (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBApp (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - React
@@ -714,47 +716,47 @@ PODS:
     - Firebase/Auth (~> 6.13.0)
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBCrashlytics (6.7.1):
     - Crashlytics (~> 3.14.0)
     - Fabric (~> 1.10.2)
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBDatabase (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Database (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBDynamicLinks (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/DynamicLinks (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBFirestore (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Firestore (~> 6.13.0)
     - React
-    - RNFBApp
-  - RNFBFunctions (6.7.1):
+    - RNFBApp (~> 6.7.1)
+  - RNFBFunctions (6.8.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Functions (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBIid (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBInAppMessaging (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/InAppMessaging (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBMessaging (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Messaging (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBMLNaturalLanguage (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/MLCommon (~> 6.13.0)
@@ -762,7 +764,7 @@ PODS:
     - Firebase/MLNLLanguageID (~> 6.13.0)
     - Firebase/MLNLSmartReply (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBMLVision (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/MLVision (~> 6.13.0)
@@ -771,22 +773,22 @@ PODS:
     - Firebase/MLVisionLabelModel (~> 6.13.0)
     - Firebase/MLVisionTextModel (~> 6.13.0)
     - React
-    - RNFBApp
-  - RNFBPerf (6.7.1):
+    - RNFBApp (~> 6.7.1)
+  - RNFBPerf (6.7.3):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Performance (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBRemoteConfig (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/RemoteConfig (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - RNFBStorage (6.7.1):
     - Firebase/Core (~> 6.13.0)
     - Firebase/Storage (~> 6.13.0)
     - React
-    - RNFBApp
+    - RNFBApp (~> 6.7.1)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -885,6 +887,7 @@ SPEC REPOS:
     - leveldb-library
     - nanopb
     - PersonalizedAdConsent
+    - PromisesObjC
     - Protobuf
 
 EXTERNAL SOURCES:
@@ -985,16 +988,16 @@ SPEC CHECKSUMS:
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
   Firebase: 458d109512200d1aca2e1b9b6cf7d68a869a4a46
-  FirebaseABTesting: 0d10f3cdc3fa00f3f175b5b56c1003c8e888299f
+  FirebaseABTesting: 821a3a3e4a145987e80fee3657c4de1cb9adf693
   FirebaseAnalytics: 45f36d9c429fc91d206283900ab75390cd05ee8a
   FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
   FirebaseAuth: ce45d7c5d46bed90159f3a73b6efbe8976ed3573
-  FirebaseAuthInterop: 0ffa57668be100582bb7643d4fcb7615496c41fc
+  FirebaseAuthInterop: a0f37ae05833af156e72028f648d313f7e7592e9
   FirebaseCore: 307ea2508df730c5865334e41965bd9ea344b0e5
-  FirebaseCoreDiagnostics: 5e78803ab276bc5b50340e3c539c06c3de35c649
+  FirebaseCoreDiagnostics: 2109d10c35e8289b1ee6cabf44d9ffb055620194
   FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
   FirebaseDatabase: 0144e0706a4761f1b0e8679572eba8095ddb59be
-  FirebaseDynamicLinks: 5ba2a0d46ba1615c6c08819fc964c495ca1d0845
+  FirebaseDynamicLinks: 417dc6dbb6013233c77558290d73296f429656a6
   FirebaseFirestore: 52120e2833f804a874ba1a9f59aab864a8ae2286
   FirebaseFunctions: 5af7c35d1c5e41608fecbb667eb6c4e672e318d0
   FirebaseInAppMessaging: 8e1190f8d8cf6f1fcfc8f82f99e0ecce522fc02b
@@ -1010,25 +1013,26 @@ SPEC CHECKSUMS:
   FirebaseMLVisionLabelModel: 7638a20d27219d5baa4b534a62375fc1d5bd077d
   FirebaseMLVisionTextModel: c264caa3100ca804580bf2a7c1cb9ff390d1f471
   FirebasePerformance: 22273a775eaed4cd3e072c9b88396a5e4b285c3f
-  FirebaseRemoteConfig: c11d74d8b1ff8463b587fc8899d92ee089f9a691
+  FirebaseRemoteConfig: 47abf7a04a9082091955ea555aa79cfdd249b19c
   FirebaseStorage: 93fe2f8190a01bfb2b2c4932df7d679744c4ef1d
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Google-Mobile-Ads-SDK: 8241b4bd0f11b4f03f5dcd4affccb04ca938f050
+  Google-Mobile-Ads-SDK: 7052557293c75c676db55feb707ace9b790f32c1
   GoogleAPIClientForREST: 0f19a8280dfe6471f76016645d26eb5dae305101
   GoogleAppMeasurement: dfe55efa543e899d906309eaaac6ca26d249862f
-  GoogleDataTransport: 0048df6388dab1c254799f2a30365b1dffe20422
-  GoogleDataTransportCCTSupport: f880d70972efa2ed1be4e9173a0f4c5f3dc2d176
+  GoogleDataTransport: 653963cf5be60fb59cf051e070f0836fdc305f81
+  GoogleDataTransportCCTSupport: 84e4d4bbab642f2e9d83ee65d78aca2b5527d314
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
-  GoogleUtilities: 06eb53bb579efe7099152735900dd04bf09e7275
+  GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
   "gRPC-C++": 9dfe7b44821e7b3e44aacad2af29d2c21f7cde83
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
-  GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
+  GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
   Jet: 84fd0e2e9d49457fc04bc79b5d8857737a01c507
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
-  PersonalizedAdConsent: 4b87320b7a0f22576bec530ae3b7adba88a24c78
-  Protobuf: dd1aaea7140debfe4dd0683fb8ef208e527ae153
+  PersonalizedAdConsent: dbecabb3467df967c16d9cebc2ef4a8890e4bbd8
+  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
+  Protobuf: 176220c526ad8bd09ab1fb40a978eac3fef665f7
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035
   RCTTypeSafety: 93006131180074cffa227a1075802c89a49dd4ce
   React: 29a8b1a02bd764fb7644ef04019270849b9a7ac3
@@ -1048,23 +1052,23 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNFBAdMob: 8e6fd1d00c34ed743ccd11b823ed78a224492d00
-  RNFBAnalytics: 7d56f7af0a1147e649df33e64372aea8923fdd01
+  RNFBAdMob: b94ddc34d0efe999c5a709685140ab90182ce928
+  RNFBAnalytics: 28b48ab2ca2280cda809f6665fdfa0299c7a4af2
   RNFBApp: 7b539bb25520fa73d6a240f5c6ea569e27683645
-  RNFBAuth: c292603069a09065a1b4d3336148beff83e4c897
-  RNFBCrashlytics: b34063b906dd0c57a5d286dd743a40c90c8326c7
-  RNFBDatabase: 2737d8e87c20246cd91e95743c514e08c791ebe1
-  RNFBDynamicLinks: 9dd4895eda7b597a8dbce706cfd3f79fbfc783b2
-  RNFBFirestore: 23757ad7c33d81587a5d7d7d77f3ea22a1103372
-  RNFBFunctions: 4b85785e03e9d0ef7ba039b398d8c3a79deaed33
-  RNFBIid: 8f673a41f45f04273d0759c5df0aef113b580822
-  RNFBInAppMessaging: 5154a6ffe88bce8464e9cc16a15c8335ed7070a9
-  RNFBMessaging: c55142d3b2d34d706bf12bd5eef9ef35254c2df1
-  RNFBMLNaturalLanguage: 534356c4d906d4b88430231f251d3ffd8366477c
-  RNFBMLVision: a7056ed3c940eb72be6a4442c5a8a2dc013fdacb
-  RNFBPerf: 5322fbb70e8a54e0cc92fb9097bd1790c5745389
-  RNFBRemoteConfig: 59818c5933149b5a6b7fe5159e3d4df09199e858
-  RNFBStorage: 0087dec3c49fcd4c805e9455239d684d8f61a6b0
+  RNFBAuth: 2b8cdb9f70c102de4877eeeb532797780dabbea7
+  RNFBCrashlytics: 9391ec620f3127c5ad0e65ec48e8c6b25043b2d9
+  RNFBDatabase: c11c57cb14b88de4d3bf7b86238f6b89e5cb7c48
+  RNFBDynamicLinks: 2b5d023bf04a6cdc956cb84e10be9e598ce9cf81
+  RNFBFirestore: f4e42d79185ae6cee82ea2fd3bb5ecbfec200e60
+  RNFBFunctions: 8b724780b8df1ab25d9cb31ab4dc2f1161560d3b
+  RNFBIid: d05c0c556a44e54c548494d981665c09faeb0a41
+  RNFBInAppMessaging: e0be1c085186ba15b8943417250952f4d1fc2997
+  RNFBMessaging: 0f62a7bb03b01396561a3d7847b70cf34e275995
+  RNFBMLNaturalLanguage: 70e61b247ddf0961b16dc736ee4c5910e2aae3a1
+  RNFBMLVision: fb3330b61635500548e69217c5da6911883e009a
+  RNFBPerf: 3771f4474828c3a419bfa513f6503b2c1d0342f8
+  RNFBRemoteConfig: fee15c5c98ba508fc3e22cbb9c19c0644a9867fa
+  RNFBStorage: 52edf50893588acc292332c3e311c53de5df8621
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
 
 PODFILE CHECKSUM: 4f83b6fd6809baac1e594bc2699f79e47652b797


### PR DESCRIPTION
### Description

Follow-up PR to allowing every RNFirebase package to be independently versioned whilst still relying on the Core/App package for native SDK versions.

For now the behaviour when a mismatch is detected is to warn on native build outputs, e.g. Gradle build or iOS pod install. We're warning as a different version isn't necessarily going to cause an issue, but it _could_.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Test Plan

Android:

![image](https://user-images.githubusercontent.com/5347038/81083507-95826c00-8eec-11ea-8034-59730bb70c56.png)

iOS:

![image](https://user-images.githubusercontent.com/5347038/81083558-a501b500-8eec-11ea-8f00-be05f06e9efa.png)


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
