### PR TITLE
chore(e2e, perf): use 2 cores and disable JNI in android E2E emu

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -29,7 +29,6 @@ jobs:
     timeout-minutes: 60
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      EMULATOR_COMMAND: "-avd TestingAVD -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -nojni -memory 2048 -timezone 'Europe/London' -cores 2"
       EMULATOR_EXECUTABLE: qemu-system-x86_64-headless
     steps:
       - uses: styfle/cancel-workflow-action@0.4.1
@@ -119,7 +118,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "Starting emulator"
-          nohup $ANDROID_HOME/emulator/emulator $EMULATOR_COMMAND &
+          nohup $ANDROID_HOME/emulator/emulator -avd TestingAVD -nojni -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -timezone 'Europe/London' -qemu -smp 2 -m 2G &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
 
       - name: Start Android Emulator Retry 1
@@ -132,7 +131,7 @@ jobs:
           $ANDROID_HOME/platform-tools/adb devices
           sudo killall -9 $EMULATOR_EXECUTABLE || true
           sleep 2
-          nohup $ANDROID_HOME/emulator/emulator $EMULATOR_COMMAND &
+          nohup $ANDROID_HOME/emulator/emulator -avd TestingAVD -nojni -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -timezone 'Europe/London' -qemu -smp 2 -m 2G &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
 
       - name: Start Android Emulator Retry 2
@@ -145,7 +144,7 @@ jobs:
           $ANDROID_HOME/platform-tools/adb devices
           sudo killall -9 $EMULATOR_EXECUTABLE || true
           sleep 2
-          nohup $ANDROID_HOME/emulator/emulator $EMULATOR_COMMAND &
+          nohup $ANDROID_HOME/emulator/emulator -avd TestingAVD -nojni -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -timezone 'Europe/London' -qemu -smp 2 -m 2G &
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done'
 
       - name: Emulator Status
@@ -167,6 +166,7 @@ jobs:
           $ANDROID_HOME/platform-tools/adb shell settings put global animator_duration_scale 0.0
           nohup sh -c "until false; do $ANDROID_HOME/platform-tools/adb shell input tap 100 800; sleep 0.2; done" &
           nohup sh -c "$ANDROID_HOME/platform-tools/adb logcat '*:D' > adb-log.txt" &
+          $ANDROID_HOME/platform-tools/adb shell setprop debug.checkjni 0
           yarn tests:android:test-cover --cleanup
         shell: bash
 


### PR DESCRIPTION
### Description

Still trying to make E2E less flaky, one of the largest sources right now is simply that the Android emulator is overwhelmed, leading to timeouts and test app kills.

In local testing I have been able to disable JNI checking and give it more CPU, hoping for a good result with the same in CI though I tried before and the settings did not seem to take.

### Related issues

#4058 


### Test Plan

The android emulator log will show whether it is working or not

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
