### PR TITLE
docs(app): note about multiple platforms for secondary app

### DIFF
--- a/docs/app/usage.md
+++ b/docs/app/usage.md
@@ -57,6 +57,47 @@ const config = {
 await firebase.initializeApp(credentials, config);
 ```
 
+Note that if you use multiple platforms, you will need to use the credentials relevant to that platform:
+
+```js
+import firebase from "@react-native-firebase/app";
+import { Platform } from "react-native";
+
+// Your secondary Firebase project credentials for Android...
+const androidCredentials = {
+  clientId: "",
+  appId: "",
+  apiKey: "",
+  databaseURL: "",
+  storageBucket: "",
+  messagingSenderId: "",
+  projectId: "",
+};
+
+// Your secondary Firebase project credentials for iOS...
+const iosCredentials = {
+  clientId: "",
+  appId: "",
+  apiKey: "",
+  databaseURL: "",
+  storageBucket: "",
+  messagingSenderId: "",
+  projectId: "",
+};
+
+// Select the relevant credentials
+const credentials = Platform.select({
+  android: androidCredentials,
+  ios: iosCredentials,
+});
+
+const config = {
+  name: "SECONDARY_APP",
+};
+
+await firebase.initializeApp(credentials, config);
+```
+
 Once created, you can confirm the app instance has been created by accessing the `apps` property on the module:
 
 ```js


### PR DESCRIPTION
### Description

Added a section + example under __Secondary Apps__ to highlight the need to use the credentials relevant to the platform.

### Related issues

Fixes #4272 

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

🔥