### PR TITLE
chore(ci): when generating patches, keep package.json from latest npm version

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -73,8 +73,9 @@ jobs:
             echo "Installing package $PACKAGE into fresh template app, then clobbering with PR version"
             yarn add @react-native-firebase/$PACKAGE
             pushd node_modules/@react-native-firebase
-            \rm -fr $PACKAGE
             tar -zxf $HOME/packages/react-native-firebase-${PACKAGE}-v*
+            mv $PACKAGE/package.json package/
+            \rm -fr $PACKAGE
             mv package $PACKAGE
             popd
             npx patch-package @react-native-firebase/$PACKAGE || true


### PR DESCRIPTION
### Related issues

Fixes #4331

### Description

:wave: Hi @mikehardy!
The patch-package failure was being caused by incomplete npm publish tasks. (repo versions higher than `npm` versions) (Related: #4283)
Looks like #4330 did not fix the issue

I've detailed that in a new issue #4343, and I suppose if that is fixed, then #4331 becomes a non-issue, but still, I've taken a self-contained approach based on the following assumptions:

1. The generated patches should **always** be for the latest npm version, **regardless of repo state**.
2. patch-package does not work well with `package.json`, so we can safely ignore package.json changes in the patches.


In the patch generation task, the `package.json` from the "live" version is now preserved.

### Release Summary

N/A

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - `Android` N/A
  - `iOS` N/A
  - [x] CI onlu
- My change includes tests;
  - N/A
- [ ] I have updated TypeScript types that are affected by my change. N/A
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I made a thrash-branch in my fork, adding bogus changes to each package to test the package generation.
It's very messy, but here are 2 Action runs:

- Bad (observe lock issues, only several generated patches): https://github.com/davidgovea/react-native-firebase/pull/1/checks?check_run_id=1195395418#step:7:1291
- Good (all patches generated once the package.json-preservation in place: https://github.com/davidgovea/react-native-firebase/pull/1/checks?check_run_id=1195543383#step:7:1174

