### PR TITLE
docs: improve autolinking & rebuilding steps

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -133,6 +133,7 @@ npx react-native run-android
 # iOS apps
 cd ios/
 pod install --repo-update
+cd ..
 npx react-native run-ios
 ```
 


### PR DESCRIPTION
Makes explicit that you need to be on the project root to run `npx react-native run-ios`
