### PR TITLE
docs(setup): Add instructions for using Firebase in an emulator

### DIFF
--- a/docs/faqs-and-tips.md
+++ b/docs/faqs-and-tips.md
@@ -39,7 +39,7 @@ This happens to be a known problem with the upstream Analytics SDKs. The Firebas
 
 ### I'm receiving `InternalFirebaseAuth.FIREBASE_AUTH_API is not available on this device`. How do I fix this?
 
-To use some Firebase services (like auth) in an emulator, you need an Android devices with Google Play and associated services installed. Check this [StackOverflow post](https://stackoverflow.com/a/46246782/2275865) for instructions on creating a new Android device with the necessary APIs installed.
+To use some Firebase services (like auth) in an emulator, you need an Android virtual device with Google Play services installed. Check this [StackOverflow post](https://stackoverflow.com/a/46246782/2275865) for instructions on creating a new Android virtual device with the necessary APIs installed.
 
 Alternatively, you can install the Google Play Services SDK. In Android Studio:
 

--- a/docs/faqs-and-tips.md
+++ b/docs/faqs-and-tips.md
@@ -39,7 +39,7 @@ This happens to be a known problem with the upstream Analytics SDKs. The Firebas
 
 ### I'm receiving `InternalFirebaseAuth.FIREBASE_AUTH_API is not available on this device`. How do I fix this?
 
-To use some Firebase services (like auth) in an emulator, you need an Android virtual device with Google Play services installed. Check this [StackOverflow post](https://stackoverflow.com/a/46246782/2275865) for instructions on creating a new Android virtual device with the necessary APIs installed.
+To use some Firebase services (like auth) in an emulator, you need an Android virtual device with Google Play services installed. Check this [Stack Overflow post](https://stackoverflow.com/a/46246782/2275865) for instructions on creating a new Android virtual device with the necessary APIs installed.
 
 Alternatively, you can install the Google Play Services SDK. In Android Studio:
 

--- a/docs/faqs-and-tips.md
+++ b/docs/faqs-and-tips.md
@@ -41,15 +41,6 @@ This happens to be a known problem with the upstream Analytics SDKs. The Firebas
 
 To use some Firebase services (like auth) in an emulator, you need an Android virtual device with Google Play services installed. Check this [Stack Overflow post](https://stackoverflow.com/a/46246782/2275865) for instructions on creating a new Android virtual device with the necessary APIs installed.
 
-Alternatively, you can install the Google Play Services SDK. In Android Studio:
-
-1. Select `Tools -> SDK Manager`
-1. Search for `SDK Tools` and select the `SDK Tools` tab under `Android SDK`
-1. Install `Google Play services`
-
-You may need to delete your Android devices to pickup Play services.
-
-
 # Tips
 
 - Whenever you face a strange issue (or an issue that causes build errors), there are two things you should always consider.

--- a/docs/faqs-and-tips.md
+++ b/docs/faqs-and-tips.md
@@ -37,6 +37,19 @@ This may be fixed by creating a `firebase.json` file at the root of your project
 This happens to be a known problem with the upstream Analytics SDKs. The Firebase team doesn't have any plans to fix it soon. More information about this can be found [here](https://github.com/invertase/react-native-firebase/issues/4018#issuecomment-682174087).
 
 
+### I'm receiving `InternalFirebaseAuth.FIREBASE_AUTH_API is not available on this device`. How do I fix this?
+
+To use some Firebase services (like auth) in an emulator, you need an Android devices with Google Play and associated services installed. Check this [StackOverflow post](https://stackoverflow.com/a/46246782/2275865) for instructions on creating a new Android device with the necessary APIs installed.
+
+Alternatively, you can install the Google Play Services SDK. In Android Studio:
+
+1. Select `Tools -> SDK Manager`
+1. Search for `SDK Tools` and select the `SDK Tools` tab under `Android SDK`
+1. Install `Google Play services`
+
+You may need to delete your Android devices to pickup Play services.
+
+
 # Tips
 
 - Whenever you face a strange issue (or an issue that causes build errors), there are two things you should always consider.

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,17 +74,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services' // <- Add this line
 ```
 
-#### Using Firebase services in an emulator
-
-To use Firebase services in an emulator, you need to install the Google Play services SDK. From Android Studio:
-
-1. Select `Tools -> SDK Manager`
-1. Search for `SDK Tools` and select the `SDK Tools` tab under `Android SDK`
-1. Install `Google Play services`
-
-If you're missing Google Play services SDK, you may see an error similar to:
-
-`InternalFirebaseAuth.FIREBASE_AUTH_API is not available on this device`
 
 ### 3. iOS Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services' // <- Add this line
 ```
 
-
 ### 3. iOS Setup
 
 To allow the iOS app to securely connect to your Firebase project, a configuration file must be downloaded and added to your project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,18 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services' // <- Add this line
 ```
 
+#### Using Firebase services in an emulator
+
+To use Firebase services in an emulator, you need to install the Google Play services SDK. From Android Studio:
+
+1. Select `Tools -> SDK Manager`
+1. Search for `SDK Tools` and select the `SDK Tools` tab under `Android SDK`
+1. Install `Google Play services`
+
+If you're missing Google Play services SDK, you may see an error similar to:
+
+`InternalFirebaseAuth.FIREBASE_AUTH_API is not available on this device`
+
 ### 3. iOS Setup
 
 To allow the iOS app to securely connect to your Firebase project, a configuration file must be downloaded and added to your project.


### PR DESCRIPTION
### Description

While troubleshooting `InternalFirebaseAuth.FIREBASE_AUTH_API is not available on this device`, it seems you need Google Play services installed. As a React Native newbie, I don't recall seeing this included in any instructions and I think this might be the best place.

### Related issues

None in this repository, but there were a lot of random results when I [searched](https://www.google.com/search?q=firebase_auth_api+is+not+available+on+this+device) for the error.

### Release Summary

Documentation change

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - Not applicable to documentation change
  - ~~[ ] `e2e` tests added or updated in `packages/\*\*/e2e`~~
  - ~~[ ] `jest` -tests added or updated in `packages/\*\*/__tests__`~~
- ~~[ ] I have updated TypeScript types that are affected by my change.~~
  - Not applicable to documentation change
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<img width="850" alt="Screen Shot 2020-10-14 at 09 02 36" src="https://user-images.githubusercontent.com/2000021/95992524-08790280-0dfc-11eb-9e6b-85dc169557c0.png">

:fire:
