### PR TITLE
chore(firestore): remove check that each read document also needs to be written for a transaction

### DIFF
--- a/packages/firestore/e2e/Transaction.e2e.js
+++ b/packages/firestore/e2e/Transaction.e2e.js
@@ -86,22 +86,6 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should throw if get command is called with no writes', async () => {
-      const docRef = firebase.firestore().doc('v6/foo');
-
-      try {
-        await firebase.firestore().runTransaction(t => {
-          return t.get(docRef);
-        });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql(
-          'Every document read in a transaction must also be written',
-        );
-        return Promise.resolve();
-      }
-    });
-
     it('should get a document and return a DocumentSnapshot', async () => {
       const docRef = firebase.firestore().doc('v6/transactions/transaction/get-delete');
       await docRef.set({});

--- a/packages/firestore/lib/FirestoreTransactionHandler.js
+++ b/packages/firestore/lib/FirestoreTransactionHandler.js
@@ -99,17 +99,6 @@ export default class FirestoreTransactionHandler {
     // native emits that the transaction is final
     transaction._pendingResult = pendingResult;
 
-    if (
-      transaction._calledGetCount > 0 &&
-      transaction._calledGetCount !== transaction._commandBuffer.length
-    ) {
-      return meta.reject(
-        new Error(
-          'firebase.firestore().runTransaction() Every document read in a transaction must also be written.',
-        ),
-      );
-    }
-
     // send the buffered update/set/delete commands for native to process
     return this._firestore.native.transactionApplyBuffer(id, transaction._commandBuffer);
   }


### PR DESCRIPTION
fixes #3830 

Firestore update: For every document you read in a transaction, you do not have to update/set. This is true for iOS, Android & web.

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - Removed test.
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
