### PR TITLE
docs(remote-config): fetch returns Promise<void>, not boolean

### DIFF
--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -395,7 +395,6 @@ export namespace FirebaseRemoteConfigTypes {
 
     /**
      * Fetches the remote config data from Firebase, as defined in the dashboard. If duration is defined (seconds), data will be locally cached for this duration.
-     * Returns true only if new values were fetched, false otherwise.
      *
      * #### Example
      *

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -409,8 +409,7 @@ export namespace FirebaseRemoteConfigTypes {
 
     /**
      * Fetches the remote config data from Firebase, as defined in the dashboard.
-     *
-     * Once fetching is complete this method immediately calls activate and returns a boolean value true if new values were fetched
+     * Once fetching is complete this method immediately calls activate and returns a boolean value true if new values were activated
      *
      * #### Example
      *


### PR DESCRIPTION
Clarify docs for config().fetch()

This is related to the recent API harmonization - `activate`/`fetchAndActivate` return booleans if-and-only-if they actually activated new values (not if a fetch failed or if nothing changed), and nothing else returns boolean
