### PR TITLE
fix(publish): never auto-cancel publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.4.1
-        with:
-          access_token: ${{ github.token }}
       - uses: actions/checkout@v2
         with:
           ref: 'master'


### PR DESCRIPTION
This is the one workflow where cancellation can become a real problem. Two publish actions are spawned for each workflow run (one is dispatched manually, the second is triggered), and if auto-cancellation is in the workflow then the second one kills the first one

Fixes #4283
