### PR TITLE
chore(remote-config): correct repository url for remote-config

### DIFF
--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/master/packages/config"
+    "url": "https://github.com/invertase/react-native-firebase/tree/master/packages/remote-config"
   },
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
### Description

The existing URL is a remnant from before the config -> remote-config rename

### Related issues

Fixes #4198 - thanks to @jwoodmansey for pointing out the error

### Release Summary

chore(remote-config): correct repository url for remote-config

### Test Plan

Click on the new link, it works

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
