### PR TITLE
docs(cloud firestore): fix cloud firestore manual installation link for android

### DIFF
--- a/docs/firestore/usage/index.md
+++ b/docs/firestore/usage/index.md
@@ -23,7 +23,7 @@ cd ios/ && pod install
 ```
 
 If you're using an older version of React Native without autolinking support, or wish to integrate into an existing project,
-you can follow the manual installation steps for [iOS](/firestore/usage/installation/ios) and [Android](firestore/usage/installation/android).
+you can follow the manual installation steps for [iOS](/firestore/usage/installation/ios) and [Android](/firestore/usage/installation/android).
 
 If you have started to receive a `app:mergeDexDebug` error after adding Cloud Firestore, please read the
 [Enabling Multidex](/enabling-multidex) documentation for more information on how to resolve this error.


### PR DESCRIPTION
### Description

The link to android manual installation was missing a `/`, guiding the user to [a 404](https://rnfirebase.io/firestore/usage/firestore/usage/installation/android). 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

No related issue AFAIK

### Release Summary

N/A

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I've just added the `/` before the android link copying the behaviour of the iOS link that works fine.

iOS link is working fine: `/firestore/usage/installation/ios` is resulting in https://rnfirebase.io/firestore/usage/installation/ios
Android link is not working: `firestore/usage/installation/android` is resulting in https://rnfirebase.io/firestore/usage/firestore/usage/installation/android

Also, route https://rnfirebase.io/firestore/usage/installation/android exists.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
