### PR TITLE
docs(analytics): correct NavigationController to `NavigationContainer`

### DIFF
--- a/docs/analytics/screen-tracking.md
+++ b/docs/analytics/screen-tracking.md
@@ -12,7 +12,7 @@ therefore there is no "one fits all" solution to screen tracking.
 # React Navigation
 
 The [React Navigation](https://reactnavigation.org/) library allows for various navigation techniques such as
-Stack, Tab, Native or even custom navigation. The `NavigationController` component which the library exposes provides
+Stack, Tab, Native or even custom navigation. The `NavigationContainer` component which the library exposes provides
 access to the current navigation state when a screen changes, allowing you to use the [`logScreenView`](/reference/analytics#logScreenView)
 method the Analytics library provides:
 


### PR DESCRIPTION

### Description
The reference to `NavigationController` should be `NavigationContainer`
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Checklist

- I read the [Contributor Guide](../blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


