### PR TITLE
test(Podfile): use firestore-ios-framework version vs master

### DIFF
--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -41,7 +41,7 @@ target 'testing' do
   pod 'Folly', :podspec => '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
   use_native_modules!
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :branch => 'master'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => $FirebaseSDKVersion
 end
 
 post_install do |installer|


### PR DESCRIPTION
### Description

The test podfile was pointing at master, but that can cause problems if the newest ios release is different then the one under test. They must be the same, so use the tag on firebase-ios-sdk-frameworks at the specified version vs master

Noticed while developing #4471 as it caused test app compile errors during baseline as master was 7.0.0 while I was still on 6.x.x originally

### Release Summary

named with conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

It actually *is* a test, so the test app either compiles or it doesn't, but with this change it will compile reliably

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
