### PR TITLE
fix(app, ios): avoid photo API not present on Catalyst 

### DIFF
--- a/packages/app/ios/RNFBApp/RNFBUtilsModule.m
+++ b/packages/app/ios/RNFBApp/RNFBUtilsModule.m
@@ -52,7 +52,7 @@ RCT_EXPORT_MODULE();
 }
 
 + (PHAsset *)fetchAssetForPath:(NSString *)localFilePath {
-  PHAsset *asset;
+  PHAsset *asset = nil;
 
   if ([localFilePath hasPrefix:@"assets-library://"] || [localFilePath hasPrefix:@"ph://"]) {
     if ([localFilePath hasPrefix:@"assets-library://"]) {
@@ -63,9 +63,10 @@ RCT_EXPORT_MODULE();
           NSLog(@"'assets-library://' & 'ph://' URLs are not supported in Catalyst-based targets or iOS 12 and higher; returning nil (future warnings will be suppressed)");
           hasWarned = YES;
         }
-        asset = nil;
       } else {
+        #if (!TARGET_OS_MACCATALYST)
         asset = [[PHAsset fetchAssetsWithALAssetURLs:@[localFile] options:nil] firstObject];
+        #endif
       }
     } else {
       NSString *assetId = [localFilePath substringFromIndex:@"ph://".length];


### PR DESCRIPTION
### Description

As it stands, firebase app causes compilation errors in Mac OS, I believe this is the way to fix it. There does seem to be an attempt to solve it I think currently but standard conditionals would not get evaluated at compile time (Cue someone with more than 5 hours worth of Objective C experience.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Mac`

- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
