### PR TITLE
fix(docs): prevent trailing slash removal from links to root

### DIFF
--- a/website/src/components/Link.tsx
+++ b/website/src/components/Link.tsx
@@ -69,7 +69,7 @@ const Link = ({
       to,
     };
 
-    if (gatsbyLinkProps.to.endsWith('/')) {
+    if (gatsbyLinkProps.to.endsWith('/') && gatsbyLinkProps.to.length > 1) {
       gatsbyLinkProps.to = gatsbyLinkProps.to.slice(0, -1);
     }
 


### PR DESCRIPTION
This PR fixes #4357 and #4220

Before links pointing to "/" were converted to links pointing to "" which rendered them useless. This was caused by the custom link component which is supposed to remove trailing slashes from internal links. This PR adds a check for the "/" edge case.