### PR TITLE
docs(storage): fix minor typo in storage docs

### DIFF
--- a/docs/storage/usage/index.md
+++ b/docs/storage/usage/index.md
@@ -103,7 +103,7 @@ such as the current upload progress:
 const task = reference.putFile(pathToFile);
 
 task.on('state_changed', taskSnapshot => {
-  console.log(`${taskSnapshot.bytesTransferred} transferred out of ${task.totalBytes}`);
+  console.log(`${taskSnapshot.bytesTransferred} transferred out of ${taskSnapshot.totalBytes}`);
 });
 
 task.then(() => {


### PR DESCRIPTION
### Description

The `putFile` docs reference the wrong variable in the first example.
Must be `taskSnapshot.totalBytes` instead of `task`.

### Related issues

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
