### PR TITLE
docs(messaging): fixed typo in iOS setup docs

### DIFF
--- a/docs/messaging/usage/ios-setup.md
+++ b/docs/messaging/usage/ios-setup.md
@@ -57,7 +57,7 @@ Now ensure that both the "Background fetch" and the "Remote notifications" sub-m
 
 # Linking APNs with FCM
 
-Even though FCM a has limited capability to work without linking with APNs, the below steps are strongly recommended
+Even though FCM has limited capability to work without linking with APNs, the below steps are strongly recommended
 to ensure the library works as expected. Without linking APNs, your device will not receive messages when in the background
 or when quit.
 


### PR DESCRIPTION
### Description

I was reading the Cloud Messaging documentation and I came across a typo. The iOS setup docs has an extra 'a'. This PR fixes this.

### Release Summary

Fix typo in the Cloud Messaging iOS setup.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

This is a documentation change, no futher testing is required.
