### PR TITLE
fix: undelivered background data message ios

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -119,7 +119,7 @@
       // TODO investigate later - RN bridge gets invalidated at start when in background and a new bridge created - losing all events
       // TODO   so we just delay sending the event for a few seconds as a workaround
       // TODO   most likely Remote Debugging causing bridge to be invalidated
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (8 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received_background" body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
       });
     } else {


### PR DESCRIPTION
### Description

This should be viewed as a temporary fix.
A lot of people are reporting that the background data messages on iOS are not being delivered. The app wakes up, but the background listener doesn’t receive the message. Some apps that have a lot of JS apparently need more than the 2s timeout to be ready. So what happens is - app is started, 2s elapse, RNFBMessaging sends the message to the js handler, but the JS handler is not ready yet and misses the message. We mitigate this by delaying the delivery of the message to the JS side.

This solution however is not optimal becasue we are sending a completionHandler after about 25s which means that our JS code would have only 16 to do something with the data message.

A correct fix would be to figure out how to dispatch the message once the JS side is actually ready.


### Related issues
https://github.com/invertase/react-native-firebase/issues/4104

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
