### PR TITLE
feat(auth,android): Apple Oauth provider support for Android

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1396,6 +1396,8 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
         return TwitterAuthProvider.getCredential(authToken, authSecret);
       case "github.com":
         return GithubAuthProvider.getCredential(authToken);
+      case "apple.com":
+        return OAuthProvider.newCredentialBuilder(provider).setIdTokenWithRawNonce(authToken, authSecret).build();
       case "oauth":
         return OAuthProvider.getCredential(provider, authToken, authSecret);
       case "phone":


### PR DESCRIPTION
### Description

Add apple.com Oauth Provider support for Android.

Motivation
There are several libraries around that support Apple Sign In for Android. The provider for Apple was not enabled, making it imposible to sign in with Firebase and Apple id_token as it requires a different credential builder. See https://firebase.google.com/docs/auth/android/apple#java_9

### Release Summary

AppleAuthProvider support for Android.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Tested in conjunction with other Apple SIgn In library. I was able to sign in with Firebase using Apple id_token.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire:
