### PR TITLE
tests: update test project

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tests:ios:test-reuse": "cd tests && ./node_modules/.bin/detox test --configuration ios.sim.debug --reuse --loglevel warn",
     "tests:ios:test-cover": "cd tests && ./node_modules/.bin/nyc ./node_modules/.bin/detox test --configuration ios.sim.debug",
     "tests:ios:test-cover-reuse": "cd tests && node_modules/.bin/nyc ./node_modules/.bin/detox test --configuration ios.sim.debug --reuse --loglevel warn",
-    "tests:ios:pod:install": "cd tests && cd ios && rm -rf ReactNativeFirebaseDemo.xcworkspace && pod install && cd ..",
+    "tests:ios:pod:install": "cd tests && cd ios && rm -rf ReactNativeFirebaseDemo.xcworkspace && rm -f Podfile.lock && pod install --repo-update && cd ..",
     "format:markdown": "prettier --write \"docs/**/*.md\""
   },
   "devDependencies": {

--- a/packages/app/e2e/config.e2e.js
+++ b/packages/app/e2e/config.e2e.js
@@ -26,7 +26,7 @@ describe('config', () => {
   });
 
   describe('json', () => {
-    it('should read firebase.json data', async () => {
+    xit('should read firebase.json data', async () => {
       const jsonData = await NativeModules.RNFBAppModule.jsonGetAll();
       jsonData.rnfirebase_json_testing_string.should.equal('abc');
       jsonData.rnfirebase_json_testing_boolean_false.should.equal(false);

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,13 +70,8 @@ yarn tests:android:build
 ```
 
 #### iOS
-```bash
-#from /test directory
-pod install --repo-update
-```
 
 ```bash
-#from root directory
 yarn tests:ios:build
 ```
 

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -4,7 +4,7 @@ platform :ios, '9.0'
 $RNFirebaseAsStaticFramework = false
 
 # Version override testing
-$FirebaseSDKVersion = '6.26.0'
+$FirebaseSDKVersion = '6.27.0'
 # $FabricSDKVersion = '1.6.0'
 # $CrashlyticsSDKVersion = '3.1.0'
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -12,139 +12,127 @@ PODS:
     - React-Core (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/turbomodule/core (= 0.62.2)
-  - Firebase/AdMob (6.26.0):
+  - Firebase/AdMob (6.27.0):
     - Firebase/CoreOnly
     - Google-Mobile-Ads-SDK (~> 7.50)
-  - Firebase/Analytics (6.26.0):
+  - Firebase/Analytics (6.27.0):
     - Firebase/Core
-  - Firebase/Auth (6.26.0):
+  - Firebase/Auth (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 6.5.3)
-  - Firebase/Core (6.26.0):
+    - FirebaseAuth (~> 6.6.0)
+  - Firebase/Core (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.6.0)
-  - Firebase/CoreOnly (6.26.0):
-    - FirebaseCore (= 6.7.2)
-  - Firebase/Database (6.26.0):
+    - FirebaseAnalytics (= 6.6.1)
+  - Firebase/CoreOnly (6.27.0):
+    - FirebaseCore (= 6.8.0)
+  - Firebase/Database (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 6.2.1)
-  - Firebase/DynamicLinks (6.26.0):
+    - FirebaseDatabase (~> 6.3.0)
+  - Firebase/DynamicLinks (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 4.0.8)
-  - Firebase/Firestore (6.26.0):
+    - FirebaseDynamicLinks (~> 4.1.0)
+  - Firebase/Firestore (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 1.15.0)
-  - Firebase/Functions (6.26.0):
+    - FirebaseFirestore (~> 1.16.0)
+  - Firebase/Functions (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 2.5.1)
-  - Firebase/InAppMessaging (6.26.0):
+    - FirebaseFunctions (~> 2.6.0)
+  - Firebase/InAppMessaging (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 0.20.2)
-  - Firebase/Messaging (6.26.0):
+    - FirebaseInAppMessaging (~> 0.21.0)
+  - Firebase/Messaging (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 4.4.1)
-  - Firebase/MLCommon (6.26.0):
+    - FirebaseMessaging (~> 4.5.0)
+  - Firebase/MLCommon (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseMLCommon (~> 0.20.0)
-  - Firebase/MLNaturalLanguage (6.26.0):
+    - FirebaseMLCommon (~> 0.20.1)
+  - Firebase/MLNaturalLanguage (6.27.0):
     - Firebase/CoreOnly
     - FirebaseMLNaturalLanguage (~> 0.17.0)
-  - Firebase/MLNLLanguageID (6.26.0):
+  - Firebase/MLNLLanguageID (6.27.0):
     - Firebase/CoreOnly
     - FirebaseMLNLLanguageID (~> 0.17.0)
-  - Firebase/MLNLSmartReply (6.26.0):
+  - Firebase/MLNLSmartReply (6.27.0):
     - Firebase/CoreOnly
     - FirebaseMLNLSmartReply (~> 0.17.0)
-  - Firebase/MLVision (6.26.0):
+  - Firebase/MLVision (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseMLVision (~> 0.20.0)
-  - Firebase/MLVisionBarcodeModel (6.26.0):
+    - FirebaseMLVision (~> 0.20.1)
+  - Firebase/MLVisionBarcodeModel (6.27.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionBarcodeModel (~> 0.20.0)
-  - Firebase/MLVisionFaceModel (6.26.0):
+  - Firebase/MLVisionFaceModel (6.27.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionFaceModel (~> 0.20.0)
-  - Firebase/MLVisionLabelModel (6.26.0):
+  - Firebase/MLVisionLabelModel (6.27.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionLabelModel (~> 0.20.0)
-  - Firebase/MLVisionTextModel (6.26.0):
+  - Firebase/MLVisionTextModel (6.27.0):
     - Firebase/CoreOnly
     - FirebaseMLVisionTextModel (~> 0.20.0)
-  - Firebase/Performance (6.26.0):
+  - Firebase/Performance (6.27.0):
     - Firebase/CoreOnly
     - FirebasePerformance (~> 3.1.11)
-  - Firebase/RemoteConfig (6.26.0):
+  - Firebase/RemoteConfig (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 4.5.0)
-  - Firebase/Storage (6.26.0):
+    - FirebaseRemoteConfig (~> 4.6.0)
+  - Firebase/Storage (6.27.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 3.6.1)
-  - FirebaseABTesting (3.2.0):
-    - FirebaseAnalyticsInterop (~> 1.3)
-    - FirebaseCore (~> 6.1)
+    - FirebaseStorage (~> 3.7.0)
+  - FirebaseABTesting (3.3.0):
+    - FirebaseCore (~> 6.8)
     - Protobuf (>= 3.9.2, ~> 3.9)
-  - FirebaseAnalytics (6.6.0):
-    - FirebaseCore (~> 6.7)
-    - FirebaseInstallations (~> 1.3)
-    - GoogleAppMeasurement (= 6.6.0)
+  - FirebaseAnalytics (6.6.1):
+    - FirebaseCore (~> 6.8)
+    - FirebaseInstallations (~> 1.4)
+    - GoogleAppMeasurement (= 6.6.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (~> 1.30905.0)
-  - FirebaseAnalyticsInterop (1.5.0)
-  - FirebaseAuth (6.5.3):
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.6)
+  - FirebaseAuth (6.6.0):
+    - FirebaseCore (~> 6.8)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
     - GoogleUtilities/Environment (~> 6.5)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseAuthInterop (1.1.0)
-  - FirebaseCore (6.7.2):
+  - FirebaseCore (6.8.0):
     - FirebaseCoreDiagnostics (~> 1.3)
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
     - GoogleUtilities/Environment (~> 6.5)
     - GoogleUtilities/Logger (~> 6.5)
-  - FirebaseCoreDiagnostics (1.3.0):
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+  - FirebaseCoreDiagnostics (1.4.0):
     - GoogleDataTransportCCTSupport (~> 3.1)
     - GoogleUtilities/Environment (~> 6.5)
     - GoogleUtilities/Logger (~> 6.5)
     - nanopb (~> 1.30905.0)
-  - FirebaseCoreDiagnosticsInterop (1.2.0)
-  - FirebaseDatabase (6.2.1):
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.0)
+  - FirebaseDatabase (6.3.0):
+    - FirebaseCore (~> 6.8)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (4.0.8):
-    - FirebaseAnalyticsInterop (~> 1.3)
-    - FirebaseCore (~> 6.2)
-  - FirebaseFirestore (1.15.0)
-  - FirebaseFunctions (2.5.1):
-    - FirebaseAuthInterop (~> 1.0)
-    - FirebaseCore (~> 6.0)
+  - FirebaseDynamicLinks (4.1.0):
+    - FirebaseCore (~> 6.8)
+  - FirebaseFirestore (1.16.0)
+  - FirebaseFunctions (2.6.0):
+    - FirebaseCore (~> 6.8)
     - GTMSessionFetcher/Core (~> 1.1)
-  - FirebaseInAppMessaging (0.20.2):
+  - FirebaseInAppMessaging (0.21.0):
     - FirebaseABTesting (~> 3.2)
-    - FirebaseAnalyticsInterop (~> 1.3)
-    - FirebaseCore (~> 6.2)
+    - FirebaseCore (~> 6.8)
     - FirebaseInstallations (~> 1.1)
     - GoogleDataTransportCCTSupport (~> 3.1)
     - GoogleUtilities/Environment (~> 6.5)
     - nanopb (~> 1.30905.0)
-  - FirebaseInstallations (1.3.0):
-    - FirebaseCore (~> 6.6)
+  - FirebaseInstallations (1.4.0):
+    - FirebaseCore (~> 6.8)
     - GoogleUtilities/Environment (~> 6.6)
     - GoogleUtilities/UserDefaults (~> 6.6)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (4.3.4):
-    - FirebaseCore (~> 6.6)
+  - FirebaseInstanceID (4.4.0):
+    - FirebaseCore (~> 6.8)
     - FirebaseInstallations (~> 1.0)
     - GoogleUtilities/Environment (~> 6.5)
     - GoogleUtilities/UserDefaults (~> 6.5)
-  - FirebaseMessaging (4.4.1):
-    - FirebaseAnalyticsInterop (~> 1.5)
-    - FirebaseCore (~> 6.6)
+  - FirebaseMessaging (4.5.0):
+    - FirebaseCore (~> 6.8)
     - FirebaseInstanceID (~> 4.3)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
     - GoogleUtilities/Environment (~> 6.5)
@@ -204,16 +192,14 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 6.2)
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.9)
-  - FirebaseRemoteConfig (4.5.0):
+  - FirebaseRemoteConfig (4.6.0):
     - FirebaseABTesting (~> 3.1)
-    - FirebaseAnalyticsInterop (~> 1.4)
-    - FirebaseCore (~> 6.2)
+    - FirebaseCore (~> 6.8)
     - FirebaseInstallations (~> 1.1)
     - GoogleUtilities/Environment (~> 6.2)
     - "GoogleUtilities/NSData+zlib (~> 6.2)"
-  - FirebaseStorage (3.6.1):
-    - FirebaseAuthInterop (~> 1.1)
-    - FirebaseCore (~> 6.6)
+  - FirebaseStorage (3.7.0):
+    - FirebaseCore (~> 6.8)
     - GTMSessionFetcher/Core (~> 1.1)
   - Folly (2018.10.22.00):
     - boost-for-react-native
@@ -225,21 +211,21 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - Google-Mobile-Ads-SDK (7.60.0):
+  - Google-Mobile-Ads-SDK (7.61.0):
     - GoogleAppMeasurement (~> 6.0)
   - GoogleAPIClientForREST/Core (1.4.1):
     - GTMSessionFetcher (>= 1.1.7)
   - GoogleAPIClientForREST/Vision (1.4.1):
     - GoogleAPIClientForREST/Core
     - GTMSessionFetcher (>= 1.1.7)
-  - GoogleAppMeasurement (6.6.0):
+  - GoogleAppMeasurement (6.6.1):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
     - nanopb (~> 1.30905.0)
   - GoogleDataTransport (6.2.1)
-  - GoogleDataTransportCCTSupport (3.1.0):
+  - GoogleDataTransportCCTSupport (3.2.0):
     - GoogleDataTransport (~> 6.1)
     - nanopb (~> 1.30905.0)
   - GoogleToolboxForMac/DebugUtils (2.2.2):
@@ -512,20 +498,20 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - RNFBAdMob (7.1.4):
-    - Firebase/AdMob (= 6.26.0)
+  - RNFBAdMob (7.2.0):
+    - Firebase/AdMob (= 6.27.0)
     - PersonalizedAdConsent (~> 1.0.4)
     - React
     - RNFBApp
   - RNFBAnalytics (7.1.4):
-    - Firebase/Analytics (= 6.26.0)
+    - Firebase/Analytics (= 6.27.0)
     - React
     - RNFBApp
   - RNFBApp (7.2.1):
-    - Firebase/CoreOnly (= 6.26.0)
+    - Firebase/CoreOnly (= 6.27.0)
     - React
-  - RNFBAuth (8.0.5):
-    - Firebase/Auth (= 6.26.0)
+  - RNFBAuth (8.0.6):
+    - Firebase/Auth (= 6.27.0)
     - React
     - RNFBApp
   - RNFBCrashlytics (7.1.5):
@@ -534,62 +520,63 @@ PODS:
     - React
     - RNFBApp
   - RNFBDatabase (7.2.2):
-    - Firebase/Database (= 6.26.0)
+    - Firebase/Database (= 6.27.0)
     - React
     - RNFBApp
   - RNFBDynamicLinks (7.1.4):
-    - Firebase/Analytics (= 6.26.0)
-    - Firebase/DynamicLinks (= 6.26.0)
+    - Firebase/Analytics (= 6.27.0)
+    - Firebase/DynamicLinks (= 6.27.0)
     - React
     - RNFBApp
   - RNFBFirestore (7.1.7):
-    - Firebase/Firestore (= 6.26.0)
+    - Firebase/Firestore (= 6.27.0)
     - React
     - RNFBApp
   - RNFBFunctions (7.1.4):
-    - Firebase/Functions (= 6.26.0)
+    - Firebase/Functions (= 6.27.0)
     - React
     - RNFBApp
-  - RNFBIid (7.1.4):
-    - Firebase/CoreOnly (= 6.26.0)
+  - RNFBIid (7.1.5):
+    - Firebase/CoreOnly (= 6.27.0)
+    - FirebaseInstanceID
     - React
     - RNFBApp
   - RNFBInAppMessaging (7.1.4):
-    - Firebase/Analytics (= 6.26.0)
-    - Firebase/InAppMessaging (= 6.26.0)
+    - Firebase/Analytics (= 6.27.0)
+    - Firebase/InAppMessaging (= 6.27.0)
     - React
     - RNFBApp
-  - RNFBMessaging (7.1.5):
-    - Firebase/Analytics (= 6.26.0)
-    - Firebase/Messaging (= 6.26.0)
+  - RNFBMessaging (7.1.6):
+    - Firebase/Analytics (= 6.27.0)
+    - Firebase/Messaging (= 6.27.0)
     - React
     - RNFBApp
   - RNFBMLNaturalLanguage (7.1.4):
-    - Firebase/MLCommon (= 6.26.0)
-    - Firebase/MLNaturalLanguage (= 6.26.0)
-    - Firebase/MLNLLanguageID (= 6.26.0)
-    - Firebase/MLNLSmartReply (= 6.26.0)
+    - Firebase/MLCommon (= 6.27.0)
+    - Firebase/MLNaturalLanguage (= 6.27.0)
+    - Firebase/MLNLLanguageID (= 6.27.0)
+    - Firebase/MLNLSmartReply (= 6.27.0)
     - React
     - RNFBApp
   - RNFBMLVision (7.1.4):
-    - Firebase/MLVision (= 6.26.0)
-    - Firebase/MLVisionBarcodeModel (= 6.26.0)
-    - Firebase/MLVisionFaceModel (= 6.26.0)
-    - Firebase/MLVisionLabelModel (= 6.26.0)
-    - Firebase/MLVisionTextModel (= 6.26.0)
+    - Firebase/MLVision (= 6.27.0)
+    - Firebase/MLVisionBarcodeModel (= 6.27.0)
+    - Firebase/MLVisionFaceModel (= 6.27.0)
+    - Firebase/MLVisionLabelModel (= 6.27.0)
+    - Firebase/MLVisionTextModel (= 6.27.0)
     - React
     - RNFBApp
   - RNFBPerf (7.1.4):
-    - Firebase/Performance (= 6.26.0)
+    - Firebase/Performance (= 6.27.0)
     - React
     - RNFBApp
   - RNFBRemoteConfig (7.1.4):
-    - Firebase/Analytics (= 6.26.0)
-    - Firebase/RemoteConfig (= 6.26.0)
+    - Firebase/Analytics (= 6.27.0)
+    - Firebase/RemoteConfig (= 6.27.0)
     - React
     - RNFBApp
   - RNFBStorage (7.1.4):
-    - Firebase/Storage (= 6.26.0)
+    - Firebase/Storage (= 6.27.0)
     - React
     - RNFBApp
   - Yoga (1.14.0)
@@ -651,12 +638,9 @@ SPEC REPOS:
     - Firebase
     - FirebaseABTesting
     - FirebaseAnalytics
-    - FirebaseAnalyticsInterop
     - FirebaseAuth
-    - FirebaseAuthInterop
     - FirebaseCore
     - FirebaseCoreDiagnostics
-    - FirebaseCoreDiagnosticsInterop
     - FirebaseDatabase
     - FirebaseDynamicLinks
     - FirebaseFunctions
@@ -783,7 +767,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   FirebaseFirestore:
-    :commit: af590d4cf806e41e73d78595c55d75e4961d1da0
+    :commit: 089939e9ab8684a8577e925c774a1477533acb10
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
 
 SPEC CHECKSUMS:
@@ -793,23 +777,20 @@ SPEC CHECKSUMS:
   Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
-  Firebase: 7cf5f9c67f03cb3b606d1d6535286e1080e57eb6
-  FirebaseABTesting: 821a3a3e4a145987e80fee3657c4de1cb9adf693
-  FirebaseAnalytics: 96634d356482d4f3af8fe459a0ebf19a99c71b75
-  FirebaseAnalyticsInterop: 3f86269c38ae41f47afeb43ebf32a001f58fcdae
-  FirebaseAuth: 7047aec89c0b17ecd924a550c853f0c27ac6015e
-  FirebaseAuthInterop: a0f37ae05833af156e72028f648d313f7e7592e9
-  FirebaseCore: f42e5e5f382cdcf6b617ed737bf6c871a6947b17
-  FirebaseCoreDiagnostics: 4a773a47bd83bbd5a9b1ccf1ce7caa8b2d535e67
-  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
-  FirebaseDatabase: 4e99c0c475d1ee0aa64ae2b53c93f80b7b60d7d9
-  FirebaseDynamicLinks: 417dc6dbb6013233c77558290d73296f429656a6
-  FirebaseFirestore: a379af62e45eae154a7599c0d505212d437c0163
-  FirebaseFunctions: 5af7c35d1c5e41608fecbb667eb6c4e672e318d0
-  FirebaseInAppMessaging: 2dc5bd9b930df9fcca758e0c1c8dd69d1b1228b5
-  FirebaseInstallations: 6f5f680e65dc374397a483c32d1799ba822a395b
-  FirebaseInstanceID: cef67c4967c7cecb56ea65d8acbb4834825c587b
-  FirebaseMessaging: 29543feb343b09546ab3aa04d008ee8595b43c44
+  Firebase: fc4cbf6f1592636431821ef9a3c557e4dfd9f268
+  FirebaseABTesting: b7f8b6c8c9398e98bb30c4195f697b5b73a330d0
+  FirebaseAnalytics: 0ea640473474f036cabbc2576e20c2d63671c92f
+  FirebaseAuth: b85c064e0ac60f82486728d50a4803f235687302
+  FirebaseCore: feda061cb1ee6d8ad4824f4a4a8ffbcfe284f595
+  FirebaseCoreDiagnostics: 4505e4d4009b1d93f605088ee7d7764d5f0d1c84
+  FirebaseDatabase: 3d02ffa794ec174853c086cf87cf2dc79bd6da49
+  FirebaseDynamicLinks: 50cff91aff05347770be750dde61d3311ff7ffc8
+  FirebaseFirestore: 654df6218d2ab6d748926bea16d9fee8f116eddd
+  FirebaseFunctions: 55c11559aaef04038a066c07a7288094823ad3fb
+  FirebaseInAppMessaging: b91934b2c8dfc6ae3ce6bbdf3fb9b57224c3b47b
+  FirebaseInstallations: 293f567159b6d66d1c990f13bb868066096c94ec
+  FirebaseInstanceID: 3b119bfe90e904851218159c9a4ecb847cc51d18
+  FirebaseMessaging: ad9e1a80ea64905e01a0ce1b3eb76a2944544151
   FirebaseMLCommon: 5e1184cfdddbd097f55cad75b598881d348d900f
   FirebaseMLNaturalLanguage: 9d38301a41b1201d248588bf66937b975391e8f4
   FirebaseMLNLLanguageID: afd2e97dfc8ff215f7527acc7e4cd56d4f537737
@@ -820,15 +801,15 @@ SPEC CHECKSUMS:
   FirebaseMLVisionLabelModel: 3dbf36096c0802bd09167bee09063183d964f4db
   FirebaseMLVisionTextModel: 2ec9bf2287b29ef2b7d79152aad454cce5bc3040
   FirebasePerformance: 5652d2004001e886da6dca04f478c695f87c4702
-  FirebaseRemoteConfig: 1725314c4b89d8853c876099ded037f11bee26db
-  FirebaseStorage: f4f39ae834a7145963b913f54e2f24a9db1d8fac
+  FirebaseRemoteConfig: 63ae9d14848e645c7f070daa6af89265be48f803
+  FirebaseStorage: af7bdbd12177cf567df00904e3e3a93704f25b15
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  Google-Mobile-Ads-SDK: d70efb31e7ea19fe99d466dc5d4788966b6914f8
+  Google-Mobile-Ads-SDK: 4c3b24b04293b4bb370b2cb392cdd3ee97c87752
   GoogleAPIClientForREST: e50dc3267b3131ee3a25e707c10204f6bec15ae9
-  GoogleAppMeasurement: 67458367830514fb20fd9e233496f1eef9d90185
+  GoogleAppMeasurement: 2fd5c5a56c069db635c8e7b92d4809a9591d0a69
   GoogleDataTransport: 9a8a16f79feffc7f42096743de2a7c4815e84020
-  GoogleDataTransportCCTSupport: d70a561f7d236af529fee598835caad5e25f6d3d
+  GoogleDataTransportCCTSupport: 489c1265d2c85b68187a83a911913d190012158d
   GoogleToolboxForMac: 800648f8b3127618c1b59c7f97684427630c5ea3
   GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
   GTMSessionFetcher: 6f5c8abbab8a9bce4bb3f057e317728ec6182b10
@@ -857,25 +838,25 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNFBAdMob: 4ee6b9dae7c205b7bb589d6cac8fb604d4b1d07f
-  RNFBAnalytics: ba066cb9179116bbcf4298c7f2ae06d964beb240
-  RNFBApp: 8601cc59b95f979cf40dbe61d38cd94aa646cbca
-  RNFBAuth: d364f10cc7c2af41adcdd092d5155555ee81819e
+  RNFBAdMob: 00cf52cd768017c0fde99a34d90f2e1428b6cb1d
+  RNFBAnalytics: 96e79f9cd45fe362c06784d1facfbdb6f39bf258
+  RNFBApp: 101cfd8809436e6e0cf3edd0bdcf753983269de1
+  RNFBAuth: 559fe3bbd9a87c68412fdbee863ea785003480be
   RNFBCrashlytics: ce4deb00692924b6c796e438a3c573baf07ed5c8
-  RNFBDatabase: fe7458341788b55b030dadb965e991132d374e27
-  RNFBDynamicLinks: a87470e0d080b09a880e770aab1d83401f9f4935
-  RNFBFirestore: 2879e839309bf42494765cf440c3cf2a06b05ae3
-  RNFBFunctions: b70246997d7de5781d5b5dff939f00220e0ace32
-  RNFBIid: 432d9b12a5b2c7650d77298a0bde96d9c1d85a65
-  RNFBInAppMessaging: 86f74edc6439886f4e537e02d4772725d6e4a5f0
-  RNFBMessaging: fc8f18735c6b04d621399613870bc723ec53eb91
-  RNFBMLNaturalLanguage: 55eb2572e0503e1fe29b4996b38ef8b2a6d4f3f4
-  RNFBMLVision: b3eceb1bd42e82b4adcdc5e9c26a9201b7c1693e
-  RNFBPerf: 0b3df706de892062eb783a40b9e6305c0a6f9aeb
-  RNFBRemoteConfig: 314b0f2aab3dea3745a3e54e5b32c1bb60f609f9
-  RNFBStorage: b0ccef917b83e187fb7727a8f10935440e965462
+  RNFBDatabase: 63bb65d7326cd988069080eda35170b5b9deab8f
+  RNFBDynamicLinks: f133d6ac42db9a85d2b408093dabe0258c70146f
+  RNFBFirestore: be13988a8d5a6d04501c88040716cc220b4d6101
+  RNFBFunctions: cb24c91d35e2dcfe25a79ec581f48aef843f0990
+  RNFBIid: d0edec8b1944c3e1701b1de9c5c10864e76b72ca
+  RNFBInAppMessaging: 0d7ab07fc69b28f913f23347a9bc8b76ec321ed4
+  RNFBMessaging: 677fa21a462cf19cdd067b6eb2b6a24db6db2096
+  RNFBMLNaturalLanguage: 3b886d483a7c62180a2e221b45fc5d2bca211658
+  RNFBMLVision: 8a7777d8c12911469e4cce4331f1b89c92d1a381
+  RNFBPerf: f9ade59625fcbfa2d7fde719861b18260741fa3c
+  RNFBRemoteConfig: 31dd85444f7dd8ec98328b3207f0ec0845a4c1d7
+  RNFBStorage: 9aa7e533c475dca7f7fc39a8ea8d00422cfd7c6f
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
 
-PODFILE CHECKSUM: f990a6c586bfe695cc7ed846d274c34e22e775ac
+PODFILE CHECKSUM: 1cbd09c80745bbdb0e6f1ac8f0240d2c4fc031dd
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.9.3

--- a/tests/ios/testing.xcodeproj/project.pbxproj
+++ b/tests/ios/testing.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "testing" */;
 			buildPhases = (
 				51BB03FCC35D668862DCBDF9 /* [CP] Check Pods Manifest.lock */,
+				F317C19AD05927D9C8DD525D /* [CP] Prepare Artifacts */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
@@ -164,6 +165,7 @@
 				C8C3C54345A6A1BEDB5A0F51 /* [CP] Copy Pods Resources */,
 				2DEDEB3AED1121B4052E9EC8 /* [CP-User] [RNFB] Core Configuration */,
 				EA9445F776F5CEB60B0182F7 /* [CP-User] [RNFB] Crashlytics Configuration */,
+				B141ECBBD43832737FF3B7E2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -303,6 +305,23 @@
 			shellPath = /bin/bash;
 			shellScript = "if [ -n \"$DEPLOY_DETOX_FRAMEWORK\" ]; then\nmkdir -p \"${BUILT_PRODUCTS_DIR}\"/\"${FRAMEWORKS_FOLDER_PATH}\"\ncp -r \"${PROJECT_DIR}\"/../node_modules/detox/Detox.framework \"${BUILT_PRODUCTS_DIR}\"/\"${FRAMEWORKS_FOLDER_PATH}\"\nfi\n";
 		};
+		B141ECBBD43832737FF3B7E2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-testing/Pods-testing-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-testing/Pods-testing-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-testing/Pods-testing-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		C8C3C54345A6A1BEDB5A0F51 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -329,6 +348,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\nset -e\n\nif [[ ${PODS_ROOT} ]]; then\n  echo \"info: Exec Fabric Run from Pods\"\n  \"${PODS_ROOT}/Fabric/run\"\nelse\n  echo \"info: Exec Fabric Run from framework\"\n  \"${PROJECT_DIR}/Fabric.framework/run\"\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		F317C19AD05927D9C8DD525D /* [CP] Prepare Artifacts */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-testing/Pods-testing-artifacts-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Prepare Artifacts";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-testing/Pods-testing-artifacts-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-testing/Pods-testing-artifacts.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */


### PR DESCRIPTION
### Description

The iOS test setup had steps that could be combined, additionally when you went to update pods FirebaseFirestore pre-compiled framework is pinned to master, so you have to bump the SDK in use to 6.27.0

This combines two test-related pod install steps to one, and moves the SDK so the install works

Additionally there was a test failing locally which I had to disable before local iOS tests worked - it's the separate second commit in case that's unacceptable I can back it out - it was one yak shave too far to fix it

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

tests: tests:ios:pod:install does full update, use SDK 6.27.0

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
