### PR TITLE
docs(v6 migration): document notifications migration path

### DIFF
--- a/docs/migrating-to-v6.md
+++ b/docs/migrating-to-v6.md
@@ -446,13 +446,13 @@ No breaking changes.
 - `firebase.utils.Native` is now deprecated and will be removed in a later release, please rename usages of this to `firebase.utils.FilePath`.
 - `firebase.utils.Native.*` some properties have been renamed and deprecated and will be removed in a later release, follow the in-app console warnings on how to migrate.
 
-### RN-Firebase notification
-In v5, `firebase.notifications()` was used to listen when a notification received or clicked, or when the app has been opened from a notification.
-This module doesn't exist anymore.
-Here are the other functions to do the same things:
-- `firebase.notifications().onNotification(Notification => void)` -> `firebase.messaging().onMessage(RemoteMessage => void)`.
-- `firebase.notifications().onNotificationOpened(NotificationOpen => void)` -> `firebase.messaging().onMessage(RemoteMessage => void)`.
-- `firebase.notifications().getInitialNotification()` -> `firebase.messaging().getInitialNotification()`.
+### Notifications
+In v5, `firebase.notifications()` had APIs for notification received or clicked, or when the app has been opened from a notification.
+This module doesn't exist anymore, a full-featured notification package should be used in it's place (for example [Notifee](notifee.app/), [react-native-push-notification](https://github.com/zo0r/react-native-push-notification) or [react-native-notifications](https://github.com/wix/react-native-notifications) may all work)
+This is the general upgrade path for notifications APIs:
+- `firebase.notifications().onNotification(Notification => void)` -> Use a 3rd party notifications module API.
+- `firebase.notifications().onNotificationOpened(NotificationOpen => void)` -> Use a 3rd party notifications module API.
+- `firebase.notifications().getInitialNotification()` -> `firebase.messaging().onNotificationOpenedApp()`.
 
 
 

--- a/docs/migrating-to-v6.md
+++ b/docs/migrating-to-v6.md
@@ -446,6 +446,16 @@ No breaking changes.
 - `firebase.utils.Native` is now deprecated and will be removed in a later release, please rename usages of this to `firebase.utils.FilePath`.
 - `firebase.utils.Native.*` some properties have been renamed and deprecated and will be removed in a later release, follow the in-app console warnings on how to migrate.
 
+### RN-Firebase notification
+In v5, `firebase.notifications()` was used to listen when a notification received or clicked, or when the app has been opened from a notification.
+This module doesn't exist anymore.
+Here are the other functions to do the same things:
+- `firebase.notifications().onNotification(Notification => void)` -> `firebase.messaging().onMessage(RemoteMessage => void)`.
+- `firebase.notifications().onNotificationOpened(NotificationOpen => void)` -> `firebase.messaging().onMessage(RemoteMessage => void)`.
+- `firebase.notifications().getInitialNotification()` -> `firebase.messaging().getInitialNotification()`.
+
+
+
 ### ML Kit Natural Language
 
 `@react-native-firebase/ml-natural-language`


### PR DESCRIPTION
### Description

Add in the migration documentation a section about the module `notification()` which has been removed from the v6.

### Related issues

None. I just came across this breaking change which wasn't documented ii the "migrating to v6" section.

### Release Summary

Improvement of the "migrating to v6" documentation.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - ✅ No
- My change supports the following platforms;
  - ✅ `Android`
  - ✅ `iOS`
- My change includes tests;
  - [  ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [  ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [  ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - ✅ No



### Test Plan

😩 It's just doc dude.