### PR TITLE
fix(app,ios): Build fails when targeting Mac (Project Catalyst)

### DIFF
--- a/packages/app/ios/RNFBApp/RNFBUtilsModule.m
+++ b/packages/app/ios/RNFBApp/RNFBUtilsModule.m
@@ -57,7 +57,16 @@ RCT_EXPORT_MODULE();
   if ([localFilePath hasPrefix:@"assets-library://"] || [localFilePath hasPrefix:@"ph://"]) {
     if ([localFilePath hasPrefix:@"assets-library://"]) {
       NSURL *localFile = [[NSURL alloc] initWithString:localFilePath];
+#if TARGET_OS_MACCATALYST
+      static BOOL hasWarned = NO;
+      if (!hasWarned) {
+          NSLog(@"assets-library:// URLs are not supported in Catalyst-based targets; returning nil (future warnings will be suppressed)");
+          hasWarned = YES;
+      }
+      asset = nil;
+#else
       asset = [[PHAsset fetchAssetsWithALAssetURLs:@[localFile] options:nil] firstObject];
+#endif
     } else {
       NSString *assetId = [localFilePath substringFromIndex:@"ph://".length];
       asset = [[PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:nil] firstObject];


### PR DESCRIPTION
### Description

The Catalyst SDK does not support `assets-library://` URLs (see #2698), which have been deprecated for many years. This patch fixes the build failure when compiling with the Catalyst SDK; requests for such assets will fail and log (the first time).

### Related issues

Fixes #2698 

### Release Summary

Fixes compilation failures when targeting macOS Catalyst.

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

### Test Plan

1. Initialize a new React Native app with `react-native init`
2. Integrate `@react-native-firebase/app`
3. Check the "macOS" platform box in Xcode to add Catalyst support.
4. Build for macOS.

🔥 