### PR TITLE
fix(messaging,ios): crash receiving notification with image

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -113,7 +113,7 @@
     }
 
     // message.mutableContent
-    if (apsDict[@"mutable-content"] != nil && [apsDict[@"mutable-content"] isEqualToString:@"1"]) {
+    if (apsDict[@"mutable-content"] != nil && [apsDict[@"mutable-content"] intValue] == 1) {
       message[@"mutableContent"] = @([RCTConvert BOOL:apsDict[@"mutable-content"]]);
     }
 


### PR DESCRIPTION
Hi,

Currently receiving notifications with images will crash the app on iOS (Fixes #3447, #3616).
This is only the patch proposed by @actuosus, thanks to him 🙌 https://github.com/invertase/react-native-firebase/issues/3447#issuecomment-618639388

### Release Summary

- Fix crash when receiving notification with an image on iOS.

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- Simulate a notification on the Firebase console using your device FCM token
- Don't forget to upload a logo
- Profit! 😄

:fire: