### PR TITLE
docs(messaging): fix example for iOS - Requesting permissions

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -49,12 +49,13 @@ iOS prevents messages containing notification (or 'alert') payloads from being d
 This module provides a `requestPermission` method which triggers a native permission dialog requesting the user's permission:
 
 ```js
-import messaging, { AuthorizationStatus } from '@react-native-firebase/messaging';
+import messaging from '@react-native-firebase/messaging';
 
 async function requestUserPermission() {
   const authStatus = await messaging().requestPermission();
   const enabled =
-    authStatus === AuthorizationStatus.AUTHORIZED || authStatus === AuthorizationStatus.PROVISIONAL;
+    authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
+    authStatus === messaging.AuthorizationStatus.PROVISIONAL;
 
   if (enabled) {
     console.log('Authorization status:', authStatus);


### PR DESCRIPTION
### Description

The [Clound Messaging > Usage](https://rnfirebase.io/messaging/usage#ios---requesting-permissions) docs on the Clound Messaging > page contain wrong code example, compared with the dedicated [Clound Messaging > iOS Permissions](https://rnfirebase.io/messaging/ios-permissions#reading-current-status) page.

### Related issues

Obsoletes #3761, #3849

### Release Summary

Fix docs for Cloud Messaging: iOS - Requesting permissions

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes (actually, your Contributing links are broken, from the main README file)
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

none
