### PR TITLE
fix(ios, analytics): remove now-optional analytics dependencies

### DIFF
--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -38,7 +38,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/DynamicLinks', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -38,7 +38,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -38,7 +38,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/Messaging', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -38,7 +38,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Analytics', firebase_sdk_version
   s.dependency          'Firebase/RemoteConfig', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)


### PR DESCRIPTION
### Description
Removed remaining analytics dependencies from IOS podspecs. Analytics cannot be used in the IOS apps in the kids category. FirebaseCore no longer pulls analytics. Analytics can still be added separately and interop correctly with these modules.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues
Fixes #4072 
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
Ran jest and e2e tests successfully.
<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
