### PR TITLE
fix(app): convert NativeFirebaseError.getStackWithMessage to static to fix crash

### DIFF
--- a/packages/app/lib/internal/NativeFirebaseError.js
+++ b/packages/app/lib/internal/NativeFirebaseError.js
@@ -59,7 +59,10 @@ export default class NativeFirebaseError extends Error {
       value: userInfo.nativeErrorMessage || null,
     });
 
-    this.stack = NativeFirebaseError.getStackWithMessage(`NativeFirebaseError: ${this.message}`, this.jsStack);
+    this.stack = NativeFirebaseError.getStackWithMessage(
+      `NativeFirebaseError: ${this.message}`,
+      this.jsStack,
+    );
 
     // Unused
     // this.nativeStackIOS = nativeError.nativeStackIOS;

--- a/packages/app/lib/internal/NativeFirebaseError.js
+++ b/packages/app/lib/internal/NativeFirebaseError.js
@@ -59,7 +59,7 @@ export default class NativeFirebaseError extends Error {
       value: userInfo.nativeErrorMessage || null,
     });
 
-    this.stack = this.getStackWithMessage(`NativeFirebaseError: ${this.message}`);
+    this.stack = NativeFirebaseError.getStackWithMessage(`NativeFirebaseError: ${this.message}`, this.jsStack);
 
     // Unused
     // this.nativeStackIOS = nativeError.nativeStackIOS;
@@ -71,7 +71,7 @@ export default class NativeFirebaseError extends Error {
    *
    * @returns {string}
    */
-  getStackWithMessage(message) {
-    return [message, ...this.jsStack.split('\n').slice(2, 13)].join('\n');
+  static getStackWithMessage(message, jsStack) {
+    return [message, ...jsStack.split('\n').slice(2, 13)].join('\n');
   }
 }

--- a/packages/functions/lib/HttpsError.js
+++ b/packages/functions/lib/HttpsError.js
@@ -15,6 +15,8 @@
  *
  */
 
+import { NativeFirebaseError } from "@react-native-firebase/app/lib/internal";
+
 export default class HttpsError extends Error {
   constructor(code, message, details, nativeErrorInstance) {
     super(message);
@@ -34,6 +36,6 @@ export default class HttpsError extends Error {
       value: message,
     });
 
-    this.stack = nativeErrorInstance.getStackWithMessage(`Error: ${this.message}`);
+    this.stack = NativeFirebaseError.getStackWithMessage(`Error: ${this.message}`, nativeErrorInstance.jsStack);
   }
 }

--- a/packages/functions/lib/HttpsError.js
+++ b/packages/functions/lib/HttpsError.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { NativeFirebaseError } from "@react-native-firebase/app/lib/internal";
+import { NativeFirebaseError } from '@react-native-firebase/app/lib/internal';
 
 export default class HttpsError extends Error {
   constructor(code, message, details, nativeErrorInstance) {
@@ -36,6 +36,9 @@ export default class HttpsError extends Error {
       value: message,
     });
 
-    this.stack = NativeFirebaseError.getStackWithMessage(`Error: ${this.message}`, nativeErrorInstance.jsStack);
+    this.stack = NativeFirebaseError.getStackWithMessage(
+      `Error: ${this.message}`,
+      nativeErrorInstance.jsStack,
+    );
   }
 }


### PR DESCRIPTION

This is a rebased carry-over from an existing PR by @BlaShadow, all information is contained there:

#3751

It has passed local testing on my machine after being rebased to tip of current master