### PR TITLE
test(storage, e2e): fix pause/cancel tests, re-enable them

### DIFF
--- a/packages/storage/lib/utils.js
+++ b/packages/storage/lib/utils.js
@@ -27,12 +27,12 @@ const SETTABLE_FIELDS = [
   'customMetadata',
 ];
 
-export function handleStorageEvent(storageInstance, event) {
+export async function handleStorageEvent(storageInstance, event) {
   const { taskId, eventName } = event;
   const body = event.body || {};
 
   if (body.error) {
-    body.error = NativeFirebaseError.fromEvent(body.error, storageInstance._config.namespace);
+    body.error = await NativeFirebaseError.fromEvent(body.error, storageInstance._config.namespace);
   }
 
   storageInstance.emitter.emit(storageInstance.eventNameForApp(taskId, eventName), body);


### PR DESCRIPTION

### Description

This is pulled from / Obsoletes #3691 by @dackers86 

The goal is to get the storage work from that PR with none of the other e2e entanglements

:crossed_fingers: it passes e2e in the current state of e2e

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
