### PR TITLE
docs(remote-config)!: update docs to be explicit about new behavior

### DIFF
--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -364,7 +364,7 @@ export namespace FirebaseRemoteConfigTypes {
 
     /**
      * Moves fetched data to the apps active config.
-     * Resolves with a boolean value of whether the fetched config was moved successfully.
+     * Resolves with a boolean value true if new local values were activated
      *
      * #### Example
      *
@@ -395,6 +395,7 @@ export namespace FirebaseRemoteConfigTypes {
 
     /**
      * Fetches the remote config data from Firebase, as defined in the dashboard. If duration is defined (seconds), data will be locally cached for this duration.
+     * Returns true only if new values were fetched, false otherwise.
      *
      * #### Example
      *
@@ -410,7 +411,7 @@ export namespace FirebaseRemoteConfigTypes {
     /**
      * Fetches the remote config data from Firebase, as defined in the dashboard.
      *
-     * Once fetching is complete this method immediately calls activate and returns a boolean value of the activation status.
+     * Once fetching is complete this method immediately calls activate and returns a boolean value true if new values were fetched
      *
      * #### Example
      *
@@ -419,9 +420,9 @@ export namespace FirebaseRemoteConfigTypes {
      * const fetchedRemotely = await firebase.remoteConfig().fetchAndActivate();
      *
      * if (fetchedRemotely) {
-     *   console.log('Configs were retrieved from the backend and activated.');
+     *   console.log('New configs were retrieved from the backend and activated.');
      * } else {
-     *   console.log('No configs were fetched from the backend, and the local configs were already activated');
+     *   console.log('No new configs were fetched from the backend, and the local configs were already activated');
      * }
      * ```
      *


### PR DESCRIPTION
A commit just to get a breaking change notice in the commit log for auto-population on semantic release.

Related #4157

```

BREAKING CHANGE:

    fetchAndActivate
        Previous behaviour returned a boolean indicating if config values were activated
        New behaviour returns a boolean indicating if any config values were fetched remotely.

    activate
        Previous behaviour returned a boolean indicating if config values were activated
        New behaviour returns a boolean indicating if any local config values were activated.
```

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
