### PR TITLE
fix(admob,android): add null checks for interstitialAd object

### DIFF
--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
@@ -125,6 +125,10 @@ public class ReactNativeFirebaseAdMobInterstitialModule extends ReactNativeFireb
     }
     getCurrentActivity().runOnUiThread(() -> {
       InterstitialAd interstitialAd = interstitialAdArray.get(requestId);
+      if (interstitialAd == null) {
+        rejectPromiseWithCodeAndMessage(promise, "null-interstitialAd", "Interstitial ad attempted to show but its object was null.");
+        return;
+      }
 
       if (showOptions.hasKey("immersiveModeEnabled")) {
         interstitialAd.setImmersiveMode(showOptions.getBoolean("immersiveModeEnabled"));


### PR DESCRIPTION
### Description
Hi, just got a null-pointer exception while using AdMob in my app:

```
java.lang.NullPointerException: 
  at io.invertase.firebase.admob.ReactNativeFirebaseAdMobInterstitialModule.lambda$interstitialShow$1 (ReactNativeFirebaseAdMobInterstitialModule.java:132)
  at io.invertase.firebase.admob.-$$Lambda$ReactNativeFirebaseAdMobInterstitialModule$HC0J2W104AWtZIk60UVqQO1y4sE.run (Unknown Source:6)
  at android.os.Handler.handleCallback (Handler.java:888)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loop (Looper.java:213)
  at android.app.ActivityThread.main (ActivityThread.java:8178)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:513)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1101)
```

I think this should sort out the issue although it was not tested.

### Related issues

Found no related issue.

### Release Summary


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x ] Yes
- My change supports the following platforms;
  - [x ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x ] No



### Test Plan

I simply ran the `yarn tests:jest` and compiled with `yarn tests:android:build` 🔥

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
