### PR TITLE
feat(inappmessaging): add support for triggering custom events

### DIFF
--- a/packages/in-app-messaging/android/src/main/java/io/invertase/firebase/fiam/UniversalFirebaseFiamModule.java
+++ b/packages/in-app-messaging/android/src/main/java/io/invertase/firebase/fiam/UniversalFirebaseFiamModule.java
@@ -46,6 +46,13 @@ public class UniversalFirebaseFiamModule extends UniversalFirebaseModule {
     });
   }
 
+  Task<Void> triggerEvent(String eventId) {
+    return Tasks.call(() -> {
+      FirebaseInAppMessaging.getInstance().triggerEvent(eventId);
+      return null;
+    });
+  }
+
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();

--- a/packages/in-app-messaging/android/src/reactnative/java/io/invertase/firebase/fiam/ReactNativeFirebaseFiamModule.java
+++ b/packages/in-app-messaging/android/src/reactnative/java/io/invertase/firebase/fiam/ReactNativeFirebaseFiamModule.java
@@ -55,6 +55,17 @@ public class ReactNativeFirebaseFiamModule extends ReactNativeFirebaseModule {
     });
   }
 
+  @ReactMethod
+  public void triggerEvent(String eventId, Promise promise) {
+    module.triggerEvent(eventId).addOnCompleteListener(task -> {
+      if (task.isSuccessful()) {
+        promise.resolve(task.getResult());
+      } else {
+        rejectPromiseWithExceptionMap(promise, task.getException());
+      }
+    });
+  }
+
   @Override
   public Map<String, Object> getConstants() {
     return module.getConstants();

--- a/packages/in-app-messaging/e2e/fiam.e2e.js
+++ b/packages/in-app-messaging/e2e/fiam.e2e.js
@@ -84,4 +84,11 @@ describe('inAppMessaging()', () => {
       }
     });
   });
+
+  xdescribe('triggerEvent()', () => {
+    it('no exceptions thrown', async () => {
+      await device.launchApp();
+      await firebase.inAppMessaging().triggerEvent('eventName');
+    });
+  });
 });

--- a/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
+++ b/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
@@ -62,5 +62,16 @@
     [FIRInAppMessaging inAppMessaging].messageDisplaySuppressed = (BOOL) enabled;
     resolve([NSNull null]);
   }
+  
+  RCT_EXPORT_METHOD(triggerEvent:
+    (NSString) eventId
+        resolver:
+        (RCTPromiseResolveBlock) resolve
+        rejecter:
+        (RCTPromiseRejectBlock) reject) {
+    [[FIRInAppMessaging inAppMessaging] triggerEvent: eventId];
+    resolve([NSNull null]);
+  }
+
 
 @end

--- a/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
+++ b/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
@@ -62,9 +62,9 @@
     [FIRInAppMessaging inAppMessaging].messageDisplaySuppressed = (BOOL) enabled;
     resolve([NSNull null]);
   }
-  
+
   RCT_EXPORT_METHOD(triggerEvent:
-    (NSString) eventId
+    (NSString*) eventId
         resolver:
         (RCTPromiseResolveBlock) resolve
         rejecter:

--- a/packages/in-app-messaging/lib/index.d.ts
+++ b/packages/in-app-messaging/lib/index.d.ts
@@ -130,6 +130,20 @@ export namespace FirebaseInAppMessagingTypes {
      * @param enabled Whether automatic data collection is enabled.
      */
     setAutomaticDataCollectionEnabled(enabled: boolean): Promise<null>;
+
+    /**
+     * Trigger in-app messages programmatically
+     *
+     * #### Example
+     *
+     * ```js
+     * // Suppress messages
+     * await firebase.inAppMessaging().triggerEvent("exampleTrigger");
+     * ```
+     *
+     * @param eventId The id of the event.
+     */
+    triggerEvent(eventId: string): Promise<null>;
   }
 }
 

--- a/packages/in-app-messaging/lib/index.js
+++ b/packages/in-app-messaging/lib/index.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { isBoolean } from '@react-native-firebase/app/lib/common';
+import { isBoolean, isString } from '@react-native-firebase/app/lib/common';
 import {
   createModuleNamespace,
   FirebaseModule,
@@ -64,6 +64,13 @@ class FirebaseFiamModule extends FirebaseModule {
 
     this._isAutomaticDataCollectionEnabled = enabled;
     return this.native.setAutomaticDataCollectionEnabled(enabled);
+  }
+
+  triggerEvent(eventId) {
+    if (!isString(eventId)) {
+      throw new Error("firebase.inAppMessaging().triggerEvent(*) 'eventId' must be a string.");
+    }
+    return this.native.triggerEvent(eventId);
   }
 }
 


### PR DESCRIPTION
### Description

I want to use the  programmatic event triggering feature in Firebase In App Messaging described here

https://firebase.google.com/docs/in-app-messaging/modify-message-behavior?platform=android#trigger_in-app_messages_programmatically

### Related issues

No issues.

### Release Summary

Support for In App Messaging's programmatic event triggering

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`

It's not obvious how we can test whether the event was triggered.

  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`

There are no existing jest tests in the inappmessaging module

- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan


I'm not sure how to test this ...
