### PR TITLE
fix(auth): use correct code on network exception

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -32,6 +32,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseException;
+import com.google.firebase.FirebaseNetworkException;
 import com.google.firebase.auth.ActionCodeResult;
 import com.google.firebase.auth.ActionCodeSettings;
 import com.google.firebase.auth.AuthCredential;
@@ -1773,9 +1774,13 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       }
     }
 
-    if (code.equals("UNKNOWN") && exception instanceof FirebaseAuthInvalidCredentialsException) {
-      code = "INVALID_EMAIL";
-      message = invalidEmail;
+    if (code.equals("UNKNOWN")) {
+      if (exception instanceof FirebaseAuthInvalidCredentialsException) {
+        code = "INVALID_EMAIL";
+        message = invalidEmail;
+      } else if (exception instanceof FirebaseNetworkException) {
+        code = "NETWORK_REQUEST_FAILED";
+      }
     }
 
     code = code
@@ -1910,7 +1915,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
 
   private ActionCodeSettings buildActionCodeSettings(ReadableMap actionCodeSettings) {
     ActionCodeSettings.Builder builder = ActionCodeSettings.newBuilder();
-    
+
     // Required
     String url = actionCodeSettings.getString("url");
     builder = builder.setUrl(Objects.requireNonNull(url));


### PR DESCRIPTION
### Description

Error code on Android should be `network-request-failed` when `FirebaseNetworkException` is throw.

### Related issues

Fixes #3654.

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
