### PR TITLE
chore: make ReactNativeFirebaseMessagingSerializer + events builder functions public

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
@@ -11,7 +11,7 @@ import io.invertase.firebase.common.SharedUtils;
 import java.util.Map;
 import java.util.Set;
 
-class ReactNativeFirebaseMessagingSerializer {
+public class ReactNativeFirebaseMessagingSerializer {
   private static final String KEY_TOKEN = "token";
   private static final String KEY_COLLAPSE_KEY = "collapseKey";
   private static final String KEY_DATA = "data";
@@ -29,28 +29,28 @@ class ReactNativeFirebaseMessagingSerializer {
   private static final String EVENT_MESSAGE_SEND_ERROR = "messaging_message_send_error";
   private static final String EVENT_NEW_TOKEN = "messaging_token_refresh";
 
-  static ReactNativeFirebaseEvent messagesDeletedToEvent() {
+  public static ReactNativeFirebaseEvent messagesDeletedToEvent() {
     return new ReactNativeFirebaseEvent(EVENT_MESSAGES_DELETED, Arguments.createMap());
   }
 
-  static ReactNativeFirebaseEvent messageSentToEvent(String messageId) {
+  public static ReactNativeFirebaseEvent messageSentToEvent(String messageId) {
     WritableMap eventBody = Arguments.createMap();
     eventBody.putString(KEY_MESSAGE_ID, messageId);
     return new ReactNativeFirebaseEvent(EVENT_MESSAGE_SENT, eventBody);
   }
 
-  static ReactNativeFirebaseEvent messageSendErrorToEvent(String messageId, Exception sendError) {
+  public static ReactNativeFirebaseEvent messageSendErrorToEvent(String messageId, Exception sendError) {
     WritableMap eventBody = Arguments.createMap();
     eventBody.putString(KEY_MESSAGE_ID, messageId);
     eventBody.putMap(KEY_ERROR, SharedUtils.getExceptionMap(sendError));
     return new ReactNativeFirebaseEvent(EVENT_MESSAGE_SEND_ERROR, eventBody);
   }
 
-  static ReactNativeFirebaseEvent remoteMessageToEvent(RemoteMessage remoteMessage, Boolean openEvent) {
+  public static ReactNativeFirebaseEvent remoteMessageToEvent(RemoteMessage remoteMessage, Boolean openEvent) {
     return new ReactNativeFirebaseEvent(openEvent ? EVENT_NOTIFICATION_OPENED : EVENT_MESSAGE_RECEIVED, remoteMessageToWritableMap(remoteMessage));
   }
 
-  static ReactNativeFirebaseEvent newTokenToTokenEvent(String newToken) {
+  public static ReactNativeFirebaseEvent newTokenToTokenEvent(String newToken) {
     WritableMap eventBody = Arguments.createMap();
     eventBody.putString(KEY_TOKEN, newToken);
     return new ReactNativeFirebaseEvent(EVENT_NEW_TOKEN, eventBody);


### PR DESCRIPTION
### Description

I am in a situation where I need to manually send events through `ReactNativeFirebaseEventEmitter`. See discussion https://github.com/invertase/react-native-firebase/discussions/4577 
In order to properly do so, I'd like to use the functions present in `ReactNativeFirebaseMessagingSerializer`. 
This PR just adds the public access modifier to that class and to the functions that build events.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

