### PR TITLE
fix(ios): handle nil messaging token

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
@@ -49,8 +49,9 @@
 
 // JS -> `onTokenRefresh`
 - (void)messaging:(FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)fcmToken {
-  if(fcmToken == nil) // Don't crash when the token is reset
+  if (fcmToken == nil) { // Don't crash when the token is reset
     return;
+  }
   [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_token_refresh" body:@{
       @"token": fcmToken
   }];

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
@@ -49,6 +49,8 @@
 
 // JS -> `onTokenRefresh`
 - (void)messaging:(FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)fcmToken {
+  if(fcmToken == nil) // Don't crash when the token is reset
+    return;
   [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_token_refresh" body:@{
       @"token": fcmToken
   }];


### PR DESCRIPTION
# Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
On iOS, calling `[FIRInstanceID instanceID] deleteIDWithHandler` causes a crash. I quite like this method since it enables me to drop all tokens generated until now, and make sure we won't send any more messages to this device (use case: user logout).

### Related issues
Not reported.

### Release Summary
[messaging] Fixed a crash if the fetched token is null (typically when deleting the cloud messaging instance).

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `iOS`
- My change includes tests: **NO** (but maybe it should!)
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
You can try to call `[FIRInstanceID instanceID] deleteIDWithHandler` in your app code (exposing it as a JS API would be welcome by the way!).

Thanks a lot for this project!