### PR TITLE
fix(dynamic-links,ios): resolveLink() does not always resolve

### DIFF
--- a/packages/dynamic-links/e2e/dynamicLinks.e2e.js
+++ b/packages/dynamic-links/e2e/dynamicLinks.e2e.js
@@ -24,6 +24,7 @@ const TEST_LINK =
   'https://reactnativefirebase.page.link/?link=https://rnfirebase.io&apn=com.invertase.testing';
 const TEST_LINK2 =
   'https://reactnativefirebase.page.link/?link=https://invertase.io/hire-us&apn=com.invertase.testing';
+const TEST_LINK3 = 'https://invertase.io';
 
 module.exports.baseParams = baseParams;
 
@@ -122,6 +123,16 @@ describe('dynamicLinks()', () => {
         return Promise.reject(new Error('Did not throw Error.'));
       } catch (e) {
         e.code.should.containEql('not-found');
+        e.message.should.containEql('Dynamic link not found');
+        return Promise.resolve();
+      }
+    });
+
+    it('throws on static links', async () => {
+      try {
+        await firebase.dynamicLinks().resolveLink(TEST_LINK3);
+        return Promise.reject(new Error('Did not throw Error.'));
+      } catch (e) {
         e.message.should.containEql('Dynamic link not found');
         return Promise.resolve();
       }

--- a/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
+++ b/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
@@ -204,10 +204,16 @@ RCT_EXPORT_METHOD(resolveLink:
           @"message":[error localizedDescription]
       }];
     }
-};
+  };
 
   NSURL *linkURL = [NSURL URLWithString:link];
-  [[FIRDynamicLinks dynamicLinks] handleUniversalLink:linkURL completion:completion];
+  BOOL success = [[FIRDynamicLinks dynamicLinks] handleUniversalLink:linkURL completion:completion];
+  if (!success) {
+    [RNFBSharedUtils rejectPromiseWithUserInfo:reject userInfo:(NSMutableDictionary *) @{
+        @"code": @"not-found",
+        @"message": @"Dynamic link not found"
+    }];
+  }
 }
 
 - (FIRDynamicLinkComponents *)createDynamicLinkComponents:(NSDictionary *)dynamicLinkDict {


### PR DESCRIPTION
### Description

Current implementation does not cover the case where `[[FIRDynamicLinks dynamicLinks] handleUniversalLink:linkURL completion:completion]` can return  `NO` without calling the completion block at all. ([See native iOS SDK method here](https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m#L443)).

### Related issues

`resolveLink()` promise never gets resolved when using a non-dynamic link. Android behaves correctly.

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Test just hangs forever without the fix.
