### PR TITLE
feat(crashlytics ios): put input files when pod install.

### DIFF
--- a/packages/crashlytics/react-native.config.js
+++ b/packages/crashlytics/react-native.config.js
@@ -25,8 +25,8 @@ module.exports = {
             execution_position: 'after_compile',
             input_files: [
               '${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}',
-              '$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)'
-            ]
+              '$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)',
+            ],
           },
         ],
       },

--- a/packages/crashlytics/react-native.config.js
+++ b/packages/crashlytics/react-native.config.js
@@ -23,6 +23,10 @@ module.exports = {
             name: '[RNFB] Crashlytics Configuration',
             path: './ios_config.sh',
             execution_position: 'after_compile',
+            input_files: [
+              '${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}',
+              '$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)'
+            ]
           },
         ],
       },


### PR DESCRIPTION
### Description
I commit to this repository for the first time.
I'm sorry if there is a wrong way.

Put the Build Phase setting of iOS when pod install.
https://firebase.google.com/docs/crashlytics/get-started?hl=ja#initialize-crashlytics

I want to add Input Files.
`${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}`
`$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`

### Related issues
Discussion #4519 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
