### PR TITLE
fix(ios,messaging): pin GoogleUtilities at 6.6.0 in Messaging

### DIFF
--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -40,6 +40,7 @@ Pod::Spec.new do |s|
   # Firebase dependencies
   s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/Messaging', firebase_sdk_version
+  s.dependency          'GoogleUtilities', '6.6.0' # Workaround: remove with resolution of #3938 - incompatible with firebase-ios-sdk >= 6.28.0
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"


### PR DESCRIPTION
### Description

This allows the messaging module to compile against firebase-ios-sdk <= 6.27.1 successfully
It is not compatible with firebase-ios-sdk >= 6.28.0

### Related issues

A real fix is pending resolution of #3938 / Adaptation to https://github.com/firebase/firebase-ios-sdk/pull/5824

### Release Summary

fix(ios): compile successfully against firebase-ios-sdk <= 6.27.1

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Tested compile with and without this vs 6.27.1 and 6.28.0, confirmed working against 6.27.1 (where a pod update would break before), confirmed not working against 6.28.0

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
