### PR TITLE
docs(storage): fix typo in ListResult.items description

### DIFF
--- a/packages/storage/lib/index.d.ts
+++ b/packages/storage/lib/index.d.ts
@@ -939,7 +939,7 @@ export namespace FirebaseStorageTypes {
    */
   export interface ListResult {
     /**
-     * Objects in this directory. You can call `getMetadate()` and `getDownloadUrl()` on them.
+     * Objects in this directory. You can call `getMetadata()` and `getDownloadUrl()` on them.
      */
     items: Reference[];
 


### PR DESCRIPTION
### Description

Fixes a typo in the documentation for the `ListResult` interface

:fire:

### Release Summary

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
