### PR TITLE
fix(ios, storage): handle nil file extension from ios14 M1 emulators

### DIFF
--- a/packages/storage/ios/RNFBStorage/RNFBStorageCommon.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageCommon.m
@@ -63,7 +63,7 @@
       (__bridge CFStringRef) [localFilePath pathExtension],
       NULL);
   CFStringRef mimeType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
-  CFRelease(UTI);
+  if (UTI) { CFRelease(UTI); }
 
   if (!mimeType) {
     return @"application/octet-stream";


### PR DESCRIPTION
### Description

This fix resolves a crash that occurs when pathExtension returns NULL, failing to detect file extension. This was detected as a result of a simulator bug with Apple Silicon Macs where pathExtension returns NULL only iOS14 (works as expected on iOS13).

This bug would probably surface on any device if file extension could not be detected when calling mimeTypeForPath, this could be used to verify the fix on intel Macs.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #4661 
### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Verified mimeTypeForPath function on Apple Silicon with iOS14 sim to return @"application/octet-stream". Verified CFRelease is being called on iOS13 sim.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
