### PR TITLE
fix!(auth): confirm code returns User instead of UserCredential

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -954,7 +954,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
           TAG,
           "confirmationResultConfirm:signInWithCredential:onComplete:success"
         );
-        promiseWithUser(Objects.requireNonNull(task.getResult()).getUser(), promise);
+        promiseWithAuthResult(Objects.requireNonNull(task.getResult()), promise);
       } else {
         Exception exception = task.getException();
         Log.e(

--- a/packages/auth/e2e/phone.e2e.js
+++ b/packages/auth/e2e/phone.e2e.js
@@ -25,9 +25,9 @@ describe('auth() => Phone', () => {
       confirmResult.verificationId.should.be.a.String();
       should.ok(confirmResult.verificationId.length, 'verificationId string should not be empty');
       confirmResult.confirm.should.be.a.Function();
-      const user = await confirmResult.confirm(TEST_CODE_A);
-      user.should.be.instanceOf(jet.require('packages/auth/lib/User'));
-      user.phoneNumber.should.equal(TEST_PHONE_A);
+      const userCredential = await confirmResult.confirm(TEST_CODE_A);
+      userCredential.user.should.be.instanceOf(jet.require('packages/auth/lib/User'));
+      userCredential.user.phoneNumber.should.equal(TEST_PHONE_A);
     });
 
     it('errors on invalid code', async () => {

--- a/packages/auth/e2e/phone.e2e.js
+++ b/packages/auth/e2e/phone.e2e.js
@@ -18,8 +18,8 @@ describe('auth() => Phone', () => {
     }
   });
 
-  // TODO temporarily disabled tests, these are flakey on CI and sometimes fail - needs investigation
-  xdescribe('signInWithPhoneNumber', () => {
+  // TODO these are flakey on CI and sometimes fail - needs investigation
+  describe('signInWithPhoneNumber', () => {
     it('signs in with a valid code', async () => {
       const confirmResult = await firebase.auth().signInWithPhoneNumber(TEST_PHONE_A);
       confirmResult.verificationId.should.be.a.String();

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -741,7 +741,7 @@ RCT_EXPORT_METHOD(confirmationResultConfirm:
     if (error) {
       [self promiseRejectAuthException:reject error:error];
     } else {
-      [self promiseWithUser:resolve rejecter:reject user:authResult.user];
+      [self promiseWithAuthResult:resolve rejecter:reject authResult:authResult];
     }
   }];
 }

--- a/packages/auth/lib/ConfirmationResult.js
+++ b/packages/auth/lib/ConfirmationResult.js
@@ -24,7 +24,7 @@ export default class ConfirmationResult {
   confirm(verificationCode) {
     return this._auth.native
       .confirmationResultConfirm(verificationCode)
-      .then(user => this._auth._setUser(user));
+      .then(userCredential => this._auth._setUserCredential(userCredential));
   }
 
   get verificationId() {

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -486,7 +486,7 @@ export namespace FirebaseAuthTypes {
      *
      * @param verificationCode The code sent to the users device from Firebase.
      */
-    confirm(verificationCode: string): Promise<User | null>;
+    confirm(verificationCode: string): Promise<UserCredential | null>;
   }
 
   /**


### PR DESCRIPTION
BREAKING CHANGE: `confirm(verificationCode)` now return `UserCredentials`

### Description

Actually the Phone provider do not follow the Firebase Web SDK.
The [docs](https://firebase.google.com/docs/reference/node/firebase.auth.ConfirmationResult?authuser=0#confirm) said the confirm method should return an `UserCredential` and not only an `User`.
 
### Related issues
Related to [this issue](https://github.com/invertase/react-native-firebase/issues/2543)
Fixes #2543 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Need help

The method now return a UserCredential, but i have a curious issue. When I log the result using for exemple there few lines of code : 
```
const result = await firebaseConfirmation.confirm(code)
console.log(result)
```
I have the expected result : 
```
{"additionalUserInfo": {"isNewUser": false, "profile": null, "providerId": "phone", "username": null}, "user": {"displayName": "Gwénolé", "email": null, "emailVerified": false, "isAnonymous": false, "metadata": [Object], "phoneNumber": "...", "photoURL": null, "providerData": [Array], "providerId": "firebase", "refreshToken": "...", "uid": "..."}}
```
But when I try to consume, for exemple the `isNewUser` I've got undefined..

I tried to list keys of the object and I have for result 
```
console.log(Object.keys(result))
> ["_auth", "_user"]
```

I think i missed something but i don't know what..
I can only consume the `isNewUser` using : 
```
const isNewUser = result._user.additionalUserInfo.isNewUser
```
🔥 