### PR TITLE
docs(ml-vision): text-recognition accepts only image file types :fire:

### DIFF
--- a/docs/ml-vision/text-recognition.md
+++ b/docs/ml-vision/text-recognition.md
@@ -8,7 +8,7 @@ previous: /ml-vision/usage
 Text recognition can automate tedious data entry for credit cards, receipts, and business cards. With the Cloud-based API,
 you can also extract text from pictures of documents, which you can use to increase accessibility or translate documents.
 
-Once a file has been processed, the API returns a [`VisionDocumentText`](/reference/ml-vision/visiondocumenttext), referencing
+Once an image file has been processed, the API returns a [`VisionDocumentText`](/reference/ml-vision/visiondocumenttext), referencing
 all found text along with each [`VisionDocumentTextBlock`](/reference/ml-vision/visiondocumenttextblock). Each block contains
 meta-data such as:
 
@@ -19,7 +19,7 @@ meta-data such as:
 
 # Cloud Text Recognition
 
-The cloud based text recognition service uploads a given document to the remote Firebase service which processes the results and returns them.
+The cloud based text recognition service uploads a given image of a document to the remote Firebase service which processes the results and returns them. Only image file types are allowed.
 To get started, call the `cloudDocumentTextRecognizerProcessImage` method with a path to a local file on your device:
 
 ```js


### PR DESCRIPTION
### Description

Went through a long debugging process only to find out that ml-vision text recognition only supports image files and not pdf files. Updated verbiage so others don't go down the rabbit hole.

### Related issues

https://github.com/invertase/react-native-firebase/issues/4334

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x ] Yes
- My change supports the following platforms;
  - [ x] `Android`
  - [x ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x ] No



### Test Plan

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
