### PR TITLE
fix(docs, messaging): tools schema declaration required for notification color override

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -454,7 +454,9 @@ Note that only predefined colors can be used in `firebase.json`. If you want to 
 </resources>
 
 <!-- <projectRoot>/android/app/src/main/AndroidManifest.xml -->
-<manifest>
+
+<!--  add "tools" to manifest tag  -->
+<manifest xmlns:tools="http://schemas.android.com/tools">
   <application>
       <!-- ... -->
 


### PR DESCRIPTION
Missing this attribute caused an error during bundle release "tools not bound"

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ + ] Yes
- My change supports the following platforms;
  - [ + ] `Android`
  - [ - ] `iOS`
- My change includes tests;
  - [ - ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ - ] `jest` tests added or updated in `packages/\*\*/__tests__`
  - [ - ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ - ] Yes
  - [ + ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
