### PR TITLE
tests: use Detox as compile reference, ignore UIManager queues

### DIFF
--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -1,14 +1,7 @@
-// Add the Firebase Crashlytics plugin.
-
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
-
-
-
-
 apply plugin: "com.google.firebase.firebase-perf"
-
 
 import com.android.build.OutputFile
 
@@ -140,7 +133,7 @@ dependencies {
   /* ------------------------
    *  TESTING SDKS/LIBRARIES
    * ------------------------ */
-  androidTestImplementation('com.wix:detox:+')
+    androidTestImplementation(project(path: ":detox"))
 }
 
 // Run this once to be able to run the application with BUCK

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -29,10 +29,10 @@ allprojects {
       // Android JSC is installed from npm
       url("$rootDir/../node_modules/jsc-android/dist")
     }
-    maven {
-      // Detox
-      url "$rootDir/../node_modules/detox/Detox-android"
-    }
+    // maven {
+    //   // Detox as an .aar file (we're going to use it as a compile dependency though, to patch it)
+    //   url "$rootDir/../node_modules/detox/Detox-android"
+    // }
     jcenter()
   }
 

--- a/tests/android/settings.gradle
+++ b/tests/android/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = '@react-native-firebase_tests'
-
+include ':detox'
+project(':detox').projectDir = new File(rootProject.projectDir, '../node_modules/detox/android/detox')
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 include ':app'

--- a/tests/patches/detox+16.7.2.patch
+++ b/tests/patches/detox+16.7.2.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java b/node_modules/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
+index 181233a..f834f6b 100644
+--- a/node_modules/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
++++ b/node_modules/detox/android/detox/src/main/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
+@@ -100,18 +100,21 @@ public class UIModuleIdlingResource implements IdlingResource, Choreographer.Fra
+             }
+ 
+             boolean isOperationQueueEmpty = (Boolean) Reflect.on(uiOperationQueue).call(METHOD_IS_EMPTY).get();
++            Log.d(LOG_TAG, "UIManagerModule queue status: runnables? / nonBatchesOps? / operationQueue? - " + runnablesAreEmpty + " / " + nonBatchesOpsEmpty + " / " + isOperationQueueEmpty);
+ 
+             if (runnablesAreEmpty && nonBatchesOpsEmpty && isOperationQueueEmpty) {
+                 if (callback != null) {
+                     callback.onTransitionToIdle();
+                 }
+-                // Log.i(LOG_TAG, "UIManagerModule is idle.");
++                Log.d(LOG_TAG, "UIManagerModule is idle.");
+                 return true;
+             }
+ 
+             Log.i(LOG_TAG, "UIManagerModule is busy.");
+-            Choreographer.getInstance().postFrameCallback(this);
+-            return false;
++            Log.w(LOG_TAG, "UIManagerModule is busy but damn the torpedoes!");
++            return true;
++            // Choreographer.getInstance().postFrameCallback(this);
++            // return false;
+         } catch (ReflectException e) {
+             Log.e(LOG_TAG, "Can't set up RN UIModule listener", e.getCause());
+         }


### PR DESCRIPTION
### Description

Still working on de-flaking Android E2E

Even with the tap stream delayed, the extra logging from the previous merge showed the React Native UIManager's dispatch queues are sometimes permanently non-empty, blocking Detox from signalling it is ready on the app/detox-testee side.

This commit switches Detox to a compile dependency (from AAR) so we can patch-package it, then I hack out the UIManager espresso idle resource waiter completely.

This would potentially be a disaster in normal apps, but for our testing app is inconsequential since we perform no UI activities (and thus they should *never* block)

### Related issues

#4058

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
