### PR TITLE
fix(remote-config,ios): fixed fetch throttling issue

### DIFF
--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -119,7 +119,7 @@ RCT_EXPORT_METHOD(fetch:
     }
   };
 
-  if (expirationDuration == @(-1)) {
+  if (expirationDuration.integerValue == -1) {
     [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithCompletionHandler:completionHandler];
   } else {
     [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithExpirationDuration:expirationDuration.doubleValue completionHandler:completionHandler];


### PR DESCRIPTION
### Description

As per documentation, apps must be very gentle when it comes to fetching from the Firebase Remote Config storage. By default, it happens not more often than once in 12 hours. For that the library provides a selector: `fetchWithCompletionHandler:` that doesn't have the time interval parameter and uses the value from settings and the second one `fetchWithExpirationDuration:completionHandler:` that allows to override this configuration. In JS it is exposed as a single method of signature `fetch(expirationDurationSeconds?: number): Promise<void>;`. When `expirationDurationSeconds` is undefined, -1 is passed to the native module and then treated as follows:
```
  if (expirationDuration == @(-1)) {
    [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithCompletionHandler:completionHandler];
  } else {
    [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithExpirationDuration:expirationDuration.doubleValue completionHandler:completionHandler];
  }
```

The problem here is that an `NSNumber` instance is compared by reference with another `NSNumber` instance (yet holding the same value) which always fails, leading to the `else` path always executed. And internally in the FirebaseRemoteConfig SDK `-1` is going to be treated same as `0` in such a way that no limitation on fetching will be applied, resulting in almost immediate throttling unleashed by the server.

This PR mitigates this issue and allows to fetch the remote config without the risk of throttling.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

:fire: