### PR TITLE
feat(ios, messaging): add getIsHeadless method to access iOS launch state

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -295,6 +295,15 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                              initialProperties:appProperties];
 ```
 
+- For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `getIsHeadless` method (iOS only) from messaging like so:
+
+```jsx
+messaging().getIsHeadless().then(isHeadless => {
+  // do sth with isHeadless
+});
+
+```
+
 
 On Android, the `isHeadless` prop will not exist.
 

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -295,13 +295,12 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                              initialProperties:appProperties];
 ```
 
-- For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `getIsHeadless` method (iOS only) from messaging like so:
+- For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `launchedHeadless` constant (iOS only) from messaging like so:
 
 ```jsx
-messaging().getIsHeadless().then(isHeadless => {
-  // do sth with isHeadless
-});
-
+if(messaging().launchedHeadless) {
+    // do sth with isHeadless
+}
 ```
 
 

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -295,12 +295,13 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                              initialProperties:appProperties];
 ```
 
-- For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `launchedHeadless` constant (iOS only) from messaging like so:
+- For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `getIsHeadless` method (iOS only) from messaging like so:
 
 ```jsx
-if(messaging().launchedHeadless) {
-    // perhaps have your Root View render empty if launchedHeadless is true and AppState.active is false
-}
+messaging().getIsHeadless().then(isHeadless => {
+  // do sth with isHeadless
+});
+
 ```
 
 

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -299,7 +299,7 @@ RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
 
 ```jsx
 if(messaging().launchedHeadless) {
-    // do sth with isHeadless
+    // perhaps have your Root View render empty if launchedHeadless is true and AppState.active is false
 }
 ```
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNFBMessagingNSNotificationCenter : NSObject
 
 + (_Nonnull instancetype)sharedInstance;
-@property (nonatomic, strong) bool isHeadless;
+@property (nonatomic) BOOL isHeadless;
 
 @end
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNFBMessagingNSNotificationCenter : NSObject
 
 + (_Nonnull instancetype)sharedInstance;
+@property (nonatomic, strong) bool isHeadless;
 
 @end
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
@@ -26,7 +26,7 @@
 #import "RNFBMessaging+FIRMessagingDelegate.h"
 
 @implementation RNFBMessagingNSNotificationCenter
-
+@synthesize isHeadless;
 + (instancetype)sharedInstance {
   static dispatch_once_t once;
   __strong static RNFBMessagingNSNotificationCenter *sharedInstance;
@@ -135,9 +135,10 @@
   if (notification.userInfo[UIApplicationLaunchOptionsRemoteNotificationKey]) {
     if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
       if (rctRootView != nil) {
+        isHeadless = YES;
         NSMutableDictionary *appPropertiesDict = rctRootView.appProperties != nil ? [rctRootView.appProperties mutableCopy] : [NSMutableDictionary dictionary];
         if([appPropertiesDict objectForKey:@"isHeadless"] != nil && [appPropertiesDict[@"isHeadless"] isEqual:@([RCTConvert BOOL:@(NO)])]) {
-          appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(YES)]);
+          appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(isHeadless)]);
           rctRootView.appProperties = appPropertiesDict;
         }
       }
@@ -153,9 +154,10 @@
       #endif
     } else {
       if (rctRootView != nil) {
+        isHeadless = NO;
         NSMutableDictionary *appPropertiesDict = rctRootView.appProperties != nil ? [rctRootView.appProperties mutableCopy] : [NSMutableDictionary dictionary];
         if([appPropertiesDict objectForKey:@"isHeadless"] != nil && [appPropertiesDict[@"isHeadless"] isEqual:@([RCTConvert BOOL:@(YES)])]) {
-          appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(NO)]);
+          appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(isHeadless)]);
           rctRootView.appProperties = appPropertiesDict;
         }
         
@@ -163,9 +165,10 @@
     }
   } else {
     if (rctRootView != nil) {
+      isHeadless = NO;
       NSMutableDictionary *appPropertiesDict = rctRootView.appProperties != nil ? [rctRootView.appProperties mutableCopy] : [NSMutableDictionary dictionary];
       if([appPropertiesDict objectForKey:@"isHeadless"] != nil && [appPropertiesDict[@"isHeadless"] isEqual:@([RCTConvert BOOL:@(YES)])]) {
-        appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(NO)]);
+        appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(isHeadless)]);
         rctRootView.appProperties = appPropertiesDict;
       }
       
@@ -182,10 +185,12 @@
     [[UIApplication sharedApplication].delegate.window.rootViewController.view isKindOfClass:[RCTRootView class]]
   ) {
     RCTRootView *rctRootView = (RCTRootView *) [UIApplication sharedApplication].delegate.window.rootViewController.view;
+
     if (rctRootView.appProperties != nil && rctRootView.appProperties[@"isHeadless"] == @(YES)) {
       NSMutableDictionary *appPropertiesDict = [rctRootView.appProperties mutableCopy];
+      isHeadless = NO;
       if([appPropertiesDict objectForKey:@"isHeadless"] != nil && [appPropertiesDict[@"isHeadless"] isEqual:@([RCTConvert BOOL:@(YES)])]) {
-        appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(NO)]);
+        appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(isHeadless)]);
         rctRootView.appProperties = appPropertiesDict;
       }
     }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -24,6 +24,7 @@
 #import "RNFBMessagingSerializer.h"
 #import "RNFBMessaging+AppDelegate.h"
 #import "RNFBMessaging+UNUserNotificationCenter.h"
+#import "RNFBMessaging+NSNotificationCenter.h"
 
 @implementation RNFBMessagingModule
 #pragma mark -
@@ -162,6 +163,15 @@ RCT_EXPORT_METHOD(getAPNSToken:
     #endif
     resolve([NSNull null]);
   }
+}
+
+RCT_EXPORT_METHOD(getIsHeadless
+    :(RCTPromiseResolveBlock) resolve
+    :(RCTPromiseRejectBlock) reject
+) {
+    RNFBMessagingNSNotificationCenter* notifCenter = [RNFBMessagingNSNotificationCenter sharedInstance];
+
+    return resolve(@([RCTConvert BOOL:@(notifCenter.isHeadless)]));
 }
 
 RCT_EXPORT_METHOD(requestPermission:

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -62,8 +62,6 @@ RCT_EXPORT_MODULE();
   NSMutableDictionary *constants = [NSMutableDictionary new];
   constants[@"isAutoInitEnabled"] = @([RCTConvert BOOL:@([FIRMessaging messaging].autoInitEnabled)]);
   constants[@"isRegisteredForRemoteNotifications"] = @([RCTConvert BOOL:@([[UIApplication sharedApplication] isRegisteredForRemoteNotifications])]);
-  RNFBMessagingNSNotificationCenter* notifCenter = [RNFBMessagingNSNotificationCenter sharedInstance];
-  constants[@"launchedHeadless"] = @([RCTConvert BOOL:@(notifCenter.isHeadless)]);
   return constants;
 }
 
@@ -165,6 +163,15 @@ RCT_EXPORT_METHOD(getAPNSToken:
     #endif
     resolve([NSNull null]);
   }
+}
+
+RCT_EXPORT_METHOD(getIsHeadless
+    :(RCTPromiseResolveBlock) resolve
+    :(RCTPromiseRejectBlock) reject
+) {
+    RNFBMessagingNSNotificationCenter* notifCenter = [RNFBMessagingNSNotificationCenter sharedInstance];
+
+    return resolve(@([RCTConvert BOOL:@(notifCenter.isHeadless)]));
 }
 
 RCT_EXPORT_METHOD(requestPermission:

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -62,6 +62,8 @@ RCT_EXPORT_MODULE();
   NSMutableDictionary *constants = [NSMutableDictionary new];
   constants[@"isAutoInitEnabled"] = @([RCTConvert BOOL:@([FIRMessaging messaging].autoInitEnabled)]);
   constants[@"isRegisteredForRemoteNotifications"] = @([RCTConvert BOOL:@([[UIApplication sharedApplication] isRegisteredForRemoteNotifications])]);
+  RNFBMessagingNSNotificationCenter* notifCenter = [RNFBMessagingNSNotificationCenter sharedInstance];
+  constants[@"launchedHeadless"] = @([RCTConvert BOOL:@(notifCenter.isHeadless)]);
   return constants;
 }
 
@@ -163,15 +165,6 @@ RCT_EXPORT_METHOD(getAPNSToken:
     #endif
     resolve([NSNull null]);
   }
-}
-
-RCT_EXPORT_METHOD(getIsHeadless
-    :(RCTPromiseResolveBlock) resolve
-    :(RCTPromiseRejectBlock) reject
-) {
-    RNFBMessagingNSNotificationCenter* notifCenter = [RNFBMessagingNSNotificationCenter sharedInstance];
-
-    return resolve(@([RCTConvert BOOL:@(notifCenter.isHeadless)]));
 }
 
 RCT_EXPORT_METHOD(requestPermission:

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -611,7 +611,7 @@ export namespace FirebaseMessagingTypes {
     getToken(authorizedEntity?: string, scope?: string = 'FCM'): Promise<string>;
 
     /**
-     * Returns wether the root view launched was headless or not
+     * Returns true if the app was launched in the background (for example, by data-only cloud message)
      * 
      * More info: https://rnfirebase.io/messaging/usage#background-application-state
      * @platform ios iOS

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -612,7 +612,6 @@ export namespace FirebaseMessagingTypes {
 
     /**
      * Returns true if the app was launched in the background (for example, by data-only cloud message)
-     * 
      * More info: https://rnfirebase.io/messaging/usage#background-application-state
      * @platform ios iOS
      */

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -611,11 +611,13 @@ export namespace FirebaseMessagingTypes {
     getToken(authorizedEntity?: string, scope?: string = 'FCM'): Promise<string>;
 
     /**
-     * Returns true if the app was launched in the background (for example, by data-only cloud message)
+     * Returns wether the root view is headless or not
+     * i.e true if the app was launched in the background (for example, by data-only cloud message)
+     *
      * More info: https://rnfirebase.io/messaging/usage#background-application-state
      * @platform ios iOS
      */
-    launchedHeadless: boolean;
+    getIsHeadless(): Promise<boolean>;
 
     /**
      * Removes access to an FCM token previously authorized by it's scope. Messages sent by the server

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -614,6 +614,7 @@ export namespace FirebaseMessagingTypes {
      * Returns wether the root view is headless or not
      * 
      * More info: https://rnfirebase.io/messaging/usage#background-application-state
+     * @platform ios iOS
      */
     getIsHeadless(): Promise<Boolean>;
 

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -616,7 +616,7 @@ export namespace FirebaseMessagingTypes {
      * More info: https://rnfirebase.io/messaging/usage#background-application-state
      * @platform ios iOS
      */
-    getIsHeadless(): Promise<Boolean>;
+    getIsHeadless(): Promise<boolean>;
 
     /**
      * Removes access to an FCM token previously authorized by it's scope. Messages sent by the server

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -611,12 +611,12 @@ export namespace FirebaseMessagingTypes {
     getToken(authorizedEntity?: string, scope?: string = 'FCM'): Promise<string>;
 
     /**
-     * Returns wether the root view is headless or not
+     * Returns wether the root view launched was headless or not
      * 
      * More info: https://rnfirebase.io/messaging/usage#background-application-state
      * @platform ios iOS
      */
-    getIsHeadless(): Promise<boolean>;
+    launchedHeadless: boolean;
 
     /**
      * Removes access to an FCM token previously authorized by it's scope. Messages sent by the server

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -611,6 +611,13 @@ export namespace FirebaseMessagingTypes {
     getToken(authorizedEntity?: string, scope?: string = 'FCM'): Promise<string>;
 
     /**
+     * Returns wether the root view is headless or not
+     * 
+     * More info: https://rnfirebase.io/messaging/usage#background-application-state
+     */
+    getIsHeadless(): Promise<Boolean>;
+
+    /**
      * Removes access to an FCM token previously authorized by it's scope. Messages sent by the server
      * to this token will fail.
      *

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -126,6 +126,10 @@ class FirebaseMessagingModule extends FirebaseModule {
     return this.native.getInitialNotification();
   }
 
+  getIsHeadless() {
+    return this.native.getIsHeadless();
+  }
+
   getToken(authorizedEntity, scope) {
     if (!isUndefined(authorizedEntity) && !isString(authorizedEntity)) {
       throw new Error(

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -70,6 +70,11 @@ class FirebaseMessagingModule extends FirebaseModule {
         ? this.native.isRegisteredForRemoteNotifications
         : true;
 
+    this._launchedHeadless =
+      (!isAndroid && this.native.launchedHeadless != null)
+        ? this.native.launchedHeadless
+        : false;
+
     AppRegistry.registerHeadlessTask('ReactNativeFirebaseMessagingHeadlessTask', () => {
       if (!backgroundMessageHandler) {
         // eslint-disable-next-line no-console
@@ -111,6 +116,16 @@ class FirebaseMessagingModule extends FirebaseModule {
     return this._isRegisteredForRemoteNotifications;
   }
 
+  /**
+   * @ios
+   */
+  get launchedHeadless() {
+    if (isAndroid) {
+      return false;
+    }
+    return this._launchedHeadless;
+  }
+
   setAutoInitEnabled(enabled) {
     if (!isBoolean(enabled)) {
       throw new Error(
@@ -126,9 +141,6 @@ class FirebaseMessagingModule extends FirebaseModule {
     return this.native.getInitialNotification();
   }
 
-  getIsHeadless() {
-    return this.native.getIsHeadless();
-  }
 
   getToken(authorizedEntity, scope) {
     if (!isUndefined(authorizedEntity) && !isString(authorizedEntity)) {

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -70,9 +70,6 @@ class FirebaseMessagingModule extends FirebaseModule {
         ? this.native.isRegisteredForRemoteNotifications
         : true;
 
-    this._launchedHeadless =
-      !isAndroid && this.native.launchedHeadless != null ? this.native.launchedHeadless : false;
-
     AppRegistry.registerHeadlessTask('ReactNativeFirebaseMessagingHeadlessTask', () => {
       if (!backgroundMessageHandler) {
         // eslint-disable-next-line no-console
@@ -114,16 +111,6 @@ class FirebaseMessagingModule extends FirebaseModule {
     return this._isRegisteredForRemoteNotifications;
   }
 
-  /**
-   * @ios
-   */
-  get launchedHeadless() {
-    if (isAndroid) {
-      return false;
-    }
-    return this._launchedHeadless;
-  }
-
   setAutoInitEnabled(enabled) {
     if (!isBoolean(enabled)) {
       throw new Error(
@@ -137,6 +124,10 @@ class FirebaseMessagingModule extends FirebaseModule {
 
   getInitialNotification() {
     return this.native.getInitialNotification();
+  }
+
+  getIsHeadless() {
+    return this.native.getIsHeadless();
   }
 
   getToken(authorizedEntity, scope) {

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -71,9 +71,7 @@ class FirebaseMessagingModule extends FirebaseModule {
         : true;
 
     this._launchedHeadless =
-      (!isAndroid && this.native.launchedHeadless != null)
-        ? this.native.launchedHeadless
-        : false;
+      !isAndroid && this.native.launchedHeadless != null ? this.native.launchedHeadless : false;
 
     AppRegistry.registerHeadlessTask('ReactNativeFirebaseMessagingHeadlessTask', () => {
       if (!backgroundMessageHandler) {
@@ -140,7 +138,6 @@ class FirebaseMessagingModule extends FirebaseModule {
   getInitialNotification() {
     return this.native.getInitialNotification();
   }
-
 
   getToken(authorizedEntity, scope) {
     if (!isUndefined(authorizedEntity) && !isString(authorizedEntity)) {


### PR DESCRIPTION
- Fixes: https://github.com/invertase/react-native-firebase/issues/4233

### Description

Motivation: for projects using react-native-navigation injecting appProperties for each screen makes it very difficult to actually stop screens from getting mounted.

### Related issues

Fixes #4233 

### Release Summary

- Added getIsHeadless to get isHeadless on demand (imperatively)

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

![isHeadless](https://user-images.githubusercontent.com/3070948/94127274-66e83c00-fe61-11ea-8295-6f83631df2ee.png)


---
