### PR TITLE
add AdEventType

### DIFF
--- a/docs/admob/displaying-ads.md
+++ b/docs/admob/displaying-ads.md
@@ -18,7 +18,7 @@ of the method is the "Ad Unit ID". For testing, we can use a Test ID, however fo
 Google AdMob dashboard under "Ad units" should be used:
 
 ```js
-import { InterstitialAd, TestIds } from '@react-native-firebase/admob';
+import { InterstitialAd, TestIds, AdEventType } from '@react-native-firebase/admob';
 
 const adUnitId = __DEV__ ? TestIds.INTERSTITIAL : 'ca-app-pub-xxxxxxxxxxxxx/yyyyyyyyyyyyyy';
 


### PR DESCRIPTION
You guys forgot to add the AdEventType

### Description

you guys forgot to add the `AdEventType` without that it will throw errors that it can't find it.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X ] Yes
- My change supports the following platforms;
  - [X ] `Android`
  - [X ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
