### PR TITLE
fix(app, android): remove firebase-core from dependencies

### DIFF
--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -78,7 +78,6 @@ repositories {
 
 dependencies {
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
-  implementation "com.google.firebase:firebase-core"
   implementation "com.google.firebase:firebase-common"
   implementation "com.google.android.gms:play-services-auth:${ReactNative.ext.getVersion("play", "play-services-auth")}"
 }


### PR DESCRIPTION
### Description
According to the [firebase release notes](https://firebase.google.com/support/release-notes/android), the `firebase-core` for Android is no longer needed.

![Screen Shot 2020-11-23 at 5 50 07 PM](https://user-images.githubusercontent.com/48589760/99948398-5ea27380-2db4-11eb-9844-292c94d0158f.png)


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #4593

### Release Summary

Remove firebase-core from Android dependencies.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- [x] Run `tests:android:build`
<img width="429" alt="截圖 2020-11-23 下午10 48 44" src="https://user-images.githubusercontent.com/48589760/99976249-2d3e9d80-2dde-11eb-9e7d-4a3631ee4d5e.png">

- [x] Build and run on our app, based on react-native-firebase v10.0.0, including packages:
- `@react-native-firebase/analytics`
- `@react-native-firebase/app`
- `@react-native-firebase/crashlytics`
- `@react-native-firebase/messaging`
- `@react-native-firebase/perf`

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
