### PR TITLE
chore(ci): removed sonar cloud code coverage

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,2 +1,0 @@
-sonar.sources=.
-sonar.inclusions=packages/*/android/src/**/*,packages/*/ios/**/*.{h,m}


### PR DESCRIPTION
Sonar cloud is currently not utilised in our CI. 

This can be removed as code coverage is covered with Codecov