### PR TITLE
fix(auth): Add `refreshToken` to `User` type

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -914,6 +914,11 @@ export namespace FirebaseAuthTypes {
     providerId: string;
 
     /**
+     *  The refresh token for the current user.
+     */
+    refreshToken: string;
+
+    /**
      *  - The user's unique ID.
      */
     uid: string;


### PR DESCRIPTION
Small addition to the `User` type inside `@react-native-firebase/auth` module. I was using this and found it to be missing.

### Release Summary

- Add `refreshToken: string;` to `User` type in `@react-native-firebase/auth`

### Checklist

I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes

My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`

My change includes tests;
  - [X] I have updated TypeScript types that are affected by my change.

This is a breaking change;
  - [ ] Yes
  - [X] No
