### PR TITLE
docs: add rebuild info to ML-Vision index-page

### DIFF
--- a/docs/ml-vision/usage/index.md
+++ b/docs/ml-vision/usage/index.md
@@ -87,3 +87,14 @@ on the `firebase.json` file at the root of your project directory.
 ```
 
 The models are disabled by default to help control app size.
+
+Since only models enabled here will be compiled into the application, any changes to this file require a rebuild.
+
+```sh
+# For Android
+npx react-native run-android
+
+# For iOS
+cd ios/ && pod install --repo-update
+npx react-native run-ios
+```


### PR DESCRIPTION
### Description

Added the rebuild info (pod repo update command) to the Usage page of ML-Vision Kit. 

### Related issues

#3623 

### Release Summary



### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



🔥