### PR TITLE
fix(ml-vision): convert options to correct type

### DIFF
--- a/packages/ml-vision/ios/RNFBMLVision/RNFBMLVisionFaceDetectorModule.m
+++ b/packages/ml-vision/ios/RNFBMLVision/RNFBMLVisionFaceDetectorModule.m
@@ -49,7 +49,7 @@ RCT_EXPORT_METHOD(faceDetectorProcessImage:
     FIRVision *vision = [FIRVision visionForApp:firebaseApp];
 
     FIRVisionFaceDetectorOptions *options = [[FIRVisionFaceDetectorOptions alloc] init];
-    
+
     NSInteger *classificationMode = [faceDetectorOptions[@"classificationMode"] integerValue];
     if (classificationMode == 1) {
       options.classificationMode = FIRVisionFaceDetectorClassificationModeNone;
@@ -79,8 +79,6 @@ RCT_EXPORT_METHOD(faceDetectorProcessImage:
     }
       
     options.minFaceSize = [faceDetectorOptions[@"minFaceSize"] doubleValue];
-      
-      
 
     FIRVisionFaceDetector *faceDetector = [vision faceDetectorWithOptions:options];
     [faceDetector processImage:visionImage completion:^(NSArray<FIRVisionFace *> *faces, NSError *error) {

--- a/packages/ml-vision/ios/RNFBMLVision/RNFBMLVisionFaceDetectorModule.m
+++ b/packages/ml-vision/ios/RNFBMLVision/RNFBMLVisionFaceDetectorModule.m
@@ -49,36 +49,38 @@ RCT_EXPORT_METHOD(faceDetectorProcessImage:
     FIRVision *vision = [FIRVision visionForApp:firebaseApp];
 
     FIRVisionFaceDetectorOptions *options = [[FIRVisionFaceDetectorOptions alloc] init];
-
-    NSInteger *classificationMode = [faceDetectorOptions[@"classificationMode"] pointerValue];
-    if (classificationMode == (NSInteger *) 1) {
+    
+    NSInteger *classificationMode = [faceDetectorOptions[@"classificationMode"] integerValue];
+    if (classificationMode == 1) {
       options.classificationMode = FIRVisionFaceDetectorClassificationModeNone;
-    } else if (classificationMode == (NSInteger *) 2) {
+    } else if (classificationMode == 2) {
       options.classificationMode = FIRVisionFaceDetectorClassificationModeAll;
     }
 
-    NSInteger *contourMode = [faceDetectorOptions[@"contourMode"] pointerValue];
-    if (contourMode == (NSInteger *) 1) {
+    NSInteger *contourMode = [faceDetectorOptions[@"contourMode"] integerValue];
+    if (contourMode == 1) {
       options.contourMode = FIRVisionFaceDetectorContourModeNone;
-    } else if (contourMode == (NSInteger *) 2) {
+    } else if (contourMode == 2) {
       options.contourMode = FIRVisionFaceDetectorContourModeAll;
     }
 
-    NSInteger *landmarkMode = [faceDetectorOptions[@"landmarkMode"] pointerValue];
-    if (landmarkMode == (NSInteger *) 1) {
+    NSInteger *landmarkMode = [faceDetectorOptions[@"landmarkMode"] integerValue];
+    if (landmarkMode == 1) {
       options.landmarkMode = FIRVisionFaceDetectorLandmarkModeNone;
-    } else if (landmarkMode == (NSInteger *) 2) {
+    } else if (landmarkMode == 2) {
       options.landmarkMode = FIRVisionFaceDetectorLandmarkModeAll;
     }
 
-    NSInteger *performanceMode = [faceDetectorOptions[@"performanceMode"] pointerValue];
-    if (performanceMode == (NSInteger *) 1) {
+    NSInteger *performanceMode = [faceDetectorOptions[@"performanceMode"] integerValue];
+    if (performanceMode == 1) {
       options.performanceMode = FIRVisionFaceDetectorPerformanceModeFast;
-    } else if (performanceMode == (NSInteger *) 2) {
+    } else if (performanceMode == 2) {
       options.performanceMode = FIRVisionFaceDetectorPerformanceModeAccurate;
     }
-
-    options.minFaceSize = (CGFloat) [faceDetectorOptions[@"minFaceSize"] doubleValue];
+      
+    options.minFaceSize = [faceDetectorOptions[@"minFaceSize"] doubleValue];
+      
+      
 
     FIRVisionFaceDetector *faceDetector = [vision faceDetectorWithOptions:options];
     [faceDetector processImage:visionImage completion:^(NSArray<FIRVisionFace *> *faces, NSError *error) {

--- a/tests/e2e/mocha.opts
+++ b/tests/e2e/mocha.opts
@@ -32,7 +32,7 @@
 ../packages/ml-natural-language/e2e/*.e2e.js
 
 # TODO - ci crashing ios
-# ../packages/ml-vision/e2e/*.e2e.js
+../packages/ml-vision/e2e/*.e2e.js
 
 ../packages/in-app-messaging/e2e/*.e2e.js
 


### PR DESCRIPTION
fixes #3585 

I couldn't recreate the error reported by the users, but I do agree that the wrong type was being called for each of the face detecting options.

I also removed the unnecessary type casting for each if statement condition as it is already an integer.

Also, removed type casting to `CGFloat` as it is just a `typedef` for a `double` anyway.
