### PR TITLE
chore: delay ios simulator logging a bit more

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -305,7 +305,7 @@ jobs:
         # With a little delay so the detox test below has time to spawn it, missing the first part of boot is fine
         # If you boot the simulator separately from detox, some other race fails and detox testee never sends ready to proxy
         continue-on-error: true
-        run: nohup sh -c "sleep 10 && xcrun simctl spawn booted log stream --level debug --style compact > simulator.log 2>&1 &"
+        run: nohup sh -c "sleep 30 && xcrun simctl spawn booted log stream --level debug --style compact > simulator.log 2>&1 &"
 
       - name: Detox Test
         timeout-minutes: 30


### PR DESCRIPTION
### Description

It is in a race with the simulator itself booting, and 10
seconds was mostly losing the race. 30 seconds should be fine?

### Related issues

#4058 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
