### PR TITLE
chore: update issue template "about" field

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,7 +1,6 @@
 ---
 name: ⚠️ Bug/Issue report - React Native
-about: Please provide as much detail as possible to help us with a bug or issue. Issues
-  are likely to be closed and locked if they do not follow the template. Also note that v5 of react-native-firebase has been deprecated, so issues or bugs related to that version are unlikely to get attention.
+about: Please provide as much detail as possible. Issues may be closed if they do not follow the template. Note V5 is deprecated, V5 issues are unlikely to get attention
 ---
 
 <!---


### PR DESCRIPTION
Apparently github won't show a template with an about that is more than 200 chars
So our main bug report template was not showing up

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
