### PR TITLE
fix(crashlytics,ios): Explicitly set crash collection setting to opt in or out for iOS

### DIFF
--- a/packages/app/ios_config.sh
+++ b/packages/app/ios_config.sh
@@ -94,7 +94,7 @@ if [[ ${_SEARCH_RESULT} ]]; then
     _PLIST_ENTRY_VALUES+=("$(jsonBoolToYesNo "$_MESSAGING_AUTO_INIT")")
   fi
 
-  # config.crashlytics_disable_auto_disabler - undocumented for now - mainly for debugging, document if becomes usful
+  # config.crashlytics_disable_auto_disabler - undocumented for now - mainly for debugging, document if becomes useful
   _CRASHLYTICS_AUTO_DISABLE_ENABLED=$(getFirebaseJsonKeyValue "$_JSON_OUTPUT_RAW" "crashlytics_disable_auto_disabler")
   if [[ $_CRASHLYTICS_AUTO_DISABLE_ENABLED == "true" ]]; then
     echo "Disabled Crashlytics auto disabler." # do nothing
@@ -137,7 +137,7 @@ for plist in "${_TARGET_PLIST}" "${_DSYM_PLIST}" ; do
   if [[ -f "${plist}" ]]; then
 
     # paths with spaces break the call to setPlistValue. temporarily modify
-    # the shell internal field separator variable (IFS), which normally 
+    # the shell internal field separator variable (IFS), which normally
     # includes spaces, to consist only of line breaks
     oldifs=$IFS
     IFS="
@@ -155,4 +155,3 @@ for plist in "${_TARGET_PLIST}" "${_DSYM_PLIST}" ; do
 done
 
 echo "info: <- RNFB build script finished"
-

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
@@ -21,6 +21,7 @@
 #import "RNFBPreferences.h"
 #import "RNFBJSON.h"
 #import "RNFBMeta.h"
+#import "RNFBApp/RNFBSharedUtils.h"
 
 NSString *const KEY_CRASHLYTICS_DEBUG_ENABLED = @"crashlytics_debug_enabled";
 NSString *const KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED = @"crashlytics_auto_collection_enabled";
@@ -28,9 +29,7 @@ NSString *const KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED = @"crashlytics_auto_col
 @implementation RNFBCrashlyticsInitProvider
 
 + (void)load {
-  if ([self isCrashlyticsCollectionEnabled]) {
-    [FIRApp registerInternalLibrary:self withName:@"react-native-firebase-crashlytics" withVersion:@"6.0.0"];
-  }
+  [FIRApp registerInternalLibrary:self withName:@"react-native-firebase-crashlytics" withVersion:@"6.0.0"];
 }
 
 + (BOOL)isCrashlyticsCollectionEnabled {
@@ -38,11 +37,17 @@ NSString *const KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED = @"crashlytics_auto_col
 
   if ([[RNFBPreferences shared] contains:KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED]) {
     enabled = [[RNFBPreferences shared] getBooleanValue:KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED defaultValue:YES];
+    DLog(@"isCrashlyticsCollectionEnabled via RNFBPreferences: %d", enabled);
   } else if ([[RNFBJSON shared] contains:KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED]) {
     enabled = [[RNFBJSON shared] getBooleanValue:KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED defaultValue:YES];
+    DLog(@"isCrashlyticsCollectionEnabled via RNFBJSON: %d", enabled);
   } else {
+    // Note that if we're here, and the key is not set on the app's bundle, we default to "YES"
     enabled = [RNFBMeta getBooleanValue:KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED defaultValue:YES];
+    DLog(@"isCrashlyticsCollectionEnabled via RNFBMeta: %d", enabled);
   }
+
+  DLog(@"isCrashlyticsCollectionEnabled: %d", enabled);
 
   return enabled;
 }
@@ -51,7 +56,19 @@ NSString *const KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED = @"crashlytics_auto_col
   return @[];
 }
 
+/*
+ * configureWithApp is automatically invoked by Firebase as this app is a registered FIRLibrary with the SDK.
+ *
+ * At this point "configure" has already been called on the FIRApp instance. This behavior is meant to mirror
+ * what is done in ReactNativeFirebaseCrashlyticsInitProvider.java
+ *
+ * This pattern may not be supported long term https://github.com/firebase/firebase-ios-sdk/issues/2933
+ */
 + (void)configureWithApp:(FIRApp *)app {
+  // This setting is sticky. setCrashlyticsCollectionEnabled persists the setting to disk until it is explicitly set otherwise or the app is deleted.
+  // Jump to the setCrashlyticsCollectionEnabled definition to see implementation details.
+  [[FIRCrashlytics crashlytics] setCrashlyticsCollectionEnabled:self.isCrashlyticsCollectionEnabled];
+  DLog(@"initialization successful");
 }
 
 @end

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -21,6 +21,7 @@
 #import "RNFBCrashlyticsInitProvider.h"
 #import "RCTConvert.h"
 #import "RNFBPreferences.h"
+#import "RNFBApp/RNFBSharedUtils.h"
 #import <Firebase/Firebase.h>
 
 @implementation RNFBCrashlyticsModule
