### PR TITLE
chore(database) Updated .once typ defs

### DIFF
--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -670,7 +670,12 @@ export namespace FirebaseDatabaseTypes {
      * @param eventType One of the following strings: "value", "child_added", "child_changed", "child_removed", or "child_moved."
      * @param successCallback A callback that fires when the specified event occurs. The callback will be passed a DataSnapshot. For ordering purposes, "child_added", "child_changed", and "child_moved" will also be passed a string containing the key of the previous child by sort order, or `null` if it is the first child.
      */
-    once(eventType: EventType, successCallback?: Function): Promise<DataSnapshot>;
+
+    once(
+      eventType: EventType,
+      successCallback?: (a: DataSnapshot, b?: string | null) => any,
+      failureCallbackContext?: ((a: Error) => void) | Record<string, any> | null,
+    ): Promise<DataSnapshot>;
 
     /**
      * Generates a new `Query` object ordered by the specified child key.


### PR DESCRIPTION
Type definitions for .once references in the database module are outdated.

This PR adds updated references and appears correctly for autocompletion descriptions.