### PR TITLE
docs(types, dynamic-links): ShortLinkType is accessible via statics

### DIFF
--- a/packages/dynamic-links/lib/index.d.ts
+++ b/packages/dynamic-links/lib/index.d.ts
@@ -363,7 +363,7 @@ export namespace FirebaseDynamicLinksTypes {
 
   /**
    * ShortLinkType determines the type of dynamic short link which Firebase creates. Used when building
-   * a new short link via `buildShortLink()`.
+   * a new short link via `buildShortLink()`. These are exported through statics connected to the module.
    *
    * #### Example
    *
@@ -371,7 +371,7 @@ export namespace FirebaseDynamicLinksTypes {
    *  const link = await firebase.dynamicLinks().buildShortLink({
    *    link: 'https://invertase.io',
    *    domainUriPrefix: 'https://xyz.page.link',
-   *  }, FirebaseDynamicLinksTypes.ShortLinkType.UNGUESSABLE);
+   *  }, firebase.dynamicLinks.ShortLinkType.UNGUESSABLE);
    * ```
    */
   export enum ShortLinkType {


### PR DESCRIPTION
Using the previously documented example style results in a symbol not found


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
