### PR TITLE
chore(lint): allow enough total time for retries to work

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   linting:
     name: ESLint
-    timeout-minutes: 5
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: styfle/cancel-workflow-action@0.4.1
@@ -37,8 +37,8 @@ jobs:
       - name: Yarn Install
         uses: nick-invision/retry@v1
         with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
+          timeout_minutes: 3
+          retry_wait_seconds: 30
           max_attempts: 3
           command: yarn --no-audit --prefer-offline
       - name: Lint
@@ -62,7 +62,7 @@ jobs:
   typescript:
     name: TypeScript Build Validation
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: styfle/cancel-workflow-action@0.4.1
         with:
@@ -87,8 +87,8 @@ jobs:
       - name: Yarn Install
         uses: nick-invision/retry@v1
         with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
+          timeout_minutes: 3
+          retry_wait_seconds: 30
           max_attempts: 3
           command: yarn --no-audit --prefer-offline
       - name: Lint


### PR DESCRIPTION
### Description

Just noticed another tuning issue (via a workflow failure) where the extra time taken by the new retries was larger than the total time allowed for the workflow, which defeats the purpose. So this tunes up the timing on the linting workflow


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
