### PR TITLE
fix(iid): RNFBid requires dep on instanceID

### DIFF
--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -39,6 +39,7 @@ Pod::Spec.new do |s|
 
   # Firebase dependencies
   s.dependency          'Firebase/CoreOnly', firebase_sdk_version
+  s.dependency          'FirebaseInstanceID'
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"


### PR DESCRIPTION
fixes #3746.

iOS Firebase InstanceId appears to be a dependency on messaging package, but no longer on core. Therefore, it is required as a dependency on RNFBId.