### PR TITLE
fix(android, timezones): timezone offset already millis, do not adjust it

### DIFF
--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -98,7 +98,7 @@ public class SharedUtils {
 
   public static String timestampToUTC(long timestamp) {
     Calendar calendar = Calendar.getInstance();
-    Date date = new Date((timestamp + calendar.getTimeZone().getOffset(timestamp)) * 1000);
+    Date date = new Date(timestamp + calendar.getTimeZone().getOffset(timestamp));
     SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
     format.setTimeZone(TimeZone.getTimeZone("UTC"));
     return format.format(date);


### PR DESCRIPTION


### Description

Timezone.getOffset() provides result in milliseconds, but was being adjusted as if it were in seconds

### Related issues

Fixes #4053 with issue noticed and fix provided by @AidanHost


### Release Summary

fix(android, timezones): timezone offset already in millis, do not adjust it

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I am literally making this change directly in the github web UI and relying on the automated test to handle it.

The documentation linked appears very clear cut and the change is so small so that seems reasonably unreasonable

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
