### PR TITLE
fix(ios, crashlytics): allow Crashlytics inclusion w/o Analytics

### DIFF
--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -39,7 +39,6 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Core', firebase_sdk_version
   s.dependency          'Firebase/Crashlytics', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)


### PR DESCRIPTION

### Description

`@react-native-firebase/crashlytics` was still bringing in `Firebase/Analytics` pod on iOS which disqualifies apps from being in the kids category on the App Store

This came from the remaining `Firebase/Core` pod dep in `RNFBCrashlytics.podspec`, which is no longer necessary - `Firebase/CoreOnly` is sufficient and that dependency is satisfied transitively by `RNFBApp.podspec`

### Related issues

#4072 - initial issue
#4131 - initial PR that fixed almost all the modules

Interested parties @pabloearg and @dlockwo 

### Release Summary

Title of PR

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I overhauled my demonstrator script so that it could run in a '--no-idfa' mode (excluding admob and analytics) to verify all modules except those two work correctly. Then inspection of the Podfile.lock showed we were free of all the forbidden (by Apple, for kids apps) dependencies

https://github.com/mikehardy/rnfbdemo/commit/4a716e9fff91ebb9fcca5b095c8278d9ada21427

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
