### PR TITLE
docs(spellcheck): add launchProperties to spellcheck file

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -62,6 +62,7 @@ iOS
 iOS13
 JS
 JSON
+launchProperties
 learnt
 Lerna
 MDX


### PR DESCRIPTION

I believe the proper procedure to get spell check to think something unexpected valid is to add it to the list of items in the spellcheck file

This is intended to allow 'launchProperties' to be used without warning in CI

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
