### PR TITLE
fix(messaging,ios): fix build error

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNNotificationServiceExtension.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNNotificationServiceExtension.m
@@ -15,6 +15,7 @@
  *
  */
 
+#import <FirebaseMessaging/FIRMessagingExtensionHelper.h>
 #import "RNFBMessaging+UNNotificationServiceExtension.h"
 #import "FirebaseMessaging.h"
 


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

`v.7.7.1` causes a build error: `Receiver type 'FIRMessagingExtensionHelper' for instance message is a forward declaration`

This PR fixes the build error by importing another header file.

### Related issues

Solve https://github.com/invertase/react-native-firebase/issues/4098

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
