### PR TITLE
fix: correct androidResolutionForPlayServices API

### DIFF
--- a/packages/app/lib/utils/index.js
+++ b/packages/app/lib/utils/index.js
@@ -69,7 +69,7 @@ class FirebaseUtilsModule extends FirebaseModule {
     if (isIOS) {
       return Promise.resolve();
     }
-    return this.native.androidGetPlayServicesStatus();
+    return this.native.androidResolutionForPlayServices();
   }
 
   logInfo(...args) {


### PR DESCRIPTION
### Description
Previously was calling the incorrect native API from JS
With thanks to @Bardiamist for reporting

### Related issues
Fixes #3864

### Release Summary

fix(android): call correct androidResolutionForPlayServices API (#3864)

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
