### PR TITLE
docs(remote-config): correct import for android

### DIFF
--- a/docs/remote-config/usage/installation/android.md
+++ b/docs/remote-config/usage/installation/android.md
@@ -36,7 +36,7 @@ Import and apply the React Native Firebase module package to your `/android/app/
 Import the package:
 
 ```java
-import io.invertase.firebase.perf.ReactNativeFirebaseConfigPackage;
+import io.invertase.firebase.config.ReactNativeFirebaseConfigPackage;
 ```
 
 Add the package to the registry:


### PR DESCRIPTION
### Description

The installation documentation for remote-config in android environment has the wrong import library. It is pointing to io.invertase.firebase.perf. instead of io.invertase.firebase.**config**

### Related issues


### Release Summary

update the installation documentation for remote-config

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
No test required.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
