### PR TITLE
fix(messaging): added missing `from` property in Remote Message type

### DIFF
--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -89,7 +89,6 @@ export namespace FirebaseMessagingTypes {
     * The topic name or message identifier.
     */
     from?: string;
-    
     /**
      * The address for the message.
      */

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -85,7 +85,7 @@ export namespace FirebaseMessagingTypes {
      */
     messageType?: string;
     /**
-    * The topic name or message identifier.
+     * The topic name or message identifier.
     */
     from?: string;
     /**

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -86,7 +86,7 @@ export namespace FirebaseMessagingTypes {
     messageType?: string;
     /**
      * The topic name or message identifier.
-    */
+     */
     from?: string;
     /**
      * The address for the message.

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -84,7 +84,6 @@ export namespace FirebaseMessagingTypes {
      * The message type of the message.
      */
     messageType?: string;
-    
     /**
     * The topic name or message identifier.
     */

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -84,7 +84,12 @@ export namespace FirebaseMessagingTypes {
      * The message type of the message.
      */
     messageType?: string;
-
+    
+    /**
+    * The topic name or message identifier.
+    */
+    from?: string;
+    
     /**
      * The address for the message.
      */


### PR DESCRIPTION
### Description

I believe the `from` property was accidentally omitted from the `FirebaseMessagingType.RemoteMessage` interface. I've added it following the standards set by the rest of the properties.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No