### PR TITLE
tests: bump soloader dependency to fix ABI lib load issues

### DIFF
--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -117,6 +117,13 @@ android {
   }
 }
 
+// Can probably remove this when tests upgrades to react-native 0.63
+configurations.all {
+    resolutionStrategy {
+        force "com.facebook.soloader:soloader:0.8.2"
+    }
+}
+
 dependencies {
   implementation fileTree(include: ['*.jar'], dir: 'libs')
   //noinspection GradleDynamicVersion


### PR DESCRIPTION
soloader 0.8.0 has problems loading ABI-specific libraries in
universal APKs, this workaround appears effective and allows the
test APK to run on x86 emulators in developer environments

Can likely be removed when moving to react-native 0.63.0

https://github.com/facebook/react-native/issues/25923#issuecomment-594047945
