### PR TITLE
fix(firestore): Added test case for orderby before where query

### DIFF
--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -569,4 +569,23 @@ describe('firestore().collection().where()', () => {
 
     return Promise.resolve();
   });
+
+  it('should handle where clause after sort by', async () => {
+    const ref = firebase.firestore().collection(`${COLLECTION}/filter/sort-by-where`);
+
+    await ref.add({ status: 1 });
+    await ref.add({ status: 2 });
+    await ref.add({ status: 3 });
+
+    const items = [];
+    await ref
+      .orderBy('status', 'desc')
+      .where('status', '<=', 2)
+      .get()
+      .then($ => $.forEach(doc => items.push(doc.data())));
+
+    items.length.should.equal(2);
+    items[0].status.should.equal(2);
+    items[1].status.should.equal(1);
+  });
 });


### PR DESCRIPTION
Query validators are ineffective when using a where clause after an order by clause. This PR investigates and adds tests cases to prove the logic.

See issue https://github.com/invertase/react-native-firebase/issues/3220