### PR TITLE
fix(android,iid): workaround IID version missing in BOM w/concrete version

### DIFF
--- a/packages/iid/android/build.gradle
+++ b/packages/iid/android/build.gradle
@@ -30,7 +30,7 @@ if (findProject(':@react-native-firebase_app')) {
 }
 def packageJson = PackageJson.getForProject(project)
 def appPackageJson = PackageJson.getForProject(appProject)
-def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "25.5.0"
+def firebaseBomVersion = appPackageJson['sdkVersions'] ? appPackageJson['sdkVersions']['android']['firebase'] : "25.5.0" // ALIGN CONCRETE VERSION BELOW WHEN CHANGING THIS
 def coreVersionDetected = appPackageJson['version']
 def coreVersionRequired = packageJson['peerDependencies'][appPackageJson['name']]
 // Only log after build completed so log warning appears at the end
@@ -87,7 +87,11 @@ repositories {
 dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
-  implementation "com.google.firebase:firebase-iid"
+  // TODO Must put the concrete version here as the BoM no longer publishes the IID version, align it with the BoM change above
+  // Upstream issue: https://github.com/firebase/firebase-android-sdk/issues/1077
+  // Issue: https://github.com/invertase/react-native-firebase/issues/3918
+  // Example of where to find concrete version to match BoM: https://firebase.google.com/support/release-notes/android#iid_v20-2-1
+  implementation "com.google.firebase:firebase-iid:20.2.1" // NEED CONCRETE VERSION HERE TO MATCH BOM RELEASE
 }
 
 ReactNative.shared.applyPackageVersion()


### PR DESCRIPTION
### Description

IID will fail if included / used directly (instead of as transitive dependency) because they stopped publishing the IID version in the BoM

This is being tracked upstream and I put breadcrumbs in the code that should help maintainers during version bumps


### Related issues

#3918 
https://github.com/firebase/firebase-android-sdk/issues/1077

### Release Summary

build(android, iid): workaround iid version missing in upstream BoM

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No - only for people already using patch-package to workaround it, but they'll see it



### Test Plan

CI will blow up completely since it's a compile fail, if this doesn't work

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
