### PR TITLE
fix(remote-config)!: fetchAndActivate API & activate API update

### DIFF
--- a/docs/remote-config/usage/index.md
+++ b/docs/remote-config/usage/index.md
@@ -82,11 +82,11 @@ remoteConfig()
     awesome_new_feature: 'disabled',
   })
   .then(() => remoteConfig().fetchAndActivate())
-  .then(activated => {
-    if (activated) {
-      console.log('Defaults set, fetched & activated!');
-    } else {
-      console.log('Defaults set, however activation failed.');
+  .then(fetchedRemotely => {
+    if (fetchedRemotely) {
+      console.log('Configs were retrieved from the backend and activated.');
+      } else {
+      console.log('No configs were fetched from the backend, and the local configs were already activated');
     }
   });
 ```

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -139,7 +139,12 @@ RCT_EXPORT_METHOD(fetchAndActivate:
         [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
         }
     } else {
-      resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
+      if(status == FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote) {
+        resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
+        return;
+      }
+      // if no data fetched remotely, return false
+      resolve([self resultWithConstants:@([RCTConvert BOOL:@(NO)]) firebaseApp:firebaseApp]);
     }
   };
 
@@ -155,7 +160,7 @@ RCT_EXPORT_METHOD(activate:
   FIRRemoteConfigActivateCompletion completionHandler = ^(NSError *__nullable error) {
     if(error){
       if(error.userInfo && error.userInfo[@"ActivationFailureReason"] != nil && [error.userInfo[@"ActivationFailureReason"] containsString:@"already activated"]){
-          resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
+          resolve([self resultWithConstants:@([RCTConvert BOOL:@(NO)]) firebaseApp:firebaseApp]);
       } else {
         [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
       }

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -376,7 +376,7 @@ export namespace FirebaseRemoteConfigTypes {
      * if (activated) {
      *  console.log('Fetched values successfully activated.');
      * } else {
-     *   console.log('Fetched values failed to activate.');
+     *   console.log('Fetched values were already activated.');
      * }
      * ```
      */
@@ -416,12 +416,12 @@ export namespace FirebaseRemoteConfigTypes {
      *
      * ```js
      * // Fetch, cache for 5 minutes and activate
-     * const activated = await firebase.remoteConfig().fetchAndActivate();
+     * const fetchedRemotely = await firebase.remoteConfig().fetchAndActivate();
      *
-     * if (activated) {
-     *  console.log('Fetched values successfully activated.');
+     * if (fetchedRemotely) {
+     *   console.log('Configs were retrieved from the backend and activated.');
      * } else {
-     *   console.log('Fetched values failed to activate.');
+     *   console.log('No configs were fetched from the backend, and the local configs were already activated');
      * }
      * ```
      *


### PR DESCRIPTION
### Description

Updated iOS to match Android & Web. Updated types as well as documentation. 

[Web](https://firebase.google.com/docs/reference/js/firebase.remoteconfig.RemoteConfig#fetchandactivate) documentation & [Android](https://firebase.google.com/docs/reference/android/com/google/firebase/remoteconfig/FirebaseRemoteConfig#returns_4) documentation indicate:

- `fetchAndActivate` - should return `false` when local config values are up to date with backend config values.
- `activate` - should return `false` when all local config values are already activated.


### Related issues

fixes #2767

### Release Summary

-  `fetchAndActivate` 
    - Previous behaviour returned a boolean indicating if config values were activated
    - New behaviour returns a boolean indicating if any config values were fetched remotely.

- `activate`
    - Previous behaviour returned a boolean indicating if config values were activated
    - New behaviour returns a boolean indicating if any local config values were activated.


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [X] Yes
  - [ ] No

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
