### PR TITLE
fix(analytics): added a validation for length in analytics().logEvent(name, params)

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -69,7 +69,7 @@ describe('Analytics', () => {
 
     it('errors if name not alphanumeric', () => {
       expect(() => firebase.analytics().logEvent('!@£$%^&*')).toThrowError(
-        "firebase.analytics().logEvent(*) 'name' invalid event name '!@£$%^&*'. Names should contain 1 to 32 alphanumeric characters or underscores.",
+        "firebase.analytics().logEvent(*) 'name' invalid event name '!@£$%^&*'. Names should contain 1 to 40 alphanumeric characters or underscores.",
       );
     });
 

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -76,9 +76,9 @@ class FirebaseAnalyticsModule extends FirebaseModule {
     }
 
     // name format validation
-    if (!isAlphaNumericUnderscore(name)) {
+    if (!isAlphaNumericUnderscore(name) || name.length > 40) {
       throw new Error(
-        `firebase.analytics().logEvent(*) 'name' invalid event name '${name}'. Names should contain 1 to 32 alphanumeric characters or underscores.`,
+        `firebase.analytics().logEvent(*) 'name' invalid event name '${name}'. Names should contain 1 to 40 alphanumeric characters or underscores.`,
       );
     }
 


### PR DESCRIPTION
### Description
I added a validation to check the length for `name` of `analytics().logEvent(name, params)`: 1-40 alphanumeric

### Related issues

Fixes #4496 

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
