### PR TITLE
chore(tests, jest): add time to jest test workflow timeout

### DIFF
--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   jest:
     name: Jest
-    timeout-minutes: 5
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
       - name: Yarn Install
         uses: nick-invision/retry@v1
         with:
-          timeout_minutes: 10
+          timeout_minutes: 5
           retry_wait_seconds: 60
           max_attempts: 3
           command: yarn --no-audit --prefer-offline
@@ -59,7 +59,7 @@ jobs:
         # This can fail on timeouts etc, wrap with retry
         uses: nick-invision/retry@v1
         with:
-          timeout_minutes: 10
+          timeout_minutes: 3
           retry_wait_seconds: 60
           max_attempts: 3
           command: ./node_modules/.bin/codecov


### PR DESCRIPTION
### Description

The retry sleep on coverage upload (a proven flake) was longer than the aggregate workflow timeout, which does not make sense of course...

### Related issues


### Release Summary

chore(tests, jest): add time to jest test workflow timeout

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
