### PR TITLE
 docs: should be asBoolean instead of asNumber

### DIFF
--- a/docs/remote-config/usage/index.md
+++ b/docs/remote-config/usage/index.md
@@ -111,7 +111,7 @@ if (awesomeNewFeature.asNumber() === 5) {
 // resolves value to boolean
 // if value is any of the following: '1', 'true', 't', 'yes', 'y', 'on', it will resolve to true
 // if source is 'static', value will be false
-if (awesomeNewFeature.asNumber() === true) {
+if (awesomeNewFeature.asBoolean() === true) {
   enableAwesomeNewFeature();
 }
 ```


### PR DESCRIPTION
### Description

It has been used `asNumber` instead of `asBoolean` in the `resolves value to boolean` section.
This can lead to confusion.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No
