### PR TITLE
fix: Add missing null to profile update

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -461,7 +461,7 @@ export namespace FirebaseAuthTypes {
     /**
      * An optional photo URL for the user.
      */
-    photoURL?: string;
+    photoURL?: string | null;
   }
 
   /**

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -455,11 +455,11 @@ export namespace FirebaseAuthTypes {
    */
   export interface UpdateProfile {
     /**
-     * An optional display name for the user.
+     * An optional display name for the user. Explicitly pass null to clear the displayName.
      */
-    displayName?: string;
+    displayName?: string | null;
     /**
-     * An optional photo URL for the user.
+     * An optional photo URL for the user. Explicitly pass null to clear the photoURL.
      */
     photoURL?: string | null;
   }


### PR DESCRIPTION
You need to specify null when you want to remove the current user's photo

### Description

Currently, if you want to remove a profile photoURL, you need to specify NULL, but typescript will complain about it.

### Related issues

N/A

### Release Summary

Fix: add missing type when removing profile photo

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x ] Yes
- My change supports the following platforms;
  - [ x] `Android`
  - [ x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x ] No



### Test Plan

N/A

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
