### PR TITLE
fix: remote config repo url in package.json

### DIFF
--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/master/packages/config"
+    "url": "https://github.com/invertase/react-native-firebase/tree/master/packages/remote-config"
   },
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
### Description

Fixes #4197 - a 404 from npm package url

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- This is a breaking change;
  - [ ] Yes
  - [x] No
