### PR TITLE
docs(messaging): document how to use custom notification colour on Android

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -278,7 +278,7 @@ AppRegistry.registerComponent('app', () => HeadlessCheck);
 ```
 
 To inject a `isHeadless` prop into your app, please update your `AppDelegate.m` file as instructed below:
- 
+
 ```objectivec
 // add this import statement at the top of your `AppDelegate.m` file
 #import "RNFBMessagingModule.h"
@@ -425,7 +425,7 @@ On Android, any messages which display a [Notification](/messaging/notifications
 (such as the small icon, title etc). To provide a custom tint color, update the `messaging_android_notification_color` property
 with a Android color resource name.
 
-The library provides a set of default [HTML colors](https://www.w3schools.com/colors/colors_names.asp) (in lowercase) for ease, for example:
+The library provides a set of [predefined colors](https://github.com/invertase/react-native-firebase/blob/master/packages/messaging/android/src/main/res/values/colors.xml) corresponding to the [HTML colors](https://www.w3schools.com/colors/colors_names.asp) for convenience, for example:
 
 ```json
 // <projectRoot>/firebase.json
@@ -434,4 +434,25 @@ The library provides a set of default [HTML colors](https://www.w3schools.com/co
     "messaging_android_notification_color": "@color/hotpink"
   }
 }
+```
+
+Note that only predefined colors can be used in `firebase.json`. If you want to use a custom color defined in your application resources, then you should set it in the `AndroidManifest.xml` instead.
+
+```xml
+<!-- <projectRoot>/android/app/src/main/res/values/colors.xml -->
+<resources>
+  <color name="my-custom-color">#123456</color>
+</resources>
+
+<!-- <projectRoot>/android/app/src/main/AndroidManifest.xml -->
+<manifest>
+  <application>
+      <!-- ... -->
+
+      <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/my-custom-color"
+            tools:replace="android:resource" />
+  </application>
+</manifest>
 ```


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Explain that only predefined colours can be used for `messaging_android_notification_color` property in `firebase.json` and add example of how to use a custom colour defined in the application

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
https://github.com/invertase/react-native-firebase/issues/3559#issuecomment-686754748

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
