### PR TITLE
fix(ios, podspec): depend on React-Core instead of React

### DIFF
--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   # Other dependencies

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.source_files        = "ios/**/*.{h,m}"
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/iid/RNFBIid.podspec
+++ b/packages/iid/RNFBIid.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
+++ b/packages/ml-natural-language/RNFBMLNaturalLanguage.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/ml-vision/RNFBMLVision.podspec
+++ b/packages/ml-vision/RNFBMLVision.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
   if defined?($FirebaseSDKVersion)

--- a/scripts/_TEMPLATE_/RNFB_Template_.podspec
+++ b/scripts/_TEMPLATE_/RNFB_Template_.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'ios/**/*.{h,m}'
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'Firebase/Core', '~> 5.20.2'
   s.dependency          'RNFBApp'
   s.static_framework    = true

--- a/scripts/_TEMPLATE_/ios/RNFB_Template_.podspec
+++ b/scripts/_TEMPLATE_/ios/RNFB_Template_.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "9.0"
   s.source_files        = 'RNFB_Template_/**/*.{h,m}'
-  s.dependency          'React'
+  s.dependency          'React-Core'
   s.dependency          'Firebase/Core', '~> 5.20.2'
   s.dependency          'RNFBApp'
   s.static_framework    = true


### PR DESCRIPTION
### Description

On Xcode 12 some wild build errors occur when trying to build a React Native app. This is because the `'React'` pod is only an umbrella pod. See: https://github.com/facebook/react-native/issues/29633

### Related issues

See: https://github.com/facebook/react-native/issues/29633

### Release Summary

* Uses 'React-Core' instead of 'React' pod in podspecs

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes for React < 0.60 (because of autolinking)
  - [ ] No


