### PR TITLE
tests(firestore): disable flaky onSnapshot unsubscribe e2e test

### DIFF
--- a/packages/firestore/e2e/Query/onSnapshot.e2e.js
+++ b/packages/firestore/e2e/Query/onSnapshot.e2e.js
@@ -338,7 +338,9 @@ describe('firestore().collection().onSnapshot()', () => {
     }
   });
 
-  it('unsubscribes from further updates', async () => {
+  // FIXME test disabled due to flakiness in CI E2E tests.
+  // Registered 4 of 3 expected calls once (!?), 3 of 2 expected calls once.
+  xit('unsubscribes from further updates', async () => {
     const callback = sinon.spy();
     const collection = firebase.firestore().collection('v6/foo/bar7');
 


### PR DESCRIPTION
### Description

Noticed firestore collection snapshot listener unsubscribe test was flaky in CI, not sure why - quarantining it

### Related issues

#4058 

Picked it up here:
- https://github.com/invertase/react-native-firebase/pull/3751#issuecomment-674191390
- https://github.com/invertase/react-native-firebase/pull/4078#issuecomment-674190258

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
