### PR TITLE
fix(analytics): added missing quantity parameter to the Item structure

### DIFF
--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -18,11 +18,16 @@ package io.invertase.firebase.analytics;
  */
 
 
+import android.os.Bundle;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
+import com.google.firebase.analytics.FirebaseAnalytics;
+
+import java.util.ArrayList;
 
 import javax.annotation.Nullable;
 
@@ -39,7 +44,7 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
 
   @ReactMethod
   public void logEvent(String name, @Nullable ReadableMap params, Promise promise) {
-    module.logEvent(name, Arguments.toBundle(params)).addOnCompleteListener(task -> {
+    module.logEvent(name, toBundle(params)).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(task.getResult());
       } else {
@@ -113,5 +118,20 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
         rejectPromiseWithExceptionMap(promise, task.getException());
       }
     });
+  }
+
+  private Bundle toBundle(ReadableMap readableMap) {
+    Bundle bundle = Arguments.toBundle(readableMap);
+    if (bundle == null) {
+      return null;
+    }
+    ArrayList itemsArray = (ArrayList) bundle.getSerializable(FirebaseAnalytics.Param.ITEMS);
+    for (Object item : itemsArray != null ? itemsArray : new ArrayList()) {
+      if (item instanceof Bundle && ((Bundle) item).containsKey(FirebaseAnalytics.Param.QUANTITY)) {
+        double number = ((Bundle) item).getDouble(FirebaseAnalytics.Param.QUANTITY);
+        ((Bundle) item).putInt(FirebaseAnalytics.Param.QUANTITY, (int) number);
+      }
+    }
+    return bundle;
   }
 }

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -141,6 +141,7 @@ describe('analytics()', () => {
             item_name: 'foo',
             item_category: 'foo',
             item_location_id: 'foo',
+            quantity: 5,
           },
         ],
         value: 123,

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -44,21 +44,7 @@
         rejecter:
         (RCTPromiseRejectBlock) reject) {
     @try {
-      if (params[kFIRParameterItems]) {
-        NSMutableDictionary *newParams = [params mutableCopy];
-        NSMutableArray *newItems = [NSMutableArray array];
-        [(NSArray *)params[kFIRParameterItems] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-          NSMutableDictionary *item = [obj mutableCopy];
-          if (item[kFIRParameterQuantity]) {
-            item[kFIRParameterQuantity] = @([item[kFIRParameterQuantity] integerValue]);
-          }
-          [newItems addObject:[item copy]];
-        }];
-        newParams[kFIRParameterItems] = [newItems copy];
-        [FIRAnalytics logEventWithName:name parameters:[newParams copy]];
-      } else {
-        [FIRAnalytics logEventWithName:name parameters:params];
-      }
+      [FIRAnalytics logEventWithName:name parameters:[self cleanJavascriptParams:params]];
     } @catch (NSException *exception) {
       return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
     }
@@ -147,6 +133,25 @@
         (RCTPromiseRejectBlock) reject) {
     // Do nothing - this only exists in android
     return resolve([NSNull null]);
+  }
+
+#pragma mark -
+#pragma mark Private methods
+
+  - (NSDictionary *)cleanJavascriptParams:(NSDictionary *)params {
+    NSMutableDictionary *newParams = [params mutableCopy];
+    if (newParams[kFIRParameterItems]) {
+      NSMutableArray *newItems = [NSMutableArray array];
+      [(NSArray *)newParams[kFIRParameterItems] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        NSMutableDictionary *item = [obj mutableCopy];
+        if (item[kFIRParameterQuantity]) {
+          item[kFIRParameterQuantity] = @([item[kFIRParameterQuantity] integerValue]);
+        }
+        [newItems addObject:[item copy]];
+      }];
+      newParams[kFIRParameterItems] = [newItems copy];
+    }
+    return [newParams copy];
   }
 
 @end

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -44,7 +44,21 @@
         rejecter:
         (RCTPromiseRejectBlock) reject) {
     @try {
-      [FIRAnalytics logEventWithName:name parameters:params];
+      if (params[kFIRParameterItems]) {
+        NSMutableDictionary *newParams = [params mutableCopy];
+        NSMutableArray *newItems = [NSMutableArray array];
+        [(NSArray *)params[kFIRParameterItems] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+          NSMutableDictionary *item = [obj mutableCopy];
+          if (item[kFIRParameterQuantity]) {
+            item[kFIRParameterQuantity] = @([item[kFIRParameterQuantity] integerValue]);
+          }
+          [newItems addObject:[item copy]];
+        }];
+        newParams[kFIRParameterItems] = [newItems copy];
+        [FIRAnalytics logEventWithName:name parameters:[newParams copy]];
+      } else {
+        [FIRAnalytics logEventWithName:name parameters:params];
+      }
     } @catch (NSException *exception) {
       return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
     }

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -99,7 +99,12 @@ export namespace FirebaseAnalyticsTypes {
      * The Item variant.
      */
     item_variant?: string;
+    /**
+     * The Item quantity.
+     */
+    quantity?: number;
   }
+
   export interface AddPaymentInfoEventParameters {
     items?: Item[];
     /**

--- a/packages/analytics/lib/structs.js
+++ b/packages/analytics/lib/structs.js
@@ -28,6 +28,7 @@ const Item = struct({
   item_list_name: 'string?',
   item_location_id: 'string?',
   item_variant: 'string?',
+  quantity: 'number?',
 });
 
 export const ScreenView = struct({


### PR DESCRIPTION
### Description

This pull request addresses the problem of not being able to pass the quantity parameter when trying to log any of these events:
- add_to_cart
- add_to_wishlist
- remove_from_cart
- view_cart
- refund

## Motivation

According to the [documentation](https://firebase.google.com/docs/analytics/measure-ecommerce#swift_7) for the aforementioned events one must or can pass the quantity parameter, but currently the library will reject such parameters, since quantity is not mentioned in the Item struct.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests;
  - [X] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

:fire: