### PR TITLE
fix: hard crash using NSInternalInconsistencyException

### DIFF
--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -53,7 +53,10 @@ RCT_EXPORT_METHOD(checkForUnsentReports:
 
 RCT_EXPORT_METHOD(crash) {
   if ([RNFBCrashlyticsInitProvider isCrashlyticsCollectionEnabled]) {
-    @[][1];
+    // https://firebase.google.com/docs/crashlytics/test-implementation?platform=ios recommends using "@[][1]" to crash,
+    // but that gets caught by react-native and shown as a red box for debug builds. Throw a different kind exception
+    // here to generate a hard crash.
+    @throw NSInternalInconsistencyException;
   }
 }
 


### PR DESCRIPTION
### Description

https://firebase.google.com/docs/crashlytics/test-implementation?platform=ios recommends using "@[][1]" to crash, but that gets caught by react-native and shown as a red box for debug builds. Throw NSInternalInconsistencyException instead to generate a hard crash.

### Related issues

https://github.com/invertase/react-native-firebase/issues/4026

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Manually tested.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