@@ -180,7 +181,7 @@ RCT_EXPORT_METHOD(setCrashlyticsCollectionEnabled:
 
   FIRExceptionModel *exceptionModel = [FIRExceptionModel exceptionModelWithName:name reason:message];
   exceptionModel.stackTrace = stackTrace;
-  
+
   [[FIRCrashlytics crashlytics] recordExceptionModel:exceptionModel];
 }
 

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -21,7 +21,6 @@
 #import "RNFBCrashlyticsInitProvider.h"
 #import "RCTConvert.h"
 #import "RNFBPreferences.h"
-#import "RNFBApp/RNFBSharedUtils.h"
 #import <Firebase/Firebase.h>
 
 @implementation RNFBCrashlyticsModule
@@ -181,7 +180,7 @@ RCT_EXPORT_METHOD(setCrashlyticsCollectionEnabled:
 
   FIRExceptionModel *exceptionModel = [FIRExceptionModel exceptionModelWithName:name reason:message];
   exceptionModel.stackTrace = stackTrace;
-
+  
   [[FIRCrashlytics crashlytics] recordExceptionModel:exceptionModel];
 }
 


### PR DESCRIPTION
### Description

PR spawned from discussion here https://github.com/invertase/react-native-firebase/discussions/4227

By my reckoning, I think there may be some behavior that is _maaaaybe_ not working as expected, and I also think there is some behavior that is _definitely_ not working as I'd expect it.

_Sorry if this is verbose, but some of this is very new for me so I wanted to be explicit. Also, apologies if I'm way off base on any of this_

#### 1. `FirebaseCrashlyticsCollectionEnabled` gets turned off by default by react-native-firebase

> By default, Crashlytics automatically collects crash reports for all your app's users. [[1]](https://firebase.google.com/docs/crashlytics/customize-crash-reports?platform=ios)

App developers using Crashlytics can go out of their way to set `FirebaseCrashlyticsCollectionEnabled` to `false` to turn off automatic crash collection in their apps. Why would a dev do that? Maybe they want to give users control over their data. They can make an "Opt-in" view in the app that allows users to opt-in to uploading crash reports.

react-native-firebase does the opposite. It disables collecting crash reports by default.

Note here, the default for react-native-firebase is to always set `FirebaseCrashlyticsCollectionEnabled` to No/false unless `_CRASHLYTICS_AUTO_DISABLE_ENABLED` is set to true, and `_CRASHLYTICS_AUTO_DISABLE_ENABLED` is derived from `crashlytics_disable_auto_disabler`. [[2]](https://github.com/invertase/react-native-firebase/blob/master/packages/app/ios_config.sh#L99)

```
  if [[ $_CRASHLYTICS_AUTO_DISABLE_ENABLED == "true" ]]; then
    echo "Disabled Crashlytics auto disabler." # do nothing
  else
    _PLIST_ENTRY_KEYS+=("FirebaseCrashlyticsCollectionEnabled")
    _PLIST_ENTRY_TYPES+=("bool")
    _PLIST_ENTRY_VALUES+=("NO")
  fi
```

If react-native-firebase devs don't set `crashlytics_disable_auto_disabler` to `true` in `firebase.json`, then the `FirebaseCrashlyticsCollectionEnabled` automatically gets set to false!

Unexpected, but also, **not actually a problem** because it's still entirely possible for the app to send crash reports. It's just not automatic by default.

#### 2. On iOS react-native-firebase apps never actually set the collection setting on the Crashlytics instance

I think this is actually a bug/missing bit of behavior.

react-native-firebase turns off automatic crash collection by default (see above), which is fine actually. it's fine because react-native-firebase can still explicitly enable collecting crash reports by calling `setCrashlyticsCollectionEnabled:true`. Calling that essentially overrides whatever was done with `FirebaseCrashlyticsCollectionEnabled`.

We call `setCrashlyticsCollectionEnabled` on the Java side, but not on the iOS side.

On both the iOS and Java side, we have `isCrashlyticsCollectionEnabled()`. We use that method to infer if the app wants to enable or disable crashlytics using one of several mechanisms (including the `crashlytics_auto_collection_enabled` key in `firebase.json`). Most importantly, we use the result of that to actually set the setting on our crashlytics instance in Java.

https://github.com/invertase/react-native-firebase/blob/55cd752f6c1c1ab063e1cb9235d3657c5b2ae27f/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsInitProvider.java#L54

iOS has a mirror version of the `isCrashlyticsCollectionEnabled()` method. **However**, on the iOS side we never actually use the result of that method to set the setting on our Crashlytics instance.

https://github.com/invertase/react-native-firebase/blob/55cd752f6c1c1ab063e1cb9235d3657c5b2ae27f/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m#L54

I verified that, by default, `isCrashlyticsCollectionEnabled` will return `true` if the developer does nothing. But because iOS never sets the setting, we don't opt-in to collecting crashes!

I feel like this is a bug, and we should use the change in this PR to do the same thing on iOS as in Java.

### Related issues

Fixes discussion #4227 

### Release Summary

Update crash collection behavior on iOS

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No

### Test Plan

For the **first issue** I mentioned, build an app with react-native-firebase. Check out the builds logs in the report navigator in Xcode (filter on `[RNFB] Core Configuration` and expand all transcripts). Notice that the default behavior (with an empty `{}` firebase.json`) is to disable automatic collection of crashes.

```
info: -> RNFB build script started
info: 1) Locating firebase.json file:
info:      (1 of 2) Searching in '/Users/will/dev/THEAPP' for a firebase.json file.
info:      firebase.json found at /Users/will/dev/THEAPP/ios/firebase.json
info: 2) Injecting Info.plist entries: 
    ->  0) firebase_json_raw string e30=
    ->  1) FirebaseCrashlyticsCollectionEnabled bool NO
