### PR TITLE
fix(ios, badge): use new JSON location for FCM badge information

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -113,6 +113,12 @@
       message[@"mutableContent"] = @([RCTConvert BOOL:apsDict[@"mutable-content"]]);
     }
 
+    // iOS only
+    // message.notification.ios.badge
+    if (apsDict[@"badge"] != nil) {
+      notificationIOS[@"badge"] = apsDict[@"badge"];
+    }
+      
     // message.notification.*
     if (apsDict[@"alert"] != nil) {
       // can be a string or dictionary
@@ -169,14 +175,7 @@
         if (apsAlertDict[@"subtitle-loc-args"] != nil) {
           notificationIOS[@"subtitleLocArgs"] = apsAlertDict[@"subtitle-loc-args"];
         }
-          
-        // iOS only
-        // message.notification.ios.badge
-        if (apsAlertDict[@"badge"] != nil) {
-          notificationIOS[@"badge"] = apsAlertDict[@"badge"];
-        }
       }
-
 
       notification[@"ios"] = notificationIOS;
       message[@"notification"] = notification;


### PR DESCRIPTION

### Description

APS badging information was being pulled from the wrong JSON chunk, this moves it to align with docs

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification

### Related issues

Fixes #4559

### Release Summary


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
