### PR TITLE
fix(messaging): get remote message from messaging store on new intent

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -49,6 +49,13 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
     reactContext.addActivityEventListener(this);
   }
 
+  private RemoteMessage popRemoteMessageFromMessagingStore(String messageId) {
+    ReactNativeFirebaseMessagingStore messagingStore = ReactNativeFirebaseMessagingStoreHelper.getInstance().getMessagingStore();
+    RemoteMessage remoteMessage = messagingStore.getFirebaseMessage(messageId);
+    messagingStore.clearFirebaseMessage(messageId);
+    return remoteMessage;
+  }
+
   @ReactMethod
   public void getInitialNotification(Promise promise) {
     if (initialNotification != null) {
@@ -70,9 +77,7 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
           if (messageId != null && initialNotificationMap.get(messageId) == null) {
             RemoteMessage remoteMessage = ReactNativeFirebaseMessagingReceiver.notifications.get(messageId);
             if (remoteMessage == null) {
-              ReactNativeFirebaseMessagingStore messagingStore = ReactNativeFirebaseMessagingStoreHelper.getInstance().getMessagingStore();
-              remoteMessage = messagingStore.getFirebaseMessage(messageId);
-              messagingStore.clearFirebaseMessage(messageId);
+              remoteMessage = popRemoteMessageFromMessagingStore(messageId);
             }
             if (remoteMessage != null) {
               promise.resolve(ReactNativeFirebaseMessagingSerializer.remoteMessageToWritableMap(remoteMessage));
@@ -212,6 +217,9 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
 
       if (messageId != null) {
         RemoteMessage remoteMessage = ReactNativeFirebaseMessagingReceiver.notifications.get(messageId);
+        if (remoteMessage == null) {
+          remoteMessage = popRemoteMessageFromMessagingStore(messageId);
+        }
 
         if (remoteMessage != null) {
           initialNotification = remoteMessage;


### PR DESCRIPTION
### Description

`ReactNativeFirebaseMessagingModule -> onNewIntent` is not checking the messaging store for remote messages (like `getInitialNotification` does).

Steps to reproduce the bug:
1. Receive a notification but don't open it (the remote message is added to `ReactNativeFirebaseMessagingReceiver.notifications`).
2. Open the app and then kill it (`ReactNativeFirebaseMessagingReceiver.notifications` is reseted).
3. Open the app again and bring it to background state.
4. Press the notification (`ReactNativeFirebaseMessagingReceiver.notifications` is empty).

This results in `onNewIntent` is unable to get the remote message because it is not checking in the persisted store.

### Related issues

I have not submitted an issue for this problem and I have not found any other issues.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