info:      setting plist entry 'firebase_json_raw' of type 'string' in file '/Users/will/Library/Developer/Xcode/DerivedData/THEAPP-domvlkryyhzgidhjsghaoaweccvo/Build/Products/Debug-iphoneos/THEAPP.app/Info.plist'
info:      setting plist entry 'FirebaseCrashlyticsCollectionEnabled' of type 'bool' in file '/Users/will/Library/Developer/Xcode/DerivedData/THEAPP-domvlkryyhzgidhjsghaoaweccvo/Build/Products/Debug-iphoneos/THEAPP.app/Info.plist'
info:      setting plist entry 'firebase_json_raw' of type 'string' in file '/Users/will/Library/Developer/Xcode/DerivedData/THEAPP-domvlkryyhzgidhjsghaoaweccvo/Build/Products/Debug-iphoneos/THEAPP.app.dSYM/Contents/Info.plist'
info:      setting plist entry 'FirebaseCrashlyticsCollectionEnabled' of type 'bool' in file '/Users/will/Library/Developer/Xcode/DerivedData/THEAPP-domvlkryyhzgidhjsghaoaweccvo/Build/Products/Debug-iphoneos/THEAPP.app.dSYM/Contents/Info.plist'
info: <- RNFB build script finished
```

For the **second issue**, enable `-FIRDebugEnabled` for the build to see Crashlytics logs.

Add something like this to your AppDelegate.m. Before my changes, you should see that setting `crashlytics_auto_collection_enabled` to `true` or `false` in `firebase.json` doesn't actually change the result here. With my changes, you should see that the firebase.json `crashlytics_auto_collection_enabled` setting actually impacts whether or not Crashlytics collects crash reports.

```
  [FIRApp configure];

  NSLog(@"Is collection enabled? %d", [FIRCrashlytics crashlytics].isCrashlyticsCollectionEnabled);
```

On my side, I couldn't get the crashlytics JS libraries to resolve properly from my in-development `../react-native-firebase` package (I don't contribute to packages often), so I just threw errors in some Swift bridged code I had. I built on the simulator, killed the app to detach the debugger, then launched it and ran code that triggered a bunch of `fatalError()` in the native code. `crashlytics_auto_collection_enabled` was `false`, then after several crashes I switched it to `true`, re-launched, and saw my exceptions show up in Crashlytics. 

Something that kinda sucks is the log looks a little confusing. The AppDelegate check is accurate, but since `configure` was already called beforehand, it has an earlier log message saying, `Automatic data collection is disabled.`, which is technically accurate, but then immediately negated. Subsequent launch debug logs would look more consistent.

```
2020-09-09 21:06:54.477375-0500 THEAPP[33868:5230341] 6.30.0 - [Firebase/Crashlytics][I-CLS000000] Automatic data collection is disabled.
2020-09-09 21:06:54.481802-0500 THEAPP[33868:5230341] 6.30.0 - [GULReachability][I-REA902003] Monitoring the network status
2020-09-09 21:06:54.481848-0500 THEAPP[33868:5230206] Is collection enabled? 1
2020-09-09 21:06:54.482806-0500 THEAPP[33868:5230341] 6.30.0 - [Firebase/Crashlytics][I-CLS000000] [Crashlytics:Crash] 8 unsent reports are available. Checking for upload permission.
2020-09-09 21:06:54.482924-0500 THEAPP[33868:5230341] 6.30.0 - [Firebase/Crashlytics][I-CLS000000] [Crashlytics:Crash] Notifying that unsent reports are available.
2020-09-09 21:06:54.483255-0500 THEAPP[33868:5230341] 6.30.0 - [Firebase/Crashlytics][I-CLS000000] [Crashlytics:Crash] Waiting for send/deleteUnsentReports to be called.
```

Without my changes, I could only change enable crash collection with `[[FIRCrashlytics crashlytics] setCrashlyticsCollectionEnabled:false];` (or `true`) in native code. Changing `firebase.json` and re-building didn't work.

```
{
  "react-native": {
    "crashlytics_auto_collection_enabled": true
  }
}
```

Searching for `unsent` in the logs allowed me to see that reports were collecting on device and that I could then try changing the collection status to test changes.

```
5 unsent reports are available. Checking for upload permission.
```

**Important testing note!** Please keep in mind that `setCrashlyticsCollectionEnabled:` writes changes to disk. it is not ephermeral. If that method is called, the setting used will stick until either the app is deleted or the setting is explicitly changed.

🔥 