### PR TITLE
feat(firestore, android): allow FirestoreSerializer native use

### DIFF
--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreSerialize.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreSerialize.java
@@ -50,7 +50,8 @@ import javax.annotation.Nullable;
 
 import static io.invertase.firebase.common.RCTConvertFirebase.toHashMap;
 
-class ReactNativeFirebaseFirestoreSerialize {
+// public access for native re-use in brownfield apps
+public class ReactNativeFirebaseFirestoreSerialize {
   private static final String TAG = "FirestoreSerialize";
 
   // Bridge Map
@@ -386,12 +387,13 @@ class ReactNativeFirebaseFirestoreSerialize {
 
   /**
    * Converts a ReadableMap to a usable format for Firestore
+   * (public access for native re-use in brownfield apps)
    *
    * @param firestore   FirebaseFirestore
    * @param readableMap ReadableMap
    * @return Map<>
    */
-  static Map<String, Object> parseReadableMap(
+  public static Map<String, Object> parseReadableMap(
     FirebaseFirestore firestore,
     @Nullable ReadableMap readableMap
   ) {


### PR DESCRIPTION


### Description

I have a brownfield use case where I do some firestore things in native code while doing most in Javascript.
For best code re-use in the app I sometimes want to send objects to the native code for further decoration before persisting to Firestore

Being able to re-use the existing serializer for that would be fantastic, and it's just two "public" markings away...

### Release Summary

feat(firestore, android): allow FirestoreSerializer native re-use in brownfield apps

### Checklist

- I read the [Contributor Guide](/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Using it already in my project via patch-package

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
