### PR TITLE
docs(app): Fix playServicesAvailability documentation example

### DIFF
--- a/docs/app/utils.md
+++ b/docs/app/utils.md
@@ -58,7 +58,7 @@ async function checkPlayServicesExample() {
     isAvailable,
     hasResolution,
     isUserResolvableError,
-  } = utils.playServicesAvailability;
+  } = utils().playServicesAvailability;
   // all good and valid \o/
   if (isAvailable) return Promise.resolve();
   // if the user can resolve the issue i.e by updating play services


### PR DESCRIPTION
`utils` export from firebase/app is a function, not an object. So `utils.playServicesAvailability` resolve to undefined.

 `utils` source code is [here](https://github.com/invertase/react-native-firebase/blob/master/packages/app/lib/utils/index.js)

### Description

If you follow the [documentation](https://rnfirebase.io/app/utils#android---checking-play-services) and check for Google Play Services availability, the example does not work on latest RNF version because the `utils` is a function, not a plain object where you can retrieve the `playServicesAvailability` key. 


### Related issues

### Release Summary

- Fix  playServicesAvailability documentation example

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


