### PR TITLE
fix(firestore): add missing MIN_SECONDS constant to FirestoreTimestamp

### DIFF
--- a/packages/firestore/lib/FirestoreTimestamp.js
+++ b/packages/firestore/lib/FirestoreTimestamp.js
@@ -17,6 +17,9 @@
 
 import { isDate, isNumber } from '@react-native-firebase/app/lib/common';
 
+// The earlist date supported by Firestore timestamps (0001-01-01T00:00:00Z).
+const MIN_SECONDS = -62135596800;
+
 export default class FirestoreTimestamp {
   static now() {
     return FirestoreTimestamp.fromMillis(Date.now());
@@ -56,7 +59,7 @@ export default class FirestoreTimestamp {
     }
 
     // Midnight at the beginning of 1/1/1 is the earliest Firestore supports.
-    if (seconds < -62135596800) {
+    if (seconds < MIN_SECONDS) {
       throw new Error(`firebase.firestore.Timestamp 'seconds' out of range: ${seconds}`);
     }
 
@@ -99,7 +102,7 @@ export default class FirestoreTimestamp {
     return `FirestoreTimestamp(seconds=${this.seconds}, nanoseconds=${this.nanoseconds})`;
   }
 
-  toJSON(): { seconds: number, nanoseconds: number } {
+  toJSON() {
     return { seconds: this.seconds, nanoseconds: this.nanoseconds };
   }
 
@@ -107,7 +110,7 @@ export default class FirestoreTimestamp {
    * Converts this object to a primitive string, which allows Timestamp objects to be compared
    * using the `>`, `<=`, `>=` and `>` operators.
    */
-  valueOf(): string {
+  valueOf() {
     // This method returns a string of the form <seconds>.<nanoseconds> where <seconds> is
     // translated to have a non-negative value and both <seconds> and <nanoseconds> are left-padded
     // with zeroes to be a consistent length. Strings with this format then have a lexiographical

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1516,11 +1516,28 @@ export namespace FirebaseFirestoreTypes {
     toDate(): Date;
 
     /**
-     * Convert a timestamp to a numeric timestamp (in milliseconds since epoch). This operation causes a loss of precision.
+     * Convert a Timestamp to a numeric timestamp (in milliseconds since epoch). This operation causes a loss of precision.
      *
      * The point in time corresponding to this timestamp, represented as the number of milliseconds since Unix epoch 1970-01-01T00:00:00Z.
      */
     toMillis(): number;
+
+    /**
+     * Convert a timestamp to a string in format "FirestoreTimestamp(seconds=`seconds`, nanoseconds=`nanoseconds`)",
+     * with the `seconds` and `nanoseconds` replaced by the values in the Timestamp object
+     */
+    toString(): string;
+
+    /**
+     * Convert a Timestamp to a JSON object with seconds and nanoseconds members
+     */
+    toJSON(): { seconds: number; nanoseconds: number };
+
+    /**
+     * Converts this object to a primitive string, which allows Timestamp objects to be compared
+     * using the `>`, `<=`, `>=` and `>` operators.
+     */
+    valueOf(): string;
   }
 
   /**


### PR DESCRIPTION

### Description

As noticed by @davidstott in https://github.com/invertase/react-native-firebase/pull/4439#issuecomment-725010712 - the new methods in FirestoreTimestamp were missing a constant from the top of their origin file from firebase-js-sdk

While repairing that I noticed they still had some typescript-isms and the correlating typescript definition file here was missing docs for those methods

### Related issues

Original PR for the new feature this polishes up #4439

### Release Summary

fix(firestore): add missing MIN_SECONDS constant to FirestoreTimestamp

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
