### PR TITLE
feat(app): bump firebase-ios-sdk / firebase-android-sdk versions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,6 +41,11 @@ module.exports = {
     '@typescript-eslint/no-empty-function': 'off',
     // off for validation tests
     '@typescript-eslint/ban-ts-ignore': 'off',
+    'mocha/no-skipped-tests': 'off', // we skip tests for a reason, frequently
+    'mocha/no-top-level-hooks': 'off', // potentially has value if anyone wants to refactor
+    'mocha/no-hooks-for-single-case': 'off', // potentially has value
+    'mocha/no-setup-in-describe': 'off', // potentially has value, large refactor here though
+    
   },
   globals: {
     __DEV__: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
   parser: '@typescript-eslint/parser', // Specifies the ESLint parser
   extends: [
-    "plugin:react/recommended",
+    'plugin:react/recommended',
+    'plugin:mocha/recommended',
     'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
     'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cross-env": "^7.0.2",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.5.0",
+    "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-react": "^7.19.0",
     "genversion": "^2.2.0",

--- a/packages/admob/__tests__/admob.test.ts
+++ b/packages/admob/__tests__/admob.test.ts
@@ -1,24 +1,24 @@
 import { firebase, FirebaseAdMobTypes } from '../lib';
 
-describe('Admob', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('Admob', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       expect(app.admob).toBeDefined();
       expect(app.admob().app).toEqual(app);
     });
   });
 
-  describe('setRequestConfiguration()', () => {
-    it('throws if config is not an object', () => {
+  describe('setRequestConfiguration()', function() {
+    it('throws if config is not an object', function() {
       // @ts-ignore
       expect(() => firebase.admob().setRequestConfiguration('123')).toThrowError(
         "firebase.admob().setRequestConfiguration(*) 'requestConfiguration' expected an object value",
       );
     });
 
-    describe('maxAdContentRating', () => {
-      it('throws if maxAdContentRating is invalid', () => {
+    describe('maxAdContentRating', function() {
+      it('throws if maxAdContentRating is invalid', function() {
         expect(() =>
           firebase.admob().setRequestConfiguration({
             maxAdContentRating: 'Y' as FirebaseAdMobTypes.MaxAdContentRating[keyof FirebaseAdMobTypes.MaxAdContentRating],
@@ -29,8 +29,8 @@ describe('Admob', () => {
       });
     });
 
-    describe('tagForChildDirectedTreatment', () => {
-      it('throws if tagForChildDirectedTreatment not a boolean', () => {
+    describe('tagForChildDirectedTreatment', function() {
+      it('throws if tagForChildDirectedTreatment not a boolean', function() {
         expect(() =>
           firebase.admob().setRequestConfiguration({
             // @ts-ignore
@@ -42,8 +42,8 @@ describe('Admob', () => {
       });
     });
 
-    describe('tagForUnderAgeOfConsent', () => {
-      it('throws if tagForUnderAgeOfConsent not a boolean', () => {
+    describe('tagForUnderAgeOfConsent', function() {
+      it('throws if tagForUnderAgeOfConsent not a boolean', function() {
         expect(() =>
           firebase.admob().setRequestConfiguration({
             // @ts-ignore

--- a/packages/admob/__tests__/consent.test.ts
+++ b/packages/admob/__tests__/consent.test.ts
@@ -1,21 +1,21 @@
 import { AdsConsent } from '../lib';
 
-describe('Admob AdsConsent', () => {
-  describe('requestInfoUpdate', () => {
-    it('throws if publisherIds is not an array', () => {
+describe('Admob AdsConsent', function() {
+  describe('requestInfoUpdate', function() {
+    it('throws if publisherIds is not an array', function() {
       // @ts-ignore
       expect(() => AdsConsent.requestInfoUpdate('pub-123')).toThrowError(
         "firebase.admob.AdsConsent.requestInfoUpdate(*) 'publisherIds' expected an array of string values.",
       );
     });
 
-    it('throws if publisherIds is empty array', () => {
+    it('throws if publisherIds is empty array', function() {
       expect(() => AdsConsent.requestInfoUpdate([])).toThrowError(
         "firebase.admob.AdsConsent.requestInfoUpdate(*) 'publisherIds' list of publisher IDs cannot be empty.",
       );
     });
 
-    it('throws if publisherIds contains non-string values', () => {
+    it('throws if publisherIds contains non-string values', function() {
       // @ts-ignore
       expect(() => AdsConsent.requestInfoUpdate(['foo', 123])).toThrowError(
         "firebase.admob.AdsConsent.requestInfoUpdate(*) 'publisherIds[1]' expected a string value.",

--- a/packages/admob/__tests__/interstitial.test.ts
+++ b/packages/admob/__tests__/interstitial.test.ts
@@ -1,15 +1,15 @@
 import { InterstitialAd } from '../lib';
 
-describe('Admob Interstitial', () => {
-  describe('createForAdRequest', () => {
-    it('throws if adUnitId is invalid', () => {
+describe('Admob Interstitial', function() {
+  describe('createForAdRequest', function() {
+    it('throws if adUnitId is invalid', function() {
       // @ts-ignore
       expect(() => InterstitialAd.createForAdRequest(123)).toThrowError(
         "'adUnitId' expected an string value",
       );
     });
 
-    it('throws if requestOptions are invalid', () => {
+    it('throws if requestOptions are invalid', function() {
       // @ts-ignore
       expect(() => InterstitialAd.createForAdRequest('123', 123)).toThrowError(
         "firebase.admob() InterstitialAd.createForAdRequest(_, *) 'options' expected an object value.",
@@ -17,15 +17,15 @@ describe('Admob Interstitial', () => {
     });
 
     // has own tests
-    it('returns a new instance', () => {
+    it('returns a new instance', function() {
       const i = InterstitialAd.createForAdRequest('abc');
       expect(i.constructor.name).toEqual('InterstitialAd');
       expect(i.adUnitId).toEqual('abc');
       expect(i.loaded).toEqual(false);
     });
 
-    describe('show', () => {
-      it('throws if showing before loaded', () => {
+    describe('show', function() {
+      it('throws if showing before loaded', function() {
         const i = InterstitialAd.createForAdRequest('abc');
 
         expect(() => i.show()).toThrowError(
@@ -34,15 +34,15 @@ describe('Admob Interstitial', () => {
       });
     });
 
-    describe('onAdEvent', () => {
-      it('throws if handler is not a function', () => {
+    describe('onAdEvent', function() {
+      it('throws if handler is not a function', function() {
         const i = InterstitialAd.createForAdRequest('abc');
 
         // @ts-ignore
         expect(() => i.onAdEvent('foo')).toThrowError("'handler' expected a function");
       });
 
-      it('returns an unsubscriber function', () => {
+      it('returns an unsubscriber function', function() {
         const i = InterstitialAd.createForAdRequest('abc');
         const unsub = i.onAdEvent(() => {});
         expect(unsub).toBeDefined();

--- a/packages/admob/e2e/admob.e2e.js
+++ b/packages/admob/e2e/admob.e2e.js
@@ -15,17 +15,17 @@
  *
  */
 
-describe('admob()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('admob()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.admob);
       app.admob().app.should.equal(app);
     });
   });
 
-  describe('setRequestConfiguration()', () => {
-    it('throws if config is not an object', () => {
+  describe('setRequestConfiguration()', function() {
+    it('throws if config is not an object', function() {
       try {
         firebase.admob().setRequestConfiguration('123');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -35,8 +35,8 @@ describe('admob()', () => {
       }
     });
 
-    describe('maxAdContentRating', () => {
-      it('throws if maxAdContentRating is invalid', () => {
+    describe('maxAdContentRating', function() {
+      it('throws if maxAdContentRating is invalid', function() {
         try {
           firebase.admob().setRequestConfiguration({
             maxAdContentRating: 'Y',
@@ -48,15 +48,15 @@ describe('admob()', () => {
         }
       });
 
-      it('accepts a age rating', async () => {
+      it('accepts a age rating', async function() {
         await firebase.admob().setRequestConfiguration({
           maxAdContentRating: firebase.admob.MaxAdContentRating.G,
         });
       });
     });
 
-    describe('tagForChildDirectedTreatment', () => {
-      it('throws if tagForChildDirectedTreatment not a boolean', () => {
+    describe('tagForChildDirectedTreatment', function() {
+      it('throws if tagForChildDirectedTreatment not a boolean', function() {
         try {
           firebase.admob().setRequestConfiguration({
             tagForChildDirectedTreatment: 'true',
@@ -70,15 +70,15 @@ describe('admob()', () => {
         }
       });
 
-      it('sets the value', async () => {
+      it('sets the value', async function() {
         await firebase.admob().setRequestConfiguration({
           tagForChildDirectedTreatment: false,
         });
       });
     });
 
-    describe('tagForUnderAgeOfConsent', () => {
-      it('throws if tagForUnderAgeOfConsent not a boolean', () => {
+    describe('tagForUnderAgeOfConsent', function() {
+      it('throws if tagForUnderAgeOfConsent not a boolean', function() {
         try {
           firebase.admob().setRequestConfiguration({
             tagForUnderAgeOfConsent: 'false',
@@ -92,7 +92,7 @@ describe('admob()', () => {
         }
       });
 
-      it('sets the value', async () => {
+      it('sets the value', async function() {
         await firebase.admob().setRequestConfiguration({
           tagForUnderAgeOfConsent: false,
         });

--- a/packages/admob/e2e/consent.e2e.js
+++ b/packages/admob/e2e/consent.e2e.js
@@ -17,21 +17,21 @@
 
 let AdsConsent;
 
-describe('admob() AdsConsent', () => {
-  before(() => {
+describe('admob() AdsConsent', function() {
+  before(function() {
     AdsConsent = jet.require('packages/admob/lib/AdsConsent');
   });
 
-  describe('requestInfoUpdate', () => {
-    it('requests info update', async () => {
+  describe('requestInfoUpdate', function() {
+    it('requests info update', async function() {
       const info = await AdsConsent.requestInfoUpdate(['pub-4406399463942824']);
       info.status.should.Number();
       info.isRequestLocationInEeaOrUnknown.should.be.Boolean();
     });
   });
 
-  describe('showForm', () => {
-    it('throws if options is not valid', () => {
+  describe('showForm', function() {
+    it('throws if options is not valid', function() {
       try {
         AdsConsent.showForm('foo');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -41,7 +41,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('throws if privacy policy is not valid', () => {
+    it('throws if privacy policy is not valid', function() {
       try {
         AdsConsent.showForm({
           privacyPolicy: 'www.invertase.io',
@@ -53,7 +53,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('throws if withPersonalizedAds is not a boolean', () => {
+    it('throws if withPersonalizedAds is not a boolean', function() {
       try {
         AdsConsent.showForm({
           privacyPolicy: 'https://invertase.io',
@@ -66,7 +66,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('throws if withNonPersonalizedAds is not a boolean', () => {
+    it('throws if withNonPersonalizedAds is not a boolean', function() {
       try {
         AdsConsent.showForm({
           privacyPolicy: 'https://invertase.io',
@@ -79,7 +79,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('throws if withAdFree is not a boolean', () => {
+    it('throws if withAdFree is not a boolean', function() {
       try {
         AdsConsent.showForm({
           privacyPolicy: 'https://invertase.io',
@@ -92,7 +92,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('throws if all options are false', () => {
+    it('throws if all options are false', function() {
       try {
         AdsConsent.showForm({
           privacyPolicy: 'https://invertase.io',
@@ -107,8 +107,8 @@ describe('admob() AdsConsent', () => {
     // TODO test show form works?
   });
 
-  describe('getAdProviders', () => {
-    it('returns a list of ad providers', async () => {
+  describe('getAdProviders', function() {
+    it('returns a list of ad providers', async function() {
       await AdsConsent.requestInfoUpdate(['pub-4406399463942824']);
       const providers = await AdsConsent.getAdProviders();
       providers.should.be.Array();
@@ -122,8 +122,8 @@ describe('admob() AdsConsent', () => {
     });
   });
 
-  describe('setDebugGeography', () => {
-    it('throws if geography is invalid', () => {
+  describe('setDebugGeography', function() {
+    it('throws if geography is invalid', function() {
       try {
         AdsConsent.setDebugGeography(3);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -133,7 +133,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('sets the geography', async () => {
+    it('sets the geography', async function() {
       await AdsConsent.setDebugGeography(0);
       const r1 = await AdsConsent.requestInfoUpdate(['pub-4406399463942824']);
       r1.isRequestLocationInEeaOrUnknown.should.eql(false);
@@ -170,8 +170,8 @@ describe('admob() AdsConsent', () => {
     });
   });
 
-  describe('getStatus / setStatus', () => {
-    it('throws if status is invalid', () => {
+  describe('getStatus / setStatus', function() {
+    it('throws if status is invalid', function() {
       try {
         AdsConsent.setStatus(4);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -181,27 +181,27 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('sets and gets unknown', async () => {
+    it('sets and gets unknown', async function() {
       await AdsConsent.setStatus(0);
       const s = await AdsConsent.getStatus();
       s.should.eql(0);
     });
 
-    it('sets and gets non-personalized', async () => {
+    it('sets and gets non-personalized', async function() {
       await AdsConsent.setStatus(1);
       const s = await AdsConsent.getStatus();
       s.should.eql(1);
     });
 
-    it('sets and gets personalized', async () => {
+    it('sets and gets personalized', async function() {
       await AdsConsent.setStatus(2);
       const s = await AdsConsent.getStatus();
       s.should.eql(2);
     });
   });
 
-  describe('setTagForUnderAgeOfConsent', () => {
-    it('throws if value is not a boolean', () => {
+  describe('setTagForUnderAgeOfConsent', function() {
+    it('throws if value is not a boolean', function() {
       try {
         AdsConsent.setTagForUnderAgeOfConsent('true');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -211,13 +211,13 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('sets a value', async () => {
+    it('sets a value', async function() {
       await AdsConsent.setTagForUnderAgeOfConsent(false);
     });
   });
 
-  describe('addTestDevices', () => {
-    it('throws if value is not an array', () => {
+  describe('addTestDevices', function() {
+    it('throws if value is not an array', function() {
       try {
         AdsConsent.addTestDevices(12345);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -227,7 +227,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('throws if deviceIds contains invalid value', () => {
+    it('throws if deviceIds contains invalid value', function() {
       try {
         AdsConsent.addTestDevices(['foo', 123]);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -237,7 +237,7 @@ describe('admob() AdsConsent', () => {
       }
     });
 
-    it('sets device IDs', async () => {
+    it('sets device IDs', async function() {
       await AdsConsent.addTestDevices(['foo', 'bar']);
     });
   });

--- a/packages/admob/e2e/interstitial.e2e.js
+++ b/packages/admob/e2e/interstitial.e2e.js
@@ -17,15 +17,15 @@
 
 let InterstitialAd;
 
-describe('admob() InterstitialAd', () => {
-  before(() => {
+describe('admob() InterstitialAd', function() {
+  before(function() {
     InterstitialAd = jet.require('packages/admob/lib/ads/InterstitialAd');
   });
 
-  describe('createForAdRequest', () => {
+  describe('createForAdRequest', function() {
     // has own tests
 
-    it('loads with requestOptions', async () => {
+    it('loads with requestOptions', async function() {
       const spy = sinon.spy();
 
       const i = InterstitialAd.createForAdRequest(firebase.admob.TestIds.INTERSTITIAL, {
@@ -50,8 +50,8 @@ describe('admob() InterstitialAd', () => {
     });
   });
 
-  describe('onAdEvent', () => {
-    it('unsubscribe should prevent events', async () => {
+  describe('onAdEvent', function() {
+    it('unsubscribe should prevent events', async function() {
       const spy = sinon.spy();
       const i = InterstitialAd.createForAdRequest('abc');
       const unsub = i.onAdEvent(spy);
@@ -61,7 +61,7 @@ describe('admob() InterstitialAd', () => {
       spy.callCount.should.be.eql(0);
     });
 
-    it('loads with a valid ad unit id', async () => {
+    it('loads with a valid ad unit id', async function() {
       const spy = sinon.spy();
 
       const i = InterstitialAd.createForAdRequest(firebase.admob.TestIds.INTERSTITIAL);
@@ -74,7 +74,7 @@ describe('admob() InterstitialAd', () => {
       spy.getCall(0).args[0].should.eql('loaded');
     });
 
-    it('errors with an invalid ad unit id', async () => {
+    it('errors with an invalid ad unit id', async function() {
       const spy = sinon.spy();
 
       const i = InterstitialAd.createForAdRequest('123');

--- a/packages/admob/e2e/requestOptions.e2e.js
+++ b/packages/admob/e2e/requestOptions.e2e.js
@@ -17,17 +17,17 @@
 
 let validator = null;
 
-describe('admob() requestOptions', () => {
-  before(() => {
+describe('admob() requestOptions', function() {
+  before(function() {
     validator = jet.require('packages/admob/lib/validateAdRequestOptions');
   });
 
-  it('returns an empty object is not defined', () => {
+  it('returns an empty object is not defined', function() {
     const v = validator();
     v.should.eql(jet.contextify({}));
   });
 
-  it('throws if options is not an object', () => {
+  it('throws if options is not an object', function() {
     try {
       validator('foo');
       return Promise.reject(new Error('Did not throw Error.'));
@@ -37,8 +37,8 @@ describe('admob() requestOptions', () => {
     }
   });
 
-  describe('requestNonPersonalizedAdsOnly', () => {
-    it('throws if requestNonPersonalizedAdsOnly is not a boolean', () => {
+  describe('requestNonPersonalizedAdsOnly', function() {
+    it('throws if requestNonPersonalizedAdsOnly is not a boolean', function() {
       try {
         validator({
           requestNonPersonalizedAdsOnly: 'true',
@@ -52,7 +52,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts requestNonPersonalizedAdsOnly boolean', () => {
+    it('accepts requestNonPersonalizedAdsOnly boolean', function() {
       const v = validator({
         requestNonPersonalizedAdsOnly: false,
       });
@@ -60,8 +60,8 @@ describe('admob() requestOptions', () => {
     });
   });
 
-  describe('networkExtras', () => {
-    it('throws if networkExtras is not an object', () => {
+  describe('networkExtras', function() {
+    it('throws if networkExtras is not an object', function() {
       try {
         validator({
           networkExtras: ['foo', 'bar'],
@@ -75,7 +75,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if networkExtras value is not a string', () => {
+    it('throws if networkExtras value is not a string', function() {
       try {
         validator({
           networkExtras: {
@@ -92,7 +92,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts networkExtras object', () => {
+    it('accepts networkExtras object', function() {
       const v = validator({
         networkExtras: {
           foo: 'bar',
@@ -105,8 +105,8 @@ describe('admob() requestOptions', () => {
     });
   });
 
-  describe('keywords', () => {
-    it('throws if keywords is not an array', () => {
+  describe('keywords', function() {
+    it('throws if keywords is not an array', function() {
       try {
         validator({
           keywords: { foo: 'bar' },
@@ -120,7 +120,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if a keyword is not a string', () => {
+    it('throws if a keyword is not a string', function() {
       try {
         validator({
           keywords: ['foo', 123],
@@ -134,7 +134,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts keywords array', () => {
+    it('accepts keywords array', function() {
       const v = validator({
         keywords: ['foo', 'bar'],
       });
@@ -145,8 +145,8 @@ describe('admob() requestOptions', () => {
     });
   });
 
-  describe('testDevices', () => {
-    it('throws if testDevices is not an array', () => {
+  describe('testDevices', function() {
+    it('throws if testDevices is not an array', function() {
       try {
         validator({
           testDevices: { foo: 'bar' },
@@ -160,7 +160,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if a testDevices is not a string', () => {
+    it('throws if a testDevices is not a string', function() {
       try {
         validator({
           testDevices: ['foo', 123],
@@ -174,7 +174,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts testDevices array', () => {
+    it('accepts testDevices array', function() {
       const v = validator({
         testDevices: ['foo', 'bar'],
       });
@@ -185,8 +185,8 @@ describe('admob() requestOptions', () => {
     });
   });
 
-  describe('contentUrl', () => {
-    it('throws if contentUrl is not a string', () => {
+  describe('contentUrl', function() {
+    it('throws if contentUrl is not a string', function() {
       try {
         validator({
           contentUrl: 123,
@@ -198,7 +198,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if contentUrl is not a valid url', () => {
+    it('throws if contentUrl is not a valid url', function() {
       try {
         validator({
           contentUrl: 'www.invertase.io',
@@ -210,7 +210,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if contentUrl is too long', () => {
+    it('throws if contentUrl is too long', function() {
       let str = '';
       for (let i = 0; i < 530; i++) {
         str += i.toString();
@@ -229,7 +229,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts a contentUrl', () => {
+    it('accepts a contentUrl', function() {
       const v = validator({
         contentUrl: 'http://invertase.io/privacy-policy',
       });
@@ -238,8 +238,8 @@ describe('admob() requestOptions', () => {
     });
   });
 
-  describe('location', () => {
-    it('throws if not an array', () => {
+  describe('location', function() {
+    it('throws if not an array', function() {
       try {
         validator({
           location: 'United Kingdom',
@@ -253,7 +253,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if latitude not a number', () => {
+    it('throws if latitude not a number', function() {
       try {
         validator({
           location: ['123', 123],
@@ -267,7 +267,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if latitude is invalid', () => {
+    it('throws if latitude is invalid', function() {
       try {
         validator({
           location: [-100, 100],
@@ -281,7 +281,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if longitude not a number', () => {
+    it('throws if longitude not a number', function() {
       try {
         validator({
           location: [10, '123'],
@@ -295,7 +295,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if longitude is invalid', () => {
+    it('throws if longitude is invalid', function() {
       try {
         validator({
           location: [50, 200],
@@ -309,7 +309,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts a latitude and longitude', () => {
+    it('accepts a latitude and longitude', function() {
       const v = validator({
         location: [10, 20],
       });
@@ -320,8 +320,8 @@ describe('admob() requestOptions', () => {
     });
   });
 
-  describe('locationAccuracy', () => {
-    it('throws if not a number', () => {
+  describe('locationAccuracy', function() {
+    it('throws if not a number', function() {
       try {
         validator({
           locationAccuracy: '10',
@@ -333,7 +333,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if less than 0', () => {
+    it('throws if less than 0', function() {
       try {
         validator({
           locationAccuracy: -1,
@@ -345,21 +345,21 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts locationAccuracy', () => {
+    it('accepts locationAccuracy', function() {
       const v = validator({
         locationAccuracy: 10.5,
       });
       v.locationAccuracy.should.eql(10.5);
     });
 
-    it('uses a defaultValue', () => {
+    it('uses a defaultValue', function() {
       const v = validator({});
       v.locationAccuracy.should.eql(5);
     });
   });
 
-  describe('requestAgent', () => {
-    it('throws if not a string', () => {
+  describe('requestAgent', function() {
+    it('throws if not a string', function() {
       try {
         validator({
           requestAgent: 1,
@@ -371,7 +371,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts a requestAgent', () => {
+    it('accepts a requestAgent', function() {
       const v = validator({
         requestAgent: 'CoolAds',
       });
@@ -379,8 +379,8 @@ describe('admob() requestOptions', () => {
     });
   });
 
-  describe('serverSideVerificationOptions', () => {
-    it('throws if userId is not a string', () => {
+  describe('serverSideVerificationOptions', function() {
+    it('throws if userId is not a string', function() {
       try {
         validator({
           serverSideVerificationOptions: {
@@ -396,7 +396,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('throws if customData is not a string', () => {
+    it('throws if customData is not a string', function() {
       try {
         validator({
           serverSideVerificationOptions: {
@@ -412,7 +412,7 @@ describe('admob() requestOptions', () => {
       }
     });
 
-    it('accepts a serverSideVerificationOptions', () => {
+    it('accepts a serverSideVerificationOptions', function() {
       const v = validator({
         serverSideVerificationOptions: {
           userId: '1',

--- a/packages/admob/e2e/rewarded.e2e.js
+++ b/packages/admob/e2e/rewarded.e2e.js
@@ -17,13 +17,13 @@
 
 let RewardedAd;
 
-describe('admob() RewardedAd', () => {
-  before(() => {
+describe('admob() RewardedAd', function() {
+  before(function() {
     RewardedAd = jet.require('packages/admob/lib/ads/RewardedAd');
   });
 
-  describe('createForAdRequest', () => {
-    it('throws if adUnitId is invalid', () => {
+  describe('createForAdRequest', function() {
+    it('throws if adUnitId is invalid', function() {
       try {
         RewardedAd.createForAdRequest(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -34,7 +34,7 @@ describe('admob() RewardedAd', () => {
     });
 
     // has own tests
-    it('throws if requestOptions are invalid', () => {
+    it('throws if requestOptions are invalid', function() {
       try {
         RewardedAd.createForAdRequest('123', 123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -43,14 +43,14 @@ describe('admob() RewardedAd', () => {
       }
     });
 
-    it('returns a new instance', () => {
+    it('returns a new instance', function() {
       const i = RewardedAd.createForAdRequest('abc');
       i.constructor.name.should.eql('RewardedAd');
       i.adUnitId.should.eql('abc');
       i.loaded.should.eql(false);
     });
 
-    it('loads with requestOptions', async () => {
+    it('loads with requestOptions', async function() {
       if (device.getPlatform() === 'ios') {
         // Flaky on local iOS
         return;
@@ -79,8 +79,8 @@ describe('admob() RewardedAd', () => {
     });
   });
 
-  describe('show', () => {
-    it('throws if showing before loaded', () => {
+  describe('show', function() {
+    it('throws if showing before loaded', function() {
       const i = RewardedAd.createForAdRequest('abc');
 
       try {
@@ -95,8 +95,8 @@ describe('admob() RewardedAd', () => {
     });
   });
 
-  describe('onAdEvent', () => {
-    it('throws if handler is not a function', () => {
+  describe('onAdEvent', function() {
+    it('throws if handler is not a function', function() {
       const i = RewardedAd.createForAdRequest('abc');
 
       try {
@@ -108,14 +108,14 @@ describe('admob() RewardedAd', () => {
       }
     });
 
-    it('returns an unsubscriber function', () => {
+    it('returns an unsubscriber function', function() {
       const i = RewardedAd.createForAdRequest('abc');
       const unsub = i.onAdEvent(() => {});
       unsub.should.be.Function();
       unsub();
     });
 
-    it('unsubscribe should prevent events', async () => {
+    it('unsubscribe should prevent events', async function() {
       if (device.getPlatform() === 'ios') {
         // Flaky on local iOS
         return;
@@ -129,7 +129,7 @@ describe('admob() RewardedAd', () => {
       spy.callCount.should.be.eql(0);
     });
 
-    it('loads with a valid ad unit id', async () => {
+    it('loads with a valid ad unit id', async function() {
       if (device.getPlatform() === 'ios') {
         // Flaky on local iOS
         return;
@@ -152,7 +152,7 @@ describe('admob() RewardedAd', () => {
       d.amount.should.be.Number();
     });
 
-    it('errors with an invalid ad unit id', async () => {
+    it('errors with an invalid ad unit id', async function() {
       const spy = sinon.spy();
 
       const i = RewardedAd.createForAdRequest('123');

--- a/packages/admob/e2e/showOptions.e2e.js
+++ b/packages/admob/e2e/showOptions.e2e.js
@@ -17,17 +17,17 @@
 
 let validator = null;
 
-describe('admob() showOptions', () => {
-  before(() => {
+describe('admob() showOptions', function() {
+  before(function() {
     validator = jet.require('packages/admob/lib/validateAdShowOptions');
   });
 
-  it('returns an empty object is not defined', () => {
+  it('returns an empty object is not defined', function() {
     const v = validator();
     v.should.eql(jet.contextify({}));
   });
 
-  it('throws if options is not an object', () => {
+  it('throws if options is not an object', function() {
     try {
       validator('foo');
       return Promise.reject(new Error('Did not throw Error.'));
@@ -37,7 +37,7 @@ describe('admob() showOptions', () => {
     }
   });
 
-  it('throws if immersiveModeEnabled is not a boolean', () => {
+  it('throws if immersiveModeEnabled is not a boolean', function() {
     try {
       validator({
         immersiveModeEnabled: 'true',
@@ -49,7 +49,7 @@ describe('admob() showOptions', () => {
     }
   });
 
-  it('sets immersiveMode', () => {
+  it('sets immersiveMode', function() {
     const v = validator({
       immersiveModeEnabled: true,
     });

--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -1,14 +1,14 @@
 import { firebase } from '../lib';
 
-describe('Analytics', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('Analytics', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       expect(app.analytics).toBeDefined();
       expect(app.analytics().app).toEqual(app);
     });
 
-    it('throws if non default app arg provided to firebase.analytics(APP)', () => {
+    it('throws if non default app arg provided to firebase.analytics(APP)', function() {
       const app = firebase.app('secondaryFromNative');
 
       const expectedError = [
@@ -21,7 +21,7 @@ describe('Analytics', () => {
       expect(() => firebase.analytics(app)).toThrowError(expectedError);
     });
 
-    it('throws if analytics access from a non default app', () => {
+    it('throws if analytics access from a non default app', function() {
       const app = firebase.app('secondaryFromNative');
 
       const expectedError = [
@@ -34,7 +34,7 @@ describe('Analytics', () => {
     });
 
     // TODO in app/registry/namespace.js - if (!hasCustomUrlOrRegionSupport)
-    xit('throws if args provided to firebase.app().analytics(ARGS)', () => {
+    xit('throws if args provided to firebase.app().analytics(ARGS)', function() {
       try {
         // @ts-ignore test
         firebase.app().analytics('foo', 'arg2');
@@ -46,38 +46,38 @@ describe('Analytics', () => {
     });
   });
 
-  it('errors if milliseconds not a number', () => {
+  it('errors if milliseconds not a number', function() {
     // @ts-ignore test
     expect(() => firebase.analytics().setSessionTimeoutDuration('123')).toThrowError(
       "'milliseconds' expected a number value",
     );
   });
 
-  it('throws if none string none null values', () => {
+  it('throws if none string none null values', function() {
     // @ts-ignore test
     expect(() => firebase.analytics().setUserId(123)).toThrowError("'id' expected a string value");
   });
 
-  it('throws if name is not a string', () => {
+  it('throws if name is not a string', function() {
     // @ts-ignore test
     expect(() => firebase.analytics().setUserProperty(1337, 'invertase')).toThrowError(
       "'name' expected a string value",
     );
   });
-  it('throws if value is invalid', () => {
+  it('throws if value is invalid', function() {
     // @ts-ignore test
     expect(() => firebase.analytics().setUserProperty('invertase3', 33.3333)).toThrowError(
       "'value' expected a string value",
     );
   });
 
-  it('throws if properties is not an object', () => {
+  it('throws if properties is not an object', function() {
     // @ts-ignore test
     expect(() => firebase.analytics().setUserProperties(1337)).toThrowError(
       "'properties' expected an object of key/value pairs",
     );
   });
-  it('throws if property value is invalid', () => {
+  it('throws if property value is invalid', function() {
     const props = {
       test: '123',
       foo: {
@@ -89,48 +89,48 @@ describe('Analytics', () => {
       "'properties' value for parameter 'foo' is invalid",
     );
   });
-  it('throws if value is a number', () => {
+  it('throws if value is a number', function() {
     // @ts-ignore test
     expect(() => firebase.analytics().setUserProperties({ invertase1: 123 })).toThrowError(
       "'properties' value for parameter 'invertase1' is invalid, expected a string.",
     );
   });
 
-  it('errors when no parameters are set', () => {
+  it('errors when no parameters are set', function() {
     // @ts-ignore test
     expect(() => firebase.analytics().logSearch()).toThrowError(
       'The supplied arg must be an object of key/values',
     );
   });
 
-  describe('logEvent()', () => {
-    it('errors if name is not a string', () => {
+  describe('logEvent()', function() {
+    it('errors if name is not a string', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logEvent(123)).toThrowError(
         "firebase.analytics().logEvent(*) 'name' expected a string value.",
       );
     });
 
-    it('errors if params is not an object', () => {
+    it('errors if params is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logEvent('invertase_event', 'foobar')).toThrowError(
         "firebase.analytics().logEvent(_, *) 'params' expected an object value.",
       );
     });
 
-    it('errors on using a reserved name', () => {
+    it('errors on using a reserved name', function() {
       expect(() => firebase.analytics().logEvent('session_start')).toThrowError(
         "firebase.analytics().logEvent(*) 'name' the event name 'session_start' is reserved and can not be used.",
       );
     });
 
-    it('errors if name not alphanumeric', () => {
+    it('errors if name not alphanumeric', function() {
       expect(() => firebase.analytics().logEvent('!@£$%^&*')).toThrowError(
         "firebase.analytics().logEvent(*) 'name' invalid event name '!@£$%^&*'. Names should contain 1 to 40 alphanumeric characters or underscores.",
       );
     });
 
-    it('errors if more than 25 params provided', () => {
+    it('errors if more than 25 params provided', function() {
       expect(() =>
         firebase.analytics().logEvent('invertase', Object.assign({}, new Array(26).fill(1))),
       ).toThrowError(
@@ -138,8 +138,8 @@ describe('Analytics', () => {
       );
     });
 
-    describe('logScreenView()', () => {
-      it('errors if param is not an object', () => {
+    describe('logScreenView()', function() {
+      it('errors if param is not an object', function() {
         // @ts-ignore test
         expect(() => firebase.analytics().logScreenView(123)).toThrowError(
           'firebase.analytics().logScreenView(*):',
@@ -147,14 +147,14 @@ describe('Analytics', () => {
       });
     });
 
-    describe('logAddPaymentInfo()', () => {
-      it('errors if param is not an object', () => {
+    describe('logAddPaymentInfo()', function() {
+      it('errors if param is not an object', function() {
         // @ts-ignore test
         expect(() => firebase.analytics().logAddPaymentInfo(123)).toThrowError(
           'firebase.analytics().logAddPaymentInfo(*):',
         );
       });
-      it('errors when compound values are not set', () => {
+      it('errors when compound values are not set', function() {
         expect(() =>
           firebase.analytics().logAddPaymentInfo({
             value: 123,
@@ -164,14 +164,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logAddToCart()', () => {
-    it('errors if param is not an object', () => {
+  describe('logAddToCart()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logAddToCart(123)).toThrowError(
         'firebase.analytics().logAddToCart(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logAddToCart({
           value: 123,
@@ -180,14 +180,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logAddShippingInfo()', () => {
-    it('errors if param is not an object', () => {
+  describe('logAddShippingInfo()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logAddShippingInfo(123)).toThrowError(
         'firebase.analytics().logAddShippingInfo(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logAddShippingInfo({
           value: 123,
@@ -196,14 +196,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logAddToWishlist()', () => {
-    it('errors if param is not an object', () => {
+  describe('logAddToWishlist()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logAddToWishlist(123)).toThrowError(
         'firebase.analytics().logAddToWishlist(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logAddToWishlist({
           value: 123,
@@ -212,14 +212,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logBeginCheckout()', () => {
-    it('errors if param is not an object', () => {
+  describe('logBeginCheckout()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logBeginCheckout(123)).toThrowError(
         'firebase.analytics().logBeginCheckout(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logBeginCheckout({
           value: 123,
@@ -228,14 +228,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logGenerateLead()', () => {
-    it('errors if param is not an object', () => {
+  describe('logGenerateLead()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logGenerateLead(123)).toThrowError(
         'firebase.analytics().logGenerateLead(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logGenerateLead({
           value: 123,
@@ -244,8 +244,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logCampaignDetails()', () => {
-    it('errors if param is not an object', () => {
+  describe('logCampaignDetails()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logCampaignDetails(123)).toThrowError(
         'firebase.analytics().logCampaignDetails(*):',
@@ -253,8 +253,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logEarnVirtualCurrency()', () => {
-    it('errors if param is not an object', () => {
+  describe('logEarnVirtualCurrency()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logEarnVirtualCurrency(123)).toThrowError(
         'firebase.analytics().logEarnVirtualCurrency(*):',
@@ -262,8 +262,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logJoinGroup()', () => {
-    it('errors if param is not an object', () => {
+  describe('logJoinGroup()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logJoinGroup(123)).toThrowError(
         'firebase.analytics().logJoinGroup(*):',
@@ -271,8 +271,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logLevelEnd()', () => {
-    it('errors if param is not an object', () => {
+  describe('logLevelEnd()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logLevelEnd(123)).toThrowError(
         'firebase.analytics().logLevelEnd(*):',
@@ -280,8 +280,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logLevelStart()', () => {
-    it('errors if param is not an object', () => {
+  describe('logLevelStart()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logLevelStart(123)).toThrowError(
         'firebase.analytics().logLevelStart(*):',
@@ -289,8 +289,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logLevelUp()', () => {
-    it('errors if param is not an object', () => {
+  describe('logLevelUp()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logLevelUp(123)).toThrowError(
         'firebase.analytics().logLevelUp(*):',
@@ -298,8 +298,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logLogin()', () => {
-    it('errors if param is not an object', () => {
+  describe('logLogin()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logLogin(123)).toThrowError(
         'firebase.analytics().logLogin(*):',
@@ -307,8 +307,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logPostScore()', () => {
-    it('errors if param is not an object', () => {
+  describe('logPostScore()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logPostScore(123)).toThrowError(
         'firebase.analytics().logPostScore(*):',
@@ -316,8 +316,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logSelectContent()', () => {
-    it('errors if param is not an object', () => {
+  describe('logSelectContent()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logSelectContent(123)).toThrowError(
         'firebase.analytics().logSelectContent(*):',
@@ -325,8 +325,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logSearch()', () => {
-    it('errors if param is not an object', () => {
+  describe('logSearch()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logSearch(123)).toThrowError(
         'firebase.analytics().logSearch(*):',
@@ -334,8 +334,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logSelectItem()', () => {
-    it('errors if param is not an object', () => {
+  describe('logSelectItem()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logSelectItem(123)).toThrowError(
         'firebase.analytics().logSelectItem(*):',
@@ -343,8 +343,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logSetCheckoutOption()', () => {
-    it('errors if param is not an object', () => {
+  describe('logSetCheckoutOption()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logSetCheckoutOption(123)).toThrowError(
         'firebase.analytics().logSetCheckoutOption(*):',
@@ -352,8 +352,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logShare()', () => {
-    it('errors if param is not an object', () => {
+  describe('logShare()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logShare(123)).toThrowError(
         'firebase.analytics().logShare(*):',
@@ -361,8 +361,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logSignUp()', () => {
-    it('errors if param is not an object', () => {
+  describe('logSignUp()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logSignUp(123)).toThrowError(
         'firebase.analytics().logSignUp(*):',
@@ -370,8 +370,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logSelectPromotion()', () => {
-    it('errors if param is not an object', () => {
+  describe('logSelectPromotion()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logSelectPromotion(123)).toThrowError(
         'firebase.analytics().logSelectPromotion(*):',
@@ -379,8 +379,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logSpendVirtualCurrency()', () => {
-    it('errors if param is not an object', () => {
+  describe('logSpendVirtualCurrency()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logSpendVirtualCurrency(123)).toThrowError(
         'firebase.analytics().logSpendVirtualCurrency(*):',
@@ -388,8 +388,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logUnlockAchievement()', () => {
-    it('errors if param is not an object', () => {
+  describe('logUnlockAchievement()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logUnlockAchievement(123)).toThrowError(
         'firebase.analytics().logUnlockAchievement(*):',
@@ -397,14 +397,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logPurchase()', () => {
-    it('errors if param is not an object', () => {
+  describe('logPurchase()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logPurchase(123)).toThrowError(
         'firebase.analytics().logPurchase(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logPurchase({
           value: 123,
@@ -413,15 +413,15 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logRefund()', () => {
-    it('errors if param is not an object', () => {
+  describe('logRefund()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logRefund(123)).toThrowError(
         'firebase.analytics().logRefund(*):',
       );
     });
 
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logRefund({
           value: 123,
@@ -430,14 +430,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logViewCart()', () => {
-    it('errors if param is not an object', () => {
+  describe('logViewCart()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logViewCart(123)).toThrowError(
         'firebase.analytics().logViewCart(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logViewCart({
           value: 123,
@@ -446,14 +446,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logViewItem()', () => {
-    it('errors if param is not an object', () => {
+  describe('logViewItem()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logViewItem(123)).toThrowError(
         'firebase.analytics().logViewItem(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logViewItem({
           value: 123,
@@ -462,8 +462,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logViewItemList()', () => {
-    it('errors if param is not an object', () => {
+  describe('logViewItemList()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logViewItemList(123)).toThrowError(
         'firebase.analytics().logViewItemList(*):',
@@ -471,14 +471,14 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logRemoveFromCart()', () => {
-    it('errors if param is not an object', () => {
+  describe('logRemoveFromCart()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logRemoveFromCart(123)).toThrowError(
         'firebase.analytics().logRemoveFromCart(*):',
       );
     });
-    it('errors when compound values are not set', () => {
+    it('errors when compound values are not set', function() {
       expect(() =>
         firebase.analytics().logRemoveFromCart({
           value: 123,
@@ -487,8 +487,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logViewPromotion()', () => {
-    it('errors if param is not an object', () => {
+  describe('logViewPromotion()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logViewPromotion(123)).toThrowError(
         'firebase.analytics().logViewPromotion(*):',
@@ -496,8 +496,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('logViewSearchResults()', () => {
-    it('errors if param is not an object', () => {
+  describe('logViewSearchResults()', function() {
+    it('errors if param is not an object', function() {
       // @ts-ignore test
       expect(() => firebase.analytics().logViewSearchResults(123)).toThrowError(
         'firebase.analytics().logViewSearchResults(*):',
@@ -505,8 +505,8 @@ describe('Analytics', () => {
     });
   });
 
-  describe('setAnalyticsCollectionEnabled()', () => {
-    it('throws if not a boolean', () => {
+  describe('setAnalyticsCollectionEnabled()', function() {
+    it('throws if not a boolean', function() {
       // @ts-ignore
       expect(() => firebase.analytics().setAnalyticsCollectionEnabled('foo')).toThrowError(
         "firebase.analytics().setAnalyticsCollectionEnabled(*) 'enabled' expected a boolean value.",

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -30,14 +30,6 @@ describe('analytics()', function() {
         string: 'string',
       });
     });
-
-    it('log an event with parameters', async function() {
-      await firebase.analytics().logEvent('invertase_event', {
-        boolean: true,
-        number: 1,
-        string: 'string',
-      });
-    });
   });
 
   describe('setAnalyticsCollectionEnabled()', function() {

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -15,15 +15,15 @@
  *
  */
 
-describe('analytics()', () => {
-  describe('namespace', () => {});
+describe('analytics()', function() {
+  describe('namespace', function() {});
 
-  describe('logEvent()', () => {
-    it('log an event without parameters', async () => {
+  describe('logEvent()', function() {
+    it('log an event without parameters', async function() {
       await firebase.analytics().logEvent('invertase_event');
     });
 
-    it('log an event with parameters', async () => {
+    it('log an event with parameters', async function() {
       await firebase.analytics().logEvent('invertase_event', {
         boolean: true,
         number: 1,
@@ -31,7 +31,7 @@ describe('analytics()', () => {
       });
     });
 
-    it('log an event with parameters', async () => {
+    it('log an event with parameters', async function() {
       await firebase.analytics().logEvent('invertase_event', {
         boolean: true,
         number: 1,
@@ -40,72 +40,72 @@ describe('analytics()', () => {
     });
   });
 
-  describe('setAnalyticsCollectionEnabled()', () => {
-    it('true', async () => {
+  describe('setAnalyticsCollectionEnabled()', function() {
+    it('true', async function() {
       await firebase.analytics().setAnalyticsCollectionEnabled(true);
     });
 
-    it('false', async () => {
+    it('false', async function() {
       await firebase.analytics().setAnalyticsCollectionEnabled(false);
     });
   });
 
-  describe('resetAnalyticsData()', () => {
-    it('calls native fn without error', async () => {
+  describe('resetAnalyticsData()', function() {
+    it('calls native fn without error', async function() {
       await firebase.analytics().resetAnalyticsData();
     });
   });
 
-  describe('setSessionTimeoutDuration()', () => {
-    it('default duration', async () => {
+  describe('setSessionTimeoutDuration()', function() {
+    it('default duration', async function() {
       await firebase.analytics().setSessionTimeoutDuration();
     });
 
-    it('custom duration', async () => {
+    it('custom duration', async function() {
       await firebase.analytics().setSessionTimeoutDuration(13371337);
     });
   });
 
-  describe('setUserId()', () => {
-    it('allows a null values to be set', async () => {
+  describe('setUserId()', function() {
+    it('allows a null values to be set', async function() {
       await firebase.analytics().setUserId(null);
     });
 
-    it('accepts string values', async () => {
+    it('accepts string values', async function() {
       await firebase.analytics().setUserId('rn-firebase');
     });
   });
 
-  describe('setUserProperty()', () => {
-    it('allows a null values to be set', async () => {
+  describe('setUserProperty()', function() {
+    it('allows a null values to be set', async function() {
       await firebase.analytics().setUserProperty('invertase', null);
     });
 
-    it('accepts string values', async () => {
+    it('accepts string values', async function() {
       await firebase.analytics().setUserProperty('invertase2', 'rn-firebase');
     });
   });
 
-  describe('setUserProperties()', () => {
-    it('allows null values to be set', async () => {
+  describe('setUserProperties()', function() {
+    it('allows null values to be set', async function() {
       await firebase.analytics().setUserProperties({ invertase2: null });
     });
 
-    it('accepts string values', async () => {
+    it('accepts string values', async function() {
       await firebase.analytics().setUserProperties({ invertase3: 'rn-firebase' });
     });
   });
 
-  describe('logScreenView()', () => {
-    it('calls logScreenView', async () => {
+  describe('logScreenView()', function() {
+    it('calls logScreenView', async function() {
       await firebase
         .analytics()
         .logScreenView({ screen_name: 'invertase screen', screen_class: 'invertase class' });
     });
   });
 
-  describe('logAddPaymentInfo()', () => {
-    it('calls logAddPaymentInfo', async () => {
+  describe('logAddPaymentInfo()', function() {
+    it('calls logAddPaymentInfo', async function() {
       await firebase.analytics().logAddPaymentInfo({
         value: 123,
         currency: 'USD',
@@ -114,8 +114,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logAddToCart()', () => {
-    it('calls logAddToCart', async () => {
+  describe('logAddToCart()', function() {
+    it('calls logAddToCart', async function() {
       await firebase.analytics().logAddToCart({
         value: 123,
         currency: 'GBP',
@@ -123,8 +123,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logAddShippingInfo()', () => {
-    it('calls logAddShippingInfo', async () => {
+  describe('logAddShippingInfo()', function() {
+    it('calls logAddShippingInfo', async function() {
       await firebase.analytics().logAddShippingInfo({
         value: 123,
         currency: 'GBP',
@@ -132,8 +132,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logAddToWishlist()', () => {
-    it('calls logAddToWishlist', async () => {
+  describe('logAddToWishlist()', function() {
+    it('calls logAddToWishlist', async function() {
       await firebase.analytics().logAddToWishlist({
         items: [
           {
@@ -150,20 +150,20 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logAppOpen()', () => {
-    it('calls logAppOpen', async () => {
+  describe('logAppOpen()', function() {
+    it('calls logAppOpen', async function() {
       await firebase.analytics().logAppOpen();
     });
   });
 
-  describe('logBeginCheckout()', () => {
-    it('calls logBeginCheckout', async () => {
+  describe('logBeginCheckout()', function() {
+    it('calls logBeginCheckout', async function() {
       await firebase.analytics().logBeginCheckout();
     });
   });
 
-  describe('logCampaignDetails()', () => {
-    it('calls logCampaignDetails', async () => {
+  describe('logCampaignDetails()', function() {
+    it('calls logCampaignDetails', async function() {
       await firebase.analytics().logCampaignDetails({
         source: 'foo',
         medium: 'bar',
@@ -172,8 +172,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logEarnVirtualCurrency()', () => {
-    it('calls logEarnVirtualCurrency', async () => {
+  describe('logEarnVirtualCurrency()', function() {
+    it('calls logEarnVirtualCurrency', async function() {
       await firebase.analytics().logEarnVirtualCurrency({
         virtual_currency_name: 'foo',
         value: 123,
@@ -181,8 +181,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logPurchase()', () => {
-    it('calls logPurchase', async () => {
+  describe('logPurchase()', function() {
+    it('calls logPurchase', async function() {
       await firebase.analytics().logPurchase({
         currency: 'USD',
         value: 123,
@@ -191,8 +191,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logViewPromotion()', () => {
-    it('calls logViewPromotion', async () => {
+  describe('logViewPromotion()', function() {
+    it('calls logViewPromotion', async function() {
       await firebase.analytics().logViewPromotion({
         creative_name: 'creative_name',
         creative_slot: 'creative_slot',
@@ -200,8 +200,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logGenerateLead()', () => {
-    it('calls logGenerateLead', async () => {
+  describe('logGenerateLead()', function() {
+    it('calls logGenerateLead', async function() {
       await firebase.analytics().logGenerateLead({
         currency: 'USD',
         value: 123,
@@ -209,16 +209,16 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logJoinGroup()', () => {
-    it('calls logJoinGroup', async () => {
+  describe('logJoinGroup()', function() {
+    it('calls logJoinGroup', async function() {
       await firebase.analytics().logJoinGroup({
         group_id: '123',
       });
     });
   });
 
-  describe('logLevelEnd()', () => {
-    it('calls logLevelEnd', async () => {
+  describe('logLevelEnd()', function() {
+    it('calls logLevelEnd', async function() {
       await firebase.analytics().logLevelEnd({
         level: 123,
         success: 'yes',
@@ -226,16 +226,16 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logLevelStart()', () => {
-    it('calls logLevelEnd', async () => {
+  describe('logLevelStart()', function() {
+    it('calls logLevelEnd', async function() {
       await firebase.analytics().logLevelStart({
         level: 123,
       });
     });
   });
 
-  describe('logLevelUp()', () => {
-    it('calls logLevelUp', async () => {
+  describe('logLevelUp()', function() {
+    it('calls logLevelUp', async function() {
       await firebase.analytics().logLevelUp({
         level: 123,
         character: 'foo',
@@ -243,24 +243,24 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logLogin()', () => {
-    it('calls logLogin', async () => {
+  describe('logLogin()', function() {
+    it('calls logLogin', async function() {
       await firebase.analytics().logLogin({
         method: 'facebook.com',
       });
     });
   });
 
-  describe('logPostScore()', () => {
-    it('calls logPostScore', async () => {
+  describe('logPostScore()', function() {
+    it('calls logPostScore', async function() {
       await firebase.analytics().logPostScore({
         score: 123,
       });
     });
   });
 
-  describe('logRemoveFromCart()', () => {
-    it('calls logRemoveFromCart', async () => {
+  describe('logRemoveFromCart()', function() {
+    it('calls logRemoveFromCart', async function() {
       await firebase.analytics().logRemoveFromCart({
         value: 123,
         currency: 'USD',
@@ -268,16 +268,16 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logSearch()', () => {
-    it('calls logSearch', async () => {
+  describe('logSearch()', function() {
+    it('calls logSearch', async function() {
       await firebase.analytics().logSearch({
         search_term: 'foo',
       });
     });
   });
 
-  describe('logSetCheckoutOption()', () => {
-    it('calls logSelectContent', async () => {
+  describe('logSetCheckoutOption()', function() {
+    it('calls logSelectContent', async function() {
       await firebase.analytics().logSetCheckoutOption({
         checkout_step: 123,
         checkout_option: 'foo',
@@ -285,8 +285,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logSelectItem()', () => {
-    it('calls logSelectItem', async () => {
+  describe('logSelectItem()', function() {
+    it('calls logSelectItem', async function() {
       await firebase.analytics().logSelectItem({
         item_list_id: 'foo',
         item_list_name: 'foo',
@@ -295,8 +295,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logShare()', () => {
-    it('calls logShare', async () => {
+  describe('logShare()', function() {
+    it('calls logShare', async function() {
       await firebase.analytics().logShare({
         content_type: 'foo',
         item_id: 'foo',
@@ -305,16 +305,16 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logSignUp()', () => {
-    it('calls logSignUp', async () => {
+  describe('logSignUp()', function() {
+    it('calls logSignUp', async function() {
       await firebase.analytics().logSignUp({
         method: 'facebook.com',
       });
     });
   });
 
-  describe('logSpendVirtualCurrency()', () => {
-    it('calls logSpendVirtualCurrency', async () => {
+  describe('logSpendVirtualCurrency()', function() {
+    it('calls logSpendVirtualCurrency', async function() {
       await firebase.analytics().logSpendVirtualCurrency({
         item_name: 'foo',
         virtual_currency_name: 'foo',
@@ -323,34 +323,34 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logTutorialBegin()', () => {
-    it('calls logTutorialBegin', async () => {
+  describe('logTutorialBegin()', function() {
+    it('calls logTutorialBegin', async function() {
       await firebase.analytics().logTutorialBegin();
     });
   });
 
-  describe('logTutorialComplete()', () => {
-    it('calls logTutorialComplete', async () => {
+  describe('logTutorialComplete()', function() {
+    it('calls logTutorialComplete', async function() {
       await firebase.analytics().logTutorialComplete();
     });
   });
 
-  describe('logUnlockAchievement()', () => {
-    it('calls logUnlockAchievement', async () => {
+  describe('logUnlockAchievement()', function() {
+    it('calls logUnlockAchievement', async function() {
       await firebase.analytics().logUnlockAchievement({
         achievement_id: 'foo',
       });
     });
   });
 
-  describe('logViewCart()', () => {
-    it('calls logViewCart', async () => {
+  describe('logViewCart()', function() {
+    it('calls logViewCart', async function() {
       await firebase.analytics().logViewCart();
     });
   });
 
-  describe('logViewItem()', () => {
-    it('calls logViewItem', async () => {
+  describe('logViewItem()', function() {
+    it('calls logViewItem', async function() {
       await firebase.analytics().logViewItem({
         items: [
           {
@@ -366,16 +366,16 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logViewItemList()', () => {
-    it('calls logViewItemList', async () => {
+  describe('logViewItemList()', function() {
+    it('calls logViewItemList', async function() {
       await firebase.analytics().logViewItemList({
         item_list_name: 'foo',
       });
     });
   });
 
-  describe('logRefund()', () => {
-    it('calls logRefund', async () => {
+  describe('logRefund()', function() {
+    it('calls logRefund', async function() {
       await firebase.analytics().logRefund({
         affiliation: 'affiliation',
         coupon: 'coupon',
@@ -383,8 +383,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logSelectContent()', () => {
-    it('calls logSelectContent', async () => {
+  describe('logSelectContent()', function() {
+    it('calls logSelectContent', async function() {
       await firebase.analytics().logSelectContent({
         content_type: 'clothing',
         item_id: 'abcd',
@@ -392,8 +392,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logSelectPromotion()', () => {
-    it('calls logSelectPromotion', async () => {
+  describe('logSelectPromotion()', function() {
+    it('calls logSelectPromotion', async function() {
       await firebase.analytics().logSelectPromotion({
         creative_name: 'string',
         creative_slot: 'string',
@@ -404,8 +404,8 @@ describe('analytics()', () => {
     });
   });
 
-  describe('logViewSearchResults()', () => {
-    it('calls logViewSearchResults', async () => {
+  describe('logViewSearchResults()', function() {
+    it('calls logViewSearchResults', async function() {
       await firebase.analytics().logViewSearchResults({
         search_term: 'promotion',
       });

--- a/packages/app/e2e/app.constants.e2e.js
+++ b/packages/app/e2e/app.constants.e2e.js
@@ -15,9 +15,9 @@
  *
  */
 
-describe('App -> NativeModules -> Constants', () => {
-  describe('.apps', () => {
-    it('should be an array', () => {
+describe('App -> NativeModules -> Constants', function() {
+  describe('.apps', function() {
+    it('should be an array', function() {
       const { NATIVE_FIREBASE_APPS } = NativeModules.RNFBAppModule;
 
       NATIVE_FIREBASE_APPS.should.be.an.Array();
@@ -25,7 +25,7 @@ describe('App -> NativeModules -> Constants', () => {
       NATIVE_FIREBASE_APPS.length.should.equal(2);
     });
 
-    it('array items contain name, options & state properties', () => {
+    it('array items contain name, options & state properties', function() {
       const { NATIVE_FIREBASE_APPS } = NativeModules.RNFBAppModule;
 
       NATIVE_FIREBASE_APPS.should.be.an.Array();

--- a/packages/app/e2e/app.e2e.js
+++ b/packages/app/e2e/app.e2e.js
@@ -53,6 +53,7 @@ describe('firebase', function() {
   });
 });
 
+// eslint-disable-next-line mocha/max-top-level-suites
 describe('firebase -> X', function() {
   it('apps should provide an array of apps', function() {
     should.equal(!!firebase.apps.length, true);

--- a/packages/app/e2e/app.e2e.js
+++ b/packages/app/e2e/app.e2e.js
@@ -15,19 +15,19 @@
  *
  */
 
-describe('firebase', () => {
-  it('it should allow read the default app from native', () => {
+describe('firebase', function() {
+  it('it should allow read the default app from native', function() {
     // app is created in tests app before all hook
     should.equal(firebase.app()._nativeInitialized, true);
     should.equal(firebase.app().name, '[DEFAULT]');
   });
 
-  it('it should create js apps for natively initialized apps', () => {
+  it('it should create js apps for natively initialized apps', function() {
     should.equal(firebase.app('secondaryFromNative')._nativeInitialized, true);
     should.equal(firebase.app('secondaryFromNative').name, 'secondaryFromNative');
   });
 
-  it('natively initialized apps should have options available in js', () => {
+  it('natively initialized apps should have options available in js', function() {
     const platformAppConfig = FirebaseHelpers.app.config();
     should.equal(firebase.app().options.apiKey, platformAppConfig.apiKey);
     should.equal(firebase.app().options.appId, platformAppConfig.appId);
@@ -37,7 +37,7 @@ describe('firebase', () => {
     should.equal(firebase.app().options.storageBucket, platformAppConfig.storageBucket);
   });
 
-  xit('it should initialize dynamic apps', () => {
+  xit('it should initialize dynamic apps', function() {
     const name = `testscoreapp${FirebaseHelpers.id}`;
     const platformAppConfig = FirebaseHelpers.app.config();
     return firebase.initializeApp(platformAppConfig, name).then(newApp => {
@@ -48,24 +48,24 @@ describe('firebase', () => {
     });
   });
 
-  it('SDK_VERSION should return a string version', () => {
+  it('SDK_VERSION should return a string version', function() {
     firebase.SDK_VERSION.should.be.a.String();
   });
 });
 
-describe('firebase -> X', () => {
-  it('apps should provide an array of apps', () => {
+describe('firebase -> X', function() {
+  it('apps should provide an array of apps', function() {
     should.equal(!!firebase.apps.length, true);
     should.equal(firebase.apps.includes(firebase.app('[DEFAULT]')), true);
     return Promise.resolve();
   });
 
-  it('apps can get and set data collection', async () => {
+  it('apps can get and set data collection', async function() {
     firebase.app().automaticDataCollectionEnabled = false;
     should.equal(firebase.app().automaticDataCollectionEnabled, false);
   });
 
-  xit('apps can be deleted', async () => {
+  xit('apps can be deleted', async function() {
     const name = `testscoreapp${FirebaseHelpers.id}`;
     const platformAppConfig = FirebaseHelpers.app.config();
     const newApp = await firebase.initializeApp(platformAppConfig, name);
@@ -85,14 +85,14 @@ describe('firebase -> X', () => {
     }).should.throw(`No Firebase App '${name}' has been created - call firebase.initializeApp()`);
   });
 
-  xit('prevents the default app from being deleted', async () => {
+  xit('prevents the default app from being deleted', async function() {
     firebase
       .app()
       .delete()
       .should.be.rejectedWith('Unable to delete the default native firebase app instance.');
   });
 
-  it('extendApp should provide additional functionality', () => {
+  it('extendApp should provide additional functionality', function() {
     const extension = {};
     firebase.app().extendApp({
       extension,

--- a/packages/app/e2e/config.e2e.js
+++ b/packages/app/e2e/config.e2e.js
@@ -15,9 +15,9 @@
  *
  */
 
-describe('config', () => {
-  describe('meta', () => {
-    it('should read Info.plist/AndroidManifest.xml meta data', async () => {
+describe('config', function() {
+  describe('meta', function() {
+    it('should read Info.plist/AndroidManifest.xml meta data', async function() {
       const metaData = await NativeModules.RNFBAppModule.metaGetAll();
       metaData.rnfirebase_meta_testing_string.should.equal('abc');
       metaData.rnfirebase_meta_testing_boolean_false.should.equal(false);
@@ -25,8 +25,8 @@ describe('config', () => {
     });
   });
 
-  describe('json', () => {
-    xit('should read firebase.json data', async () => {
+  describe('json', function() {
+    xit('should read firebase.json data', async function() {
       const jsonData = await NativeModules.RNFBAppModule.jsonGetAll();
       jsonData.rnfirebase_json_testing_string.should.equal('abc');
       jsonData.rnfirebase_json_testing_boolean_false.should.equal(false);
@@ -34,19 +34,19 @@ describe('config', () => {
     });
   });
 
-  describe('prefs', () => {
-    beforeEach(async () => {
+  describe('prefs', function() {
+    beforeEach(async function() {
       await NativeModules.RNFBAppModule.preferencesClearAll();
     });
 
     // NOTE: "preferencesClearAll" clears Firestore settings. Set DB as emulator again.
-    after(async () => {
+    after(async function() {
       await firebase
         .firestore()
         .settings({ host: 'localhost:8080', ssl: false, persistence: true });
     });
 
-    it('should set bool values', async () => {
+    it('should set bool values', async function() {
       const prefsBefore = await NativeModules.RNFBAppModule.preferencesGetAll();
       should.equal(prefsBefore.invertase_oss, undefined);
       await NativeModules.RNFBAppModule.preferencesSetBool('invertase_oss', true);
@@ -54,7 +54,7 @@ describe('config', () => {
       prefsAfter.invertase_oss.should.equal(true);
     });
 
-    it('should set string values', async () => {
+    it('should set string values', async function() {
       const prefsBefore = await NativeModules.RNFBAppModule.preferencesGetAll();
       should.equal(prefsBefore.invertase_oss, undefined);
       await NativeModules.RNFBAppModule.preferencesSetString('invertase_oss', 'invertase.io');
@@ -62,7 +62,7 @@ describe('config', () => {
       prefsAfter.invertase_oss.should.equal('invertase.io');
     });
 
-    it('should clear all values', async () => {
+    it('should clear all values', async function() {
       await NativeModules.RNFBAppModule.preferencesSetString('invertase_oss', 'invertase.io');
       const prefsBefore = await NativeModules.RNFBAppModule.preferencesGetAll();
       prefsBefore.invertase_oss.should.equal('invertase.io');

--- a/packages/app/e2e/events.e2e.js
+++ b/packages/app/e2e/events.e2e.js
@@ -21,9 +21,9 @@ const eventBody = {
   foo: 'bar',
 };
 
-describe('Core -> EventEmitter', () => {
-  describe('ReactNativeFirebaseEventEmitter', () => {
-    it('queues events before app is ready', async () => {
+describe('Core -> EventEmitter', function() {
+  describe('ReactNativeFirebaseEventEmitter', function() {
+    it('queues events before app is ready', async function() {
       const { eventsPing, eventsNotifyReady, eventsGetListeners } = NativeModules.RNFBAppModule;
       await eventsNotifyReady(false);
 
@@ -57,7 +57,7 @@ describe('Core -> EventEmitter', () => {
       should.equal(nativeListenersAfter.events.pong, undefined);
     });
 
-    it('queues events before a js listener is registered', async () => {
+    it('queues events before a js listener is registered', async function() {
       const {
         eventsPing,
         eventsNotifyReady,

--- a/packages/app/e2e/utils.e2e.js
+++ b/packages/app/e2e/utils.e2e.js
@@ -15,23 +15,23 @@
  *
  */
 
-describe('utils()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('utils()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.utils);
       app.utils().app.should.equal(app);
     });
   });
 
-  describe('isRunningInTestLab', () => {
-    it('returns true or false', () => {
+  describe('isRunningInTestLab', function() {
+    it('returns true or false', function() {
       should.equal(firebase.utils().isRunningInTestLab, false);
     });
   });
 
-  describe('playServicesAvailability', () => {
-    it('returns isAvailable and Play Service status', async () => {
+  describe('playServicesAvailability', function() {
+    it('returns isAvailable and Play Service status', async function() {
       const playService = await firebase.utils().playServicesAvailability;
       //iOS always returns { isAvailable: true, status: 0}
       should(playService.isAvailable).equal(true);
@@ -39,8 +39,8 @@ describe('utils()', () => {
     });
   });
 
-  describe('getPlayServicesStatus', () => {
-    it('returns isAvailable and Play Service status', async () => {
+  describe('getPlayServicesStatus', function() {
+    it('returns isAvailable and Play Service status', async function() {
       const status = await firebase.utils().getPlayServicesStatus();
       //iOS always returns { isAvailable: true, status: 0}
       should(status.isAvailable).equal(true);

--- a/packages/app/e2e/utilsStatics.e2e.js
+++ b/packages/app/e2e/utilsStatics.e2e.js
@@ -15,9 +15,9 @@
  *
  */
 
-describe('utils()', () => {
-  describe('statics', () => {
-    it('provides native path strings', () => {
+describe('utils()', function() {
+  describe('statics', function() {
+    it('provides native path strings', function() {
       firebase.utils.FilePath.should.be.an.Object();
       if (device.getPlatform() === 'ios') {
         firebase.utils.FilePath.MAIN_BUNDLE.should.be.a.String();

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,14 +62,14 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "~> 7.2.0"
+      "firebase": "~> 7.3.0"
     },
     "android": {
       "minSdk": 16,
       "targetSdk": 30,
       "compileSdk": 30,
       "buildTools": "30.0.2",
-      "firebase": "26.1.1",
+      "firebase": "26.2.0",
       "playServicesAuth": "19.0.0"
     }
   }

--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -1,16 +1,16 @@
 import auth, { firebase } from '../lib';
 
-describe('Auth', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('Auth', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       expect(app.auth).toBeDefined();
       expect(app.auth().useEmulator).toBeDefined();
     });
   });
 
-  describe('useEmulator()', () => {
-    it('useEmulator requires a string url', () => {
+  describe('useEmulator()', function() {
+    it('useEmulator requires a string url', function() {
       // @ts-ignore because we pass an invalid argument...
       expect(() => auth().useEmulator()).toThrow(
         'firebase.auth().useEmulator() takes a non-empty string',
@@ -24,7 +24,7 @@ describe('Auth', () => {
       );
     });
 
-    it('useEmulator requires a well-formed url', () => {
+    it('useEmulator requires a well-formed url', function() {
       // No http://
       expect(() => auth().useEmulator('localhost:9099')).toThrow(
         'firebase.auth().useEmulator() unable to parse host and port from url',
@@ -35,7 +35,7 @@ describe('Auth', () => {
       );
     });
 
-    it('useEmulator -> remaps Android loopback to host', () => {
+    it('useEmulator -> remaps Android loopback to host', function() {
       const foo = auth().useEmulator('http://localhost:9099');
       expect(foo).toEqual(['10.0.2.2', 9099]);
 

--- a/packages/auth/e2e/auth.e2e.js
+++ b/packages/auth/e2e/auth.e2e.js
@@ -23,8 +23,8 @@ const DISABLED_PASS = 'test1234';
 
 const { clearAllUsers, disableUser, getLastOob, resetPassword } = require('./helpers');
 
-describe('auth()', () => {
-  before(async () => {
+describe('auth()', function() {
+  before(async function() {
     await clearAllUsers();
     await firebase.auth().createUserWithEmailAndPassword(TEST_EMAIL, TEST_PASS);
     const disabledUserCredential = await firebase
@@ -33,22 +33,22 @@ describe('auth()', () => {
     await disableUser(disabledUserCredential.user.uid);
   });
 
-  beforeEach(async () => {
+  beforeEach(async function() {
     if (firebase.auth().currentUser) {
       await firebase.auth().signOut();
       await Utils.sleep(50);
     }
   });
 
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.auth);
       app.auth().app.should.equal(app);
     });
 
     // removing as pending if module.options.hasMultiAppSupport = true
-    it('supports multiple apps', async () => {
+    it('supports multiple apps', async function() {
       firebase.auth().app.name.should.equal('[DEFAULT]');
 
       firebase
@@ -62,15 +62,15 @@ describe('auth()', () => {
     });
   });
 
-  describe('applyActionCode()', () => {
+  describe('applyActionCode()', function() {
     // Needs a different setup to work against the auth emulator
-    xit('works as expected', async () => {
+    xit('works as expected', async function() {
       await firebase
         .auth()
         .applyActionCode('fooby shooby dooby')
         .then($ => $);
     });
-    it('errors on invalid code', async () => {
+    it('errors on invalid code', async function() {
       try {
         await firebase
           .auth()
@@ -82,8 +82,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('checkActionCode()', () => {
-    it('errors on invalid code', async () => {
+  describe('checkActionCode()', function() {
+    it('errors on invalid code', async function() {
       try {
         await firebase.auth().checkActionCode('fooby shooby dooby');
       } catch (e) {
@@ -92,8 +92,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('reload()', () => {
-    it('Meta data returns as expected with annonymous sign in', async () => {
+  describe('reload()', function() {
+    it('Meta data returns as expected with annonymous sign in', async function() {
       await firebase.auth().signInAnonymously();
       await Utils.sleep(50);
       const firstUser = firebase.auth().currentUser;
@@ -109,7 +109,7 @@ describe('auth()', () => {
       firstUser.metadata.creationTime.should.not.equal(secondUser.metadata.creationTime);
     });
 
-    it('Meta data returns as expected with email and password sign in', async () => {
+    it('Meta data returns as expected with email and password sign in', async function() {
       const random = Utils.randString(12, '#aA');
       const email1 = `${random}@${random}.com`;
       const pass = random;
@@ -131,8 +131,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('confirmPasswordReset()', () => {
-    it('errors on invalid code via API', async () => {
+  describe('confirmPasswordReset()', function() {
+    it('errors on invalid code via API', async function() {
       try {
         await firebase.auth().confirmPasswordReset('fooby shooby dooby', 'passwordthing');
       } catch (e) {
@@ -141,9 +141,9 @@ describe('auth()', () => {
     });
   });
 
-  describe('signInWithCustomToken()', () => {
+  describe('signInWithCustomToken()', function() {
     // Needs a different setup when running against the emulator
-    xit('signs in with a admin sdk created custom auth token', async () => {
+    xit('signs in with a admin sdk created custom auth token', async function() {
       const successCb = currentUserCredential => {
         const currentUser = currentUserCredential.user;
         currentUser.should.be.an.Object();
@@ -179,8 +179,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('onAuthStateChanged()', () => {
-    it('calls callback with the current user and when auth state changes', async () => {
+  describe('onAuthStateChanged()', function() {
+    it('calls callback with the current user and when auth state changes', async function() {
       await firebase.auth().signInAnonymously();
 
       await Utils.sleep(50);
@@ -215,7 +215,7 @@ describe('auth()', () => {
       unsubscribe();
     });
 
-    it('accept observer instead callback as well', async () => {
+    it('accept observer instead callback as well', async function() {
       await firebase.auth().signInAnonymously();
       await Utils.sleep(200);
 
@@ -250,7 +250,7 @@ describe('auth()', () => {
       unsubscribe();
     });
 
-    it('stops listening when unsubscribed', async () => {
+    it('stops listening when unsubscribed', async function() {
       await firebase.auth().signInAnonymously();
       await Utils.sleep(200);
 
@@ -290,7 +290,7 @@ describe('auth()', () => {
       await Utils.sleep(50);
     });
 
-    it('returns the same user with multiple subscribers #1815', async () => {
+    it('returns the same user with multiple subscribers #1815', async function() {
       const callback = sinon.spy();
 
       let unsubscribe1;
@@ -340,8 +340,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('onIdTokenChanged()', () => {
-    it('calls callback with the current user and when auth state changes', async () => {
+  describe('onIdTokenChanged()', function() {
+    it('calls callback with the current user and when auth state changes', async function() {
       await firebase.auth().signInAnonymously();
       await Utils.sleep(200);
 
@@ -371,7 +371,7 @@ describe('auth()', () => {
       unsubscribe();
     });
 
-    it('stops listening when unsubscribed', async () => {
+    it('stops listening when unsubscribed', async function() {
       await firebase.auth().signInAnonymously();
       await Utils.sleep(200);
 
@@ -411,7 +411,7 @@ describe('auth()', () => {
       await Utils.sleep(50);
     });
 
-    it('listens to a null user when auth result is not defined', async () => {
+    it('listens to a null user when auth result is not defined', async function() {
       let unsubscribe;
 
       const callback = sinon.spy();
@@ -427,8 +427,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('onUserChanged()', () => {
-    it('calls callback with the current user and when auth state changes', async () => {
+  describe('onUserChanged()', function() {
+    it('calls callback with the current user and when auth state changes', async function() {
       await firebase.auth().signInAnonymously();
       await Utils.sleep(200);
 
@@ -461,7 +461,7 @@ describe('auth()', () => {
       unsubscribe();
     });
 
-    it('stops listening when unsubscribed', async () => {
+    it('stops listening when unsubscribed', async function() {
       await firebase.auth().signInAnonymously();
       await Utils.sleep(200);
 
@@ -505,8 +505,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('signInAnonymously()', () => {
-    it('it should sign in anonymously', () => {
+  describe('signInAnonymously()', function() {
+    it('it should sign in anonymously', function() {
       const successCb = currentUserCredential => {
         const currentUser = currentUserCredential.user;
         currentUser.should.be.an.Object();
@@ -530,8 +530,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('signInWithEmailAndPassword()', () => {
-    it('it should login with email and password', () => {
+  describe('signInWithEmailAndPassword()', function() {
+    it('it should login with email and password', function() {
       const successCb = currentUserCredential => {
         const currentUser = currentUserCredential.user;
         currentUser.should.be.an.Object();
@@ -555,7 +555,7 @@ describe('auth()', () => {
         .then(successCb);
     });
 
-    it('it should error on login if user is disabled', () => {
+    it('it should error on login if user is disabled', function() {
       const successCb = () => Promise.reject(new Error('Did not error.'));
 
       const failureCb = error => {
@@ -571,7 +571,7 @@ describe('auth()', () => {
         .catch(failureCb);
     });
 
-    it('it should error on login if password incorrect', () => {
+    it('it should error on login if password incorrect', function() {
       const successCb = () => Promise.reject(new Error('Did not error.'));
 
       const failureCb = error => {
@@ -589,7 +589,7 @@ describe('auth()', () => {
         .catch(failureCb);
     });
 
-    it('it should error on login if user not found', () => {
+    it('it should error on login if user not found', function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -612,8 +612,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('signInWithCredential()', () => {
-    it('it should login with email and password', () => {
+  describe('signInWithCredential()', function() {
+    it('it should login with email and password', function() {
       const credential = firebase.auth.EmailAuthProvider.credential(TEST_EMAIL, TEST_PASS);
 
       const successCb = currentUserCredential => {
@@ -639,7 +639,7 @@ describe('auth()', () => {
         .then(successCb);
     });
 
-    it('it should error on login if user is disabled', () => {
+    it('it should error on login if user is disabled', function() {
       const credential = firebase.auth.EmailAuthProvider.credential(DISABLED_EMAIL, DISABLED_PASS);
 
       const successCb = () => Promise.reject(new Error('Did not error.'));
@@ -657,7 +657,7 @@ describe('auth()', () => {
         .catch(failureCb);
     });
 
-    it('it should error on login if password incorrect', () => {
+    it('it should error on login if password incorrect', function() {
       const credential = firebase.auth.EmailAuthProvider.credential(TEST_EMAIL, TEST_PASS + '666');
 
       const successCb = () => Promise.reject(new Error('Did not error.'));
@@ -677,7 +677,7 @@ describe('auth()', () => {
         .catch(failureCb);
     });
 
-    it('it should error on login if user not found', () => {
+    it('it should error on login if user not found', function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -702,8 +702,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('createUserWithEmailAndPassword()', () => {
-    it('it should create a user with an email and password', () => {
+  describe('createUserWithEmailAndPassword()', function() {
+    it('it should create a user with an email and password', function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -729,7 +729,7 @@ describe('auth()', () => {
         .then(successCb);
     });
 
-    it('it should error on create with invalid email', () => {
+    it('it should error on create with invalid email', function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}${random}.com.boop.shoop`;
       const pass = random;
@@ -749,7 +749,7 @@ describe('auth()', () => {
         .catch(failureCb);
     });
 
-    it('it should error on create if email in use', () => {
+    it('it should error on create if email in use', function() {
       const successCb = () => Promise.reject(new Error('Did not error.'));
 
       const failureCb = error => {
@@ -765,7 +765,7 @@ describe('auth()', () => {
         .catch(failureCb);
     });
 
-    it('it should error on create if password weak', () => {
+    it('it should error on create if password weak', function() {
       const email = 'testy@testy.com';
       const pass = '123';
 
@@ -786,9 +786,9 @@ describe('auth()', () => {
     });
   });
 
-  describe('fetchSignInMethodsForEmail()', () => {
-    it('it should return password provider for an email address', () =>
-      new Promise((resolve, reject) => {
+  describe('fetchSignInMethodsForEmail()', function() {
+    it('it should return password provider for an email address', function() {
+      return new Promise((resolve, reject) => {
         const successCb = providers => {
           providers.should.be.a.Array();
           providers.should.containEql('password');
@@ -804,10 +804,11 @@ describe('auth()', () => {
           .fetchSignInMethodsForEmail(TEST_EMAIL)
           .then(successCb)
           .catch(failureCb);
-      }));
+      });
+    });
 
-    it('it should return an empty array for a not found email', () =>
-      new Promise((resolve, reject) => {
+    it('it should return an empty array for a not found email', function() {
+      return new Promise((resolve, reject) => {
         const successCb = providers => {
           providers.should.be.a.Array();
           providers.should.be.empty();
@@ -823,10 +824,11 @@ describe('auth()', () => {
           .fetchSignInMethodsForEmail('test@i-do-not-exist.com')
           .then(successCb)
           .catch(failureCb);
-      }));
+      });
+    });
 
-    it('it should return an error for a bad email address', () =>
-      new Promise((resolve, reject) => {
+    it('it should return an error for a bad email address', function() {
+      return new Promise((resolve, reject) => {
         const successCb = () => {
           reject(new Error('Should not have successfully resolved.'));
         };
@@ -842,12 +844,13 @@ describe('auth()', () => {
           .fetchSignInMethodsForEmail('foobar')
           .then(successCb)
           .catch(failureCb);
-      }));
+      });
+    });
   });
 
-  describe('signOut()', () => {
-    it('it should reject signOut if no currentUser', () =>
-      new Promise((resolve, reject) => {
+  describe('signOut()', function() {
+    it('it should reject signOut if no currentUser', function() {
+      return new Promise((resolve, reject) => {
         if (firebase.auth().currentUser) {
           return reject(
             new Error(`A user is currently signed in. ${firebase.auth().currentUser.uid}`),
@@ -869,11 +872,12 @@ describe('auth()', () => {
           .signOut()
           .then(successCb)
           .catch(failureCb);
-      }));
+      });
+    });
   });
 
-  describe('delete()', () => {
-    it('should delete a user', () => {
+  describe('delete()', function() {
+    it('should delete a user', function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -895,8 +899,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('languageCode', () => {
-    it('it should change the language code', async () => {
+  describe('languageCode', function() {
+    it('it should change the language code', async function() {
       await firebase.auth().setLanguageCode('en');
 
       if (firebase.auth().languageCode !== 'en') {
@@ -921,8 +925,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('getRedirectResult()', () => {
-    it('should throw an unsupported error', () => {
+  describe('getRedirectResult()', function() {
+    it('should throw an unsupported error', function() {
       (() => {
         firebase.auth().getRedirectResult();
       }).should.throw(
@@ -931,8 +935,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('setPersistence()', () => {
-    it('should throw an unsupported error', () => {
+  describe('setPersistence()', function() {
+    it('should throw an unsupported error', function() {
       (() => {
         firebase.auth().setPersistence();
       }).should.throw(
@@ -941,8 +945,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('signInWithPopup', () => {
-    it('should throw an unsupported error', () => {
+  describe('signInWithPopup', function() {
+    it('should throw an unsupported error', function() {
       (() => {
         firebase.auth().signInWithPopup();
       }).should.throw(
@@ -951,8 +955,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('sendPasswordResetEmail()', () => {
-    it('should not error', async () => {
+  describe('sendPasswordResetEmail()', function() {
+    it('should not error', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -966,7 +970,7 @@ describe('auth()', () => {
       }
     });
 
-    it('should verify with valid code', async () => {
+    it('should verify with valid code', async function() {
       // FIXME Fails on android against auth emulator with:
       // com.google.firebase.FirebaseException: An internal error has occurred.
       if (device.getPlatform() === 'ios') {
@@ -989,7 +993,7 @@ describe('auth()', () => {
       }
     });
 
-    it('should fail to verify with invalid code', async () => {
+    it('should fail to verify with invalid code', async function() {
       const random = Utils.randString(12, '#a');
       const email = `${random}@${random}.com`;
       const userCredential = await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -1009,7 +1013,7 @@ describe('auth()', () => {
       }
     });
 
-    it('should change password correctly OOB', async () => {
+    it('should change password correctly OOB', async function() {
       const random = Utils.randString(12, '#a');
       const email = `${random}@${random}.com`;
       const userCredential = await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -1031,7 +1035,7 @@ describe('auth()', () => {
       }
     });
 
-    it('should change password correctly via API', async () => {
+    it('should change password correctly via API', async function() {
       const random = Utils.randString(12, '#a');
       const email = `${random}@${random}.com`;
       const userCredential = await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -1054,8 +1058,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('signInWithRedirect()', () => {
-    it('should throw an unsupported error', () => {
+  describe('signInWithRedirect()', function() {
+    it('should throw an unsupported error', function() {
       (() => {
         firebase.auth().signInWithRedirect();
       }).should.throw(
@@ -1064,8 +1068,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('useDeviceLanguage()', () => {
-    it('should throw an unsupported error', () => {
+  describe('useDeviceLanguage()', function() {
+    it('should throw an unsupported error', function() {
       (() => {
         firebase.auth().useDeviceLanguage();
       }).should.throw(
@@ -1074,8 +1078,8 @@ describe('auth()', () => {
     });
   });
 
-  describe('useUserAccessGroup()', () => {
-    it('should return "null" on successful keychain implementation', async () => {
+  describe('useUserAccessGroup()', function() {
+    it('should return "null" on successful keychain implementation', async function() {
       const successfulKeychain = await firebase.auth().useUserAccessGroup('mysecretkeychain');
 
       should.not.exist(successfulKeychain);

--- a/packages/auth/e2e/emailLink.e2e.js
+++ b/packages/auth/e2e/emailLink.e2e.js
@@ -1,15 +1,15 @@
 const { getLastOob, signInUser } = require('./helpers');
 
-describe('auth() -> emailLink Provider', () => {
-  beforeEach(async () => {
+describe('auth() -> emailLink Provider', function() {
+  beforeEach(async function() {
     if (firebase.auth().currentUser) {
       await firebase.auth().signOut();
       await Utils.sleep(50);
     }
   });
 
-  describe('sendSignInLinkToEmail', () => {
-    it('should send email', async () => {
+  describe('sendSignInLinkToEmail', function() {
+    it('should send email', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       // const email = 'MANUAL TEST EMAIL HERE';
@@ -28,7 +28,7 @@ describe('auth() -> emailLink Provider', () => {
       await firebase.auth().sendSignInLinkToEmail(email, actionCodeSettings);
     });
 
-    it('sign in via email works', async () => {
+    it('sign in via email works', async function() {
       const random = Utils.randString(12, '#aa');
       const email = `${random}@${random}.com`;
       const continueUrl = 'http://localhost:1337/authLinkFoo?bar=' + random;
@@ -52,7 +52,7 @@ describe('auth() -> emailLink Provider', () => {
       signInResponse.should.containEql(oobInfo.oobCode);
     });
 
-    xit('should send email with defaults', async () => {
+    xit('should send email with defaults', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
 
@@ -60,8 +60,8 @@ describe('auth() -> emailLink Provider', () => {
     });
   });
 
-  describe('isSignInWithEmailLink', () => {
-    it('should return true/false', async () => {
+  describe('isSignInWithEmailLink', function() {
+    it('should return true/false', async function() {
       const emailLink1 = 'https://www.example.com/action?mode=signIn&oobCode=oobCode';
       const emailLink2 = 'https://www.example.com/action?mode=verifyEmail&oobCode=oobCode';
       const emailLink3 = 'https://www.example.com/action?mode=signIn';
@@ -76,8 +76,8 @@ describe('auth() -> emailLink Provider', () => {
   });
 
   // FOR MANUAL TESTING ONLY
-  xdescribe('signInWithEmailLink', () => {
-    it('should signIn', async () => {
+  xdescribe('signInWithEmailLink', function() {
+    it('should signIn', async function() {
       const email = 'MANUAL TEST EMAIL HERE';
       const emailLink = 'MANUAL TEST CODE HERE';
 

--- a/packages/auth/e2e/phone.e2e.js
+++ b/packages/auth/e2e/phone.e2e.js
@@ -3,8 +3,8 @@
 
 const { clearAllUsers, getLastSmsCode, getRandomPhoneNumber } = require('./helpers');
 
-describe('auth() => Phone', () => {
-  before(async () => {
+describe('auth() => Phone', function() {
+  before(async function() {
     try {
       await clearAllUsers();
     } catch (e) {
@@ -14,15 +14,15 @@ describe('auth() => Phone', () => {
     await Utils.sleep(50);
   });
 
-  beforeEach(async () => {
+  beforeEach(async function() {
     if (firebase.auth().currentUser) {
       await firebase.auth().signOut();
       await Utils.sleep(50);
     }
   });
 
-  describe('signInWithPhoneNumber', () => {
-    it('signs in with a valid code', async () => {
+  describe('signInWithPhoneNumber', function() {
+    it('signs in with a valid code', async function() {
       const testPhone = await getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       confirmResult.verificationId.should.be.a.String();
@@ -36,7 +36,7 @@ describe('auth() => Phone', () => {
       // userCredential.user.phoneNumber.should.equal(TEST_PHONE_A);
     });
 
-    it('errors on invalid code', async () => {
+    it('errors on invalid code', async function() {
       const testPhone = await getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       confirmResult.verificationId.should.be.a.String();
@@ -54,8 +54,8 @@ describe('auth() => Phone', () => {
     });
   });
 
-  describe('verifyPhoneNumber', async () => {
-    it('successfully verifies', async () => {
+  describe('verifyPhoneNumber', function() {
+    it('successfully verifies', async function() {
       const testPhone = await getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       const lastSmsCode = await getLastSmsCode(testPhone);
@@ -63,7 +63,7 @@ describe('auth() => Phone', () => {
       await firebase.auth().verifyPhoneNumber(testPhone, false, false);
     });
 
-    it('uses the autoVerifyTimeout when a non boolean autoVerifyTimeoutOrForceResend is provided', async () => {
+    it('uses the autoVerifyTimeout when a non boolean autoVerifyTimeoutOrForceResend is provided', async function() {
       const testPhone = await getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       const lastSmsCode = await getLastSmsCode(testPhone);
@@ -71,7 +71,7 @@ describe('auth() => Phone', () => {
       await firebase.auth().verifyPhoneNumber(testPhone, 0, false);
     });
 
-    it('throws an error with an invalid on event', async () => {
+    it('throws an error with an invalid on event', async function() {
       const testPhone = await getRandomPhoneNumber();
       try {
         await firebase
@@ -88,7 +88,7 @@ describe('auth() => Phone', () => {
       }
     });
 
-    it('throws an error with an invalid observer event', async () => {
+    it('throws an error with an invalid observer event', async function() {
       const testPhone = await getRandomPhoneNumber();
       try {
         await firebase
@@ -105,7 +105,7 @@ describe('auth() => Phone', () => {
       }
     });
 
-    it('successfully runs verification complete handler', async () => {
+    it('successfully runs verification complete handler', async function() {
       const testPhone = await getRandomPhoneNumber();
       await firebase
         .auth()
@@ -115,7 +115,7 @@ describe('auth() => Phone', () => {
       return Promise.resolve();
     });
 
-    it('successfully runs and adds emitters', async () => {
+    it('successfully runs and adds emitters', async function() {
       const testPhone = await getRandomPhoneNumber();
       const obervserCb = () => {};
       const errorCb = () => {};
@@ -129,7 +129,7 @@ describe('auth() => Phone', () => {
         .on('state_changed', obervserCb, errorCb, successCb, () => {});
     });
 
-    it('catches an error and emits an error event', async () => {
+    it('catches an error and emits an error event', async function() {
       return firebase
         .auth()
         .verifyPhoneNumber('test')

--- a/packages/auth/e2e/provider.e2e.js
+++ b/packages/auth/e2e/provider.e2e.js
@@ -1,22 +1,22 @@
-describe('auth() -> Providers', () => {
-  beforeEach(async () => {
+describe('auth() -> Providers', function() {
+  beforeEach(async function() {
     if (firebase.auth().currentUser) {
       await firebase.auth().signOut();
       await Utils.sleep(50);
     }
   });
 
-  describe('EmailAuthProvider', () => {
-    describe('constructor', () => {
-      it('should throw an unsupported error', () => {
+  describe('EmailAuthProvider', function() {
+    describe('constructor', function() {
+      it('should throw an unsupported error', function() {
         (() => new firebase.auth.EmailAuthProvider()).should.throw(
           '`new EmailAuthProvider()` is not supported on the native Firebase SDKs.',
         );
       });
     });
 
-    describe('credential', () => {
-      it('should return a credential object', () => {
+    describe('credential', function() {
+      it('should return a credential object', function() {
         const email = 'email@email.com';
         const password = 'password';
         const credential = firebase.auth.EmailAuthProvider.credential(email, password);
@@ -26,8 +26,8 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('credentialWithLink', () => {
-      it('should return a credential object', () => {
+    describe('credentialWithLink', function() {
+      it('should return a credential object', function() {
         const email = 'email@email.com';
         const link = 'link';
         const credential = firebase.auth.EmailAuthProvider.credentialWithLink(email, link);
@@ -37,36 +37,36 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('EMAIL_PASSWORD_SIGN_IN_METHOD', () => {
-      it('should return password', () => {
+    describe('EMAIL_PASSWORD_SIGN_IN_METHOD', function() {
+      it('should return password', function() {
         firebase.auth.EmailAuthProvider.EMAIL_PASSWORD_SIGN_IN_METHOD.should.equal('password');
       });
     });
 
-    describe('EMAIL_LINK_SIGN_IN_METHOD', () => {
-      it('should return emailLink', () => {
+    describe('EMAIL_LINK_SIGN_IN_METHOD', function() {
+      it('should return emailLink', function() {
         firebase.auth.EmailAuthProvider.EMAIL_LINK_SIGN_IN_METHOD.should.equal('emailLink');
       });
     });
 
-    describe('PROVIDER_ID', () => {
-      it('should return password', () => {
+    describe('PROVIDER_ID', function() {
+      it('should return password', function() {
         firebase.auth.EmailAuthProvider.PROVIDER_ID.should.equal('password');
       });
     });
   });
 
-  describe('FacebookAuthProvider', () => {
-    describe('constructor', () => {
-      it('should throw an unsupported error', () => {
+  describe('FacebookAuthProvider', function() {
+    describe('constructor', function() {
+      it('should throw an unsupported error', function() {
         (() => new firebase.auth.FacebookAuthProvider()).should.throw(
           '`new FacebookAuthProvider()` is not supported on the native Firebase SDKs.',
         );
       });
     });
 
-    describe('credential', () => {
-      it('should return a credential object', () => {
+    describe('credential', function() {
+      it('should return a credential object', function() {
         const token = '123456';
         const credential = firebase.auth.FacebookAuthProvider.credential(token);
         credential.providerId.should.equal('facebook.com');
@@ -75,24 +75,24 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('PROVIDER_ID', () => {
-      it('should return facebook.com', () => {
+    describe('PROVIDER_ID', function() {
+      it('should return facebook.com', function() {
         firebase.auth.FacebookAuthProvider.PROVIDER_ID.should.equal('facebook.com');
       });
     });
   });
 
-  describe('GithubAuthProvider', () => {
-    describe('constructor', () => {
-      it('should throw an unsupported error', () => {
+  describe('GithubAuthProvider', function() {
+    describe('constructor', function() {
+      it('should throw an unsupported error', function() {
         (() => new firebase.auth.GithubAuthProvider()).should.throw(
           '`new GithubAuthProvider()` is not supported on the native Firebase SDKs.',
         );
       });
     });
 
-    describe('credential', () => {
-      it('should return a credential object', () => {
+    describe('credential', function() {
+      it('should return a credential object', function() {
         const token = '123456';
         const credential = firebase.auth.GithubAuthProvider.credential(token);
         credential.providerId.should.equal('github.com');
@@ -101,24 +101,24 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('PROVIDER_ID', () => {
-      it('should return github.com', () => {
+    describe('PROVIDER_ID', function() {
+      it('should return github.com', function() {
         firebase.auth.GithubAuthProvider.PROVIDER_ID.should.equal('github.com');
       });
     });
   });
 
-  describe('GoogleAuthProvider', () => {
-    describe('constructor', () => {
-      it('should throw an unsupported error', () => {
+  describe('GoogleAuthProvider', function() {
+    describe('constructor', function() {
+      it('should throw an unsupported error', function() {
         (() => new firebase.auth.GoogleAuthProvider()).should.throw(
           '`new GoogleAuthProvider()` is not supported on the native Firebase SDKs.',
         );
       });
     });
 
-    describe('credential', () => {
-      it('should return a credential object', () => {
+    describe('credential', function() {
+      it('should return a credential object', function() {
         const token = '123456';
         const secret = '654321';
         const credential = firebase.auth.GoogleAuthProvider.credential(token, secret);
@@ -128,24 +128,24 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('PROVIDER_ID', () => {
-      it('should return google.com', () => {
+    describe('PROVIDER_ID', function() {
+      it('should return google.com', function() {
         firebase.auth.GoogleAuthProvider.PROVIDER_ID.should.equal('google.com');
       });
     });
   });
 
-  describe('OAuthProvider', () => {
-    describe('constructor', () => {
-      it('should throw an unsupported error', () => {
+  describe('OAuthProvider', function() {
+    describe('constructor', function() {
+      it('should throw an unsupported error', function() {
         (() => new firebase.auth.OAuthProvider()).should.throw(
           '`new OAuthProvider()` is not supported on the native Firebase SDKs.',
         );
       });
     });
 
-    describe('credential', () => {
-      it('should return a credential object', () => {
+    describe('credential', function() {
+      it('should return a credential object', function() {
         const idToken = '123456';
         const accessToken = '654321';
         const credential = firebase.auth.OAuthProvider.credential(idToken, accessToken);
@@ -155,24 +155,24 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('PROVIDER_ID', () => {
-      it('should return oauth', () => {
+    describe('PROVIDER_ID', function() {
+      it('should return oauth', function() {
         firebase.auth.OAuthProvider.PROVIDER_ID.should.equal('oauth');
       });
     });
   });
 
-  describe('PhoneAuthProvider', () => {
-    describe('constructor', () => {
-      it('should throw an unsupported error', () => {
+  describe('PhoneAuthProvider', function() {
+    describe('constructor', function() {
+      it('should throw an unsupported error', function() {
         (() => new firebase.auth.PhoneAuthProvider()).should.throw(
           '`new PhoneAuthProvider()` is not supported on the native Firebase SDKs.',
         );
       });
     });
 
-    describe('credential', () => {
-      it('should return a credential object', () => {
+    describe('credential', function() {
+      it('should return a credential object', function() {
         const verificationId = '123456';
         const code = '654321';
         const credential = firebase.auth.PhoneAuthProvider.credential(verificationId, code);
@@ -182,24 +182,24 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('PROVIDER_ID', () => {
-      it('should return phone', () => {
+    describe('PROVIDER_ID', function() {
+      it('should return phone', function() {
         firebase.auth.PhoneAuthProvider.PROVIDER_ID.should.equal('phone');
       });
     });
   });
 
-  describe('TwitterAuthProvider', () => {
-    describe('constructor', () => {
-      it('should throw an unsupported error', () => {
+  describe('TwitterAuthProvider', function() {
+    describe('constructor', function() {
+      it('should throw an unsupported error', function() {
         (() => new firebase.auth.TwitterAuthProvider()).should.throw(
           '`new TwitterAuthProvider()` is not supported on the native Firebase SDKs.',
         );
       });
     });
 
-    describe('credential', () => {
-      it('should return a credential object', () => {
+    describe('credential', function() {
+      it('should return a credential object', function() {
         const token = '123456';
         const secret = '654321';
         const credential = firebase.auth.TwitterAuthProvider.credential(token, secret);
@@ -209,8 +209,8 @@ describe('auth() -> Providers', () => {
       });
     });
 
-    describe('PROVIDER_ID', () => {
-      it('should return twitter.com', () => {
+    describe('PROVIDER_ID', function() {
+      it('should return twitter.com', function() {
         firebase.auth.TwitterAuthProvider.PROVIDER_ID.should.equal('twitter.com');
       });
     });

--- a/packages/auth/e2e/rnReload.e2e.js
+++ b/packages/auth/e2e/rnReload.e2e.js
@@ -3,8 +3,8 @@ const TEST_PASS = 'test1234';
 
 const { clearAllUsers } = require('./helpers');
 
-describe('auth()', () => {
-  before(async () => {
+describe('auth()', function() {
+  before(async function() {
     try {
       await clearAllUsers();
     } catch (e) {
@@ -17,7 +17,7 @@ describe('auth()', () => {
     }
   });
 
-  beforeEach(async () => {
+  beforeEach(async function() {
     if (firebase.auth().currentUser) {
       await firebase.auth().signOut();
       await Utils.sleep(50);
@@ -26,7 +26,7 @@ describe('auth()', () => {
 
   // TODO(salakar): Detox on iOS crashing app on reloads
   android.describe('firebase.auth().currentUser', () => {
-    it('exists after reload', async () => {
+    it('exists after reload', async function() {
       let currentUser;
       // before reload
       await firebase.auth().signInAnonymously();

--- a/packages/auth/e2e/user.e2e.js
+++ b/packages/auth/e2e/user.e2e.js
@@ -9,8 +9,8 @@ const {
   verifyEmail,
 } = require('./helpers');
 
-describe('auth().currentUser', () => {
-  before(async () => {
+describe('auth().currentUser', function() {
+  before(async function() {
     try {
       await clearAllUsers();
     } catch (e) {
@@ -24,15 +24,15 @@ describe('auth().currentUser', () => {
     }
   });
 
-  beforeEach(async () => {
+  beforeEach(async function() {
     if (firebase.auth().currentUser) {
       await firebase.auth().signOut();
       await Utils.sleep(50);
     }
   });
 
-  describe('getIdToken()', () => {
-    it('should return a token', async () => {
+  describe('getIdToken()', function() {
+    it('should return a token', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
 
@@ -50,8 +50,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('getIdTokenResult()', () => {
-    it('should return a valid IdTokenResult Object', async () => {
+  describe('getIdTokenResult()', function() {
+    it('should return a valid IdTokenResult Object', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
 
@@ -81,9 +81,9 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('linkWithCredential()', () => {
+  describe('linkWithCredential()', function() {
     // hanging against auth emulator?
-    it('should link anonymous account <-> email account', async () => {
+    it('should link anonymous account <-> email account', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -110,7 +110,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error on link anon <-> email if email already exists', async () => {
+    it('should error on link anon <-> email if email already exists', async function() {
       await firebase.auth().signInAnonymously();
       const { currentUser } = firebase.auth();
 
@@ -137,8 +137,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('reauthenticateWithCredential()', () => {
-    it('should reauthenticate correctly', async () => {
+  describe('reauthenticateWithCredential()', function() {
+    it('should reauthenticate correctly', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -159,8 +159,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('reload()', () => {
-    it('should not error', async () => {
+  describe('reload()', function() {
+    it('should not error', async function() {
       await firebase.auth().signInAnonymously();
 
       try {
@@ -176,8 +176,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('sendEmailVerification()', () => {
-    it('should error if actionCodeSettings.url is not present', async () => {
+  describe('sendEmailVerification()', function() {
+    it('should error if actionCodeSettings.url is not present', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -190,7 +190,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.url is not a string', async () => {
+    it('should error if actionCodeSettings.url is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -203,7 +203,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.dynamicLinkDomain is not a string', async () => {
+    it('should error if actionCodeSettings.dynamicLinkDomain is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -220,7 +220,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if handleCodeInApp is not a string', async () => {
+    it('should error if handleCodeInApp is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -235,7 +235,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.iOS is not an object', async () => {
+    it('should error if actionCodeSettings.iOS is not an object', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -248,7 +248,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.iOS.bundleId is not a string', async () => {
+    it('should error if actionCodeSettings.iOS.bundleId is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -265,7 +265,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android is not an object', async () => {
+    it('should error if actionCodeSettings.android is not an object', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -278,7 +278,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android.packageName is not a string', async () => {
+    it('should error if actionCodeSettings.android.packageName is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -295,7 +295,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android.installApp is not a string', async () => {
+    it('should error if actionCodeSettings.android.installApp is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -313,7 +313,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android.minimumVersion is not a string', async () => {
+    it('should error if actionCodeSettings.android.minimumVersion is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -331,7 +331,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should not error', async () => {
+    it('should not error', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -347,7 +347,7 @@ describe('auth().currentUser', () => {
       return Promise.resolve();
     });
 
-    it('should correctly report emailVerified status', async () => {
+    it('should correctly report emailVerified status', async function() {
       const random = Utils.randString(12, '#a');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -370,7 +370,7 @@ describe('auth().currentUser', () => {
       return Promise.resolve();
     });
 
-    it('should work with actionCodeSettings', async () => {
+    it('should work with actionCodeSettings', async function() {
       const actionCodeSettings = {
         handleCodeInApp: true,
         url: 'https://react-native-firebase-testing.firebaseapp.com/foo',
@@ -392,7 +392,7 @@ describe('auth().currentUser', () => {
       return Promise.resolve();
     });
 
-    it('should throw an error within an invalid action code url', async () => {
+    it('should throw an error within an invalid action code url', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -405,8 +405,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('verifyBeforeUpdateEmail()', () => {
-    it('should error if newEmail is not a string', async () => {
+  describe('verifyBeforeUpdateEmail()', function() {
+    it('should error if newEmail is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
 
@@ -419,7 +419,7 @@ describe('auth().currentUser', () => {
       }
       await firebase.auth().currentUser.delete();
     });
-    it('should error if actionCodeSettings.url is not present', async () => {
+    it('should error if actionCodeSettings.url is not present', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -435,7 +435,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.url is not a string', async () => {
+    it('should error if actionCodeSettings.url is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -451,7 +451,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.dynamicLinkDomain is not a string', async () => {
+    it('should error if actionCodeSettings.dynamicLinkDomain is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -472,7 +472,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if handleCodeInApp is not a boolean', async () => {
+    it('should error if handleCodeInApp is not a boolean', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -493,7 +493,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.iOS is not an object', async () => {
+    it('should error if actionCodeSettings.iOS is not an object', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -512,7 +512,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.iOS.bundleId is not a string', async () => {
+    it('should error if actionCodeSettings.iOS.bundleId is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -533,7 +533,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android is not an object', async () => {
+    it('should error if actionCodeSettings.android is not an object', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -552,7 +552,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android.packageName is not a string', async () => {
+    it('should error if actionCodeSettings.android.packageName is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -573,7 +573,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android.installApp is not a boolean', async () => {
+    it('should error if actionCodeSettings.android.installApp is not a boolean', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -594,7 +594,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should error if actionCodeSettings.android.minimumVersion is not a string', async () => {
+    it('should error if actionCodeSettings.android.minimumVersion is not a string', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -617,7 +617,7 @@ describe('auth().currentUser', () => {
 
     // FIXME ios+android failing with an internal error against auth emulator
     // com.google.firebase.FirebaseException: An internal error has occurred. [ VERIFY_AND_CHANGE_EMAIL ]
-    xit('should not error', async () => {
+    xit('should not error', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -634,7 +634,7 @@ describe('auth().currentUser', () => {
 
     // FIXME ios+android failing with an internal error against auth emulator
     // com.google.firebase.FirebaseException: An internal error has occurred. [ VERIFY_AND_CHANGE_EMAIL ]
-    xit('should work with actionCodeSettings', async () => {
+    xit('should work with actionCodeSettings', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -659,8 +659,8 @@ describe('auth().currentUser', () => {
       return Promise.resolve();
     });
   });
-  describe('unlink()', () => {
-    it('should unlink the email address', async () => {
+  describe('unlink()', function() {
+    it('should unlink the email address', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -684,8 +684,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('updateEmail()', () => {
-    it('should update the email address', async () => {
+  describe('updateEmail()', function() {
+    it('should update the email address', async function() {
       const random = Utils.randString(12, '#a');
       const random2 = Utils.randString(12, '#a');
       const email = `${random}@${random}.com`;
@@ -705,8 +705,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('updatePhoneNumber()', () => {
-    it('should update the phone number', async () => {
+  describe('updatePhoneNumber()', function() {
+    it('should update the phone number', async function() {
       const testPhone = await getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       const smsCode = await getLastSmsCode(testPhone);
@@ -748,8 +748,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('updatePassword()', () => {
-    it('should update the password', async () => {
+  describe('updatePassword()', function() {
+    it('should update the password', async function() {
       const random = Utils.randString(12, '#aA');
       const random2 = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
@@ -777,7 +777,7 @@ describe('auth().currentUser', () => {
     });
 
     // Can only be run/reproduced locally with Firebase Auth rate limits lowered on the Firebase console.
-    xit('should throw too many requests when limit has been reached', async () => {
+    xit('should throw too many requests when limit has been reached', async function() {
       await Utils.sleep(10000);
       try {
         // Setup for creating new accounts
@@ -804,8 +804,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('updateProfile()', () => {
-    it('should update the profile', async () => {
+  describe('updateProfile()', function() {
+    it('should update the profile', async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
       const pass = random;
@@ -832,7 +832,7 @@ describe('auth().currentUser', () => {
       await firebase.auth().currentUser.delete();
     });
 
-    it('should return a valid profile when signing in anonymously', async () => {
+    it('should return a valid profile when signing in anonymously', async function() {
       // Setup
       await firebase.auth().signInAnonymously();
       const { currentUser } = firebase.auth();
@@ -856,8 +856,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('linkWithPhoneNumber()', () => {
-    it('should throw an unsupported error', async () => {
+  describe('linkWithPhoneNumber()', function() {
+    it('should throw an unsupported error', async function() {
       await firebase.auth().signInAnonymously();
       (() => {
         firebase.auth().currentUser.linkWithPhoneNumber();
@@ -868,8 +868,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('linkWithPopup()', () => {
-    it('should throw an unsupported error', async () => {
+  describe('linkWithPopup()', function() {
+    it('should throw an unsupported error', async function() {
       await firebase.auth().signInAnonymously();
       (() => {
         firebase.auth().currentUser.linkWithPopup();
@@ -880,8 +880,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('linkWithRedirect()', () => {
-    it('should throw an unsupported error', async () => {
+  describe('linkWithRedirect()', function() {
+    it('should throw an unsupported error', async function() {
       await firebase.auth().signInAnonymously();
       (() => {
         firebase.auth().currentUser.linkWithRedirect();
@@ -892,8 +892,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('reauthenticateWithPhoneNumber()', () => {
-    it('should throw an unsupported error', async () => {
+  describe('reauthenticateWithPhoneNumber()', function() {
+    it('should throw an unsupported error', async function() {
       await firebase.auth().signInAnonymously();
       (() => {
         firebase.auth().currentUser.reauthenticateWithPhoneNumber();
@@ -904,8 +904,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('reauthenticateWithPopup()', () => {
-    it('should throw an unsupported error', async () => {
+  describe('reauthenticateWithPopup()', function() {
+    it('should throw an unsupported error', async function() {
       await firebase.auth().signInAnonymously();
       (() => {
         firebase.auth().currentUser.reauthenticateWithPopup();
@@ -916,8 +916,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('reauthenticateWithRedirect()', () => {
-    it('should throw an unsupported error', async () => {
+  describe('reauthenticateWithRedirect()', function() {
+    it('should throw an unsupported error', async function() {
       await firebase.auth().signInAnonymously();
       (() => {
         firebase.auth().currentUser.reauthenticateWithRedirect();
@@ -928,8 +928,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('refreshToken', () => {
-    it('should throw an unsupported error', async () => {
+  describe('refreshToken', function() {
+    it('should throw an unsupported error', async function() {
       await firebase.auth().signInAnonymously();
       (() => firebase.auth().currentUser.refreshToken).should.throw(
         'firebase.auth.User.refreshToken is unsupported by the native Firebase SDKs.',
@@ -938,8 +938,8 @@ describe('auth().currentUser', () => {
     });
   });
 
-  describe('user.metadata', () => {
-    it("should have the properties 'lastSignInTime' & 'creationTime' which are ISO strings", async () => {
+  describe('user.metadata', function() {
+    it("should have the properties 'lastSignInTime' & 'creationTime' which are ISO strings", async function() {
       const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
 

--- a/packages/crashlytics/__tests__/crashlytics.test.ts
+++ b/packages/crashlytics/__tests__/crashlytics.test.ts
@@ -1,8 +1,8 @@
 import { firebase } from '../lib';
 
-describe('Crashlytics', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('Crashlytics', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       expect(app.crashlytics).toBeDefined();
       expect(app.crashlytics().app).toEqual(app);

--- a/packages/crashlytics/e2e/crashlytics.e2e.js
+++ b/packages/crashlytics/e2e/crashlytics.e2e.js
@@ -15,10 +15,10 @@
  *
  */
 
-describe('crashlytics()', () => {
+describe('crashlytics()', function() {
   // Run locally only - flakey on CI
-  xdescribe('crash()', () => {
-    it('crashes the app', async () => {
+  xdescribe('crash()', function() {
+    it('crashes the app', async function() {
       jet.context._BEFORE_CRASH_ = 1;
       firebase.crashlytics().crash();
       await Utils.sleep(1500);
@@ -28,8 +28,8 @@ describe('crashlytics()', () => {
     });
   });
 
-  describe('log()', () => {
-    it('accepts any value', async () => {
+  describe('log()', function() {
+    it('accepts any value', async function() {
       firebase.crashlytics().log('invertase');
       firebase.crashlytics().log(1337);
       firebase.crashlytics().log(null);
@@ -40,12 +40,12 @@ describe('crashlytics()', () => {
     });
   });
 
-  describe('setUserId()', () => {
-    it('accepts string values', async () => {
+  describe('setUserId()', function() {
+    it('accepts string values', async function() {
       await firebase.crashlytics().setUserId('invertase');
     });
 
-    it('rejects none string values', async () => {
+    it('rejects none string values', async function() {
       try {
         await firebase.crashlytics().setUserId(666.1337);
         return Promise.reject(new Error('Did not throw.'));
@@ -55,12 +55,12 @@ describe('crashlytics()', () => {
     });
   });
 
-  describe('setAttribute()', () => {
-    it('accepts string values', async () => {
+  describe('setAttribute()', function() {
+    it('accepts string values', async function() {
       await firebase.crashlytics().setAttribute('invertase', '1337');
     });
 
-    it('rejects none string values', async () => {
+    it('rejects none string values', async function() {
       try {
         await firebase.crashlytics().setAttribute('invertase', 33.3333);
         return Promise.reject(new Error('Did not throw.'));
@@ -69,7 +69,7 @@ describe('crashlytics()', () => {
       }
     });
 
-    it('errors if attribute name is not a string', async () => {
+    it('errors if attribute name is not a string', async function() {
       try {
         await firebase.crashlytics().setAttribute(1337, 'invertase');
         return Promise.reject(new Error('Did not throw.'));
@@ -79,8 +79,8 @@ describe('crashlytics()', () => {
     });
   });
 
-  describe('setAttributes()', () => {
-    it('errors if arg is not an object', async () => {
+  describe('setAttributes()', function() {
+    it('errors if arg is not an object', async function() {
       try {
         await firebase.crashlytics().setAttributes(1337);
         return Promise.reject(new Error('Did not throw.'));
@@ -89,13 +89,13 @@ describe('crashlytics()', () => {
       }
     });
 
-    it('accepts string values', async () => {
+    it('accepts string values', async function() {
       await firebase.crashlytics().setAttributes({ invertase: '1337' });
     });
   });
 
-  describe('recordError()', () => {
-    it('warns if not an error', async () => {
+  describe('recordError()', function() {
+    it('warns if not an error', async function() {
       const orig = jet.context.console.warn;
       let logged = false;
       jet.context.console.warn = msg => {
@@ -108,12 +108,12 @@ describe('crashlytics()', () => {
       should.equal(logged, true);
     });
 
-    it('accepts Error values', async () => {
+    it('accepts Error values', async function() {
       firebase.crashlytics().recordError(new Error("I'm a teapot!"));
       // TODO verify stack obj
     });
 
-    it('accepts optional jsErrorName', async () => {
+    it('accepts optional jsErrorName', async function() {
       firebase
         .crashlytics()
         .recordError(
@@ -124,14 +124,14 @@ describe('crashlytics()', () => {
     });
   });
 
-  describe('sendUnsentReports()', () => {
-    it("sends unsent reports to the crashlytic's server", () => {
+  describe('sendUnsentReports()', function() {
+    it("sends unsent reports to the crashlytic's server", function() {
       firebase.crashlytics().sendUnsentReports();
     });
   });
 
-  describe('checkForUnsentReports()', () => {
-    it('errors if automatic crash report collection is enabled', async () => {
+  describe('checkForUnsentReports()', function() {
+    it('errors if automatic crash report collection is enabled', async function() {
       await firebase.crashlytics().setCrashlyticsCollectionEnabled(true);
       try {
         await firebase.crashlytics().checkForUnsentReports();
@@ -140,7 +140,7 @@ describe('crashlytics()', () => {
         e.message.should.containEql("has been set to 'true', all reports are automatically sent");
       }
     });
-    it("checks device cache for unsent crashlytic's reports", async () => {
+    it("checks device cache for unsent crashlytic's reports", async function() {
       await firebase.crashlytics().setCrashlyticsCollectionEnabled(false);
       const anyUnsentReports = await firebase.crashlytics().checkForUnsentReports();
 
@@ -148,32 +148,32 @@ describe('crashlytics()', () => {
     });
   });
 
-  describe('deleteUnsentReports()', () => {
-    it('deletes unsent crashlytics reports', async () => {
+  describe('deleteUnsentReports()', function() {
+    it('deletes unsent crashlytics reports', async function() {
       await firebase.crashlytics().deleteUnsentReports();
     });
   });
 
-  describe('didCrashOnPreviousExecution()', () => {
-    it('checks if app crached on previous execution', async () => {
+  describe('didCrashOnPreviousExecution()', function() {
+    it('checks if app crached on previous execution', async function() {
       const didCrash = await firebase.crashlytics().didCrashOnPreviousExecution();
 
       should(didCrash).equal(false);
     });
   });
 
-  describe('setCrashlyticsCollectionEnabled()', () => {
-    it('true', async () => {
+  describe('setCrashlyticsCollectionEnabled()', function() {
+    it('true', async function() {
       await firebase.crashlytics().setCrashlyticsCollectionEnabled(true);
       should.equal(firebase.crashlytics().isCrashlyticsCollectionEnabled, true);
     });
 
-    it('false', async () => {
+    it('false', async function() {
       await firebase.crashlytics().setCrashlyticsCollectionEnabled(false);
       should.equal(firebase.crashlytics().isCrashlyticsCollectionEnabled, false);
     });
 
-    it('errors if not boolean', async () => {
+    it('errors if not boolean', async function() {
       try {
         await firebase.crashlytics().setCrashlyticsCollectionEnabled(1337);
         return Promise.reject(new Error('Did not throw.'));

--- a/packages/database/e2e/DatabaseStatics.e2e.js
+++ b/packages/database/e2e/DatabaseStatics.e2e.js
@@ -19,11 +19,13 @@ const { PATH, wipe } = require('./helpers');
 
 const TEST_PATH = `${PATH}/statics`;
 
-describe('database.X', () => {
-  after(() => wipe(TEST_PATH));
+describe('database.X', function() {
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  describe('ServerValue.TIMESTAMP', () => {
-    it('returns a valid object', () => {
+  describe('ServerValue.TIMESTAMP', function() {
+    it('returns a valid object', function() {
       const { TIMESTAMP } = firebase.database.ServerValue;
       should.equal(Object.keys(TIMESTAMP).length, 1);
       TIMESTAMP.should.have.property('.sv');
@@ -31,15 +33,15 @@ describe('database.X', () => {
     });
   });
 
-  describe('ServerValue.increment', () => {
-    it('returns a valid object', () => {
+  describe('ServerValue.increment', function() {
+    it('returns a valid object', function() {
       const incrementObject = firebase.database.ServerValue.increment(1);
       should.equal(Object.keys(incrementObject).length, 1);
       incrementObject.should.have.property('.sv');
       incrementObject['.sv'].should.have.property('increment');
     });
 
-    it('increments on the server', async () => {
+    it('increments on the server', async function() {
       const ref = firebase.database().ref(`${TEST_PATH}/increment`);
 
       await ref.set({ increment: 0 });
@@ -53,7 +55,7 @@ describe('database.X', () => {
       res2.val().increment.should.equal(1);
     });
 
-    it('increments on the server when no value is present', async () => {
+    it('increments on the server when no value is present', async function() {
       const ref = firebase.database().ref(`${TEST_PATH}/increment-empty`);
 
       await ref.set({ increment: firebase.database.ServerValue.increment(2) });

--- a/packages/database/e2e/database.e2e.js
+++ b/packages/database/e2e/database.e2e.js
@@ -15,15 +15,15 @@
  *
  */
 
-describe('database()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('database()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.database);
       app.database().app.should.eql(app);
     });
 
-    it('supports multiple apps', async () => {
+    it('supports multiple apps', async function() {
       firebase.database().app.name.should.eql('[DEFAULT]');
 
       firebase
@@ -37,7 +37,7 @@ describe('database()', () => {
     });
   });
 
-  it('supports custom database URL', async () => {
+  it('supports custom database URL', async function() {
     firebase.database().app.name.should.eql('[DEFAULT]');
 
     firebase
@@ -50,8 +50,8 @@ describe('database()', () => {
       .app.name.should.eql('secondaryFromNative');
   });
 
-  describe('ref()', () => {
-    it('throws if path is not a string', async () => {
+  describe('ref()', function() {
+    it('throws if path is not a string', async function() {
       try {
         firebase.database().ref({ foo: 'bar' });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -61,7 +61,7 @@ describe('database()', () => {
       }
     });
 
-    it('throws if path is not a valid string', async () => {
+    it('throws if path is not a valid string', async function() {
       try {
         firebase.database().ref('$$$$$');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -74,8 +74,8 @@ describe('database()', () => {
     });
   });
 
-  describe('refFromURL()', () => {
-    it('throws if url is not a url', async () => {
+  describe('refFromURL()', function() {
+    it('throws if url is not a url', async function() {
       try {
         firebase.database().refFromURL('foobar');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -85,7 +85,7 @@ describe('database()', () => {
       }
     });
 
-    it('throws if url from a different domain', async () => {
+    it('throws if url from a different domain', async function() {
       try {
         firebase.database().refFromURL('https://foobar.firebaseio.com');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -95,7 +95,7 @@ describe('database()', () => {
       }
     });
 
-    it('returns a reference', async () => {
+    it('returns a reference', async function() {
       const ref1 = firebase.database().refFromURL(firebase.database()._customUrlOrRegion);
       const ref2 = firebase
         .database()
@@ -109,14 +109,14 @@ describe('database()', () => {
     });
   });
 
-  describe('goOnline()', () => {
-    it('calls goOnline successfully', async () => {
+  describe('goOnline()', function() {
+    it('calls goOnline successfully', async function() {
       await firebase.database().goOnline();
     });
   });
 
-  describe('goOffline()', () => {
-    it('calls goOffline successfully', async () => {
+  describe('goOffline()', function() {
+    it('calls goOffline successfully', async function() {
       // await Utils.sleep(5000);
       await firebase.database().goOffline();
 
@@ -124,8 +124,8 @@ describe('database()', () => {
     });
   });
 
-  describe('setPersistenceEnabled()', () => {
-    it('throws if enabled is not a boolean', async () => {
+  describe('setPersistenceEnabled()', function() {
+    it('throws if enabled is not a boolean', async function() {
       try {
         firebase.database().setPersistenceEnabled('foo');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -135,14 +135,14 @@ describe('database()', () => {
       }
     });
 
-    it('calls setPersistenceEnabled successfully', async () => {
+    it('calls setPersistenceEnabled successfully', async function() {
       firebase.database().setPersistenceEnabled(true);
       firebase.database().setPersistenceEnabled(false);
     });
   });
 
-  describe('setLoggingEnabled()', () => {
-    it('throws if enabled is not a boolean', async () => {
+  describe('setLoggingEnabled()', function() {
+    it('throws if enabled is not a boolean', async function() {
       try {
         firebase.database().setLoggingEnabled('foo');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -152,14 +152,14 @@ describe('database()', () => {
       }
     });
 
-    it('calls setLoggingEnabled successfully', async () => {
+    it('calls setLoggingEnabled successfully', async function() {
       firebase.database().setLoggingEnabled(true);
       firebase.database().setLoggingEnabled(false);
     });
   });
 
-  describe('setPersistenceCacheSizeBytes()', () => {
-    it('throws if bytes is not a number', async () => {
+  describe('setPersistenceCacheSizeBytes()', function() {
+    it('throws if bytes is not a number', async function() {
       try {
         firebase.database().setPersistenceCacheSizeBytes('foo');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -169,7 +169,7 @@ describe('database()', () => {
       }
     });
 
-    it('throws if bytes is less than 1MB', async () => {
+    it('throws if bytes is less than 1MB', async function() {
       try {
         firebase.database().setPersistenceCacheSizeBytes(1234);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -179,7 +179,7 @@ describe('database()', () => {
       }
     });
 
-    it('throws if bytes is greater than 10MB', async () => {
+    it('throws if bytes is greater than 10MB', async function() {
       try {
         firebase.database().setPersistenceCacheSizeBytes(100000000000000);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -189,20 +189,20 @@ describe('database()', () => {
       }
     });
 
-    it('calls setPersistenceCacheSizeBytes successfully', async () => {
+    it('calls setPersistenceCacheSizeBytes successfully', async function() {
       firebase.database().setPersistenceCacheSizeBytes(1048576); // 1mb
     });
   });
 
-  describe('getServerTime()', () => {
-    it('returns a valid date', async () => {
+  describe('getServerTime()', function() {
+    it('returns a valid date', async function() {
       const date = firebase.database().getServerTime();
       date.getDate.should.be.Function();
     });
   });
 
-  describe('handles invalid references()', () => {
-    it('returns a valid date', async () => {
+  describe('handles invalid references()', function() {
+    it('returns a valid date', async function() {
       try {
         firebase.database().ref('$');
         return Promise.reject(new Error('Did not throw an Error.'));

--- a/packages/database/e2e/internal/connected.e2e.js
+++ b/packages/database/e2e/internal/connected.e2e.js
@@ -15,11 +15,13 @@
  *
  */
 
-describe("database().ref('.info/connected')", () => {
-  after(() => firebase.database().goOnline());
+describe("database().ref('.info/connected')", function() {
+  after(function() {
+    return firebase.database().goOnline();
+  });
 
   // FIXME needs a bug logged for triage - fails e2e testing on ios, android sometimes
-  xit('returns false when used with once', async () => {
+  xit('returns false when used with once', async function() {
     const snapshot = await firebase
       .database()
       .ref('.info/connected')
@@ -27,7 +29,7 @@ describe("database().ref('.info/connected')", () => {
     snapshot.val().should.equal(false);
   });
 
-  it('returns true when used with once with a previous call', async () => {
+  it('returns true when used with once with a previous call', async function() {
     await firebase
       .database()
       .ref('tests')
@@ -39,7 +41,7 @@ describe("database().ref('.info/connected')", () => {
     snapshot.val().should.equal(true);
   });
 
-  it('subscribes to online state', async () => {
+  it('subscribes to online state', async function() {
     const callback = sinon.spy();
     await firebase.database().goOffline();
 

--- a/packages/database/e2e/internal/serverTimeOffset.e2e.js
+++ b/packages/database/e2e/internal/serverTimeOffset.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe("database().ref('.info/serverTimeOffset')", () => {
-  it('returns a valid number value', async () => {
+describe("database().ref('.info/serverTimeOffset')", function() {
+  it('returns a valid number value', async function() {
     const snapshot = await firebase
       .database()
       .ref('.info/serverTimeOffset')

--- a/packages/database/e2e/issues.e2e.js
+++ b/packages/database/e2e/issues.e2e.js
@@ -19,10 +19,12 @@ const { PATH, wipe } = require('./helpers');
 
 const TEST_PATH = `${PATH}/issues`;
 
-describe('database issues', () => {
-  after(() => wipe(TEST_PATH));
+describe('database issues', function() {
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('#2813 should return a null snapshot key if path is root', async () => {
+  it('#2813 should return a null snapshot key if path is root', async function() {
     const ref = firebase
       .app()
       .database('https://react-native-firebase-testing-db2.firebaseio.com')
@@ -31,7 +33,7 @@ describe('database issues', () => {
     should.equal(snapshot.key, null);
   });
 
-  it('#2833 should not mutate modifiers ordering', async () => {
+  it('#2833 should not mutate modifiers ordering', async function() {
     const callback = sinon.spy();
     const testRef = firebase
       .database()
@@ -52,7 +54,7 @@ describe('database issues', () => {
     testRef.off('value');
   });
 
-  it('#100 array should return null where key is missing', async () => {
+  it('#100 array should return null where key is missing', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}/issue_100`);
 
     const data = {
@@ -85,8 +87,8 @@ describe('database issues', () => {
       );
   });
 
-  describe('#108 filters correctly by float values', () => {
-    it('returns filtered results', async () => {
+  describe('#108 filters correctly by float values', function() {
+    it('returns filtered results', async function() {
       const ref = firebase.database().ref(`${TEST_PATH}/issue_108/filter`);
 
       const data = {
@@ -117,7 +119,7 @@ describe('database issues', () => {
       should.equal(Object.keys(val).length, 1);
     });
 
-    it('returns correct results when not using float values', async () => {
+    it('returns correct results when not using float values', async function() {
       const ref = firebase.database().ref(`${TEST_PATH}/issue_108/integer`);
 
       const data = {
@@ -149,7 +151,7 @@ describe('database issues', () => {
     });
   });
 
-  it('#489 reutrns long numbers correctly', async () => {
+  it('#489 reutrns long numbers correctly', async function() {
     const LONG = 1508777379000;
     const ref = firebase.database().ref(`${TEST_PATH}/issue_489`);
     await ref.set(LONG);

--- a/packages/database/e2e/onDisconnect/cancel.e2e.js
+++ b/packages/database/e2e/onDisconnect/cancel.e2e.js
@@ -19,15 +19,17 @@ const { PATH, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/onDisconnectCancel`;
 
-describe('database().ref().onDisconnect().cancel()', () => {
-  after(() => wipe(TEST_PATH));
+describe('database().ref().onDisconnect().cancel()', function() {
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  afterEach(() => {
+  afterEach(function() {
     // Ensures the db is online before running each test
     firebase.database().goOnline();
   });
 
-  it('throws if onComplete is not a function', () => {
+  it('throws if onComplete is not a function', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -41,7 +43,7 @@ describe('database().ref().onDisconnect().cancel()', () => {
     }
   });
 
-  it('cancels all previously queued events', async () => {
+  it('cancels all previously queued events', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     await ref.set('foobar');
@@ -56,7 +58,7 @@ describe('database().ref().onDisconnect().cancel()', () => {
     snapshot.val().should.eql('foobar');
   });
 
-  it('calls back to the onComplete function', async () => {
+  it('calls back to the onComplete function', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(TEST_PATH);
 

--- a/packages/database/e2e/onDisconnect/remove.e2e.js
+++ b/packages/database/e2e/onDisconnect/remove.e2e.js
@@ -19,15 +19,17 @@ const { PATH, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/onDisconnectRemove`;
 
-describe('database().ref().onDisconnect().remove()', () => {
-  after(() => wipe(TEST_PATH));
+describe('database().ref().onDisconnect().remove()', function() {
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  afterEach(() => {
+  afterEach(function() {
     // Ensures the db is online before running each test
     firebase.database().goOnline();
   });
 
-  it('throws if onComplete is not a function', () => {
+  it('throws if onComplete is not a function', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -41,7 +43,7 @@ describe('database().ref().onDisconnect().remove()', () => {
     }
   });
 
-  it('removes a node whilst offline', async () => {
+  it('removes a node whilst offline', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -57,7 +59,7 @@ describe('database().ref().onDisconnect().remove()', () => {
     snapshot.exists().should.eql(false);
   });
 
-  it('calls back to the onComplete function', async () => {
+  it('calls back to the onComplete function', async function() {
     const callback = sinon.spy();
     const ref = firebase
       .database()

--- a/packages/database/e2e/onDisconnect/set.e2e.js
+++ b/packages/database/e2e/onDisconnect/set.e2e.js
@@ -19,15 +19,17 @@ const { PATH, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/onDisconnectSet`;
 
-describe('database().ref().onDisconnect().set()', () => {
-  after(() => wipe(TEST_PATH));
+describe('database().ref().onDisconnect().set()', function() {
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  afterEach(() => {
+  afterEach(function() {
     // Ensures the db is online before running each test
     firebase.database().goOnline();
   });
 
-  it('throws if value is not a defined', () => {
+  it('throws if value is not a defined', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -41,7 +43,7 @@ describe('database().ref().onDisconnect().set()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', () => {
+  it('throws if onComplete is not a function', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -55,7 +57,7 @@ describe('database().ref().onDisconnect().set()', () => {
     }
   });
 
-  it('sets value when disconnected', async () => {
+  it('sets value when disconnected', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     const value = Date.now();
@@ -68,7 +70,7 @@ describe('database().ref().onDisconnect().set()', () => {
     snapshot.val().should.eql(value);
   });
 
-  it('calls back to the onComplete function', async () => {
+  it('calls back to the onComplete function', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(TEST_PATH);
 

--- a/packages/database/e2e/onDisconnect/setWithPriority.e2e.js
+++ b/packages/database/e2e/onDisconnect/setWithPriority.e2e.js
@@ -19,15 +19,17 @@ const { PATH, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/onDisconnectSetWithPriority`;
 
-describe('database().ref().onDisconnect().setWithPriority()', () => {
-  after(() => wipe(TEST_PATH));
+describe('database().ref().onDisconnect().setWithPriority()', function() {
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  afterEach(() => {
+  afterEach(function() {
     // Ensures the db is online before running each test
     firebase.database().goOnline();
   });
 
-  it('throws if value is not a defined', () => {
+  it('throws if value is not a defined', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -41,7 +43,7 @@ describe('database().ref().onDisconnect().setWithPriority()', () => {
     }
   });
 
-  it('throws if priority is not a valid type', () => {
+  it('throws if priority is not a valid type', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -55,7 +57,7 @@ describe('database().ref().onDisconnect().setWithPriority()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', () => {
+  it('throws if onComplete is not a function', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -69,7 +71,7 @@ describe('database().ref().onDisconnect().setWithPriority()', () => {
     }
   });
 
-  it('sets value with priority when disconnected', async () => {
+  it('sets value with priority when disconnected', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     const value = Date.now();
@@ -83,7 +85,7 @@ describe('database().ref().onDisconnect().setWithPriority()', () => {
     snapshot.exportVal()['.priority'].should.eql(3);
   });
 
-  it('calls back to the onComplete function', async () => {
+  it('calls back to the onComplete function', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(TEST_PATH);
 

--- a/packages/database/e2e/onDisconnect/update.e2e.js
+++ b/packages/database/e2e/onDisconnect/update.e2e.js
@@ -19,15 +19,17 @@ const { PATH, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/onDisconnectUpdate`;
 
-describe('database().ref().onDisconnect().update()', () => {
-  after(() => wipe(TEST_PATH));
+describe('database().ref().onDisconnect().update()', function() {
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  afterEach(() => {
+  afterEach(function() {
     // Ensures the db is online before running each test
     firebase.database().goOnline();
   });
 
-  it('throws if values is not an object', async () => {
+  it('throws if values is not an object', async function() {
     try {
       await firebase
         .database()
@@ -41,7 +43,7 @@ describe('database().ref().onDisconnect().update()', () => {
     }
   });
 
-  it('throws if values does not contain any values', async () => {
+  it('throws if values does not contain any values', async function() {
     try {
       await firebase
         .database()
@@ -55,7 +57,7 @@ describe('database().ref().onDisconnect().update()', () => {
     }
   });
 
-  it('throws if update paths are not valid', async () => {
+  it('throws if update paths are not valid', async function() {
     try {
       await firebase
         .database()
@@ -71,7 +73,7 @@ describe('database().ref().onDisconnect().update()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', () => {
+  it('throws if onComplete is not a function', function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -85,7 +87,7 @@ describe('database().ref().onDisconnect().update()', () => {
     }
   });
 
-  it('updates value when disconnected', async () => {
+  it('updates value when disconnected', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     const value = Date.now();
@@ -112,7 +114,7 @@ describe('database().ref().onDisconnect().update()', () => {
     );
   });
 
-  it('calls back to the onComplete function', async () => {
+  it('calls back to the onComplete function', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(TEST_PATH);
 

--- a/packages/database/e2e/query/endAt.e2e.js
+++ b/packages/database/e2e/query/endAt.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/endAt`;
 
-describe('database().ref().endAt()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().endAt()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if an value is undefined', async () => {
+  it('throws if an value is undefined', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().endAt()', () => {
     }
   });
 
-  it('throws if an key is not a string', async () => {
+  it('throws if an key is not a string', async function() {
     try {
       await firebase
         .database()
@@ -49,7 +53,7 @@ describe('database().ref().endAt()', () => {
     }
   });
 
-  it('throws if a ending point has already been set', async () => {
+  it('throws if a ending point has already been set', async function() {
     try {
       await firebase
         .database()
@@ -65,7 +69,7 @@ describe('database().ref().endAt()', () => {
     }
   });
 
-  it('throws if ordering by key and the key param is set', async () => {
+  it('throws if ordering by key and the key param is set', async function() {
     try {
       await firebase
         .database()
@@ -81,7 +85,7 @@ describe('database().ref().endAt()', () => {
     }
   });
 
-  it('throws if ordering by key and the value param is not a string', async () => {
+  it('throws if ordering by key and the value param is not a string', async function() {
     try {
       await firebase
         .database()
@@ -97,7 +101,7 @@ describe('database().ref().endAt()', () => {
     }
   });
 
-  it('throws if ordering by priority and the value param is not priority type', async () => {
+  it('throws if ordering by priority and the value param is not priority type', async function() {
     try {
       await firebase
         .database()
@@ -113,7 +117,7 @@ describe('database().ref().endAt()', () => {
     }
   });
 
-  it('snapshot value returns all when no ordering modifier is applied', async () => {
+  it('snapshot value returns all when no ordering modifier is applied', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     await ref.set({
@@ -132,7 +136,7 @@ describe('database().ref().endAt()', () => {
     });
   });
 
-  it('ends at the correct value', async () => {
+  it('ends at the correct value', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     await ref.set({

--- a/packages/database/e2e/query/equalTo.e2e.js
+++ b/packages/database/e2e/query/equalTo.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/equalTo`;
 
-describe('database().ref().equalTo()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().equalTo()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if value is not a valid type', async () => {
+  it('throws if value is not a valid type', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().equalTo()', () => {
     }
   });
 
-  it('throws if key is not a string', async () => {
+  it('throws if key is not a string', async function() {
     try {
       await firebase
         .database()
@@ -49,7 +53,7 @@ describe('database().ref().equalTo()', () => {
     }
   });
 
-  it('throws if a starting point has already been set', async () => {
+  it('throws if a starting point has already been set', async function() {
     try {
       await firebase
         .database()
@@ -65,7 +69,7 @@ describe('database().ref().equalTo()', () => {
     }
   });
 
-  it('throws if a ending point has already been set', async () => {
+  it('throws if a ending point has already been set', async function() {
     try {
       await firebase
         .database()
@@ -81,7 +85,7 @@ describe('database().ref().equalTo()', () => {
     }
   });
 
-  it('snapshot value is null when no ordering modifier is applied', async () => {
+  it('snapshot value is null when no ordering modifier is applied', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     await ref.set({
@@ -95,7 +99,7 @@ describe('database().ref().equalTo()', () => {
     should.equal(snapshot.val(), null);
   });
 
-  it('returns the correct equal to values', async () => {
+  it('returns the correct equal to values', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     await ref.set({

--- a/packages/database/e2e/query/isEqual.e2e.js
+++ b/packages/database/e2e/query/isEqual.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('database().ref().isEqual()', () => {
-  it('throws if limit other param is not a query instance', async () => {
+describe('database().ref().isEqual()', function() {
+  it('throws if limit other param is not a query instance', async function() {
     try {
       await firebase
         .database()
@@ -29,13 +29,13 @@ describe('database().ref().isEqual()', () => {
     }
   });
 
-  it('returns true if the query is the same instance', async () => {
+  it('returns true if the query is the same instance', async function() {
     const query = await firebase.database().ref();
     const same = query.isEqual(query);
     same.should.eql(true);
   });
 
-  it('returns false if the query is different', async () => {
+  it('returns false if the query is different', async function() {
     const query = await firebase.database().ref();
     const other = await firebase
       .database()
@@ -45,7 +45,7 @@ describe('database().ref().isEqual()', () => {
     same.should.eql(false);
   });
 
-  it('returns true if the query is created differently', async () => {
+  it('returns true if the query is created differently', async function() {
     const query = await firebase
       .database()
       .ref()

--- a/packages/database/e2e/query/keepSynced.e2e.js
+++ b/packages/database/e2e/query/keepSynced.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('database().ref().keepSynced()', () => {
-  it('throws if bool is not a valid type', async () => {
+describe('database().ref().keepSynced()', function() {
+  it('throws if bool is not a valid type', async function() {
     try {
       await firebase
         .database()
@@ -29,7 +29,7 @@ describe('database().ref().keepSynced()', () => {
     }
   });
 
-  it('toggles keepSynced on and off without throwing', async () => {
+  it('toggles keepSynced on and off without throwing', async function() {
     const ref = firebase
       .database()
       .ref('noop')

--- a/packages/database/e2e/query/limitToFirst.e2e.js
+++ b/packages/database/e2e/query/limitToFirst.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/limitToFirst`;
 
-describe('database().ref().limitToFirst()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().limitToFirst()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if limit is invalid', async () => {
+  it('throws if limit is invalid', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().limitToFirst()', () => {
     }
   });
 
-  it('throws if limit has already been set', async () => {
+  it('throws if limit has already been set', async function() {
     try {
       await firebase
         .database()
@@ -52,7 +56,7 @@ describe('database().ref().limitToFirst()', () => {
     }
   });
 
-  it('returns a limited array data set', async () => {
+  it('returns a limited array data set', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}`);
 
     const initial = {
@@ -72,7 +76,7 @@ describe('database().ref().limitToFirst()', () => {
       });
   });
 
-  it('returns a limited object data set', async () => {
+  it('returns a limited object data set', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}`);
 
     const initial = {
@@ -97,7 +101,7 @@ describe('database().ref().limitToFirst()', () => {
       });
   });
 
-  it('returns a null value when not possible to limit', async () => {
+  it('returns a null value when not possible to limit', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}`);
 
     const initial = 'foo';

--- a/packages/database/e2e/query/limitToLast.e2e.js
+++ b/packages/database/e2e/query/limitToLast.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/limitToLast`;
 
-describe('database().ref().limitToLast()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().limitToLast()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if limit is invalid', async () => {
+  it('throws if limit is invalid', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().limitToLast()', () => {
     }
   });
 
-  it('throws if limit has already been set', async () => {
+  it('throws if limit has already been set', async function() {
     try {
       await firebase
         .database()
@@ -52,7 +56,7 @@ describe('database().ref().limitToLast()', () => {
     }
   });
 
-  it('returns a limited array data set', async () => {
+  it('returns a limited array data set', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}`);
 
     const initial = {
@@ -72,7 +76,7 @@ describe('database().ref().limitToLast()', () => {
       });
   });
 
-  it('returns a limited object data set', async () => {
+  it('returns a limited object data set', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}`);
 
     const initial = {
@@ -97,7 +101,7 @@ describe('database().ref().limitToLast()', () => {
       });
   });
 
-  it('returns a null value when not possible to limit', async () => {
+  it('returns a null value when not possible to limit', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}`);
 
     const initial = 'foo';

--- a/packages/database/e2e/query/on.e2e.js
+++ b/packages/database/e2e/query/on.e2e.js
@@ -20,8 +20,8 @@ const { PATH } = require('../helpers');
 const TEST_PATH = `${PATH}/on`;
 
 // TODO flakey on CI - improve database paths so no current test conflicts & remove sleep util usage
-xdescribe('database().ref().on()', () => {
-  it('throws if event type is invalid', async () => {
+xdescribe('database().ref().on()', function() {
+  it('throws if event type is invalid', async function() {
     try {
       await firebase
         .database()
@@ -34,7 +34,7 @@ xdescribe('database().ref().on()', () => {
     }
   });
 
-  it('throws if callback is not a function', async () => {
+  it('throws if callback is not a function', async function() {
     try {
       await firebase
         .database()
@@ -47,7 +47,7 @@ xdescribe('database().ref().on()', () => {
     }
   });
 
-  it('throws if cancel callback is not a function', async () => {
+  it('throws if cancel callback is not a function', async function() {
     try {
       await firebase
         .database()
@@ -60,7 +60,7 @@ xdescribe('database().ref().on()', () => {
     }
   });
 
-  it('throws if context is not an object', async () => {
+  it('throws if context is not an object', async function() {
     try {
       await firebase
         .database()
@@ -78,7 +78,7 @@ xdescribe('database().ref().on()', () => {
     }
   });
   // TODO test flakey on CI - swap out Util.sleep
-  xit('should callback with an initial value', async () => {
+  xit('should callback with an initial value', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/init`);
     const value = Date.now();
@@ -95,7 +95,7 @@ xdescribe('database().ref().on()', () => {
     ref.off('value');
   });
 
-  it('should callback multiple times when the value changes', async () => {
+  it('should callback multiple times when the value changes', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/changes`);
     await ref.set('foo');
@@ -114,7 +114,7 @@ xdescribe('database().ref().on()', () => {
     callback.getCall(1).args[0].should.equal('bar');
   });
 
-  it('should cancel when something goes wrong', async () => {
+  it('should cancel when something goes wrong', async function() {
     const successCallback = sinon.spy();
     const cancelCallback = sinon.spy();
     const ref = firebase.database().ref('nope');
@@ -138,7 +138,7 @@ xdescribe('database().ref().on()', () => {
     cancelCallback.should.be.calledOnce();
   });
 
-  it('subscribe to child added events', async () => {
+  it('subscribe to child added events', async function() {
     const successCallback = sinon.spy();
     const cancelCallback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childAdded`);
@@ -164,7 +164,7 @@ xdescribe('database().ref().on()', () => {
     cancelCallback.should.be.callCount(0);
   });
 
-  it('subscribe to child changed events', async () => {
+  it('subscribe to child changed events', async function() {
     const successCallback = sinon.spy();
     const cancelCallback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childChanged`);
@@ -195,7 +195,7 @@ xdescribe('database().ref().on()', () => {
     cancelCallback.should.be.callCount(0);
   });
 
-  it('subscribe to child removed events', async () => {
+  it('subscribe to child removed events', async function() {
     const successCallback = sinon.spy();
     const cancelCallback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childRemoved`);
@@ -221,7 +221,7 @@ xdescribe('database().ref().on()', () => {
     cancelCallback.should.be.callCount(0);
   });
 
-  it('subscribe to child moved events', async () => {
+  it('subscribe to child moved events', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childMoved`);
     const orderedRef = ref.orderByChild('nuggets');

--- a/packages/database/e2e/query/once.e2e.js
+++ b/packages/database/e2e/query/once.e2e.js
@@ -20,11 +20,15 @@ const { PATH, CONTENT, seed, wipe } = require('../helpers');
 const TEST_PATH = `${PATH}/once`;
 
 // TODO flakey on CI - improve database paths so no current test conflicts & remove sleep util usage
-describe('database().ref().once()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().once()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if event type is invalid', async () => {
+  it('throws if event type is invalid', async function() {
     try {
       await firebase
         .database()
@@ -37,7 +41,7 @@ describe('database().ref().once()', () => {
     }
   });
 
-  it('throws if success callback is not a function', async () => {
+  it('throws if success callback is not a function', async function() {
     try {
       await firebase
         .database()
@@ -50,7 +54,7 @@ describe('database().ref().once()', () => {
     }
   });
 
-  it('throws if failure callback is not a function', async () => {
+  it('throws if failure callback is not a function', async function() {
     try {
       await firebase
         .database()
@@ -63,7 +67,7 @@ describe('database().ref().once()', () => {
     }
   });
 
-  it('throws if context is not an object', async () => {
+  it('throws if context is not an object', async function() {
     try {
       await firebase
         .database()
@@ -81,13 +85,13 @@ describe('database().ref().once()', () => {
     }
   });
 
-  it('returns a promise', async () => {
+  it('returns a promise', async function() {
     const ref = firebase.database().ref('tests/types/number');
     const returnValue = ref.once('value');
     returnValue.should.be.Promise();
   });
 
-  it('resolves with the correct values', async () => {
+  it('resolves with the correct values', async function() {
     const ref = firebase.database().ref(`${TEST_PATH}/types`);
 
     await Promise.all(
@@ -99,7 +103,7 @@ describe('database().ref().once()', () => {
     );
   });
 
-  it('is is called when the value is changed', async () => {
+  it('is is called when the value is changed', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/types/number`);
     ref.once('value').then(callback);
@@ -107,7 +111,7 @@ describe('database().ref().once()', () => {
     callback.should.be.calledOnce();
   });
 
-  it('errors if permission denied', async () => {
+  it('errors if permission denied', async function() {
     const ref = firebase.database().ref('nope');
     try {
       await ref.once('value');
@@ -118,7 +122,7 @@ describe('database().ref().once()', () => {
     }
   });
 
-  it('it calls when a child is added', async () => {
+  it('it calls when a child is added', async function() {
     const value = Date.now();
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childAdded`);
@@ -131,7 +135,7 @@ describe('database().ref().once()', () => {
     callback.should.be.calledWith(value);
   });
 
-  it('resolves when a child is changed', async () => {
+  it('resolves when a child is changed', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childChanged`);
 
@@ -144,7 +148,7 @@ describe('database().ref().once()', () => {
     callback.should.be.calledWith(2);
   });
 
-  it('resolves when a child is removed', async () => {
+  it('resolves when a child is removed', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childRemoved`);
     const child = ref.child('removeme');
@@ -160,7 +164,7 @@ describe('database().ref().once()', () => {
   });
 
   // https://github.com/firebase/firebase-js-sdk/blob/6b53e0058483c9002d2fe56119f86fc9fb96b56c/packages/database/test/order_by.test.ts#L104
-  it('resolves when a child is moved', async () => {
+  it('resolves when a child is moved', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/childMoved`);
     const orderedRef = ref.orderByChild('nuggets');

--- a/packages/database/e2e/query/once.e2e.js
+++ b/packages/database/e2e/query/once.e2e.js
@@ -125,7 +125,7 @@ describe('database().ref().once()', () => {
 
     ref.once('child_added').then($ => callback($.val()));
     await ref.child('foo').set(value);
-    await Utils.sleep(100);
+    await Utils.sleep(1000);
 
     callback.should.be.calledOnce();
     callback.should.be.calledWith(value);

--- a/packages/database/e2e/query/orderByChild.e2e.js
+++ b/packages/database/e2e/query/orderByChild.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/orderByChild`;
 
-describe('database().ref().orderByChild()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().orderByChild()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if path is not a string value', async () => {
+  it('throws if path is not a string value', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().orderByChild()', () => {
     }
   });
 
-  it('throws if path is an empty path', async () => {
+  it('throws if path is an empty path', async function() {
     try {
       await firebase
         .database()
@@ -49,7 +53,7 @@ describe('database().ref().orderByChild()', () => {
     }
   });
 
-  it('throws if an orderBy call has already been set', async () => {
+  it('throws if an orderBy call has already been set', async function() {
     try {
       await firebase
         .database()
@@ -63,7 +67,7 @@ describe('database().ref().orderByChild()', () => {
     }
   });
 
-  it('order by a child value', async () => {
+  it('order by a child value', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     try {

--- a/packages/database/e2e/query/orderByKey.e2e.js
+++ b/packages/database/e2e/query/orderByKey.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/orderByKey`;
 
-describe('database().ref().orderByKey()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().orderByKey()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if an orderBy call has already been set', async () => {
+  it('throws if an orderBy call has already been set', async function() {
     try {
       await firebase
         .database()
@@ -37,7 +41,7 @@ describe('database().ref().orderByKey()', () => {
     }
   });
 
-  it('order by a key', async () => {
+  it('order by a key', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     try {

--- a/packages/database/e2e/query/orderByPriority.e2e.js
+++ b/packages/database/e2e/query/orderByPriority.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/orderByPriority`;
 
-describe('database().ref().orderByPriority()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().orderByPriority()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if an orderBy call has already been set', async () => {
+  it('throws if an orderBy call has already been set', async function() {
     try {
       await firebase
         .database()
@@ -37,7 +41,7 @@ describe('database().ref().orderByPriority()', () => {
     }
   });
 
-  it('order by priority', async () => {
+  it('order by priority', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)

--- a/packages/database/e2e/query/orderByValue.e2e.js
+++ b/packages/database/e2e/query/orderByValue.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/orderByValue`;
 
-describe('database().ref().orderByValue()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().orderByValue()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if an orderBy call has already been set', async () => {
+  it('throws if an orderBy call has already been set', async function() {
     try {
       await firebase
         .database()
@@ -37,7 +41,7 @@ describe('database().ref().orderByValue()', () => {
     }
   });
   // TODO potentially flakey on CI iOS - possible crash
-  xit('order by value', async () => {
+  xit('order by value', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)

--- a/packages/database/e2e/query/query.e2e.js
+++ b/packages/database/e2e/query/query.e2e.js
@@ -14,8 +14,8 @@
  *  limitations under the License.
  */
 
-describe('DatabaseQuery/DatabaseQueryModifiers', () => {
-  it('should not mutate previous queries (#2691)', async () => {
+describe('DatabaseQuery/DatabaseQueryModifiers', function() {
+  it('should not mutate previous queries (#2691)', async function() {
     const queryBefore = firebase.database().ref();
     queryBefore._modifiers._modifiers.length.should.equal(0);
 

--- a/packages/database/e2e/query/startAt.e2e.js
+++ b/packages/database/e2e/query/startAt.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/startAt`;
 
-describe('database().ref().startAt()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().startAt()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if an value is undefined', async () => {
+  it('throws if an value is undefined', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().startAt()', () => {
     }
   });
 
-  it('throws if an key is not a string', async () => {
+  it('throws if an key is not a string', async function() {
     try {
       await firebase
         .database()
@@ -49,7 +53,7 @@ describe('database().ref().startAt()', () => {
     }
   });
 
-  it('throws if a starting point has already been set', async () => {
+  it('throws if a starting point has already been set', async function() {
     try {
       await firebase
         .database()
@@ -65,7 +69,7 @@ describe('database().ref().startAt()', () => {
     }
   });
 
-  it('throws if ordering by key and the key param is set', async () => {
+  it('throws if ordering by key and the key param is set', async function() {
     try {
       await firebase
         .database()
@@ -81,7 +85,7 @@ describe('database().ref().startAt()', () => {
     }
   });
 
-  it('throws if ordering by key and the value param is not a string', async () => {
+  it('throws if ordering by key and the value param is not a string', async function() {
     try {
       await firebase
         .database()
@@ -97,7 +101,7 @@ describe('database().ref().startAt()', () => {
     }
   });
 
-  it('throws if ordering by priority and the value param is not priority type', async () => {
+  it('throws if ordering by priority and the value param is not priority type', async function() {
     try {
       await firebase
         .database()
@@ -113,7 +117,7 @@ describe('database().ref().startAt()', () => {
     }
   });
 
-  it('snapshot value is null when no ordering modifier is applied', async () => {
+  it('snapshot value is null when no ordering modifier is applied', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     await ref.set({
@@ -127,7 +131,7 @@ describe('database().ref().startAt()', () => {
     should.equal(snapshot.val(), null);
   });
 
-  it('starts at the correct value', async () => {
+  it('starts at the correct value', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     await ref.set({

--- a/packages/database/e2e/query/toJSON.e2e.js
+++ b/packages/database/e2e/query/toJSON.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('database().ref().toJSON()', () => {
-  it('returns a string version of the current query path', async () => {
+describe('database().ref().toJSON()', function() {
+  it('returns a string version of the current query path', async function() {
     const res = firebase
       .database()
       .ref('foo/bar/baz')

--- a/packages/database/e2e/reference/child.e2e.js
+++ b/packages/database/e2e/reference/child.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('database().ref().child()', () => {
-  it('throws if path is not a string', async () => {
+describe('database().ref().child()', function() {
+  it('throws if path is not a string', async function() {
     try {
       firebase
         .database()
@@ -29,7 +29,7 @@ describe('database().ref().child()', () => {
     }
   });
 
-  it('throws if path is not a valid string', async () => {
+  it('throws if path is not a valid string', async function() {
     try {
       firebase
         .database()

--- a/packages/database/e2e/reference/key.e2e.js
+++ b/packages/database/e2e/reference/key.e2e.js
@@ -15,13 +15,13 @@
  *
  */
 
-describe('database().ref().key', () => {
-  it('returns null when no reference path is provides', () => {
+describe('database().ref().key', function() {
+  it('returns null when no reference path is provides', function() {
     const ref = firebase.database().ref();
     should.equal(ref.key, null);
   });
 
-  it('return last token in reference path', () => {
+  it('return last token in reference path', function() {
     const ref1 = firebase.database().ref('foo');
     const ref2 = firebase.database().ref('foo/bar/baz');
     ref1.key.should.equal('foo');

--- a/packages/database/e2e/reference/onDisconnect.e2e.js
+++ b/packages/database/e2e/reference/onDisconnect.e2e.js
@@ -17,8 +17,8 @@
 
 // See onDisconnect directory for specific tests
 
-describe('database().ref().onDisconnect()', () => {
-  it('returns a new DatabaseOnDisconnect instance', () => {
+describe('database().ref().onDisconnect()', function() {
+  it('returns a new DatabaseOnDisconnect instance', function() {
     const instance = firebase
       .database()
       .ref()

--- a/packages/database/e2e/reference/parent.e2e.js
+++ b/packages/database/e2e/reference/parent.e2e.js
@@ -15,13 +15,13 @@
  *
  */
 
-describe('database().ref().parent', () => {
-  it('returns null when no reference path is provides', () => {
+describe('database().ref().parent', function() {
+  it('returns null when no reference path is provides', function() {
     const ref = firebase.database().ref();
     should.equal(ref.parent, null);
   });
 
-  it('return last token in reference path', () => {
+  it('return last token in reference path', function() {
     const ref1 = firebase.database().ref('/foo').parent;
     const ref2 = firebase.database().ref('/foo/bar/baz').parent;
     should.equal(ref1, null);

--- a/packages/database/e2e/reference/push.e2e.js
+++ b/packages/database/e2e/reference/push.e2e.js
@@ -19,8 +19,8 @@ const { PATH } = require('../helpers');
 
 const TEST_PATH = `${PATH}/push`;
 
-describe('database().ref().push()', () => {
-  it('throws if on complete callback is not a function', () => {
+describe('database().ref().push()', function() {
+  it('throws if on complete callback is not a function', function() {
     try {
       firebase
         .database()
@@ -33,7 +33,7 @@ describe('database().ref().push()', () => {
     }
   });
 
-  it('returns a promise when no value is passed', () => {
+  it('returns a promise when no value is passed', function() {
     const ref = firebase.database().ref(`${TEST_PATH}/boop`);
     const pushed = ref.push();
     return pushed
@@ -48,7 +48,7 @@ describe('database().ref().push()', () => {
       });
   });
 
-  it('returns a promise and sets the provided value', () => {
+  it('returns a promise and sets the provided value', function() {
     const ref = firebase.database().ref(`${TEST_PATH}/value`);
     const pushed = ref.push(6);
     return pushed
@@ -63,7 +63,7 @@ describe('database().ref().push()', () => {
       });
   });
 
-  it('returns a to the callback if provided once set', async () => {
+  it('returns a to the callback if provided once set', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref(`${TEST_PATH}/callback`);
     const value = Date.now();
@@ -74,7 +74,7 @@ describe('database().ref().push()', () => {
     callback.should.be.calledOnce();
   });
 
-  it('throws if push errors', async () => {
+  it('throws if push errors', async function() {
     const ref = firebase.database().ref('nope');
     return ref.push('foo').catch(error => {
       error.message.should.containEql("doesn't have permission to access");
@@ -82,7 +82,7 @@ describe('database().ref().push()', () => {
     });
   });
 
-  it('returns an error to the callback', async () => {
+  it('returns an error to the callback', async function() {
     const callback = sinon.spy();
     const ref = firebase.database().ref('nope');
     ref.push('foo', error => {

--- a/packages/database/e2e/reference/remove.e2e.js
+++ b/packages/database/e2e/reference/remove.e2e.js
@@ -19,8 +19,8 @@ const { PATH } = require('../helpers');
 
 const TEST_PATH = `${PATH}/remove`;
 
-describe('database().ref().remove()', () => {
-  it('throws if onComplete is not a function', async () => {
+describe('database().ref().remove()', function() {
+  it('throws if onComplete is not a function', async function() {
     try {
       await firebase
         .database()
@@ -33,7 +33,7 @@ describe('database().ref().remove()', () => {
     }
   });
 
-  it('removes a value at the path', async () => {
+  it('removes a value at the path', async function() {
     const ref = firebase.database().ref(TEST_PATH);
     await ref.set('foo');
     await ref.remove();

--- a/packages/database/e2e/reference/root.e2e.js
+++ b/packages/database/e2e/reference/root.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('database().ref().root', () => {
-  it('returns a root reference', () => {
+describe('database().ref().root', function() {
+  it('returns a root reference', function() {
     const ref = firebase.database().ref('foo/bar/baz');
     should.equal(ref.root.key, null);
   });

--- a/packages/database/e2e/reference/set.e2e.js
+++ b/packages/database/e2e/reference/set.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/set`;
 
-describe('database().ref().set()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().set()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if no value is provided', async () => {
+  it('throws if no value is provided', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().set()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', async () => {
+  it('throws if onComplete is not a function', async function() {
     try {
       await firebase
         .database()
@@ -49,7 +53,7 @@ describe('database().ref().set()', () => {
     }
   });
 
-  it('sets a new value', async () => {
+  it('sets a new value', async function() {
     const value = Date.now();
     const ref = firebase.database().ref(TEST_PATH);
     await ref.set(value);
@@ -57,7 +61,7 @@ describe('database().ref().set()', () => {
     snapshot.val().should.eql(value);
   });
 
-  it('callback if function is passed', async () => {
+  it('callback if function is passed', async function() {
     const value = Date.now();
     return new Promise(async resolve => {
       await firebase
@@ -67,7 +71,7 @@ describe('database().ref().set()', () => {
     });
   });
 
-  it('throws if permission defined', async () => {
+  it('throws if permission defined', async function() {
     const value = Date.now();
     try {
       await firebase

--- a/packages/database/e2e/reference/setPriority.e2e.js
+++ b/packages/database/e2e/reference/setPriority.e2e.js
@@ -19,11 +19,15 @@ const { PATH, CONTENT, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/priority`;
 
-describe('database().ref().setPriority()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().setPriority()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if priority is not a valid type', async () => {
+  it('throws if priority is not a valid type', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().setPriority()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', async () => {
+  it('throws if onComplete is not a function', async function() {
     try {
       await firebase
         .database()
@@ -49,7 +53,7 @@ describe('database().ref().setPriority()', () => {
     }
   });
 
-  it('should correctly set a priority for all non-null values', async () => {
+  it('should correctly set a priority for all non-null values', async function() {
     await Promise.all(
       Object.keys(CONTENT.TYPES).map(async dataRef => {
         const ref = firebase.database().ref(`${TEST_PATH}/types/${dataRef}`);
@@ -62,7 +66,7 @@ describe('database().ref().setPriority()', () => {
     );
   });
 
-  it('callback if function is passed', async () => {
+  it('callback if function is passed', async function() {
     const value = Date.now();
     return new Promise(async resolve => {
       await firebase
@@ -72,7 +76,7 @@ describe('database().ref().setPriority()', () => {
     });
   });
 
-  it('throws if setting priority on non-existent node', async () => {
+  it('throws if setting priority on non-existent node', async function() {
     try {
       await firebase
         .database()
@@ -86,7 +90,7 @@ describe('database().ref().setPriority()', () => {
     }
   });
 
-  it('throws if permission defined', async () => {
+  it('throws if permission defined', async function() {
     try {
       await firebase
         .database()

--- a/packages/database/e2e/reference/setWithPriority.e2e.js
+++ b/packages/database/e2e/reference/setWithPriority.e2e.js
@@ -19,11 +19,15 @@ const { PATH, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/setWithPriority`;
 
-describe('database().ref().setWithPriority()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().setWithPriority()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if newVal is not defined', async () => {
+  it('throws if newVal is not defined', async function() {
     try {
       await firebase
         .database()
@@ -36,7 +40,7 @@ describe('database().ref().setWithPriority()', () => {
     }
   });
 
-  it('throws if newPriority is incorrect type', async () => {
+  it('throws if newPriority is incorrect type', async function() {
     try {
       await firebase
         .database()
@@ -49,7 +53,7 @@ describe('database().ref().setWithPriority()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', async () => {
+  it('throws if onComplete is not a function', async function() {
     try {
       await firebase
         .database()
@@ -62,7 +66,7 @@ describe('database().ref().setWithPriority()', () => {
     }
   });
 
-  it('callback if function is passed', async () => {
+  it('callback if function is passed', async function() {
     const value = Date.now();
     return new Promise(async resolve => {
       await firebase
@@ -72,7 +76,7 @@ describe('database().ref().setWithPriority()', () => {
     });
   });
 
-  it('sets with a new value and priority', async () => {
+  it('sets with a new value and priority', async function() {
     const value = Date.now();
     const ref = firebase.database().ref(`${TEST_PATH}/setValue`);
     await ref.setWithPriority(value, 2);

--- a/packages/database/e2e/reference/transaction.e2e.js
+++ b/packages/database/e2e/reference/transaction.e2e.js
@@ -20,11 +20,15 @@ const { PATH, seed, wipe } = require('../helpers');
 const TEST_PATH = `${PATH}/transaction`;
 const NOOP = () => {};
 
-describe('database().ref().transaction()', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database().ref().transaction()', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('throws if no transactionUpdate is provided', async () => {
+  it('throws if no transactionUpdate is provided', async function() {
     try {
       await firebase
         .database()
@@ -37,7 +41,7 @@ describe('database().ref().transaction()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', async () => {
+  it('throws if onComplete is not a function', async function() {
     try {
       await firebase
         .database()
@@ -50,7 +54,7 @@ describe('database().ref().transaction()', () => {
     }
   });
 
-  it('throws if applyLocally is not a boolean', async () => {
+  it('throws if applyLocally is not a boolean', async function() {
     try {
       await firebase
         .database()
@@ -79,7 +83,7 @@ describe('database().ref().transaction()', () => {
     snapshot.val().should.equal(2);
   });
 
-  it('aborts transaction if undefined returned', async () => {
+  it('aborts transaction if undefined returned', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -107,7 +111,7 @@ describe('database().ref().transaction()', () => {
   });
 
   // FIXME failing for me locally on android and ios as well
-  xit('passes valid data through the callback', async () => {
+  xit('passes valid data through the callback', async function() {
     // FIXME failing in CI
     if (!global.isCI) {
       const ref = firebase
@@ -139,7 +143,7 @@ describe('database().ref().transaction()', () => {
   });
 
   // FIXME failing for me locally on android and ios as well
-  xit('throws when an error occurs', async () => {
+  xit('throws when an error occurs', async function() {
     // FIXME failing in CI
     if (!global.isCI) {
       const ref = firebase.database().ref('nope');
@@ -159,7 +163,7 @@ describe('database().ref().transaction()', () => {
   });
 
   // FIXME failing for me locally on android and ios as well
-  xit('passes error back to the callback', async () => {
+  xit('passes error back to the callback', async function() {
     // FIXME failing in CI
     if (!global.isCI) {
       const ref = firebase.database().ref('nope');
@@ -193,7 +197,7 @@ describe('database().ref().transaction()', () => {
   });
 
   // FIXME failing for me locally on android and ios as well
-  xit('sets a value if one does not exist', async () => {
+  xit('sets a value if one does not exist', async function() {
     // FIXME failing in CI
     if (!global.isCI) {
       const ref = firebase

--- a/packages/database/e2e/reference/update.e2e.js
+++ b/packages/database/e2e/reference/update.e2e.js
@@ -19,15 +19,15 @@ const { PATH } = require('../helpers');
 
 const TEST_PATH = `${PATH}/update`;
 
-describe('database().ref().update()', () => {
-  after(async () => {
+describe('database().ref().update()', function() {
+  after(async function() {
     await firebase
       .database()
       .ref(TEST_PATH)
       .remove();
   });
 
-  it('throws if values is not an object', async () => {
+  it('throws if values is not an object', async function() {
     try {
       await firebase
         .database()
@@ -40,7 +40,7 @@ describe('database().ref().update()', () => {
     }
   });
 
-  it('throws if values does not contain any values', async () => {
+  it('throws if values does not contain any values', async function() {
     try {
       await firebase
         .database()
@@ -53,7 +53,7 @@ describe('database().ref().update()', () => {
     }
   });
 
-  it('throws if update paths are not valid', async () => {
+  it('throws if update paths are not valid', async function() {
     try {
       await firebase
         .database()
@@ -68,7 +68,7 @@ describe('database().ref().update()', () => {
     }
   });
 
-  it('throws if onComplete is not a function', async () => {
+  it('throws if onComplete is not a function', async function() {
     try {
       await firebase
         .database()
@@ -86,7 +86,7 @@ describe('database().ref().update()', () => {
     }
   });
 
-  it('updates values', async () => {
+  it('updates values', async function() {
     const value = Date.now();
     const ref = firebase.database().ref(TEST_PATH);
     await ref.update({
@@ -100,7 +100,7 @@ describe('database().ref().update()', () => {
     );
   });
 
-  it('callback if function is passed', async () => {
+  it('callback if function is passed', async function() {
     const value = Date.now();
     return new Promise(async resolve => {
       await firebase

--- a/packages/database/e2e/snapshot/snapshot.e2e.js
+++ b/packages/database/e2e/snapshot/snapshot.e2e.js
@@ -19,11 +19,15 @@ const { PATH, CONTENT, seed, wipe } = require('../helpers');
 
 const TEST_PATH = `${PATH}/snapshot`;
 
-describe('database()...snapshot', () => {
-  before(() => seed(TEST_PATH));
-  after(() => wipe(TEST_PATH));
+describe('database()...snapshot', function() {
+  before(function() {
+    return seed(TEST_PATH);
+  });
+  after(function() {
+    return wipe(TEST_PATH);
+  });
 
-  it('returns the snapshot key', async () => {
+  it('returns the snapshot key', async function() {
     const snapshot = await firebase
       .database()
       .ref(TEST_PATH)
@@ -33,7 +37,7 @@ describe('database()...snapshot', () => {
     snapshot.key.should.equal('boolean');
   });
 
-  it('returns the snapshot reference', async () => {
+  it('returns the snapshot reference', async function() {
     const snapshot = await firebase
       .database()
       .ref(TEST_PATH)
@@ -43,7 +47,7 @@ describe('database()...snapshot', () => {
     snapshot.ref.key.should.equal('boolean');
   });
 
-  it('returns the correct boolean for exists', async () => {
+  it('returns the correct boolean for exists', async function() {
     const snapshot1 = await firebase
       .database()
       .ref(TEST_PATH)
@@ -60,7 +64,7 @@ describe('database()...snapshot', () => {
     snapshot2.exists().should.equal(false);
   });
 
-  it('exports a valid object', async () => {
+  it('exports a valid object', async function() {
     const snapshot = await firebase
       .database()
       .ref(TEST_PATH)
@@ -75,7 +79,7 @@ describe('database()...snapshot', () => {
     should.equal(exported['.priority'], null);
   });
 
-  it('exports a valid object with a object value', async () => {
+  it('exports a valid object with a object value', async function() {
     const snapshot = await firebase
       .database()
       .ref(TEST_PATH)
@@ -90,7 +94,7 @@ describe('database()...snapshot', () => {
     should.equal(exported['.priority'], null);
   });
 
-  it('forEach throws if action param is not a function', async () => {
+  it('forEach throws if action param is not a function', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -111,7 +115,7 @@ describe('database()...snapshot', () => {
     }
   });
 
-  it('forEach returns an ordered list of snapshots', async () => {
+  it('forEach returns an ordered list of snapshots', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -132,7 +136,7 @@ describe('database()...snapshot', () => {
     });
   });
 
-  it('forEach works with arrays', async () => {
+  it('forEach works with arrays', async function() {
     const callback = sinon.spy();
     const ref = firebase
       .database()
@@ -150,7 +154,7 @@ describe('database()...snapshot', () => {
     callback.should.be.callCount(snapshot.child('array').numChildren());
   });
 
-  it('forEach works with objects and cancels when returning true', async () => {
+  it('forEach works with objects and cancels when returning true', async function() {
     const callback = sinon.spy();
     const ref = firebase
       .database()
@@ -170,7 +174,7 @@ describe('database()...snapshot', () => {
     callback.should.be.calledOnce();
   });
 
-  it('forEach works with arrays and cancels when returning true', async () => {
+  it('forEach works with arrays and cancels when returning true', async function() {
     const callback = sinon.spy();
     const ref = firebase
       .database()
@@ -189,7 +193,7 @@ describe('database()...snapshot', () => {
     callback.should.be.calledOnce();
   });
 
-  it('forEach returns false when no child keys', async () => {
+  it('forEach returns false when no child keys', async function() {
     const callback = sinon.spy();
     const ref = firebase
       .database()
@@ -206,7 +210,7 @@ describe('database()...snapshot', () => {
     callback.should.be.callCount(0);
   });
 
-  it('forEach cancels iteration when returning true', async () => {
+  it('forEach cancels iteration when returning true', async function() {
     const callback = sinon.spy();
     const ref = firebase
       .database()
@@ -225,7 +229,7 @@ describe('database()...snapshot', () => {
     callback.getCall(0).args[0].should.equal(0);
   });
 
-  it('getPriority returns the correct value', async () => {
+  it('getPriority returns the correct value', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -237,7 +241,7 @@ describe('database()...snapshot', () => {
     snapshot.getPriority().should.equal('bar');
   });
 
-  it('hasChild throws if path is not a string value', async () => {
+  it('hasChild throws if path is not a string value', async function() {
     const ref = firebase
       .database()
       .ref(TEST_PATH)
@@ -252,7 +256,7 @@ describe('database()...snapshot', () => {
     }
   });
 
-  it('hasChild returns the correct boolean value', async () => {
+  it('hasChild returns the correct boolean value', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     const snapshot1 = await ref.child('types/boolean').once('value');
@@ -262,13 +266,13 @@ describe('database()...snapshot', () => {
     snapshot2.hasChild('boolean').should.equal(true);
   });
 
-  it('hasChildren returns the correct boolean value', async () => {
+  it('hasChildren returns the correct boolean value', async function() {
     const ref = firebase.database().ref(TEST_PATH);
     const snapshot = await ref.child('types/object').once('value');
     snapshot.hasChildren().should.equal(true);
   });
 
-  it('numChildren returns the correct number value', async () => {
+  it('numChildren returns the correct number value', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     const snapshot1 = await ref.child('types/boolean').once('value');
@@ -280,7 +284,7 @@ describe('database()...snapshot', () => {
     snapshot3.numChildren().should.equal(Object.keys(CONTENT.TYPES.object).length);
   });
 
-  it('toJSON returns the value of the snapshot', async () => {
+  it('toJSON returns the value of the snapshot', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     const snapshot1 = await ref.child('types/string').once('value');
@@ -290,7 +294,7 @@ describe('database()...snapshot', () => {
     snapshot2.toJSON().should.eql(jet.contextify(CONTENT.TYPES.object));
   });
 
-  it('val returns the value of the snapshot', async () => {
+  it('val returns the value of the snapshot', async function() {
     const ref = firebase.database().ref(TEST_PATH);
 
     const snapshot1 = await ref.child('types/string').once('value');

--- a/packages/dynamic-links/e2e/builder.analytics.e2e.js
+++ b/packages/dynamic-links/e2e/builder.analytics.e2e.js
@@ -17,8 +17,8 @@
 
 const { baseParams } = require('./dynamicLinks.e2e');
 
-describe('dynamicLinks() dynamicLinkParams.analytics', () => {
-  it('throws if analytics is not an object', () => {
+describe('dynamicLinks() dynamicLinkParams.analytics', function() {
+  it('throws if analytics is not an object', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -31,7 +31,7 @@ describe('dynamicLinks() dynamicLinkParams.analytics', () => {
     }
   });
 
-  it('throws if analytics.campaign is not a string', () => {
+  it('throws if analytics.campaign is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -46,7 +46,7 @@ describe('dynamicLinks() dynamicLinkParams.analytics', () => {
     }
   });
 
-  it('throws if analytics.content is not a string', () => {
+  it('throws if analytics.content is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -61,7 +61,7 @@ describe('dynamicLinks() dynamicLinkParams.analytics', () => {
     }
   });
 
-  it('throws if analytics.medium is not a string', () => {
+  it('throws if analytics.medium is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -76,7 +76,7 @@ describe('dynamicLinks() dynamicLinkParams.analytics', () => {
     }
   });
 
-  it('throws if analytics.source is not a string', () => {
+  it('throws if analytics.source is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -91,7 +91,7 @@ describe('dynamicLinks() dynamicLinkParams.analytics', () => {
     }
   });
 
-  it('throws if analytics.term is not a string', () => {
+  it('throws if analytics.term is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,

--- a/packages/dynamic-links/e2e/builder.android.e2e.js
+++ b/packages/dynamic-links/e2e/builder.android.e2e.js
@@ -17,8 +17,8 @@
 
 const { baseParams } = require('./dynamicLinks.e2e');
 
-describe('dynamicLinks() dynamicLinkParams.android', () => {
-  it('throws if android is not an object', () => {
+describe('dynamicLinks() dynamicLinkParams.android', function() {
+  it('throws if android is not an object', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -31,7 +31,7 @@ describe('dynamicLinks() dynamicLinkParams.android', () => {
     }
   });
 
-  it('throws if android.fallbackUrl is not a string', () => {
+  it('throws if android.fallbackUrl is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -46,7 +46,7 @@ describe('dynamicLinks() dynamicLinkParams.android', () => {
     }
   });
 
-  it('throws if android.minimumVersion is not a string', () => {
+  it('throws if android.minimumVersion is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -61,7 +61,7 @@ describe('dynamicLinks() dynamicLinkParams.android', () => {
     }
   });
 
-  it('throws if android.packageName is not a string', () => {
+  it('throws if android.packageName is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -76,7 +76,7 @@ describe('dynamicLinks() dynamicLinkParams.android', () => {
     }
   });
 
-  it('throws if android.packageName is not set', () => {
+  it('throws if android.packageName is not set', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,

--- a/packages/dynamic-links/e2e/builder.e2e.js
+++ b/packages/dynamic-links/e2e/builder.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('dynamicLinks() dynamicLinkParams', () => {
-  it('throws if params are not an object', () => {
+describe('dynamicLinks() dynamicLinkParams', function() {
+  it('throws if params are not an object', function() {
     try {
       firebase.dynamicLinks().buildLink(123);
       return Promise.reject(new Error('Did not throw Error.'));
@@ -26,7 +26,7 @@ describe('dynamicLinks() dynamicLinkParams', () => {
     }
   });
 
-  it('throws if link is not provided', () => {
+  it('throws if link is not provided', function() {
     try {
       firebase.dynamicLinks().buildLink({});
       return Promise.reject(new Error('Did not throw Error.'));
@@ -36,7 +36,7 @@ describe('dynamicLinks() dynamicLinkParams', () => {
     }
   });
 
-  it('throws if link is not a string', () => {
+  it('throws if link is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         link: 123,
@@ -48,7 +48,7 @@ describe('dynamicLinks() dynamicLinkParams', () => {
     }
   });
 
-  it('throws if link is invalid', () => {
+  it('throws if link is invalid', function() {
     try {
       firebase.dynamicLinks().buildLink({
         link: 'invertase.io',
@@ -62,7 +62,7 @@ describe('dynamicLinks() dynamicLinkParams', () => {
     }
   });
 
-  it('throws if domainUriPrefix is not provided', () => {
+  it('throws if domainUriPrefix is not provided', function() {
     try {
       firebase.dynamicLinks().buildLink({
         link: 'https://invertase.io',
@@ -74,7 +74,7 @@ describe('dynamicLinks() dynamicLinkParams', () => {
     }
   });
 
-  it('throws if domainUriPrefix is not a string', () => {
+  it('throws if domainUriPrefix is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         link: 'https://invertase.io',
@@ -87,7 +87,7 @@ describe('dynamicLinks() dynamicLinkParams', () => {
     }
   });
 
-  it('throws if domainUriPrefix is invalid', () => {
+  it('throws if domainUriPrefix is invalid', function() {
     try {
       firebase.dynamicLinks().buildLink({
         link: 'https://invertase.io',

--- a/packages/dynamic-links/e2e/builder.ios.e2e.js
+++ b/packages/dynamic-links/e2e/builder.ios.e2e.js
@@ -17,8 +17,8 @@
 
 const { baseParams } = require('./dynamicLinks.e2e');
 
-describe('dynamicLinks() dynamicLinkParams.ios', () => {
-  it('throws if ios is not an object', () => {
+describe('dynamicLinks() dynamicLinkParams.ios', function() {
+  it('throws if ios is not an object', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -31,7 +31,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.appStoreId is not a string', () => {
+  it('throws if ios.appStoreId is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -46,7 +46,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.bundleId is not a string', () => {
+  it('throws if ios.bundleId is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -61,7 +61,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.customScheme is not a string', () => {
+  it('throws if ios.customScheme is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -76,7 +76,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.fallbackUrl is not a string', () => {
+  it('throws if ios.fallbackUrl is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -91,7 +91,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.iPadBundleId is not a string', () => {
+  it('throws if ios.iPadBundleId is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -106,7 +106,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.iPadFallbackUrl is not a string', () => {
+  it('throws if ios.iPadFallbackUrl is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -121,7 +121,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.minimumVersion is not a string', () => {
+  it('throws if ios.minimumVersion is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -136,7 +136,7 @@ describe('dynamicLinks() dynamicLinkParams.ios', () => {
     }
   });
 
-  it('throws if ios.bundleId is not set', () => {
+  it('throws if ios.bundleId is not set', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,

--- a/packages/dynamic-links/e2e/builder.itunes.e2e.js
+++ b/packages/dynamic-links/e2e/builder.itunes.e2e.js
@@ -17,8 +17,8 @@
 
 const { baseParams } = require('./dynamicLinks.e2e');
 
-describe('dynamicLinks() dynamicLinkParams.itunes', () => {
-  it('throws if itunes is not an object', () => {
+describe('dynamicLinks() dynamicLinkParams.itunes', function() {
+  it('throws if itunes is not an object', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -31,7 +31,7 @@ describe('dynamicLinks() dynamicLinkParams.itunes', () => {
     }
   });
 
-  it('throws if itunes.affiliateToken is not a string', () => {
+  it('throws if itunes.affiliateToken is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -46,7 +46,7 @@ describe('dynamicLinks() dynamicLinkParams.itunes', () => {
     }
   });
 
-  it('throws if itunes.campaignToken is not a string', () => {
+  it('throws if itunes.campaignToken is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -61,7 +61,7 @@ describe('dynamicLinks() dynamicLinkParams.itunes', () => {
     }
   });
 
-  it('throws if itunes.providerToken is not a string', () => {
+  it('throws if itunes.providerToken is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,

--- a/packages/dynamic-links/e2e/builder.navigation.e2e.js
+++ b/packages/dynamic-links/e2e/builder.navigation.e2e.js
@@ -17,8 +17,8 @@
 
 const { baseParams } = require('./dynamicLinks.e2e');
 
-describe('dynamicLinks() dynamicLinkParams.navigation', () => {
-  it('throws if navigation is not an object', () => {
+describe('dynamicLinks() dynamicLinkParams.navigation', function() {
+  it('throws if navigation is not an object', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -31,7 +31,7 @@ describe('dynamicLinks() dynamicLinkParams.navigation', () => {
     }
   });
 
-  it('throws if navigation.forcedRedirectEnabled is not a boolean', () => {
+  it('throws if navigation.forcedRedirectEnabled is not a boolean', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,

--- a/packages/dynamic-links/e2e/builder.social.e2e.js
+++ b/packages/dynamic-links/e2e/builder.social.e2e.js
@@ -17,8 +17,8 @@
 
 const { baseParams } = require('./dynamicLinks.e2e');
 
-describe('dynamicLinks() dynamicLinkParams.social', () => {
-  it('throws if social is not an object', () => {
+describe('dynamicLinks() dynamicLinkParams.social', function() {
+  it('throws if social is not an object', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -31,7 +31,7 @@ describe('dynamicLinks() dynamicLinkParams.social', () => {
     }
   });
 
-  it('throws if social.descriptionText is not a string', () => {
+  it('throws if social.descriptionText is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -46,7 +46,7 @@ describe('dynamicLinks() dynamicLinkParams.social', () => {
     }
   });
 
-  it('throws if social.imageUrl is not a string', () => {
+  it('throws if social.imageUrl is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,
@@ -61,7 +61,7 @@ describe('dynamicLinks() dynamicLinkParams.social', () => {
     }
   });
 
-  it('throws if social.title is not a string', () => {
+  it('throws if social.title is not a string', function() {
     try {
       firebase.dynamicLinks().buildLink({
         ...baseParams,

--- a/packages/dynamic-links/e2e/dynamicLinks.e2e.js
+++ b/packages/dynamic-links/e2e/dynamicLinks.e2e.js
@@ -28,31 +28,31 @@ const TEST_LINK3 = 'https://invertase.io';
 
 module.exports.baseParams = baseParams;
 
-describe('dynamicLinks()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('dynamicLinks()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.dynamicLinks);
       app.dynamicLinks().app.should.equal(app);
     });
   });
 
-  describe('buildLink()', () => {
-    it('returns a dynamic link', async () => {
+  describe('buildLink()', function() {
+    it('returns a dynamic link', async function() {
       const link = await firebase.dynamicLinks().buildLink(baseParams);
       link.should.be.String();
       link.length.should.be.greaterThan(6);
     });
   });
 
-  describe('buildShortLink()', () => {
-    it('returns a short link', async () => {
+  describe('buildShortLink()', function() {
+    it('returns a short link', async function() {
       const link = await firebase.dynamicLinks().buildShortLink(baseParams);
       link.should.be.String();
       link.length.should.be.greaterThan(6);
     });
 
-    it('throws if type is invalid', () => {
+    it('throws if type is invalid', function() {
       try {
         firebase.dynamicLinks().buildShortLink(baseParams, 'LONG');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -65,15 +65,15 @@ describe('dynamicLinks()', () => {
     });
   });
 
-  describe('resolveLink()', () => {
-    it('resolves a long link', async () => {
+  describe('resolveLink()', function() {
+    it('resolves a long link', async function() {
       const link = await firebase.dynamicLinks().resolveLink(TEST_LINK2);
       link.should.be.an.Object();
       link.url.should.equal('https://invertase.io/hire-us');
       should.equal(link.minimumAppVersion, null);
     });
 
-    it('resolves a short link', async () => {
+    it('resolves a short link', async function() {
       const shortLink = await firebase.dynamicLinks().buildShortLink(
         {
           ...baseParams,
@@ -101,7 +101,7 @@ describe('dynamicLinks()', () => {
       parseInt(link.minimumAppVersion, 10).should.equal(123);
     });
 
-    it('throws on links that do not exist', async () => {
+    it('throws on links that do not exist', async function() {
       try {
         await firebase.dynamicLinks().resolveLink(baseParams.domainUriPrefix + '/not-a-valid-link');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -112,7 +112,7 @@ describe('dynamicLinks()', () => {
       }
     });
 
-    it('throws on static links', async () => {
+    it('throws on static links', async function() {
       try {
         await firebase.dynamicLinks().resolveLink(TEST_LINK3);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -122,7 +122,7 @@ describe('dynamicLinks()', () => {
       }
     });
 
-    it('throws on invalid links', async () => {
+    it('throws on invalid links', async function() {
       try {
         await firebase.dynamicLinks().resolveLink(null);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -146,7 +146,7 @@ describe('dynamicLinks()', () => {
   });
 
   ios.describe('getInitialLink()', () => {
-    it('should return the dynamic link instance that launched the app', async () => {
+    it('should return the dynamic link instance that launched the app', async function() {
       await device.openURL({
         url: TEST_LINK,
       });
@@ -159,7 +159,7 @@ describe('dynamicLinks()', () => {
   });
 
   ios.describe('onLink()', () => {
-    it('should emit dynamic links', async () => {
+    it('should emit dynamic links', async function() {
       const spy = sinon.spy();
 
       firebase.dynamicLinks().onLink(spy);

--- a/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
+++ b/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
@@ -193,7 +193,7 @@ RCT_EXPORT_METHOD(resolveLink:
             @"url": dynamicLink.url.absoluteString,
             @"minimumAppVersion": dynamicLink.minimumAppVersion == nil ? [NSNull null] : dynamicLink.minimumAppVersion,
         });
-    } else if (!error) {
+    } else if (!error || (error && [error.localizedDescription containsString:@"dynamicLinks error 404"])) {
       [RNFBSharedUtils rejectPromiseWithUserInfo:reject userInfo:(NSMutableDictionary *) @{
           @"code": @"not-found",
           @"message": @"Dynamic link not found"

--- a/packages/firestore/e2e/Blob.e2e.js
+++ b/packages/firestore/e2e/Blob.e2e.js
@@ -25,8 +25,8 @@ const testStringLarge = JSON.stringify(testObjectLarge);
 const testBufferLarge = Buffer.from(testStringLarge);
 const testBase64Large = testBufferLarge.toString('base64');
 
-describe('firestore.Blob', () => {
-  it('should throw if constructed manually', () => {
+describe('firestore.Blob', function() {
+  it('should throw if constructed manually', function() {
     try {
       new firebase.firestore.Blob();
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -36,12 +36,12 @@ describe('firestore.Blob', () => {
     }
   });
 
-  it('should be exported as a static', () => {
+  it('should be exported as a static', function() {
     const { Blob } = firebase.firestore;
     should.exist(Blob);
   });
 
-  it('.fromBase64String() -> returns new instance of Blob', async () => {
+  it('.fromBase64String() -> returns new instance of Blob', async function() {
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromBase64String(testBase64);
     myBlob.should.be.instanceOf(Blob);
@@ -53,7 +53,7 @@ describe('firestore.Blob', () => {
     );
   });
 
-  it('.fromBase64String() -> throws if arg not typeof string and length > 0', async () => {
+  it('.fromBase64String() -> throws if arg not typeof string and length > 0', async function() {
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromBase64String(testBase64);
     myBlob.should.be.instanceOf(Blob);
@@ -61,7 +61,7 @@ describe('firestore.Blob', () => {
     (() => Blob.fromBase64String('')).should.throwError();
   });
 
-  it('.fromUint8Array() -> returns new instance of Blob', async () => {
+  it('.fromUint8Array() -> returns new instance of Blob', async function() {
     const testUInt8Array = new jet.context.window.Uint8Array(testBuffer);
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromUint8Array(testUInt8Array);
@@ -70,7 +70,7 @@ describe('firestore.Blob', () => {
     json.hello.should.equal('world');
   });
 
-  it('.fromUint8Array() -> throws if arg not instanceof Uint8Array', async () => {
+  it('.fromUint8Array() -> throws if arg not instanceof Uint8Array', async function() {
     const testUInt8Array = new jet.context.window.Uint8Array(testBuffer);
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromUint8Array(testUInt8Array);
@@ -78,7 +78,7 @@ describe('firestore.Blob', () => {
     (() => Blob.fromUint8Array('derp')).should.throwError();
   });
 
-  it('.toString() -> returns string representation of blob instance', async () => {
+  it('.toString() -> returns string representation of blob instance', async function() {
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromBase64String(testBase64);
     myBlob.should.be.instanceOf(Blob);
@@ -89,7 +89,7 @@ describe('firestore.Blob', () => {
     );
   });
 
-  it('.isEqual() -> returns true or false', async () => {
+  it('.isEqual() -> returns true or false', async function() {
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromBase64String(testBase64);
     const myBlob2 = Blob.fromBase64String(testBase64Large);
@@ -97,7 +97,7 @@ describe('firestore.Blob', () => {
     myBlob2.isEqual(myBlob).should.equal(false);
   });
 
-  it('.isEqual() -> throws if arg not instanceof Blob', async () => {
+  it('.isEqual() -> throws if arg not instanceof Blob', async function() {
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromBase64String(testBase64);
     const myBlob2 = Blob.fromBase64String(testBase64Large);
@@ -105,14 +105,14 @@ describe('firestore.Blob', () => {
     (() => myBlob2.isEqual('derp')).should.throwError();
   });
 
-  it('.toBase64() -> returns base64 string', async () => {
+  it('.toBase64() -> returns base64 string', async function() {
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromBase64String(testBase64);
     myBlob.should.be.instanceOf(Blob);
     myBlob.toBase64().should.equal(testBase64);
   });
 
-  it('.toUint8Array() -> returns Uint8Array', async () => {
+  it('.toUint8Array() -> returns Uint8Array', async function() {
     const { Blob } = firebase.firestore;
     const myBlob = Blob.fromBase64String(testBase64);
     const testUInt8Array = new jet.context.window.Uint8Array(testBuffer);

--- a/packages/firestore/e2e/CollectionReference/add.e2e.js
+++ b/packages/firestore/e2e/CollectionReference/add.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.collection().add()', () => {
-  before(() => wipe());
-  it('throws if data is not an object', () => {
+describe('firestore.collection().add()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if data is not an object', function() {
     try {
       firebase
         .firestore()
@@ -32,7 +34,7 @@ describe('firestore.collection().add()', () => {
     }
   });
 
-  it('adds a new document', async () => {
+  it('adds a new document', async function() {
     const data = { foo: 'bar' };
     const docRef = await firebase
       .firestore()

--- a/packages/firestore/e2e/CollectionReference/doc.e2e.js
+++ b/packages/firestore/e2e/CollectionReference/doc.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.collection().doc()', () => {
-  before(() => wipe());
-  it('throws if path is not a document', () => {
+describe('firestore.collection().doc()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if path is not a document', function() {
     try {
       firebase
         .firestore()
@@ -32,7 +34,7 @@ describe('firestore.collection().doc()', () => {
     }
   });
 
-  it('generates an ID if no path is provided', () => {
+  it('generates an ID if no path is provided', function() {
     const instance = firebase
       .firestore()
       .collection(COLLECTION)
@@ -40,7 +42,7 @@ describe('firestore.collection().doc()', () => {
     should.equal(20, instance.id.length);
   });
 
-  it('uses path if provided', () => {
+  it('uses path if provided', function() {
     const instance = firebase
       .firestore()
       .collection(COLLECTION)

--- a/packages/firestore/e2e/CollectionReference/properties.e2e.js
+++ b/packages/firestore/e2e/CollectionReference/properties.e2e.js
@@ -17,21 +17,23 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.collection()', () => {
-  before(() => wipe());
-  it('returns the firestore instance', () => {
+describe('firestore.collection()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('returns the firestore instance', function() {
     const instance = firebase.firestore().collection(COLLECTION);
     instance.firestore.app.name.should.eql('[DEFAULT]');
   });
 
-  it('returns the collection id', () => {
+  it('returns the collection id', function() {
     const instance1 = firebase.firestore().collection(COLLECTION);
     const instance2 = firebase.firestore().collection(`${COLLECTION}/bar/baz`);
     instance1.id.should.eql(COLLECTION);
     instance2.id.should.eql('baz');
   });
 
-  it('returns the collection parent', () => {
+  it('returns the collection parent', function() {
     const instance1 = firebase.firestore().collection(COLLECTION);
     should.equal(instance1.parent, null);
     const instance2 = firebase
@@ -42,7 +44,7 @@ describe('firestore.collection()', () => {
     should.equal(instance2.parent.id, 'bar');
   });
 
-  it('returns the firestore path', () => {
+  it('returns the firestore path', function() {
     const instance1 = firebase.firestore().collection(COLLECTION);
     instance1.path.should.eql(COLLECTION);
     const instance2 = firebase

--- a/packages/firestore/e2e/DocumentChange.e2e.js
+++ b/packages/firestore/e2e/DocumentChange.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('./helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.DocumentChange', () => {
-  before(() => wipe());
-  it('.doc -> returns a DocumentSnapshot', async () => {
+describe('firestore.DocumentChange', function() {
+  before(function() {
+    return wipe();
+  });
+  it('.doc -> returns a DocumentSnapshot', async function() {
     const colRef = firebase.firestore().collection(COLLECTION);
     await colRef.add({});
     const snapshot = await colRef.limit(1).get();
@@ -30,7 +32,7 @@ describe('firestore.DocumentChange', () => {
     docChange.doc.constructor.name.should.eql('FirestoreDocumentSnapshot');
   });
 
-  it('returns the correct metadata when adding and removing', async () => {
+  it('returns the correct metadata when adding and removing', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/docChanges/docChangesCollection`);
     const doc1 = firebase.firestore().doc(`${COLLECTION}/docChanges/docChangesCollection/doc1`);
 
@@ -70,7 +72,7 @@ describe('firestore.DocumentChange', () => {
     unsub();
   });
 
-  it('returns the correct metadata when modifying documents', async () => {
+  it('returns the correct metadata when modifying documents', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/docChanges/docMovedCollection`);
 
     const doc1 = firebase.firestore().doc(`${COLLECTION}/docChanges/docMovedCollection/doc1`);

--- a/packages/firestore/e2e/DocumentReference/collection.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/collection.e2e.js
@@ -17,8 +17,8 @@
 
 const COLLECTION = 'firestore';
 
-describe('firestore.doc().collection()', () => {
-  it('throws if path is not a string', () => {
+describe('firestore.doc().collection()', function() {
+  it('throws if path is not a string', function() {
     try {
       firebase
         .firestore()
@@ -31,7 +31,7 @@ describe('firestore.doc().collection()', () => {
     }
   });
 
-  it('throws if path empty', () => {
+  it('throws if path empty', function() {
     try {
       firebase
         .firestore()
@@ -44,7 +44,7 @@ describe('firestore.doc().collection()', () => {
     }
   });
 
-  it('throws if path does not point to a collection', () => {
+  it('throws if path does not point to a collection', function() {
     try {
       firebase
         .firestore()
@@ -57,7 +57,7 @@ describe('firestore.doc().collection()', () => {
     }
   });
 
-  it('returns a collection instance', () => {
+  it('returns a collection instance', function() {
     const instance1 = firebase
       .firestore()
       .doc(`${COLLECTION}/bar`)

--- a/packages/firestore/e2e/DocumentReference/delete.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/delete.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.doc().delete()', () => {
-  before(() => wipe());
-  it('deletes a document', async () => {
+describe('firestore.doc().delete()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('deletes a document', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/deleteme`);
     await ref.set({ foo: 'bar' });
     const snapshot1 = await ref.get();

--- a/packages/firestore/e2e/DocumentReference/get.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/get.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.doc().get()', () => {
-  before(() => wipe());
-  it('throws if get options are not an object', () => {
+describe('firestore.doc().get()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if get options are not an object', function() {
     try {
       firebase
         .firestore()
@@ -32,7 +34,7 @@ describe('firestore.doc().get()', () => {
     }
   });
 
-  it('throws if get options are invalid', () => {
+  it('throws if get options are invalid', function() {
     try {
       firebase
         .firestore()
@@ -47,7 +49,7 @@ describe('firestore.doc().get()', () => {
     }
   });
 
-  it('gets data from default source', async () => {
+  it('gets data from default source', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/get`);
     const data = { foo: 'bar', bar: 123 };
     await ref.set(data);
@@ -56,7 +58,7 @@ describe('firestore.doc().get()', () => {
     await ref.delete();
   });
 
-  it('gets data from the server', async () => {
+  it('gets data from the server', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/get`);
     const data = { foo: 'bar', bar: 123 };
     await ref.set(data);
@@ -66,7 +68,7 @@ describe('firestore.doc().get()', () => {
     await ref.delete();
   });
 
-  it('gets data from cache', async () => {
+  it('gets data from cache', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/get`);
     const data = { foo: 'bar', bar: 123 };
     await ref.set(data);

--- a/packages/firestore/e2e/DocumentReference/isEqual.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/isEqual.e2e.js
@@ -16,8 +16,8 @@
  */
 const COLLECTION = 'firestore';
 
-describe('firestore.doc().isEqual()', () => {
-  it('throws if other is not a DocumentReference', () => {
+describe('firestore.doc().isEqual()', function() {
+  it('throws if other is not a DocumentReference', function() {
     try {
       firebase
         .firestore()
@@ -30,7 +30,7 @@ describe('firestore.doc().isEqual()', () => {
     }
   });
 
-  it('returns false when not equal', () => {
+  it('returns false when not equal', function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/baz`);
 
     const eql1 = docRef.isEqual(firebase.firestore().doc(`${COLLECTION}/foo`));
@@ -42,7 +42,7 @@ describe('firestore.doc().isEqual()', () => {
     eql2.should.be.False();
   });
 
-  it('returns true when equal', () => {
+  it('returns true when equal', function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/baz`);
 
     const eql1 = docRef.isEqual(docRef);

--- a/packages/firestore/e2e/DocumentReference/onSnapshot.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/onSnapshot.e2e.js
@@ -18,9 +18,11 @@ const COLLECTION = 'firestore';
 const NO_RULE_COLLECTION = 'no_rules';
 const { wipe } = require('../helpers');
 
-describe('firestore().doc().onSnapshot()', () => {
-  before(() => wipe());
-  it('throws if no arguments are provided', () => {
+describe('firestore().doc().onSnapshot()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if no arguments are provided', function() {
     try {
       firebase
         .firestore()
@@ -33,7 +35,7 @@ describe('firestore().doc().onSnapshot()', () => {
     }
   });
 
-  it('returns an unsubscribe function', () => {
+  it('returns an unsubscribe function', function() {
     const unsub = firebase
       .firestore()
       .doc(`${COLLECTION}/foo`)
@@ -43,7 +45,7 @@ describe('firestore().doc().onSnapshot()', () => {
     unsub();
   });
 
-  it('accepts a single callback function with snapshot', async () => {
+  it('accepts a single callback function with snapshot', async function() {
     const callback = sinon.spy();
     const unsub = firebase
       .firestore()
@@ -58,7 +60,7 @@ describe('firestore().doc().onSnapshot()', () => {
     unsub();
   });
 
-  it('accepts a single callback function with Error', async () => {
+  it('accepts a single callback function with Error', async function() {
     const callback = sinon.spy();
     const unsub = firebase
       .firestore()
@@ -73,8 +75,8 @@ describe('firestore().doc().onSnapshot()', () => {
     unsub();
   });
 
-  describe('multiple callbacks', () => {
-    it('calls onNext when successful', async () => {
+  describe('multiple callbacks', function() {
+    it('calls onNext when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -91,7 +93,7 @@ describe('firestore().doc().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls onError with Error', async () => {
+    it('calls onError with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -109,8 +111,8 @@ describe('firestore().doc().onSnapshot()', () => {
     });
   });
 
-  describe('objects of callbacks', () => {
-    it('calls next when successful', async () => {
+  describe('objects of callbacks', function() {
+    it('calls next when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -130,7 +132,7 @@ describe('firestore().doc().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls error with Error', async () => {
+    it('calls error with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -151,8 +153,8 @@ describe('firestore().doc().onSnapshot()', () => {
     });
   });
 
-  describe('SnapshotListenerOptions + callbacks', () => {
-    it('calls callback with snapshot when successful', async () => {
+  describe('SnapshotListenerOptions + callbacks', function() {
+    it('calls callback with snapshot when successful', async function() {
       const callback = sinon.spy();
       const unsub = firebase
         .firestore()
@@ -172,7 +174,7 @@ describe('firestore().doc().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls callback with Error', async () => {
+    it('calls callback with Error', async function() {
       const callback = sinon.spy();
       const unsub = firebase
         .firestore()
@@ -192,7 +194,7 @@ describe('firestore().doc().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls next with snapshot when successful', async () => {
+    it('calls next with snapshot when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -215,7 +217,7 @@ describe('firestore().doc().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls error with Error', async () => {
+    it('calls error with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -239,8 +241,8 @@ describe('firestore().doc().onSnapshot()', () => {
     });
   });
 
-  describe('SnapshotListenerOptions + object of callbacks', () => {
-    it('calls next with snapshot when successful', async () => {
+  describe('SnapshotListenerOptions + object of callbacks', function() {
+    it('calls next with snapshot when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -265,7 +267,7 @@ describe('firestore().doc().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls error with Error', async () => {
+    it('calls error with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -291,7 +293,7 @@ describe('firestore().doc().onSnapshot()', () => {
     });
   });
 
-  it('throws if SnapshotListenerOptions is invalid', () => {
+  it('throws if SnapshotListenerOptions is invalid', function() {
     try {
       firebase
         .firestore()
@@ -308,7 +310,7 @@ describe('firestore().doc().onSnapshot()', () => {
     }
   });
 
-  it('throws if next callback is invalid', () => {
+  it('throws if next callback is invalid', function() {
     try {
       firebase
         .firestore()
@@ -323,7 +325,7 @@ describe('firestore().doc().onSnapshot()', () => {
     }
   });
 
-  it('throws if error callback is invalid', () => {
+  it('throws if error callback is invalid', function() {
     try {
       firebase
         .firestore()
@@ -338,7 +340,7 @@ describe('firestore().doc().onSnapshot()', () => {
     }
   });
 
-  it('unsubscribes from further updates', async () => {
+  it('unsubscribes from further updates', async function() {
     const callback = sinon.spy();
     const doc = firebase.firestore().doc(`${COLLECTION}/unsub`);
 

--- a/packages/firestore/e2e/DocumentReference/properties.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/properties.e2e.js
@@ -17,23 +17,23 @@
 
 const COLLECTION = 'firestore';
 
-describe('firestore.doc()', () => {
-  it('returns a Firestore instance', () => {
+describe('firestore.doc()', function() {
+  it('returns a Firestore instance', function() {
     const instance = firebase.firestore().doc(`${COLLECTION}/bar`);
     should.equal(instance.firestore.constructor.name, 'FirebaseFirestoreModule');
   });
 
-  it('returns the document id', () => {
+  it('returns the document id', function() {
     const instance = firebase.firestore().doc(`${COLLECTION}/bar`);
     instance.id.should.equal('bar');
   });
 
-  it('returns the parent collection reference', () => {
+  it('returns the parent collection reference', function() {
     const instance = firebase.firestore().doc(`${COLLECTION}/bar`);
     instance.parent.id.should.equal(COLLECTION);
   });
 
-  it('returns the path', () => {
+  it('returns the path', function() {
     const instance1 = firebase.firestore().doc(`${COLLECTION}/bar`);
     const instance2 = firebase
       .firestore()

--- a/packages/firestore/e2e/DocumentReference/set.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/set.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.doc().set()', () => {
-  before(() => wipe());
-  it('throws if data is not an object', () => {
+describe('firestore.doc().set()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if data is not an object', function() {
     try {
       firebase
         .firestore()
@@ -32,7 +34,7 @@ describe('firestore.doc().set()', () => {
     }
   });
 
-  it('throws if options is not an object', () => {
+  it('throws if options is not an object', function() {
     try {
       firebase
         .firestore()
@@ -45,7 +47,7 @@ describe('firestore.doc().set()', () => {
     }
   });
 
-  it('throws if options contains both merge types', () => {
+  it('throws if options contains both merge types', function() {
     try {
       firebase
         .firestore()
@@ -64,7 +66,7 @@ describe('firestore.doc().set()', () => {
     }
   });
 
-  it('throws if merge is not a boolean', () => {
+  it('throws if merge is not a boolean', function() {
     try {
       firebase
         .firestore()
@@ -82,7 +84,7 @@ describe('firestore.doc().set()', () => {
     }
   });
 
-  it('throws if mergeFields is not an array', () => {
+  it('throws if mergeFields is not an array', function() {
     try {
       firebase
         .firestore()
@@ -100,7 +102,7 @@ describe('firestore.doc().set()', () => {
     }
   });
 
-  it('throws if mergeFields contains invalid data', () => {
+  it('throws if mergeFields contains invalid data', function() {
     try {
       firebase
         .firestore()
@@ -125,7 +127,7 @@ describe('firestore.doc().set()', () => {
     }
   });
 
-  it('sets new data', async () => {
+  it('sets new data', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/set`);
     const data1 = { foo: 'bar' };
     const data2 = { foo: 'baz', bar: 123 };
@@ -138,7 +140,7 @@ describe('firestore.doc().set()', () => {
     await ref.delete();
   });
 
-  it('merges all fields', async () => {
+  it('merges all fields', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/merge`);
     const data1 = { foo: 'bar' };
     const data2 = { bar: 'baz' };
@@ -154,7 +156,7 @@ describe('firestore.doc().set()', () => {
     await ref.delete();
   });
 
-  it('merges specific fields', async () => {
+  it('merges specific fields', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/merge`);
     const data1 = { foo: '123', bar: 123, baz: '456' };
     const data2 = { foo: '234', bar: 234, baz: '678' };

--- a/packages/firestore/e2e/DocumentReference/update.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/update.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.doc().update()', () => {
-  before(() => wipe());
-  it('throws if no arguments are provided', () => {
+describe('firestore.doc().update()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if no arguments are provided', function() {
     try {
       firebase
         .firestore()
@@ -34,7 +36,7 @@ describe('firestore.doc().update()', () => {
     }
   });
 
-  it('throws if document does not exist', async () => {
+  it('throws if document does not exist', async function() {
     try {
       await firebase
         .firestore()
@@ -47,7 +49,7 @@ describe('firestore.doc().update()', () => {
     }
   });
 
-  it('throws if field/value sequence is invalid', () => {
+  it('throws if field/value sequence is invalid', function() {
     try {
       firebase
         .firestore()
@@ -60,7 +62,7 @@ describe('firestore.doc().update()', () => {
     }
   });
 
-  it('updates data with an object value', async () => {
+  it('updates data with an object value', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/update-obj`);
     const value = Date.now();
     const data1 = { foo: value };
@@ -74,7 +76,7 @@ describe('firestore.doc().update()', () => {
     await ref.delete();
   });
 
-  it('updates data with an key/value pairs', async () => {
+  it('updates data with an key/value pairs', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/update-obj`);
     const value = Date.now();
     const data1 = { foo: value, bar: value };

--- a/packages/firestore/e2e/DocumentSnapshot/data.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/data.e2e.js
@@ -23,15 +23,17 @@ const blobString = JSON.stringify(blobObject);
 const blobBuffer = Buffer.from(blobString);
 const blobBase64 = blobBuffer.toString('base64');
 
-describe('firestore().doc() -> snapshot.data()', () => {
-  before(() => wipe());
-  it('returns undefined if documet does not exist', async () => {
+describe('firestore().doc() -> snapshot.data()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('returns undefined if documet does not exist', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/idonotexist`);
     const snapshot = await ref.get();
     should.equal(snapshot.data(), undefined);
   });
 
-  it('returns an object if exists', async () => {
+  it('returns an object if exists', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/getData`);
     const data = { foo: 'bar' };
     await ref.set(data);
@@ -40,7 +42,7 @@ describe('firestore().doc() -> snapshot.data()', () => {
     await ref.delete();
   });
 
-  it('returns an object when document is empty', async () => {
+  it('returns an object when document is empty', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/getData`);
     const data = {};
     await ref.set(data);
@@ -49,11 +51,11 @@ describe('firestore().doc() -> snapshot.data()', () => {
     await ref.delete();
   });
 
-  xit('handles SnapshotOptions', () => {
+  xit('handles SnapshotOptions', function() {
     // TODO
   });
 
-  it('handles all data types', async () => {
+  it('handles all data types', async function() {
     const types = {
       string: '123456',
       stringEmpty: '',

--- a/packages/firestore/e2e/DocumentSnapshot/get.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/get.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore().doc() -> snapshot.get()', () => {
-  before(() => wipe());
-  it('throws if invalid fieldPath argument', async () => {
+describe('firestore().doc() -> snapshot.get()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if invalid fieldPath argument', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const snapshot = await ref.get();
 
@@ -32,7 +34,7 @@ describe('firestore().doc() -> snapshot.get()', () => {
     }
   });
 
-  it('throws if fieldPath is an empty string', async () => {
+  it('throws if fieldPath is an empty string', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const snapshot = await ref.get();
 
@@ -45,7 +47,7 @@ describe('firestore().doc() -> snapshot.get()', () => {
     }
   });
 
-  it('throws if fieldPath starts with a period (.)', async () => {
+  it('throws if fieldPath starts with a period (.)', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const snapshot = await ref.get();
 
@@ -58,7 +60,7 @@ describe('firestore().doc() -> snapshot.get()', () => {
     }
   });
 
-  it('throws if fieldPath ends with a period (.)', async () => {
+  it('throws if fieldPath ends with a period (.)', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const snapshot = await ref.get();
 
@@ -71,7 +73,7 @@ describe('firestore().doc() -> snapshot.get()', () => {
     }
   });
 
-  it('throws if fieldPath contains ..', async () => {
+  it('throws if fieldPath contains ..', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const snapshot = await ref.get();
 
@@ -84,7 +86,7 @@ describe('firestore().doc() -> snapshot.get()', () => {
     }
   });
 
-  it('returns undefined if the data does not exist', async () => {
+  it('returns undefined if the data does not exist', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const snapshot = await ref.get();
 
@@ -101,7 +103,7 @@ describe('firestore().doc() -> snapshot.get()', () => {
     should.equal(val5, undefined);
   });
 
-  it('returns the correct data with string fieldPath', async () => {
+  it('returns the correct data with string fieldPath', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const types = {
       string: '12345',
@@ -131,7 +133,7 @@ describe('firestore().doc() -> snapshot.get()', () => {
     await ref.delete();
   });
 
-  it('returns the correct data with FieldPath', async () => {
+  it('returns the correct data with FieldPath', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
     const types = {
       string: '12345',

--- a/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
@@ -16,8 +16,8 @@
  */
 const COLLECTION = 'firestore';
 
-describe('firestore.doc() -> snapshot.isEqual()', () => {
-  it('throws if other is not a DocumentSnapshot', async () => {
+describe('firestore.doc() -> snapshot.isEqual()', function() {
+  it('throws if other is not a DocumentSnapshot', async function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/baz`);
 
@@ -30,7 +30,7 @@ describe('firestore.doc() -> snapshot.isEqual()', () => {
     }
   });
 
-  it('returns false when not equal', async () => {
+  it('returns false when not equal', async function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/isEqual-false-exists`);
     await docRef.set({ foo: 'bar' });
 
@@ -49,7 +49,7 @@ describe('firestore.doc() -> snapshot.isEqual()', () => {
     eql2.should.be.False();
   });
 
-  it('returns true when equal', async () => {
+  it('returns true when equal', async function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/isEqual-true-exists`);
     await docRef.set({ foo: 'bar' });
 

--- a/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore().doc() -> snapshot', () => {
-  before(() => wipe());
-  it('.exists -> returns a boolean for exists', async () => {
+describe('firestore().doc() -> snapshot', function() {
+  before(function() {
+    return wipe();
+  });
+  it('.exists -> returns a boolean for exists', async function() {
     const ref1 = firebase.firestore().doc(`${COLLECTION}/exists`);
     const ref2 = firebase.firestore().doc(`${COLLECTION}/idonotexist`);
     await ref1.set({ foo: ' bar' });
@@ -31,7 +33,7 @@ describe('firestore().doc() -> snapshot', () => {
     await ref1.delete();
   });
 
-  it('.id -> returns the correct id', async () => {
+  it('.id -> returns the correct id', async function() {
     const ref1 = firebase.firestore().doc(`${COLLECTION}/exists`);
     const ref2 = firebase.firestore().doc(`${COLLECTION}/idonotexist`);
     await ref1.set({ foo: ' bar' });
@@ -43,13 +45,13 @@ describe('firestore().doc() -> snapshot', () => {
     await ref1.delete();
   });
 
-  it('.metadata -> returns a SnapshotMetadata instance', async () => {
+  it('.metadata -> returns a SnapshotMetadata instance', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/exists`);
     const snapshot = await ref.get();
     snapshot.metadata.constructor.name.should.eql('FirestoreSnapshotMetadata');
   });
 
-  it('.ref -> returns the correct document ref', async () => {
+  it('.ref -> returns the correct document ref', async function() {
     const ref1 = firebase.firestore().doc(`${COLLECTION}/exists`);
     const ref2 = firebase.firestore().doc(`${COLLECTION}/idonotexist`);
     await ref1.set({ foo: ' bar' });

--- a/packages/firestore/e2e/FieldPath.e2e.js
+++ b/packages/firestore/e2e/FieldPath.e2e.js
@@ -16,8 +16,8 @@
  */
 const COLLECTION = 'firestore';
 
-describe('firestore.FieldPath', () => {
-  it('should throw if no segments', () => {
+describe('firestore.FieldPath', function() {
+  it('should throw if no segments', function() {
     try {
       new firebase.firestore.FieldPath();
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -27,7 +27,7 @@ describe('firestore.FieldPath', () => {
     }
   });
 
-  it('should throw if any segments are empty strings', () => {
+  it('should throw if any segments are empty strings', function() {
     try {
       new firebase.firestore.FieldPath('foo', '');
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -37,7 +37,7 @@ describe('firestore.FieldPath', () => {
     }
   });
 
-  it('should throw if any segments are not strings', () => {
+  it('should throw if any segments are not strings', function() {
     try {
       new firebase.firestore.FieldPath('foo', 123);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -47,7 +47,7 @@ describe('firestore.FieldPath', () => {
     }
   });
 
-  it('should throw if string fieldPath is invalid', () => {
+  it('should throw if string fieldPath is invalid', function() {
     try {
       // Dummy create
       firebase
@@ -61,7 +61,7 @@ describe('firestore.FieldPath', () => {
     }
   });
 
-  it('should throw if string fieldPath contains invalid characters', () => {
+  it('should throw if string fieldPath contains invalid characters', function() {
     try {
       // Dummy create
       firebase
@@ -75,27 +75,27 @@ describe('firestore.FieldPath', () => {
     }
   });
 
-  it('should provide access to segments as array', () => {
+  it('should provide access to segments as array', function() {
     const expect = ['foo', 'bar', 'baz'];
     const path = new firebase.firestore.FieldPath('foo', 'bar', 'baz');
     path._segments.should.eql(jet.contextify(expect));
   });
 
-  it('should provide access to string dot notated path', () => {
+  it('should provide access to string dot notated path', function() {
     const expect = 'foo.bar.baz';
     const path = new firebase.firestore.FieldPath('foo', 'bar', 'baz');
     path._toPath().should.equal(expect);
   });
 
-  it('should return document ID path', () => {
+  it('should return document ID path', function() {
     const expect = '__name__';
     const path = firebase.firestore.FieldPath.documentId();
     path._segments.length.should.equal(1);
     path._toPath().should.equal(expect);
   });
 
-  describe('isEqual()', () => {
-    it('throws if other isnt a FieldPath', () => {
+  describe('isEqual()', function() {
+    it('throws if other isnt a FieldPath', function() {
       try {
         const path = new firebase.firestore.FieldPath('foo');
         path.isEqual({});
@@ -106,13 +106,13 @@ describe('firestore.FieldPath', () => {
       }
     });
 
-    it('should return true if isEqual', () => {
+    it('should return true if isEqual', function() {
       const path1 = new firebase.firestore.FieldPath('foo', 'bar');
       const path2 = new firebase.firestore.FieldPath('foo', 'bar');
       path1.isEqual(path2).should.equal(true);
     });
 
-    it('should return false if not isEqual', () => {
+    it('should return false if not isEqual', function() {
       const path1 = new firebase.firestore.FieldPath('foo', 'bar');
       const path2 = new firebase.firestore.FieldPath('foo', 'baz');
       path1.isEqual(path2).should.equal(false);

--- a/packages/firestore/e2e/FieldValue.e2e.js
+++ b/packages/firestore/e2e/FieldValue.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('./helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.FieldValue', () => {
-  before(() => wipe());
-  it('should throw if constructed manually', () => {
+describe('firestore.FieldValue', function() {
+  before(function() {
+    return wipe();
+  });
+  it('should throw if constructed manually', function() {
     try {
       new firebase.firestore.FieldValue();
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -29,8 +31,8 @@ describe('firestore.FieldValue', () => {
     }
   });
 
-  describe('isEqual()', () => {
-    it('throws if other is not a FieldValue', () => {
+  describe('isEqual()', function() {
+    it('throws if other is not a FieldValue', function() {
       try {
         firebase.firestore.FieldValue.increment(1).isEqual(1);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -40,7 +42,7 @@ describe('firestore.FieldValue', () => {
       }
     });
 
-    it('returns false if not equal', () => {
+    it('returns false if not equal', function() {
       const fv = firebase.firestore.FieldValue.increment(1);
 
       const fieldValue1 = firebase.firestore.FieldValue.increment(2);
@@ -53,7 +55,7 @@ describe('firestore.FieldValue', () => {
       eql2.should.be.False();
     });
 
-    it('returns true if equal', () => {
+    it('returns true if equal', function() {
       const fv = firebase.firestore.FieldValue.arrayUnion(1, '123', 3);
 
       const fieldValue1 = firebase.firestore.FieldValue.arrayUnion(1, '123', 3);
@@ -64,8 +66,8 @@ describe('firestore.FieldValue', () => {
     });
   });
 
-  describe('increment()', () => {
-    it('throws if value is not a number', () => {
+  describe('increment()', function() {
+    it('throws if value is not a number', function() {
       try {
         firebase.firestore.FieldValue.increment('1');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -75,7 +77,7 @@ describe('firestore.FieldValue', () => {
       }
     });
 
-    it('increments a number if it exists', async () => {
+    it('increments a number if it exists', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/increment`);
       await ref.set({ foo: 2 });
       await ref.update({ foo: firebase.firestore.FieldValue.increment(1) });
@@ -84,7 +86,7 @@ describe('firestore.FieldValue', () => {
       await ref.delete();
     });
 
-    it('sets the value if it doesnt exist or being set', async () => {
+    it('sets the value if it doesnt exist or being set', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/increment`);
       await ref.set({ foo: firebase.firestore.FieldValue.increment(1) });
       const snapshot = await ref.get();
@@ -93,8 +95,8 @@ describe('firestore.FieldValue', () => {
     });
   });
 
-  describe('serverTime()', () => {
-    it('sets a new server time value', async () => {
+  describe('serverTime()', function() {
+    it('sets a new server time value', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/servertime`);
       await ref.set({ foo: firebase.firestore.FieldValue.serverTimestamp() });
       const snapshot = await ref.get();
@@ -102,7 +104,7 @@ describe('firestore.FieldValue', () => {
       await ref.delete();
     });
 
-    it('updates a server time value', async () => {
+    it('updates a server time value', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/servertime`);
       await ref.set({ foo: firebase.firestore.FieldValue.serverTimestamp() });
       const snapshot1 = await ref.get();
@@ -117,8 +119,8 @@ describe('firestore.FieldValue', () => {
     });
   });
 
-  describe('delete()', () => {
-    it('removes a value', async () => {
+  describe('delete()', function() {
+    it('removes a value', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/valuedelete`);
       await ref.set({ foo: 'bar', bar: 'baz' });
       await ref.update({ bar: firebase.firestore.FieldValue.delete() });
@@ -128,8 +130,8 @@ describe('firestore.FieldValue', () => {
     });
   });
 
-  describe('arrayUnion()', () => {
-    it('throws if attempting to use own class', () => {
+  describe('arrayUnion()', function() {
+    it('throws if attempting to use own class', function() {
       try {
         firebase.firestore.FieldValue.arrayUnion(firebase.firestore.FieldValue.serverTimestamp());
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -141,7 +143,7 @@ describe('firestore.FieldValue', () => {
       }
     });
 
-    it('throws if using nested arrays', () => {
+    it('throws if using nested arrays', function() {
       try {
         firebase.firestore.FieldValue.arrayUnion([1]);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -151,7 +153,7 @@ describe('firestore.FieldValue', () => {
       }
     });
 
-    it('updates an existing array', async () => {
+    it('updates an existing array', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/arrayunion`);
       await ref.set({
         foo: [1, 2],
@@ -165,7 +167,7 @@ describe('firestore.FieldValue', () => {
       await ref.delete();
     });
 
-    it('sets an array if existing value isnt an array with update', async () => {
+    it('sets an array if existing value isnt an array with update', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/arrayunion`);
       await ref.set({
         foo: 123,
@@ -179,7 +181,7 @@ describe('firestore.FieldValue', () => {
       await ref.delete();
     });
 
-    it('sets an existing array to the new array with set', async () => {
+    it('sets an existing array to the new array with set', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/arrayunion`);
       await ref.set({
         foo: [1, 2],
@@ -194,8 +196,8 @@ describe('firestore.FieldValue', () => {
     });
   });
 
-  describe('arrayRemove()', () => {
-    it('throws if attempting to use own class', () => {
+  describe('arrayRemove()', function() {
+    it('throws if attempting to use own class', function() {
       try {
         firebase.firestore.FieldValue.arrayRemove(firebase.firestore.FieldValue.serverTimestamp());
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -207,7 +209,7 @@ describe('firestore.FieldValue', () => {
       }
     });
 
-    it('throws if using nested arrays', () => {
+    it('throws if using nested arrays', function() {
       try {
         firebase.firestore.FieldValue.arrayRemove([1]);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -217,7 +219,7 @@ describe('firestore.FieldValue', () => {
       }
     });
 
-    it('removes items in an array', async () => {
+    it('removes items in an array', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/arrayremove`);
       await ref.set({
         foo: [1, 2, 3, 4],
@@ -231,7 +233,7 @@ describe('firestore.FieldValue', () => {
       await ref.delete();
     });
 
-    it('removes all items in the array if existing value isnt array with update', async () => {
+    it('removes all items in the array if existing value isnt array with update', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/arrayunion`);
       await ref.set({
         foo: 123,
@@ -245,7 +247,7 @@ describe('firestore.FieldValue', () => {
       await ref.delete();
     });
 
-    it('removes all items in the array if existing value isnt array with set', async () => {
+    it('removes all items in the array if existing value isnt array with set', async function() {
       const ref = firebase.firestore().doc(`${COLLECTION}/arrayunion`);
       await ref.set({
         foo: 123,

--- a/packages/firestore/e2e/FirestoreStatics.e2e.js
+++ b/packages/firestore/e2e/FirestoreStatics.e2e.js
@@ -15,9 +15,9 @@
  *
  */
 
-describe('firestore.X', () => {
-  describe('setLogLevel', () => {
-    it('throws if invalid level', () => {
+describe('firestore.X', function() {
+  describe('setLogLevel', function() {
+    it('throws if invalid level', function() {
       try {
         firebase.firestore.setLogLevel('verbose');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -27,7 +27,7 @@ describe('firestore.X', () => {
       }
     });
 
-    it('enabled and disables logging', () => {
+    it('enabled and disables logging', function() {
       firebase.firestore.setLogLevel('silent');
       firebase.firestore.setLogLevel('debug');
     });

--- a/packages/firestore/e2e/GeoPoint.e2e.js
+++ b/packages/firestore/e2e/GeoPoint.e2e.js
@@ -16,9 +16,11 @@
  */
 const COLLECTION = 'firestore';
 const { wipe } = require('./helpers');
-describe('firestore.GeoPoint', () => {
-  before(() => wipe());
-  it('throws if invalid number of arguments', () => {
+describe('firestore.GeoPoint', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if invalid number of arguments', function() {
     try {
       new firebase.firestore.GeoPoint(123);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -28,7 +30,7 @@ describe('firestore.GeoPoint', () => {
     }
   });
 
-  it('throws if latitude is not a number', () => {
+  it('throws if latitude is not a number', function() {
     try {
       new firebase.firestore.GeoPoint('123', 0);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -38,7 +40,7 @@ describe('firestore.GeoPoint', () => {
     }
   });
 
-  it('throws if latitude is not a number', () => {
+  it('throws if latitude is not a number', function() {
     try {
       new firebase.firestore.GeoPoint(0, '123');
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -48,7 +50,7 @@ describe('firestore.GeoPoint', () => {
     }
   });
 
-  it('throws if latitude is not valid', () => {
+  it('throws if latitude is not valid', function() {
     try {
       new firebase.firestore.GeoPoint(-100, 0);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -58,7 +60,7 @@ describe('firestore.GeoPoint', () => {
     }
   });
 
-  it('throws if longitude is not valid', () => {
+  it('throws if longitude is not valid', function() {
     try {
       new firebase.firestore.GeoPoint(0, 200);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -68,18 +70,18 @@ describe('firestore.GeoPoint', () => {
     }
   });
 
-  it('gets the latitude value', () => {
+  it('gets the latitude value', function() {
     const geo = new firebase.firestore.GeoPoint(20, 0);
     geo.latitude.should.equal(20);
   });
 
-  it('gets the longitude value', () => {
+  it('gets the longitude value', function() {
     const geo = new firebase.firestore.GeoPoint(20, 15);
     geo.longitude.should.equal(15);
   });
 
-  describe('isEqual()', () => {
-    it('throws if other is a GeoPoint instance', () => {
+  describe('isEqual()', function() {
+    it('throws if other is a GeoPoint instance', function() {
       try {
         const geo = new firebase.firestore.GeoPoint(0, 0);
         geo.isEqual();
@@ -90,21 +92,21 @@ describe('firestore.GeoPoint', () => {
       }
     });
 
-    it('returns false if not the same', () => {
+    it('returns false if not the same', function() {
       const geo1 = new firebase.firestore.GeoPoint(0, 0);
       const geo2 = new firebase.firestore.GeoPoint(0, 1);
       const equal = geo1.isEqual(geo2);
       equal.should.equal(false);
     });
 
-    it('returns true if the same', () => {
+    it('returns true if the same', function() {
       const geo1 = new firebase.firestore.GeoPoint(40, 40);
       const geo2 = new firebase.firestore.GeoPoint(40, 40);
       const equal = geo1.isEqual(geo2);
       equal.should.equal(true);
     });
   });
-  it('sets & returns correctly', async () => {
+  it('sets & returns correctly', async function() {
     const ref = firebase.firestore().doc(`${COLLECTION}/geopoint`);
     await ref.set({
       geopoint: new firebase.firestore.GeoPoint(20, 30),

--- a/packages/firestore/e2e/GeoPoint.e2e.js
+++ b/packages/firestore/e2e/GeoPoint.e2e.js
@@ -40,7 +40,7 @@ describe('firestore.GeoPoint', function() {
     }
   });
 
-  it('throws if latitude is not a number', function() {
+  it('throws if longitude is not a number', function() {
     try {
       new firebase.firestore.GeoPoint(0, '123');
       return Promise.reject(new Error('Did not throw an Error.'));

--- a/packages/firestore/e2e/Query/endAt.e2e.js
+++ b/packages/firestore/e2e/Query/endAt.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore().collection().endAt()', () => {
-  before(() => wipe());
-  it('throws if no argument provided', () => {
+describe('firestore().collection().endAt()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if no argument provided', function() {
     try {
       firebase
         .firestore()
@@ -34,7 +36,7 @@ describe('firestore().collection().endAt()', () => {
     }
   });
 
-  it('throws if a inconsistent order number', () => {
+  it('throws if a inconsistent order number', function() {
     try {
       firebase
         .firestore()
@@ -48,7 +50,7 @@ describe('firestore().collection().endAt()', () => {
     }
   });
 
-  it('throws if providing snapshot and field values', async () => {
+  it('throws if providing snapshot and field values', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -66,7 +68,7 @@ describe('firestore().collection().endAt()', () => {
     }
   });
 
-  it('throws if provided snapshot does not exist', async () => {
+  it('throws if provided snapshot does not exist', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -83,7 +85,7 @@ describe('firestore().collection().endAt()', () => {
     }
   });
 
-  it('throws if order used with snapshot but fields do not exist', async () => {
+  it('throws if order used with snapshot but fields do not exist', async function() {
     try {
       const doc = firebase.firestore().doc(`${COLLECTION}/iexist`);
       await doc.set({ foo: { bar: 'baz' } });
@@ -103,7 +105,7 @@ describe('firestore().collection().endAt()', () => {
     }
   });
 
-  it('ends at field values', async () => {
+  it('ends at field values', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/endsAt/collection`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -125,7 +127,7 @@ describe('firestore().collection().endAt()', () => {
     qs.docs[1].id.should.eql('doc2');
   });
 
-  it('ends at snapshot field values', async () => {
+  it('ends at snapshot field values', async function() {
     // await Utils.sleep(3000);
     const colRef = firebase.firestore().collection(`${COLLECTION}/endsAt/snapshotFields`);
     const doc1 = colRef.doc('doc1');
@@ -150,7 +152,7 @@ describe('firestore().collection().endAt()', () => {
     qs.docs[1].id.should.eql('doc2');
   });
 
-  it('ends at snapshot', async () => {
+  it('ends at snapshot', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/endsAt/snapshot`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');

--- a/packages/firestore/e2e/Query/endBefore.e2e.js
+++ b/packages/firestore/e2e/Query/endBefore.e2e.js
@@ -17,10 +17,12 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore().collection().endBefore()', () => {
-  before(() => wipe());
+describe('firestore().collection().endBefore()', function() {
+  before(function() {
+    return wipe();
+  });
 
-  it('throws if no argument provided', () => {
+  it('throws if no argument provided', function() {
     try {
       firebase
         .firestore()
@@ -35,7 +37,7 @@ describe('firestore().collection().endBefore()', () => {
     }
   });
 
-  it('throws if a inconsistent order number', () => {
+  it('throws if a inconsistent order number', function() {
     try {
       firebase
         .firestore()
@@ -49,7 +51,7 @@ describe('firestore().collection().endBefore()', () => {
     }
   });
 
-  it('throws if providing snapshot and field values', async () => {
+  it('throws if providing snapshot and field values', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -67,7 +69,7 @@ describe('firestore().collection().endBefore()', () => {
     }
   });
 
-  it('throws if provided snapshot does not exist', async () => {
+  it('throws if provided snapshot does not exist', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -84,7 +86,7 @@ describe('firestore().collection().endBefore()', () => {
     }
   });
 
-  it('throws if order used with snapshot but fields do not exist', async () => {
+  it('throws if order used with snapshot but fields do not exist', async function() {
     try {
       const doc = firebase.firestore().doc(`${COLLECTION}/iexist`);
       await doc.set({ foo: { bar: 'baz' } });
@@ -104,7 +106,7 @@ describe('firestore().collection().endBefore()', () => {
     }
   });
 
-  it('ends before field values', async () => {
+  it('ends before field values', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/endBefore/collection`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -125,7 +127,7 @@ describe('firestore().collection().endBefore()', () => {
     qs.docs[0].id.should.eql('doc3');
   });
 
-  xit('ends before snapshot field values', async () => {
+  xit('ends before snapshot field values', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/endBefore/snapshotFields`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -148,7 +150,7 @@ describe('firestore().collection().endBefore()', () => {
     qs.docs[0].id.should.eql('doc3');
   });
 
-  it('ends before snapshot', async () => {
+  it('ends before snapshot', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/endBefore/snapshot`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');

--- a/packages/firestore/e2e/Query/get.e2e.js
+++ b/packages/firestore/e2e/Query/get.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore().collection().get()', () => {
-  before(() => wipe());
-  it('throws if get options is not an object', () => {
+describe('firestore().collection().get()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if get options is not an object', function() {
     try {
       firebase
         .firestore()
@@ -32,7 +34,7 @@ describe('firestore().collection().get()', () => {
     }
   });
 
-  it('throws if get options.source is not valid', () => {
+  it('throws if get options.source is not valid', function() {
     try {
       firebase
         .firestore()
@@ -49,7 +51,7 @@ describe('firestore().collection().get()', () => {
     }
   });
 
-  it('returns a QuerySnapshot', async () => {
+  it('returns a QuerySnapshot', async function() {
     const docRef = firebase
       .firestore()
       .collection(COLLECTION)
@@ -60,7 +62,7 @@ describe('firestore().collection().get()', () => {
     snapshot.constructor.name.should.eql('FirestoreQuerySnapshot');
   });
 
-  it('returns a correct cache setting (true)', async () => {
+  it('returns a correct cache setting (true)', async function() {
     const docRef = firebase
       .firestore()
       .collection(COLLECTION)
@@ -74,7 +76,7 @@ describe('firestore().collection().get()', () => {
     snapshot.metadata.fromCache.should.be.True();
   });
 
-  it('returns a correct cache setting (false)', async () => {
+  it('returns a correct cache setting (false)', async function() {
     const docRef = firebase
       .firestore()
       .collection(COLLECTION)

--- a/packages/firestore/e2e/Query/isEqual.e2e.js
+++ b/packages/firestore/e2e/Query/isEqual.e2e.js
@@ -16,8 +16,8 @@
  */
 const COLLECTION = 'firestore';
 
-describe('firestore().collection().isEqual()', () => {
-  it('throws if other is not a Query', () => {
+describe('firestore().collection().isEqual()', function() {
+  it('throws if other is not a Query', function() {
     try {
       firebase
         .firestore()
@@ -30,7 +30,7 @@ describe('firestore().collection().isEqual()', () => {
     }
   });
 
-  it('returns false when not equal (simple checks)', () => {
+  it('returns false when not equal (simple checks)', function() {
     const subCol = `${COLLECTION}/isequal/simplechecks`;
     const query = firebase.firestore().collection(subCol);
 
@@ -70,7 +70,7 @@ describe('firestore().collection().isEqual()', () => {
     eql5.should.be.True();
   });
 
-  it('returns false when not equal (expensive checks)', () => {
+  it('returns false when not equal (expensive checks)', function() {
     const query = firebase
       .firestore()
       .collection(COLLECTION)
@@ -122,7 +122,7 @@ describe('firestore().collection().isEqual()', () => {
     eql4.should.be.False();
   });
 
-  it('returns true when equal', () => {
+  it('returns true when equal', function() {
     const query = firebase
       .firestore()
       .collection(COLLECTION)

--- a/packages/firestore/e2e/Query/limit.e2e.js
+++ b/packages/firestore/e2e/Query/limit.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore().collection().limit()', () => {
-  before(() => wipe());
-  it('throws if limit is invalid', () => {
+describe('firestore().collection().limit()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if limit is invalid', function() {
     try {
       firebase
         .firestore()
@@ -32,7 +34,7 @@ describe('firestore().collection().limit()', () => {
     }
   });
 
-  it('sets limit on internals', async () => {
+  it('sets limit on internals', async function() {
     const colRef = firebase
       .firestore()
       .collection(COLLECTION)
@@ -41,7 +43,7 @@ describe('firestore().collection().limit()', () => {
     colRef._modifiers.options.limit.should.eql(123);
   });
 
-  it('limits the number of documents', async () => {
+  it('limits the number of documents', async function() {
     const colRef = firebase.firestore().collection(COLLECTION);
 
     // Add 3

--- a/packages/firestore/e2e/Query/limitToLast.e2e.js
+++ b/packages/firestore/e2e/Query/limitToLast.e2e.js
@@ -17,9 +17,11 @@
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
 
-describe('firestore().collection().limitToLast()', () => {
-  before(() => wipe());
-  it('throws if limitToLast is invalid', () => {
+describe('firestore().collection().limitToLast()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if limitToLast is invalid', function() {
     try {
       firebase
         .firestore()
@@ -32,7 +34,7 @@ describe('firestore().collection().limitToLast()', () => {
     }
   });
 
-  it('sets limitToLast on internals', async () => {
+  it('sets limitToLast on internals', async function() {
     const colRef = firebase
       .firestore()
       .collection(COLLECTION)
@@ -41,7 +43,7 @@ describe('firestore().collection().limitToLast()', () => {
     should(colRef._modifiers.options.limitToLast).equal(123);
   });
 
-  it('removes limit query if limitToLast is set afterwards', () => {
+  it('removes limit query if limitToLast is set afterwards', function() {
     const colRef = firebase
       .firestore()
       .collection(COLLECTION)
@@ -52,7 +54,7 @@ describe('firestore().collection().limitToLast()', () => {
   });
 
   // FIXME flaky on local tests
-  xit('removes limitToLast query if limit is set afterwards', () => {
+  xit('removes limitToLast query if limit is set afterwards', function() {
     const colRef = firebase
       .firestore()
       .collection(COLLECTION)
@@ -63,7 +65,7 @@ describe('firestore().collection().limitToLast()', () => {
   });
 
   // FIXME flaky on local tests
-  xit('limitToLast the number of documents', async () => {
+  xit('limitToLast the number of documents', async function() {
     const subCol = `${COLLECTION}/limitToLast/count`;
     const colRef = firebase.firestore().collection(subCol);
 
@@ -90,7 +92,7 @@ describe('firestore().collection().limitToLast()', () => {
     should(results[1].count).equal(1);
   });
 
-  it("throws error if no 'orderBy' is set on the query", () => {
+  it("throws error if no 'orderBy' is set on the query", function() {
     try {
       firebase
         .firestore()

--- a/packages/firestore/e2e/Query/onSnapshot.e2e.js
+++ b/packages/firestore/e2e/Query/onSnapshot.e2e.js
@@ -18,9 +18,11 @@ const { wipe } = require('../helpers');
 const COLLECTION = 'firestore';
 const NO_RULE_COLLECTION = 'no_rules';
 
-describe('firestore().collection().onSnapshot()', () => {
-  before(() => wipe());
-  it('throws if no arguments are provided', () => {
+describe('firestore().collection().onSnapshot()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if no arguments are provided', function() {
     try {
       firebase
         .firestore()
@@ -33,7 +35,7 @@ describe('firestore().collection().onSnapshot()', () => {
     }
   });
 
-  it('returns an unsubscribe function', () => {
+  it('returns an unsubscribe function', function() {
     const unsub = firebase
       .firestore()
       .collection(`${COLLECTION}/foo/bar1`)
@@ -43,7 +45,7 @@ describe('firestore().collection().onSnapshot()', () => {
     unsub();
   });
 
-  it('accepts a single callback function with snapshot', async () => {
+  it('accepts a single callback function with snapshot', async function() {
     const callback = sinon.spy();
     const unsub = firebase
       .firestore()
@@ -58,7 +60,7 @@ describe('firestore().collection().onSnapshot()', () => {
     unsub();
   });
 
-  it('accepts a single callback function with Error', async () => {
+  it('accepts a single callback function with Error', async function() {
     const callback = sinon.spy();
     const unsub = firebase
       .firestore()
@@ -73,8 +75,8 @@ describe('firestore().collection().onSnapshot()', () => {
     unsub();
   });
 
-  describe('multiple callbacks', () => {
-    it('calls onNext when successful', async () => {
+  describe('multiple callbacks', function() {
+    it('calls onNext when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -91,7 +93,7 @@ describe('firestore().collection().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls onError with Error', async () => {
+    it('calls onError with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -109,8 +111,8 @@ describe('firestore().collection().onSnapshot()', () => {
     });
   });
 
-  describe('objects of callbacks', () => {
-    it('calls next when successful', async () => {
+  describe('objects of callbacks', function() {
+    it('calls next when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -130,7 +132,7 @@ describe('firestore().collection().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls error with Error', async () => {
+    it('calls error with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -151,8 +153,8 @@ describe('firestore().collection().onSnapshot()', () => {
     });
   });
 
-  describe('SnapshotListenerOptions + callbacks', () => {
-    it('calls callback with snapshot when successful', async () => {
+  describe('SnapshotListenerOptions + callbacks', function() {
+    it('calls callback with snapshot when successful', async function() {
       const callback = sinon.spy();
       const unsub = firebase
         .firestore()
@@ -172,7 +174,7 @@ describe('firestore().collection().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls callback with Error', async () => {
+    it('calls callback with Error', async function() {
       const callback = sinon.spy();
       const unsub = firebase
         .firestore()
@@ -192,7 +194,7 @@ describe('firestore().collection().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls next with snapshot when successful', async () => {
+    it('calls next with snapshot when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -215,7 +217,7 @@ describe('firestore().collection().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls error with Error', async () => {
+    it('calls error with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -239,8 +241,8 @@ describe('firestore().collection().onSnapshot()', () => {
     });
   });
 
-  describe('SnapshotListenerOptions + object of callbacks', () => {
-    it('calls next with snapshot when successful', async () => {
+  describe('SnapshotListenerOptions + object of callbacks', function() {
+    it('calls next with snapshot when successful', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -265,7 +267,7 @@ describe('firestore().collection().onSnapshot()', () => {
       unsub();
     });
 
-    it('calls error with Error', async () => {
+    it('calls error with Error', async function() {
       const onNext = sinon.spy();
       const onError = sinon.spy();
       const unsub = firebase
@@ -291,7 +293,7 @@ describe('firestore().collection().onSnapshot()', () => {
     });
   });
 
-  it('throws if SnapshotListenerOptions is invalid', () => {
+  it('throws if SnapshotListenerOptions is invalid', function() {
     try {
       firebase
         .firestore()
@@ -308,7 +310,7 @@ describe('firestore().collection().onSnapshot()', () => {
     }
   });
 
-  it('throws if next callback is invalid', () => {
+  it('throws if next callback is invalid', function() {
     try {
       firebase
         .firestore()
@@ -323,7 +325,7 @@ describe('firestore().collection().onSnapshot()', () => {
     }
   });
 
-  it('throws if error callback is invalid', () => {
+  it('throws if error callback is invalid', function() {
     try {
       firebase
         .firestore()
@@ -340,7 +342,7 @@ describe('firestore().collection().onSnapshot()', () => {
 
   // FIXME test disabled due to flakiness in CI E2E tests.
   // Registered 4 of 3 expected calls once (!?), 3 of 2 expected calls once.
-  xit('unsubscribes from further updates', async () => {
+  xit('unsubscribes from further updates', async function() {
     const callback = sinon.spy();
 
     const collection = firebase.firestore().collection(`${COLLECTION}/foo/bar7`);

--- a/packages/firestore/e2e/Query/orderBy.e2e.js
+++ b/packages/firestore/e2e/Query/orderBy.e2e.js
@@ -16,9 +16,11 @@
  */
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
-describe('firestore().collection().orderBy()', () => {
-  before(() => wipe());
-  it('throws if fieldPath is not valid', () => {
+describe('firestore().collection().orderBy()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if fieldPath is not valid', function() {
     try {
       firebase
         .firestore()
@@ -31,7 +33,7 @@ describe('firestore().collection().orderBy()', () => {
     }
   });
 
-  it('throws if fieldPath string is invalid', () => {
+  it('throws if fieldPath string is invalid', function() {
     try {
       firebase
         .firestore()
@@ -44,7 +46,7 @@ describe('firestore().collection().orderBy()', () => {
     }
   });
 
-  it('throws if direction string is not valid', () => {
+  it('throws if direction string is not valid', function() {
     try {
       firebase
         .firestore()
@@ -57,7 +59,7 @@ describe('firestore().collection().orderBy()', () => {
     }
   });
 
-  it('throws if a startAt()/startAfter() has already been set', async () => {
+  it('throws if a startAt()/startAfter() has already been set', async function() {
     try {
       const doc = firebase.firestore().doc(`${COLLECTION}/startATstartAfter`);
       await doc.set({ foo: 'bar' });
@@ -75,7 +77,7 @@ describe('firestore().collection().orderBy()', () => {
     }
   });
 
-  it('throws if a endAt()/endBefore() has already been set', async () => {
+  it('throws if a endAt()/endBefore() has already been set', async function() {
     try {
       const doc = firebase.firestore().doc(`${COLLECTION}/endAtendBefore`);
       await doc.set({ foo: 'bar' });
@@ -93,7 +95,7 @@ describe('firestore().collection().orderBy()', () => {
     }
   });
 
-  it('throws if duplicating the order field path', () => {
+  it('throws if duplicating the order field path', function() {
     try {
       firebase
         .firestore()
@@ -108,7 +110,7 @@ describe('firestore().collection().orderBy()', () => {
   });
 
   // FIXME flaky in local tests
-  xit('orders by a value ASC', async () => {
+  xit('orders by a value ASC', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/order/asc`);
 
     await colRef.add({ value: 1 });
@@ -124,7 +126,7 @@ describe('firestore().collection().orderBy()', () => {
   });
 
   // FIXME flaky in local tests
-  xit('orders by a value DESC', async () => {
+  xit('orders by a value DESC', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/order/desc`);
 
     await colRef.add({ value: 1 });

--- a/packages/firestore/e2e/Query/query.e2e.js
+++ b/packages/firestore/e2e/Query/query.e2e.js
@@ -15,8 +15,8 @@
  */
 const COLLECTION = 'firestore';
 
-describe('FirestoreQuery/FirestoreQueryModifiers', () => {
-  it('should not mutate previous queries (#2691)', async () => {
+describe('FirestoreQuery/FirestoreQueryModifiers', function() {
+  it('should not mutate previous queries (#2691)', async function() {
     const queryBefore = firebase
       .firestore()
       .collection(COLLECTION)
@@ -29,7 +29,7 @@ describe('FirestoreQuery/FirestoreQueryModifiers', () => {
     queryAfter._modifiers._filters.length.should.equal(1);
   });
 
-  it('throws if where equality operator is invoked, and the where fieldPath parameter matches any orderBy parameter', async () => {
+  it('throws if where equality operator is invoked, and the where fieldPath parameter matches any orderBy parameter', async function() {
     try {
       firebase
         .firestore()
@@ -58,7 +58,7 @@ describe('FirestoreQuery/FirestoreQueryModifiers', () => {
     }
   });
 
-  it('throws if where inequality operator is invoked, and the where fieldPath does not match initial orderBy parameter', async () => {
+  it('throws if where inequality operator is invoked, and the where fieldPath does not match initial orderBy parameter', async function() {
     try {
       firebase
         .firestore()

--- a/packages/firestore/e2e/Query/startAfter.e2e.js
+++ b/packages/firestore/e2e/Query/startAfter.e2e.js
@@ -16,9 +16,11 @@
  */
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
-describe('firestore().collection().startAfter()', () => {
-  before(() => wipe());
-  it('throws if no argument provided', () => {
+describe('firestore().collection().startAfter()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if no argument provided', function() {
     try {
       firebase
         .firestore()
@@ -33,7 +35,7 @@ describe('firestore().collection().startAfter()', () => {
     }
   });
 
-  it('throws if a inconsistent order number', () => {
+  it('throws if a inconsistent order number', function() {
     try {
       firebase
         .firestore()
@@ -47,7 +49,7 @@ describe('firestore().collection().startAfter()', () => {
     }
   });
 
-  it('throws if providing snapshot and field values', async () => {
+  it('throws if providing snapshot and field values', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -64,7 +66,7 @@ describe('firestore().collection().startAfter()', () => {
     }
   });
 
-  it('throws if provided snapshot does not exist', async () => {
+  it('throws if provided snapshot does not exist', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -81,7 +83,7 @@ describe('firestore().collection().startAfter()', () => {
     }
   });
 
-  it('throws if order used with snapshot but fields do not exist', async () => {
+  it('throws if order used with snapshot but fields do not exist', async function() {
     try {
       const doc = firebase.firestore().doc(`${COLLECTION}/iexist`);
       await doc.set({ foo: { bar: 'baz' } });
@@ -101,7 +103,7 @@ describe('firestore().collection().startAfter()', () => {
     }
   });
 
-  it('starts after field values', async () => {
+  it('starts after field values', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/startAfter/collection`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -122,7 +124,7 @@ describe('firestore().collection().startAfter()', () => {
     qs.docs[0].id.should.eql('doc1');
   });
 
-  it('starts after snapshot field values', async () => {
+  it('starts after snapshot field values', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/startAfter/snapshotFields`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -145,7 +147,7 @@ describe('firestore().collection().startAfter()', () => {
     qs.docs[0].id.should.eql('doc3');
   });
 
-  it('startAfter snapshot', async () => {
+  it('startAfter snapshot', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/endsAt/snapshot`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -161,7 +163,7 @@ describe('firestore().collection().startAfter()', () => {
     qs.docs[0].id.should.eql('doc3');
   });
 
-  it('runs startAfter & endBefore in the same query', async () => {
+  it('runs startAfter & endBefore in the same query', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/startAfter/snapshot`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');

--- a/packages/firestore/e2e/Query/startAt.e2e.js
+++ b/packages/firestore/e2e/Query/startAt.e2e.js
@@ -16,9 +16,11 @@
  */
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
-describe('firestore().collection().starAt()', () => {
-  before(() => wipe());
-  it('throws if no argument provided', () => {
+describe('firestore().collection().starAt()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('throws if no argument provided', function() {
     try {
       firebase
         .firestore()
@@ -33,7 +35,7 @@ describe('firestore().collection().starAt()', () => {
     }
   });
 
-  it('throws if a inconsistent order number', () => {
+  it('throws if a inconsistent order number', function() {
     try {
       firebase
         .firestore()
@@ -47,7 +49,7 @@ describe('firestore().collection().starAt()', () => {
     }
   });
 
-  it('throws if providing snapshot and field values', async () => {
+  it('throws if providing snapshot and field values', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -64,7 +66,7 @@ describe('firestore().collection().starAt()', () => {
     }
   });
 
-  it('throws if provided snapshot does not exist', async () => {
+  it('throws if provided snapshot does not exist', async function() {
     try {
       const doc = await firebase
         .firestore()
@@ -81,7 +83,7 @@ describe('firestore().collection().starAt()', () => {
     }
   });
 
-  it('throws if order used with snapshot but fields do not exist', async () => {
+  it('throws if order used with snapshot but fields do not exist', async function() {
     try {
       const doc = firebase.firestore().doc(`${COLLECTION}/iexist`);
 
@@ -102,7 +104,7 @@ describe('firestore().collection().starAt()', () => {
     }
   });
 
-  it('starts at field values', async () => {
+  it('starts at field values', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/startAt/collection`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -124,7 +126,7 @@ describe('firestore().collection().starAt()', () => {
     qs.docs[1].id.should.eql('doc1');
   });
 
-  it('starts at snapshot field values', async () => {
+  it('starts at snapshot field values', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/startAt/snapshotFields`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');
@@ -148,7 +150,7 @@ describe('firestore().collection().starAt()', () => {
     qs.docs[1].id.should.eql('doc3');
   });
 
-  it('startAt at snapshot', async () => {
+  it('startAt at snapshot', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/endsAt/snapshot`);
     const doc1 = colRef.doc('doc1');
     const doc2 = colRef.doc('doc2');

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -16,9 +16,11 @@
  */
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
-describe('firestore().collection().where()', () => {
-  beforeEach(async () => await wipe());
-  it('throws if fieldPath is invalid', () => {
+describe('firestore().collection().where()', function() {
+  beforeEach(async function() {
+    return await wipe();
+  });
+  it('throws if fieldPath is invalid', function() {
     try {
       firebase
         .firestore()
@@ -31,7 +33,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if fieldPath string is invalid', () => {
+  it('throws if fieldPath string is invalid', function() {
     try {
       firebase
         .firestore()
@@ -44,7 +46,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if operator string is invalid', () => {
+  it('throws if operator string is invalid', function() {
     try {
       firebase
         .firestore()
@@ -57,7 +59,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if query contains multiple array-contains', () => {
+  it('throws if query contains multiple array-contains', function() {
     try {
       firebase
         .firestore()
@@ -71,7 +73,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if value is not defined', () => {
+  it('throws if value is not defined', function() {
     try {
       firebase
         .firestore()
@@ -84,7 +86,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if null value and no equal operator', () => {
+  it('throws if null value and no equal operator', function() {
     try {
       firebase
         .firestore()
@@ -97,14 +99,14 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('allows null to be used with equal operator', () => {
+  it('allows null to be used with equal operator', function() {
     firebase
       .firestore()
       .collection(COLLECTION)
       .where('foo.bar', '==', null);
   });
 
-  it('throws if multiple inequalities on different paths is provided', () => {
+  it('throws if multiple inequalities on different paths is provided', function() {
     try {
       firebase
         .firestore()
@@ -118,7 +120,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('allows inequality on the same path', () => {
+  it('allows inequality on the same path', function() {
     firebase
       .firestore()
       .collection(COLLECTION)
@@ -126,7 +128,7 @@ describe('firestore().collection().where()', () => {
       .where(new firebase.firestore.FieldPath('foo', 'bar'), '>', 1234);
   });
 
-  it('throws if in query with no array value', () => {
+  it('throws if in query with no array value', function() {
     try {
       firebase
         .firestore()
@@ -139,7 +141,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if array-contains-any query with no array value', () => {
+  it('throws if array-contains-any query with no array value', function() {
     try {
       firebase
         .firestore()
@@ -152,7 +154,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if in query array length is greater than 10', () => {
+  it('throws if in query array length is greater than 10', function() {
     try {
       firebase
         .firestore()
@@ -165,7 +167,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if query has multiple array-contains-any filter', () => {
+  it('throws if query has multiple array-contains-any filter', function() {
     try {
       firebase
         .firestore()
@@ -179,7 +181,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if query has array-contains-any & in filter', () => {
+  it('throws if query has array-contains-any & in filter', function() {
     try {
       firebase
         .firestore()
@@ -195,7 +197,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if query has multiple in filter', () => {
+  it('throws if query has multiple in filter', function() {
     try {
       firebase
         .firestore()
@@ -209,7 +211,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('throws if query has in & array-contains-any filter', () => {
+  it('throws if query has in & array-contains-any filter', function() {
     try {
       firebase
         .firestore()
@@ -227,7 +229,7 @@ describe('firestore().collection().where()', () => {
 
   /* Queries */
 
-  it('returns with where equal filter', async () => {
+  it('returns with where equal filter', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/equal`);
 
     const search = Date.now();
@@ -245,7 +247,7 @@ describe('firestore().collection().where()', () => {
     });
   });
 
-  it('returns with where greater than filter', async () => {
+  it('returns with where greater than filter', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greater`);
 
     const search = Date.now();
@@ -264,7 +266,7 @@ describe('firestore().collection().where()', () => {
     });
   });
 
-  it('returns with where greater than or equal filter', async () => {
+  it('returns with where greater than or equal filter', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greaterequal`);
 
     const search = Date.now();
@@ -283,7 +285,7 @@ describe('firestore().collection().where()', () => {
     });
   });
 
-  it('returns with where less than filter', async () => {
+  it('returns with where less than filter', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/less`);
 
     const search = -Date.now();
@@ -301,7 +303,7 @@ describe('firestore().collection().where()', () => {
     });
   });
 
-  it('returns with where less than or equal filter', async () => {
+  it('returns with where less than or equal filter', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/lessequal`);
 
     const search = -Date.now();
@@ -320,7 +322,7 @@ describe('firestore().collection().where()', () => {
     });
   });
 
-  it('returns with where array-contains filter', async () => {
+  it('returns with where array-contains filter', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/array-contains`);
 
     const match = Date.now();
@@ -339,7 +341,7 @@ describe('firestore().collection().where()', () => {
     });
   });
 
-  it('returns with in filter', async () => {
+  it('returns with in filter', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/in${Date.now() + ''}`);
 
     await Promise.all([
@@ -358,7 +360,7 @@ describe('firestore().collection().where()', () => {
     });
   });
 
-  it('returns with array-contains-any filter', async () => {
+  it('returns with array-contains-any filter', async function() {
     const colRef = firebase
       .firestore()
       .collection(`${COLLECTION}/filter/array-contains-any${Date.now() + ''}`);
@@ -375,7 +377,7 @@ describe('firestore().collection().where()', () => {
     snapshot.size.should.eql(3); // 2nd record should only be returned once
   });
 
-  it('returns with a FieldPath', async () => {
+  it('returns with a FieldPath', async function() {
     const colRef = firebase
       .firestore()
       .collection(`${COLLECTION}/filter/where-fieldpath${Date.now() + ''}`);
@@ -398,7 +400,7 @@ describe('firestore().collection().where()', () => {
     should.equal(data.map['foo.bar@gmail.com'], true);
   });
 
-  it('should throw an error if you use a FieldPath on a filter in conjunction with an orderBy() parameter that is not FieldPath', async () => {
+  it('should throw an error if you use a FieldPath on a filter in conjunction with an orderBy() parameter that is not FieldPath', async function() {
     try {
       firebase
         .firestore()
@@ -413,7 +415,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it('should correctly query integer values with in operator', async () => {
+  it('should correctly query integer values with in operator', async function() {
     const ref = firebase.firestore().collection(`${COLLECTION}/filter/int-in${Date.now() + ''}`);
 
     await ref.add({ status: 1 });
@@ -427,7 +429,7 @@ describe('firestore().collection().where()', () => {
     items.length.should.equal(1);
   });
 
-  it('should correctly query integer values with array-contains operator', async () => {
+  it('should correctly query integer values with array-contains operator', async function() {
     const ref = firebase
       .firestore()
       .collection(`${COLLECTION}/filter/int-array-contains${Date.now() + ''}`);
@@ -443,7 +445,7 @@ describe('firestore().collection().where()', () => {
     items.length.should.equal(1);
   });
 
-  it("should correctly retrieve data when using 'not-in' operator", async () => {
+  it("should correctly retrieve data when using 'not-in' operator", async function() {
     const ref = firebase.firestore().collection(`${COLLECTION}/filter/not-in${Date.now() + ''}`);
 
     await Promise.all([ref.add({ notIn: 'here' }), ref.add({ notIn: 'now' })]);
@@ -453,7 +455,7 @@ describe('firestore().collection().where()', () => {
     should(result.docs[0].data().notIn).equal('now');
   });
 
-  it("should throw error when using 'not-in' operator twice", async () => {
+  it("should throw error when using 'not-in' operator twice", async function() {
     const ref = firebase.firestore().collection(COLLECTION);
 
     try {
@@ -465,7 +467,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it("should throw error when combining 'not-in' operator with '!=' operator", async () => {
+  it("should throw error when combining 'not-in' operator with '!=' operator", async function() {
     const ref = firebase.firestore().collection(COLLECTION);
 
     try {
@@ -479,7 +481,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it("should throw error when combining 'not-in' operator with 'in' operator", async () => {
+  it("should throw error when combining 'not-in' operator with 'in' operator", async function() {
     const ref = firebase.firestore().collection(COLLECTION);
 
     try {
@@ -491,7 +493,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it("should throw error when combining 'not-in' operator with 'array-contains-any' operator", async () => {
+  it("should throw error when combining 'not-in' operator with 'array-contains-any' operator", async function() {
     const ref = firebase.firestore().collection(COLLECTION);
 
     try {
@@ -505,7 +507,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it("should throw error when 'not-in' filter has a list of more than 10 items", async () => {
+  it("should throw error when 'not-in' filter has a list of more than 10 items", async function() {
     const ref = firebase.firestore().collection(COLLECTION);
 
     try {
@@ -519,7 +521,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it("should correctly retrieve data when using '!=' operator", async () => {
+  it("should correctly retrieve data when using '!=' operator", async function() {
     const ref = firebase
       .firestore()
       .collection(`${COLLECTION}/filter/bang-equals${Date.now() + ''}`);
@@ -532,7 +534,7 @@ describe('firestore().collection().where()', () => {
     should(result.docs[0].data().notEqual).equal('now');
   });
 
-  it("should throw error when using '!=' operator twice ", async () => {
+  it("should throw error when using '!=' operator twice ", async function() {
     const ref = firebase.firestore().collection(COLLECTION);
 
     try {
@@ -544,7 +546,7 @@ describe('firestore().collection().where()', () => {
     }
   });
 
-  it("should throw error when combining '!=' operator with any other inequality operator on a different field", async () => {
+  it("should throw error when combining '!=' operator with any other inequality operator on a different field", async function() {
     const ref = firebase.firestore().collection(COLLECTION);
 
     try {
@@ -578,7 +580,7 @@ describe('firestore().collection().where()', () => {
     return Promise.resolve();
   });
 
-  it('should handle where clause after sort by', async () => {
+  it('should handle where clause after sort by', async function() {
     const ref = firebase
       .firestore()
       .collection(`${COLLECTION}/filter/sort-by-where${Date.now() + ''}`);

--- a/packages/firestore/e2e/QuerySnapshot.e2e.js
+++ b/packages/firestore/e2e/QuerySnapshot.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('./helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.QuerySnapshot', () => {
-  before(() => wipe());
-  it('is returned from a collection get()', async () => {
+describe('firestore.QuerySnapshot', function() {
+  before(function() {
+    return wipe();
+  });
+  it('is returned from a collection get()', async function() {
     const snapshot = await firebase
       .firestore()
       .collection(COLLECTION)
@@ -28,7 +30,7 @@ describe('firestore.QuerySnapshot', () => {
     snapshot.constructor.name.should.eql('FirestoreQuerySnapshot');
   });
 
-  it('is returned from a collection onSnapshot()', async () => {
+  it('is returned from a collection onSnapshot()', async function() {
     const callback = sinon.spy();
     firebase
       .firestore()
@@ -38,7 +40,7 @@ describe('firestore.QuerySnapshot', () => {
     callback.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
   });
 
-  it('returns an array of DocumentSnapshots', async () => {
+  it('returns an array of DocumentSnapshots', async function() {
     const colRef = firebase.firestore().collection(COLLECTION);
     await colRef.add({});
     const snapshot = await colRef.get();
@@ -47,7 +49,7 @@ describe('firestore.QuerySnapshot', () => {
     snapshot.docs[0].constructor.name.should.eql('FirestoreDocumentSnapshot');
   });
 
-  it('returns false if not empty', async () => {
+  it('returns false if not empty', async function() {
     const colRef = firebase.firestore().collection(COLLECTION);
     await colRef.add({});
     const snapshot = await colRef.get();
@@ -55,33 +57,33 @@ describe('firestore.QuerySnapshot', () => {
     snapshot.empty.should.be.False();
   });
 
-  it('returns true if empty', async () => {
+  it('returns true if empty', async function() {
     const colRef = firebase.firestore().collection(`${COLLECTION}/foo/emptycollection`);
     const snapshot = await colRef.get();
     snapshot.empty.should.be.Boolean();
     snapshot.empty.should.be.True();
   });
 
-  it('returns a SnapshotMetadata instance', async () => {
+  it('returns a SnapshotMetadata instance', async function() {
     const colRef = firebase.firestore().collection(COLLECTION);
     const snapshot = await colRef.get();
     snapshot.metadata.constructor.name.should.eql('FirestoreSnapshotMetadata');
   });
 
-  it('returns a Query instance', async () => {
+  it('returns a Query instance', async function() {
     const colRef = firebase.firestore().collection(COLLECTION);
     const snapshot = await colRef.get();
     snapshot.query.constructor.name.should.eql('FirestoreCollectionReference');
   });
 
-  it('returns size as a number', async () => {
+  it('returns size as a number', async function() {
     const colRef = firebase.firestore().collection(COLLECTION);
     const snapshot = await colRef.get();
     snapshot.size.should.be.Number();
   });
 
-  describe('docChanges()', () => {
-    it('throws if options is not an object', async () => {
+  describe('docChanges()', function() {
+    it('throws if options is not an object', async function() {
       try {
         const colRef = firebase.firestore().collection(COLLECTION);
         const snapshot = await colRef.limit(1).get();
@@ -93,7 +95,7 @@ describe('firestore.QuerySnapshot', () => {
       }
     });
 
-    it('throws if options.includeMetadataChanges is not a boolean', async () => {
+    it('throws if options.includeMetadataChanges is not a boolean', async function() {
       try {
         const colRef = firebase.firestore().collection(COLLECTION);
         const snapshot = await colRef.limit(1).get();
@@ -105,7 +107,7 @@ describe('firestore.QuerySnapshot', () => {
       }
     });
 
-    it('throws if options.includeMetadataChanges is true, but snapshot does not include those changes', async () => {
+    it('throws if options.includeMetadataChanges is true, but snapshot does not include those changes', async function() {
       const callback = sinon.spy();
       const colRef = firebase.firestore().collection(COLLECTION);
       const unsub = colRef.onSnapshot(
@@ -127,7 +129,7 @@ describe('firestore.QuerySnapshot', () => {
       }
     });
 
-    it('returns an array of DocumentChange instances', async () => {
+    it('returns an array of DocumentChange instances', async function() {
       const colRef = firebase.firestore().collection(COLLECTION);
       colRef.add({});
       const snapshot = await colRef.limit(1).get();
@@ -138,7 +140,7 @@ describe('firestore.QuerySnapshot', () => {
     });
 
     // TODO: fixme @ehesp - flaky test: `AssertionError: expected 3 to equal 1` on  line 155
-    xit('returns the correct number of document changes if listening to metadata changes', async () => {
+    xit('returns the correct number of document changes if listening to metadata changes', async function() {
       const callback = sinon.spy();
       const colRef = firebase.firestore().collection('v6/metadatachanges/true-true');
       const unsub = colRef.onSnapshot({ includeMetadataChanges: true }, callback);
@@ -156,7 +158,7 @@ describe('firestore.QuerySnapshot', () => {
     });
 
     // TODO: fixme @ehesp - flaky test: `AssertionError: expected 5 to equal 1`
-    xit('returns the correct number of document changes if listening to metadata changes, but not including them in docChanges', async () => {
+    xit('returns the correct number of document changes if listening to metadata changes, but not including them in docChanges', async function() {
       const callback = sinon.spy();
       const colRef = firebase.firestore().collection('v6/metadatachanges/true-false');
       const unsub = colRef.onSnapshot({ includeMetadataChanges: true }, callback);
@@ -174,8 +176,8 @@ describe('firestore.QuerySnapshot', () => {
     });
   });
 
-  describe('forEach()', () => {
-    it('throws if callback is not a function', async () => {
+  describe('forEach()', function() {
+    it('throws if callback is not a function', async function() {
       try {
         const colRef = firebase.firestore().collection(COLLECTION);
         const snapshot = await colRef.limit(1).get();
@@ -187,7 +189,7 @@ describe('firestore.QuerySnapshot', () => {
       }
     });
 
-    it('calls back a function', async () => {
+    it('calls back a function', async function() {
       const colRef = firebase.firestore().collection(COLLECTION);
       colRef.add({});
       colRef.add({});
@@ -202,7 +204,7 @@ describe('firestore.QuerySnapshot', () => {
       callback.args[1][1].should.be.Number();
     });
 
-    it('provides context to the callback', async () => {
+    it('provides context to the callback', async function() {
       const colRef = firebase.firestore().collection(COLLECTION);
       colRef.add({});
       const snapshot = await colRef.limit(1).get();
@@ -216,8 +218,8 @@ describe('firestore.QuerySnapshot', () => {
     });
   });
 
-  describe('isEqual()', () => {
-    it('throws if other is not a QuerySnapshot', async () => {
+  describe('isEqual()', function() {
+    it('throws if other is not a QuerySnapshot', async function() {
       try {
         const qs = await firebase
           .firestore()
@@ -231,7 +233,7 @@ describe('firestore.QuerySnapshot', () => {
       }
     });
 
-    it('returns false if not equal (simple checks)', async () => {
+    it('returns false if not equal (simple checks)', async function() {
       const colRef = firebase.firestore().collection(COLLECTION);
       // Ensure a doc exists
       await colRef.add({});
@@ -248,7 +250,7 @@ describe('firestore.QuerySnapshot', () => {
       eq1.should.be.False();
     });
 
-    it('returns false if not equal (expensive checks)', async () => {
+    it('returns false if not equal (expensive checks)', async function() {
       const colRef = firebase
         .firestore()
         .collection(`${COLLECTION}/querysnapshot/querySnapshotIsEqual-False`);
@@ -278,7 +280,7 @@ describe('firestore.QuerySnapshot', () => {
       eq1.should.be.False();
     });
 
-    it('returns true when equal', async () => {
+    it('returns true when equal', async function() {
       const colRef = firebase
         .firestore()
         .collection(`${COLLECTION}/querysnapshot/querySnapshotIsEqual-True`);

--- a/packages/firestore/e2e/SnapshotMetadata.e2e.js
+++ b/packages/firestore/e2e/SnapshotMetadata.e2e.js
@@ -17,9 +17,11 @@
 const { wipe } = require('./helpers');
 const COLLECTION = 'firestore';
 
-describe('firestore.SnapshotMetadata', () => {
-  before(() => wipe());
-  it('.fromCache -> returns a boolean', async () => {
+describe('firestore.SnapshotMetadata', function() {
+  before(function() {
+    return wipe();
+  });
+  it('.fromCache -> returns a boolean', async function() {
     const ref1 = firebase.firestore().collection(COLLECTION);
     const ref2 = firebase.firestore().doc(`${COLLECTION}/idonotexist`);
     const colRef = await ref1.get();
@@ -28,7 +30,7 @@ describe('firestore.SnapshotMetadata', () => {
     docRef.metadata.fromCache.should.be.Boolean();
   });
 
-  it('.hasPendingWrites -> returns a boolean', async () => {
+  it('.hasPendingWrites -> returns a boolean', async function() {
     const ref1 = firebase.firestore().collection(COLLECTION);
     const ref2 = firebase.firestore().doc(`${COLLECTION}/idonotexist`);
     const colRef = await ref1.get();
@@ -37,8 +39,8 @@ describe('firestore.SnapshotMetadata', () => {
     docRef.metadata.hasPendingWrites.should.be.Boolean();
   });
 
-  describe('isEqual()', () => {
-    it('throws if other is not a valid type', async () => {
+  describe('isEqual()', function() {
+    it('throws if other is not a valid type', async function() {
       try {
         const snapshot = await firebase
           .firestore()
@@ -52,7 +54,7 @@ describe('firestore.SnapshotMetadata', () => {
       }
     });
 
-    it('returns true if is equal', async () => {
+    it('returns true if is equal', async function() {
       const snapshot1 = await firebase
         .firestore()
         .collection(COLLECTION)
@@ -64,7 +66,7 @@ describe('firestore.SnapshotMetadata', () => {
       snapshot1.metadata.isEqual(snapshot2.metadata).should.eql(true);
     });
 
-    it('returns false if not equal', async () => {
+    it('returns false if not equal', async function() {
       const snapshot1 = await firebase
         .firestore()
         .collection(COLLECTION)

--- a/packages/firestore/e2e/Timestamp.e2e.js
+++ b/packages/firestore/e2e/Timestamp.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('firestore.Timestamp', () => {
-  it('throws if seconds is not a number', () => {
+describe('firestore.Timestamp', function() {
+  it('throws if seconds is not a number', function() {
     try {
       new firebase.firestore.Timestamp('1234');
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -26,7 +26,7 @@ describe('firestore.Timestamp', () => {
     }
   });
 
-  it('throws if nanoseconds is not a number', () => {
+  it('throws if nanoseconds is not a number', function() {
     try {
       new firebase.firestore.Timestamp(123, '456');
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -36,7 +36,7 @@ describe('firestore.Timestamp', () => {
     }
   });
 
-  it('throws if nanoseconds less than 0', () => {
+  it('throws if nanoseconds less than 0', function() {
     try {
       new firebase.firestore.Timestamp(123, -1);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -46,7 +46,7 @@ describe('firestore.Timestamp', () => {
     }
   });
 
-  it('throws if nanoseconds greater than 1e9', () => {
+  it('throws if nanoseconds greater than 1e9', function() {
     try {
       new firebase.firestore.Timestamp(123, 10000000000);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -56,7 +56,7 @@ describe('firestore.Timestamp', () => {
     }
   });
 
-  it('throws if seconds less than -62135596800', () => {
+  it('throws if seconds less than -62135596800', function() {
     try {
       new firebase.firestore.Timestamp(-63135596800, 123);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -66,7 +66,7 @@ describe('firestore.Timestamp', () => {
     }
   });
 
-  it('throws if seconds greater-equal than 253402300800', () => {
+  it('throws if seconds greater-equal than 253402300800', function() {
     try {
       new firebase.firestore.Timestamp(253402300800, 123);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -76,18 +76,18 @@ describe('firestore.Timestamp', () => {
     }
   });
 
-  it('returns number of seconds', () => {
+  it('returns number of seconds', function() {
     const ts = new firebase.firestore.Timestamp(123, 123);
     ts.seconds.should.equal(123);
   });
 
-  it('returns number of nanoseconds', () => {
+  it('returns number of nanoseconds', function() {
     const ts = new firebase.firestore.Timestamp(123, 123456);
     ts.nanoseconds.should.equal(123456);
   });
 
-  describe('isEqual()', () => {
-    it('throws if invalid other is procided', () => {
+  describe('isEqual()', function() {
+    it('throws if invalid other is procided', function() {
       try {
         const ts = new firebase.firestore.Timestamp(123, 1234);
         ts.isEqual(123);
@@ -98,52 +98,52 @@ describe('firestore.Timestamp', () => {
       }
     });
 
-    it('returns false if not equal', () => {
+    it('returns false if not equal', function() {
       const ts1 = new firebase.firestore.Timestamp(123, 123456);
       const ts2 = new firebase.firestore.Timestamp(1234, 123456);
       ts1.isEqual(ts2).should.equal(false);
     });
 
-    it('returns true if equal', () => {
+    it('returns true if equal', function() {
       const ts1 = new firebase.firestore.Timestamp(123, 123456);
       const ts2 = new firebase.firestore.Timestamp(123, 123456);
       ts1.isEqual(ts2).should.equal(true);
     });
   });
 
-  describe('toDate()', () => {
-    it('returns a valid Date object', () => {
+  describe('toDate()', function() {
+    it('returns a valid Date object', function() {
       const ts = new firebase.firestore.Timestamp(123, 123456);
       const date = ts.toDate();
       should.equal(date.constructor.name, 'Date');
     });
   });
 
-  describe('toMillis()', () => {
-    it('returns the number of milliseconds', () => {
+  describe('toMillis()', function() {
+    it('returns the number of milliseconds', function() {
       const ts = new firebase.firestore.Timestamp(123, 123456);
       const ms = ts.toMillis();
       should.equal(typeof ms, 'number');
     });
   });
 
-  describe('toString()', () => {
-    it('returns a string representation of the class', () => {
+  describe('toString()', function() {
+    it('returns a string representation of the class', function() {
       const ts = new firebase.firestore.Timestamp(123, 123456);
       const str = ts.toString();
       str.should.equal(`FirestoreTimestamp(seconds=${123}, nanoseconds=${123456})`);
     });
   });
 
-  describe('Timestamp.now()', () => {
-    it('returns a new instance', () => {
+  describe('Timestamp.now()', function() {
+    it('returns a new instance', function() {
       const ts = firebase.firestore.Timestamp.now();
       should.equal(ts.constructor.name, 'FirestoreTimestamp');
     });
   });
 
-  describe('Timestamp.fromDate()', () => {
-    it('throws if date is not a valid Date', () => {
+  describe('Timestamp.fromDate()', function() {
+    it('throws if date is not a valid Date', function() {
       try {
         firebase.firestore.Timestamp.fromDate(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -153,14 +153,14 @@ describe('firestore.Timestamp', () => {
       }
     });
 
-    it('returns a new instance', () => {
+    it('returns a new instance', function() {
       const ts = firebase.firestore.Timestamp.fromDate(new Date());
       should.equal(ts.constructor.name, 'FirestoreTimestamp');
     });
   });
 
-  describe('Timestamp.fromMillis()', () => {
-    it('returns a new instance', () => {
+  describe('Timestamp.fromMillis()', function() {
+    it('returns a new instance', function() {
       const ts = firebase.firestore.Timestamp.fromMillis(123);
       should.equal(ts.constructor.name, 'FirestoreTimestamp');
     });

--- a/packages/firestore/e2e/Transaction.e2e.js
+++ b/packages/firestore/e2e/Transaction.e2e.js
@@ -17,8 +17,8 @@
 const COLLECTION = 'firestore';
 const NO_RULE_COLLECTION = 'no_rules';
 
-describe('firestore.Transaction', () => {
-  it('should throw if updateFunction is not a Promise', async () => {
+describe('firestore.Transaction', function() {
+  it('should throw if updateFunction is not a Promise', async function() {
     try {
       await firebase.firestore().runTransaction(() => 123);
       return Promise.reject(new Error('Did not throw an Error.'));
@@ -28,14 +28,14 @@ describe('firestore.Transaction', () => {
     }
   });
 
-  it('should return an instance of FirestoreTransaction', async () => {
+  it('should return an instance of FirestoreTransaction', async function() {
     await firebase.firestore().runTransaction(async transaction => {
       transaction.constructor.name.should.eql('FirestoreTransaction');
       return null;
     });
   });
 
-  it('should resolve with user value', async () => {
+  it('should resolve with user value', async function() {
     const expected = Date.now();
 
     const value = await firebase.firestore().runTransaction(async () => {
@@ -45,7 +45,7 @@ describe('firestore.Transaction', () => {
     value.should.eql(expected);
   });
 
-  it('should reject with user Error', async () => {
+  it('should reject with user Error', async function() {
     const message = `Error: ${Date.now()}`;
 
     try {
@@ -59,7 +59,7 @@ describe('firestore.Transaction', () => {
     }
   });
 
-  it('should reject a native error', async () => {
+  it('should reject a native error', async function() {
     const docRef = firebase.firestore().doc(`${NO_RULE_COLLECTION}/foo`);
 
     try {
@@ -75,8 +75,8 @@ describe('firestore.Transaction', () => {
     }
   });
 
-  describe('transaction.get()', () => {
-    it('should throw if not providing a document reference', async () => {
+  describe('transaction.get()', function() {
+    it('should throw if not providing a document reference', async function() {
       try {
         await firebase.firestore().runTransaction(t => {
           return t.get(123);
@@ -88,7 +88,7 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should get a document and return a DocumentSnapshot', async () => {
+    it('should get a document and return a DocumentSnapshot', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/transactions/transaction/get-delete`);
       await docRef.set({});
 
@@ -103,8 +103,8 @@ describe('firestore.Transaction', () => {
     });
   });
 
-  describe('transaction.delete()', () => {
-    it('should throw if not providing a document reference', async () => {
+  describe('transaction.delete()', function() {
+    it('should throw if not providing a document reference', async function() {
       try {
         await firebase.firestore().runTransaction(async t => {
           t.delete(123);
@@ -116,7 +116,7 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should delete documents', async () => {
+    it('should delete documents', async function() {
       const docRef1 = firebase
         .firestore()
         .doc(`${COLLECTION}/transactions/transaction/delete-delete1`);
@@ -140,8 +140,8 @@ describe('firestore.Transaction', () => {
     });
   });
 
-  describe('transaction.update()', () => {
-    it('should throw if not providing a document reference', async () => {
+  describe('transaction.update()', function() {
+    it('should throw if not providing a document reference', async function() {
       try {
         await firebase.firestore().runTransaction(async t => {
           t.update(123);
@@ -153,7 +153,7 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should throw if update args are invalid', async () => {
+    it('should throw if update args are invalid', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
       try {
@@ -167,7 +167,7 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should update documents', async () => {
+    it('should update documents', async function() {
       const value = Date.now();
 
       const docRef1 = firebase
@@ -208,8 +208,8 @@ describe('firestore.Transaction', () => {
     });
   });
 
-  describe('transaction.set()', () => {
-    it('should throw if not providing a document reference', async () => {
+  describe('transaction.set()', function() {
+    it('should throw if not providing a document reference', async function() {
       try {
         await firebase.firestore().runTransaction(async t => {
           t.set(123);
@@ -221,7 +221,7 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should throw if set data is invalid', async () => {
+    it('should throw if set data is invalid', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
       try {
@@ -235,7 +235,7 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should throw if set options are invalid', async () => {
+    it('should throw if set options are invalid', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
       try {
@@ -256,7 +256,7 @@ describe('firestore.Transaction', () => {
       }
     });
 
-    it('should set data', async () => {
+    it('should set data', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/transactions/transaction/set`);
       await docRef.set({
         foo: 'bar',
@@ -273,7 +273,7 @@ describe('firestore.Transaction', () => {
       snapshot.data().should.eql(jet.contextify(expected));
     });
 
-    it('should set data with merge', async () => {
+    it('should set data with merge', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/transactions/transaction/set-merge`);
       await docRef.set({
         foo: 'bar',
@@ -300,7 +300,7 @@ describe('firestore.Transaction', () => {
       snapshot.data().should.eql(jet.contextify(expected));
     });
 
-    it('should set data with merge fields', async () => {
+    it('should set data with merge fields', async function() {
       const docRef = firebase
         .firestore()
         .doc(`${COLLECTION}/transactions/transaction/set-mergefields`);
@@ -332,7 +332,7 @@ describe('firestore.Transaction', () => {
       snapshot.data().should.eql(jet.contextify(expected));
     });
 
-    it('should roll back any updates that failed', async () => {
+    it('should roll back any updates that failed', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/transactions/transaction/rollback`);
 
       await docRef.set({

--- a/packages/firestore/e2e/WriteBatch/commit.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/commit.e2e.js
@@ -17,9 +17,11 @@
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
 
-describe('firestore.WriteBatch.commit()', () => {
-  before(() => wipe());
-  it('returns a Promise', () => {
+describe('firestore.WriteBatch.commit()', function() {
+  before(function() {
+    return wipe();
+  });
+  it('returns a Promise', function() {
     const commit = firebase
       .firestore()
       .batch()
@@ -27,7 +29,7 @@ describe('firestore.WriteBatch.commit()', () => {
     commit.should.be.a.Promise();
   });
 
-  it('throws if committing more than 500 writes', async () => {
+  it('throws if committing more than 500 writes', async function() {
     const filledArray = new Array(501).fill({ foo: 'bar' });
     const batch = firebase.firestore().batch();
 
@@ -49,7 +51,7 @@ describe('firestore.WriteBatch.commit()', () => {
     }
   });
 
-  it('throws if already committed', async () => {
+  it('throws if already committed', async function() {
     try {
       const batch = firebase.firestore().batch();
       await batch.commit();
@@ -61,7 +63,7 @@ describe('firestore.WriteBatch.commit()', () => {
     }
   });
 
-  it('should set & commit', async () => {
+  it('should set & commit', async function() {
     const lRef = firebase.firestore().doc(`${COLLECTION}/LON`);
     const nycRef = firebase.firestore().doc(`${COLLECTION}/NYC`);
     const sfRef = firebase.firestore().doc(`${COLLECTION}/SF`);
@@ -82,7 +84,7 @@ describe('firestore.WriteBatch.commit()', () => {
     await Promise.all([lRef.delete(), nycRef.delete(), sfRef.delete()]);
   });
 
-  it('should set/merge & commit', async () => {
+  it('should set/merge & commit', async function() {
     const lRef = firebase.firestore().doc(`${COLLECTION}/LON`);
     const nycRef = firebase.firestore().doc(`${COLLECTION}/NYC`);
     const sfRef = firebase.firestore().doc(`${COLLECTION}/SF`);
@@ -113,7 +115,7 @@ describe('firestore.WriteBatch.commit()', () => {
     await Promise.all([lRef.delete(), nycRef.delete(), sfRef.delete()]);
   });
 
-  it('should set/mergeFields & commit', async () => {
+  it('should set/mergeFields & commit', async function() {
     const lRef = firebase.firestore().doc(`${COLLECTION}/LON`);
     const nycRef = firebase.firestore().doc(`${COLLECTION}/NYC`);
     const sfRef = firebase.firestore().doc(`${COLLECTION}/SF`);
@@ -148,7 +150,7 @@ describe('firestore.WriteBatch.commit()', () => {
     await Promise.all([lRef.delete(), nycRef.delete(), sfRef.delete()]);
   });
 
-  it('should delete & commit', async () => {
+  it('should delete & commit', async function() {
     const lRef = firebase.firestore().doc(`${COLLECTION}/LON`);
     const nycRef = firebase.firestore().doc(`${COLLECTION}/NYC`);
     const sfRef = firebase.firestore().doc(`${COLLECTION}/SF`);
@@ -174,7 +176,7 @@ describe('firestore.WriteBatch.commit()', () => {
     sDoc.exists.should.be.False();
   });
 
-  it('should update & commit', async () => {
+  it('should update & commit', async function() {
     const lRef = firebase.firestore().doc(`${COLLECTION}/LON`);
     const nycRef = firebase.firestore().doc(`${COLLECTION}/NYC`);
     const sfRef = firebase.firestore().doc(`${COLLECTION}/SF`);

--- a/packages/firestore/e2e/WriteBatch/delete.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/delete.e2e.js
@@ -16,8 +16,8 @@
  */
 const COLLECTION = 'firestore';
 
-describe('firestore.WriteBatch.delete()', () => {
-  it('throws if a DocumentReference instance is not provided', () => {
+describe('firestore.WriteBatch.delete()', function() {
+  it('throws if a DocumentReference instance is not provided', function() {
     try {
       firebase
         .firestore()
@@ -30,7 +30,7 @@ describe('firestore.WriteBatch.delete()', () => {
     }
   });
 
-  it('throws if a DocumentReference firestore instance is different', () => {
+  it('throws if a DocumentReference firestore instance is different', function() {
     try {
       const app2 = firebase.app('secondaryFromNative');
       const docRef = firebase.firestore(app2).doc(`${COLLECTION}/foo`);
@@ -48,7 +48,7 @@ describe('firestore.WriteBatch.delete()', () => {
     }
   });
 
-  it('adds the DocumentReference to the internal writes', () => {
+  it('adds the DocumentReference to the internal writes', function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
     const wb = firebase
       .firestore()

--- a/packages/firestore/e2e/WriteBatch/set.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/set.e2e.js
@@ -16,8 +16,8 @@
  */
 const COLLECTION = 'firestore';
 
-describe('firestore.WriteBatch.set()', () => {
-  it('throws if a DocumentReference instance is not provided', () => {
+describe('firestore.WriteBatch.set()', function() {
+  it('throws if a DocumentReference instance is not provided', function() {
     try {
       firebase
         .firestore()
@@ -30,7 +30,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if a DocumentReference firestore instance is different', () => {
+  it('throws if a DocumentReference firestore instance is different', function() {
     try {
       const app2 = firebase.app('secondaryFromNative');
       const docRef = firebase.firestore(app2).doc(`${COLLECTION}/foo`);
@@ -48,7 +48,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if a data is not an object', () => {
+  it('throws if a data is not an object', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
@@ -63,7 +63,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if a options is not an object', () => {
+  it('throws if a options is not an object', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
@@ -78,7 +78,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if merge and mergeFields is provided', () => {
+  it('throws if merge and mergeFields is provided', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
       firebase
@@ -99,7 +99,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if merge is not a boolean', () => {
+  it('throws if merge is not a boolean', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
       firebase
@@ -119,7 +119,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if mergeFields is not an array', () => {
+  it('throws if mergeFields is not an array', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
       firebase
@@ -139,7 +139,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if mergeFields item is not valid', () => {
+  it('throws if mergeFields item is not valid', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
@@ -162,7 +162,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('throws if string fieldpath is invalid', () => {
+  it('throws if string fieldpath is invalid', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
@@ -183,7 +183,7 @@ describe('firestore.WriteBatch.set()', () => {
     }
   });
 
-  it('accepts string fieldpath & FieldPath', () => {
+  it('accepts string fieldpath & FieldPath', function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
     firebase
@@ -198,7 +198,7 @@ describe('firestore.WriteBatch.set()', () => {
       );
   });
 
-  it('adds the DocumentReference to the internal writes', () => {
+  it('adds the DocumentReference to the internal writes', function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
 
     const wb = firebase

--- a/packages/firestore/e2e/WriteBatch/update.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/update.e2e.js
@@ -17,8 +17,8 @@
 
 const COLLECTION = 'firestore';
 
-describe('firestore.WriteBatch.update()', () => {
-  it('throws if a DocumentReference instance is not provided', () => {
+describe('firestore.WriteBatch.update()', function() {
+  it('throws if a DocumentReference instance is not provided', function() {
     try {
       firebase
         .firestore()
@@ -31,7 +31,7 @@ describe('firestore.WriteBatch.update()', () => {
     }
   });
 
-  it('throws if a DocumentReference firestore instance is different', () => {
+  it('throws if a DocumentReference firestore instance is different', function() {
     try {
       const app2 = firebase.app('secondaryFromNative');
       const docRef = firebase.firestore(app2).doc(`${COLLECTION}/foo`);
@@ -49,7 +49,7 @@ describe('firestore.WriteBatch.update()', () => {
     }
   });
 
-  it('throws if update args are not provided', () => {
+  it('throws if update args are not provided', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
       firebase
@@ -63,7 +63,7 @@ describe('firestore.WriteBatch.update()', () => {
     }
   });
 
-  it('throws if update arg is not an object', () => {
+  it('throws if update arg is not an object', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
       firebase
@@ -77,7 +77,7 @@ describe('firestore.WriteBatch.update()', () => {
     }
   });
 
-  it('throws if update key/values are invalid', () => {
+  it('throws if update key/values are invalid', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
       firebase
@@ -91,7 +91,7 @@ describe('firestore.WriteBatch.update()', () => {
     }
   });
 
-  it('throws if update keys are invalid', () => {
+  it('throws if update keys are invalid', function() {
     try {
       const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
       firebase
@@ -105,7 +105,7 @@ describe('firestore.WriteBatch.update()', () => {
     }
   });
 
-  it('adds the DocumentReference to the internal writes', () => {
+  it('adds the DocumentReference to the internal writes', function() {
     const docRef = firebase.firestore().doc(`${COLLECTION}/foo`);
     const wb = firebase
       .firestore()

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -17,16 +17,16 @@
 const COLLECTION = 'firestore';
 const COLLECTION_GROUP = 'collectionGroup';
 
-describe('firestore()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('firestore()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.firestore);
       app.firestore().app.should.equal(app);
     });
 
     // removing as pending if module.options.hasMultiAppSupport = true
-    it('supports multiple apps', async () => {
+    it('supports multiple apps', async function() {
       firebase.firestore().app.name.should.equal('[DEFAULT]');
 
       firebase
@@ -40,17 +40,17 @@ describe('firestore()', () => {
     });
   });
 
-  describe('batch()', () => {
-    it('returns a new WriteBatch instance', () => {
+  describe('batch()', function() {
+    it('returns a new WriteBatch instance', function() {
       const instance = firebase.firestore().batch();
       instance.constructor.name.should.eql('FirestoreWriteBatch');
     });
   });
 
-  describe('clearPersistence()', () => {});
+  describe('clearPersistence()', function() {});
 
-  describe('collection()', () => {
-    it('throws if path is not a string', () => {
+  describe('collection()', function() {
+    it('throws if path is not a string', function() {
       try {
         firebase.firestore().collection(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -60,7 +60,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if path is empty string', () => {
+    it('throws if path is empty string', function() {
       try {
         firebase.firestore().collection('');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -70,7 +70,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if path does not point to a collection', () => {
+    it('throws if path does not point to a collection', function() {
       try {
         firebase.firestore().collection(`${COLLECTION}/bar`);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -80,15 +80,15 @@ describe('firestore()', () => {
       }
     });
 
-    it('returns a new CollectionReference', () => {
+    it('returns a new CollectionReference', function() {
       const collectionReference = firebase.firestore().collection(COLLECTION);
       should.equal(collectionReference.constructor.name, 'FirestoreCollectionReference');
       collectionReference.path.should.eql(COLLECTION);
     });
   });
 
-  describe('doc()', () => {
-    it('throws if path is not a string', () => {
+  describe('doc()', function() {
+    it('throws if path is not a string', function() {
       try {
         firebase.firestore().doc(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -98,7 +98,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if path is empty string', () => {
+    it('throws if path is empty string', function() {
       try {
         firebase.firestore().doc('');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -108,7 +108,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if path does not point to a document', () => {
+    it('throws if path does not point to a document', function() {
       try {
         firebase.firestore().doc(`${COLLECTION}/bar/baz`);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -118,15 +118,15 @@ describe('firestore()', () => {
       }
     });
 
-    it('returns a new DocumentReference', () => {
+    it('returns a new DocumentReference', function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
       should.equal(docRef.constructor.name, 'FirestoreDocumentReference');
       docRef.path.should.eql(`${COLLECTION}/bar`);
     });
   });
 
-  describe('collectionGroup()', () => {
-    it('throws if id is not a string', () => {
+  describe('collectionGroup()', function() {
+    it('throws if id is not a string', function() {
       try {
         firebase.firestore().collectionGroup(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -136,7 +136,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if id is empty', () => {
+    it('throws if id is empty', function() {
       try {
         firebase.firestore().collectionGroup('');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -146,7 +146,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if id contains forward-slash', () => {
+    it('throws if id contains forward-slash', function() {
       try {
         firebase.firestore().collectionGroup(`${COLLECTION}/bar`);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -156,12 +156,12 @@ describe('firestore()', () => {
       }
     });
 
-    it('returns a new query instance', () => {
+    it('returns a new query instance', function() {
       const query = firebase.firestore().collectionGroup(COLLECTION);
       should.equal(query.constructor.name, 'FirestoreQuery');
     });
 
-    it('performs a collection group query', async () => {
+    it('performs a collection group query', async function() {
       const docRef1 = firebase.firestore().doc(`${COLLECTION}/collectionGroup1`);
       const docRef2 = firebase.firestore().doc(`${COLLECTION}/collectionGroup2`);
       const docRef3 = firebase.firestore().doc(`${COLLECTION}/collectionGroup3`);
@@ -207,7 +207,7 @@ describe('firestore()', () => {
       ]);
     });
 
-    it('performs a collection group query with cursor queries', async () => {
+    it('performs a collection group query with cursor queries', async function() {
       const docRef = firebase.firestore().doc(`${COLLECTION}/collectionGroupCursor`);
 
       const ref1 = await docRef.collection(COLLECTION_GROUP).add({ number: 1 });
@@ -231,15 +231,15 @@ describe('firestore()', () => {
     });
   });
 
-  describe('disableNetwork() & enableNetwork()', () => {
-    it('disables and enables with no errors', async () => {
+  describe('disableNetwork() & enableNetwork()', function() {
+    it('disables and enables with no errors', async function() {
       await firebase.firestore().disableNetwork();
       await firebase.firestore().enableNetwork();
     });
   });
 
-  describe('runTransaction()', () => {
-    it('throws if updateFunction is not a function', () => {
+  describe('runTransaction()', function() {
+    it('throws if updateFunction is not a function', function() {
       try {
         firebase.firestore().runTransaction('foo');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -250,8 +250,8 @@ describe('firestore()', () => {
     });
   });
 
-  describe('settings()', () => {
-    it('throws if settings is not an object', () => {
+  describe('settings()', function() {
+    it('throws if settings is not an object', function() {
       try {
         firebase.firestore().settings('foo');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -261,7 +261,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if passing an incorrect setting key', () => {
+    it('throws if passing an incorrect setting key', function() {
       try {
         firebase.firestore().settings({ foo: 'bar' });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -271,7 +271,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if cacheSizeBytes is not a number', () => {
+    it('throws if cacheSizeBytes is not a number', function() {
       try {
         firebase.firestore().settings({ cacheSizeBytes: 'foo' });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -281,7 +281,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if cacheSizeBytes is less than 1MB', () => {
+    it('throws if cacheSizeBytes is less than 1MB', function() {
       try {
         firebase.firestore().settings({ cacheSizeBytes: 123 });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -291,11 +291,11 @@ describe('firestore()', () => {
       }
     });
     // NOTE: removed as it breaks emulator tests along with 'should clear any cached data' test below
-    xit('accepts an unlimited cache size', () => {
+    xit('accepts an unlimited cache size', function() {
       firebase.firestore().settings({ cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED });
     });
 
-    it('throws if host is not a string', () => {
+    it('throws if host is not a string', function() {
       try {
         firebase.firestore().settings({ host: 123 });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -305,7 +305,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if host is an empty string', () => {
+    it('throws if host is an empty string', function() {
       try {
         firebase.firestore().settings({ host: '' });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -315,7 +315,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if persistence is not a boolean', () => {
+    it('throws if persistence is not a boolean', function() {
       try {
         firebase.firestore().settings({ persistence: 'true' });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -325,7 +325,7 @@ describe('firestore()', () => {
       }
     });
 
-    it('throws if ssl is not a boolean', () => {
+    it('throws if ssl is not a boolean', function() {
       try {
         firebase.firestore().settings({ ssl: 'true' });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -336,9 +336,9 @@ describe('firestore()', () => {
     });
   });
 
-  describe('Clear cached data persistence', () => {
+  describe('Clear cached data persistence', function() {
     // NOTE: removed as it breaks emulator tests along with 'accepts an unlimited cache size' test above
-    xit('should clear any cached data', async () => {
+    xit('should clear any cached data', async function() {
       const db = firebase.firestore();
       const id = 'foobar';
       const ref = db.doc(`${COLLECTION}/${id}`);
@@ -363,8 +363,8 @@ describe('firestore()', () => {
     });
   });
 
-  describe('wait for pending writes', () => {
-    xit('waits for pending writes', async () => {
+  describe('wait for pending writes', function() {
+    xit('waits for pending writes', async function() {
       const waitForPromiseMs = 500;
       const testTimeoutMs = 10000;
 

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -17,9 +17,9 @@
 
 const COLLECTION = 'firestore';
 
-describe('firestore()', () => {
-  describe(COLLECTION, () => {
-    before(async () => {
+describe('firestore()', function() {
+  describe(COLLECTION, function() {
+    before(async function() {
       await Promise.all([
         firebase
           .firestore()
@@ -48,7 +48,7 @@ describe('firestore()', () => {
       ]);
     });
 
-    it('returns all results', async () => {
+    it('returns all results', async function() {
       const db = firebase.firestore();
       const ref = db.collection(COLLECTION).orderBy('number', 'desc');
       const allResultsSnapshot = await ref.get();
@@ -74,7 +74,7 @@ describe('firestore()', () => {
       });
     });
 
-    it('returns first page', async () => {
+    it('returns first page', async function() {
       const db = firebase.firestore();
       const ref = db.collection(COLLECTION).orderBy('number', 'desc');
       const firstPageSnapshot = await ref.limit(2).get();
@@ -89,7 +89,7 @@ describe('firestore()', () => {
       });
     });
 
-    it('returns second page', async () => {
+    it('returns second page', async function() {
       const db = firebase.firestore();
       const ref = db.collection(COLLECTION).orderBy('number', 'desc');
       const firstPageSnapshot = await ref.limit(2).get();

--- a/packages/functions/__tests__/functions.test.ts
+++ b/packages/functions/__tests__/functions.test.ts
@@ -1,16 +1,16 @@
 import functions, { firebase } from '../lib';
 
-describe('Cloud Functions', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('Cloud Functions', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       expect(app.functions).toBeDefined();
       expect(app.functions().httpsCallable).toBeDefined();
     });
   });
 
-  describe('useFunctionsEmulator()', () => {
-    it('useFunctionsEmulator -> uses 10.0.2.2', () => {
+  describe('useFunctionsEmulator()', function() {
+    it('useFunctionsEmulator -> uses 10.0.2.2', function() {
       functions().useFunctionsEmulator('http://localhost');
 
       // @ts-ignore
@@ -23,8 +23,8 @@ describe('Cloud Functions', () => {
     });
   });
 
-  describe('httpcallable()', () => {
-    it('throws an error with an incorrect timeout', () => {
+  describe('httpcallable()', function() {
+    it('throws an error with an incorrect timeout', function() {
       const app = firebase.app();
 
       // @ts-ignore

--- a/packages/functions/e2e/functions.e2e.js
+++ b/packages/functions/e2e/functions.e2e.js
@@ -17,9 +17,9 @@
 
 const { SAMPLE_DATA } = require('@react-native-firebase/private-tests-firebase-functions');
 
-describe('functions()', () => {
-  describe('namespace', () => {
-    it('accepts passing in an FirebaseApp instance as first arg', async () => {
+describe('functions()', function() {
+  describe('namespace', function() {
+    it('accepts passing in an FirebaseApp instance as first arg', async function() {
       const appName = `functionsApp${FirebaseHelpers.id}1`;
       const platformAppConfig = FirebaseHelpers.app.config();
       const app = await firebase.initializeApp(platformAppConfig, appName);
@@ -34,7 +34,7 @@ describe('functions()', () => {
       app.functions().app.name.should.equal(app.name);
     });
 
-    it('accepts passing in a region string as first arg to an app', async () => {
+    it('accepts passing in a region string as first arg to an app', async function() {
       const region = 'europe-west1';
       const functionsForRegion = firebase.app().functions(region);
 
@@ -59,7 +59,7 @@ describe('functions()', () => {
     });
   });
 
-  it('useFunctionsEmulator', async () => {
+  it('useFunctionsEmulator', async function() {
     const region = 'europe-west2';
     const fnName = 'invertaseReactNativeFirebaseFunctionsEmulator';
     const functions = firebase.app().functions(region);
@@ -72,44 +72,44 @@ describe('functions()', () => {
     response.data.fnName.should.equal(fnName);
   });
 
-  describe('httpsCallable(fnName)(args)', () => {
-    it('accepts primitive args: undefined', async () => {
+  describe('httpsCallable(fnName)(args)', function() {
+    it('accepts primitive args: undefined', async function() {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
       const response = await functionRunner();
       response.data.should.equal('null');
     });
 
-    it('accepts primitive args: string', async () => {
+    it('accepts primitive args: string', async function() {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
       const response = await functionRunner('hello');
       response.data.should.equal('string');
     });
 
-    it('accepts primitive args: number', async () => {
+    it('accepts primitive args: number', async function() {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
       const response = await functionRunner(123);
       response.data.should.equal('number');
     });
 
-    it('accepts primitive args: boolean', async () => {
+    it('accepts primitive args: boolean', async function() {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
       const response = await functionRunner(true);
       response.data.should.equal('boolean');
     });
 
-    it('accepts primitive args: null', async () => {
+    it('accepts primitive args: null', async function() {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
       const response = await functionRunner(null);
       response.data.should.equal('null');
     });
 
-    it('accepts array args', async () => {
+    it('accepts array args', async function() {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
       const response = await functionRunner([1, 2, 3, 4]);
       response.data.should.equal('array');
     });
 
-    it('accepts object args', async () => {
+    it('accepts object args', async function() {
       const type = 'object';
       const inputData = SAMPLE_DATA[type];
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
@@ -120,7 +120,7 @@ describe('functions()', () => {
       should.deepEqual(outputData, inputData);
     });
 
-    it('accepts complex nested objects', async () => {
+    it('accepts complex nested objects', async function() {
       const type = 'deepObject';
       const inputData = SAMPLE_DATA[type];
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
@@ -131,7 +131,7 @@ describe('functions()', () => {
       should.deepEqual(outputData, inputData);
     });
 
-    it('accepts complex nested arrays', async () => {
+    it('accepts complex nested arrays', async function() {
       const type = 'deepArray';
       const inputData = SAMPLE_DATA[type];
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
@@ -143,8 +143,8 @@ describe('functions()', () => {
     });
   });
 
-  describe('HttpsError', () => {
-    it('errors return instance of HttpsError', async () => {
+  describe('HttpsError', function() {
+    it('errors return instance of HttpsError', async function() {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
 
       try {
@@ -159,7 +159,7 @@ describe('functions()', () => {
       return Promise.resolve();
     });
 
-    it('HttpsError.details -> allows returning complex data', async () => {
+    it('HttpsError.details -> allows returning complex data', async function() {
       let type = 'deepObject';
       let inputData = SAMPLE_DATA[type];
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
@@ -198,7 +198,7 @@ describe('functions()', () => {
       return Promise.resolve();
     });
 
-    it('HttpsError.details -> allows returning primitives', async () => {
+    it('HttpsError.details -> allows returning primitives', async function() {
       let type = 'number';
       let inputData = SAMPLE_DATA[type];
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');
@@ -271,7 +271,7 @@ describe('functions()', () => {
       return Promise.resolve();
     });
 
-    it('HttpsCallableOptions.timeout will error when timeout is exceeded', async () => {
+    it('HttpsCallableOptions.timeout will error when timeout is exceeded', async function() {
       const fnName = 'invertaseReactNativeFirebaseFunctionsEmulator';
       const region = 'europe-west2';
 

--- a/packages/iid/e2e/iid.e2e.js
+++ b/packages/iid/e2e/iid.e2e.js
@@ -15,18 +15,18 @@
  *
  */
 
-describe('iid()', () => {
-  afterEach(async () => {
+describe('iid()', function() {
+  afterEach(async function() {
     await Utils.sleep(150);
   });
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.iid);
       app.iid().app.should.equal(app);
     });
 
-    it('supports multiple apps', async () => {
+    it('supports multiple apps', async function() {
       firebase.iid().app.name.should.equal('[DEFAULT]');
 
       firebase
@@ -58,14 +58,14 @@ describe('iid()', () => {
     });
   });
 
-  describe('get()', () => {
-    it('returns instance id string', async () => {
+  describe('get()', function() {
+    it('returns instance id string', async function() {
       const iid = await firebase.iid().get();
       iid.should.be.a.String();
     });
   });
 
-  describe('delete()', () => {
+  describe('delete()', function() {
     android.it('deletes the current instance id', async () => {
       const iidBefore = await firebase.iid().get();
       await Utils.sleep(1000);
@@ -80,19 +80,19 @@ describe('iid()', () => {
     });
   });
 
-  describe('getToken()', () => {
-    it('should return an FCM token from getToken with arguments', async () => {
+  describe('getToken()', function() {
+    it('should return an FCM token from getToken with arguments', async function() {
       const authorizedEntity = firebase.iid().app.options.messagingSenderId;
       const token = await firebase.iid().getToken(authorizedEntity, '*');
       token.should.be.a.String();
     });
 
-    it('should return an FCM token from getToken without arguments', async () => {
+    it('should return an FCM token from getToken without arguments', async function() {
       const token = await firebase.iid().getToken();
       token.should.be.a.String();
     });
 
-    it('should return an FCM token from getToken with 1 argument', async () => {
+    it('should return an FCM token from getToken with 1 argument', async function() {
       const authorizedEntity = firebase.iid().app.options.messagingSenderId;
 
       const token = await firebase.iid().getToken(authorizedEntity);
@@ -100,7 +100,7 @@ describe('iid()', () => {
     });
   });
 
-  describe('deleteToken()', () => {
+  describe('deleteToken()', function() {
     android.it('should return nil from deleteToken with arguments', async () => {
       const authorizedEntity = firebase.iid().app.options.messagingSenderId;
       const token = await firebase.iid().deleteToken(authorizedEntity, '*');

--- a/packages/in-app-messaging/e2e/fiam.e2e.js
+++ b/packages/in-app-messaging/e2e/fiam.e2e.js
@@ -15,17 +15,17 @@
  *
  */
 
-describe('inAppMessaging()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('inAppMessaging()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.inAppMessaging);
       app.inAppMessaging().app.should.equal(app);
     });
   });
 
-  describe('setAutomaticDataCollectionEnabled()', () => {
-    it('true', async () => {
+  describe('setAutomaticDataCollectionEnabled()', function() {
+    it('true', async function() {
       if (Platform.ios) {
         // android has this as false when Perf tests run prior - internally all share the same flag on the native SDK
         should.equal(firebase.inAppMessaging().isAutomaticDataCollectionEnabled, true);
@@ -35,7 +35,7 @@ describe('inAppMessaging()', () => {
       await Utils.sleep(2000);
     });
     // TODO flakey on CI
-    xit('false', async () => {
+    xit('false', async function() {
       await device.launchApp();
       await firebase.inAppMessaging().setAutomaticDataCollectionEnabled(false);
       should.equal(firebase.inAppMessaging().isAutomaticDataCollectionEnabled, false);
@@ -45,7 +45,7 @@ describe('inAppMessaging()', () => {
       await Utils.sleep(1500);
     });
 
-    it('errors if not boolean', async () => {
+    it('errors if not boolean', async function() {
       try {
         firebase.inAppMessaging().setAutomaticDataCollectionEnabled();
         return Promise.reject(new Error('Did not throw'));
@@ -56,15 +56,15 @@ describe('inAppMessaging()', () => {
     });
   });
 
-  xdescribe('setMessagesDisplaySuppressed()', () => {
-    it('false', async () => {
+  xdescribe('setMessagesDisplaySuppressed()', function() {
+    it('false', async function() {
       should.equal(firebase.inAppMessaging().isMessagesDisplaySuppressed, false);
       await firebase.inAppMessaging().setMessagesDisplaySuppressed(false);
       should.equal(firebase.inAppMessaging().isMessagesDisplaySuppressed, false);
       await Utils.sleep(2000);
     });
 
-    it('true', async () => {
+    it('true', async function() {
       await device.launchApp();
       await firebase.inAppMessaging().setMessagesDisplaySuppressed(true);
       should.equal(firebase.inAppMessaging().isMessagesDisplaySuppressed, true);
@@ -74,7 +74,7 @@ describe('inAppMessaging()', () => {
       await Utils.sleep(1500);
     });
 
-    it('errors if not boolean', async () => {
+    it('errors if not boolean', async function() {
       try {
         firebase.inAppMessaging().setMessagesDisplaySuppressed();
         return Promise.reject(new Error('Did not throw'));
@@ -85,8 +85,8 @@ describe('inAppMessaging()', () => {
     });
   });
 
-  xdescribe('triggerEvent()', () => {
-    it('no exceptions thrown', async () => {
+  xdescribe('triggerEvent()', function() {
+    it('no exceptions thrown', async function() {
       await device.launchApp();
       await firebase.inAppMessaging().triggerEvent('eventName');
     });

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -15,17 +15,17 @@
  *
  */
 
-describe('messaging()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('messaging()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.messaging);
       app.messaging().app.should.equal(app);
     });
   });
 
-  describe('setAutoInitEnabled()', () => {
-    it('throws if enabled is not a boolean', () => {
+  describe('setAutoInitEnabled()', function() {
+    it('throws if enabled is not a boolean', function() {
       try {
         firebase.messaging().setAutoInitEnabled(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -35,7 +35,7 @@ describe('messaging()', () => {
       }
     });
 
-    it('sets the value', async () => {
+    it('sets the value', async function() {
       should.equal(firebase.messaging().isAutoInitEnabled, true);
       await firebase.messaging().setAutoInitEnabled(false);
       should.equal(firebase.messaging().isAutoInitEnabled, false);
@@ -46,74 +46,74 @@ describe('messaging()', () => {
     });
   });
 
-  describe('isDeviceRegisteredForRemoteMessages', () => {
+  describe('isDeviceRegisteredForRemoteMessages', function() {
     android.it('returns true on android', () => {
       should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, true);
     });
-    it('defaults to false on ios before registering', () => {
+    it('defaults to false on ios before registering', function() {
       if (device.getPlatform() === 'ios') {
         should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, false);
       }
     });
   });
 
-  describe('unregisterDeviceForRemoteMessages', () => {
+  describe('unregisterDeviceForRemoteMessages', function() {
     android.it('resolves on android', async () => {
       await firebase.messaging().unregisterDeviceForRemoteMessages();
     });
   });
 
-  describe('hasPermission', () => {
+  describe('hasPermission', function() {
     android.it('returns true android (default)', async () => {
       should.equal(await firebase.messaging().hasPermission(), true);
     });
-    it('returns -1 on ios (default)', async () => {
+    it('returns -1 on ios (default)', async function() {
       if (device.getPlatform() === 'ios') {
         should.equal(await firebase.messaging().hasPermission(), -1);
       }
     });
   });
 
-  describe('unregisterDeviceForRemoteMessages', () => {
+  describe('unregisterDeviceForRemoteMessages', function() {
     android.it('resolves on android', async () => {
       await firebase.messaging().unregisterDeviceForRemoteMessages();
     });
   });
 
-  describe('requestPermission', () => {
+  describe('requestPermission', function() {
     android.it('resolves 1 on android', async () => {
       should.equal(await firebase.messaging().requestPermission(), 1);
     });
   });
 
-  describe('getAPNSToken', () => {
+  describe('getAPNSToken', function() {
     android.it('resolves null on android', async () => {
       should.equal(await firebase.messaging().getAPNSToken(), null);
     });
-    it('resolves null on ios if using simulator', async () => {
+    it('resolves null on ios if using simulator', async function() {
       if (device.getPlatform() === 'ios') {
         should.equal(await firebase.messaging().getAPNSToken(), null);
       }
     });
   });
 
-  describe('unsupported web sdk methods', () => {
-    it('useServiceWorker should not error when called', () => {
+  describe('unsupported web sdk methods', function() {
+    it('useServiceWorker should not error when called', function() {
       firebase.messaging().useServiceWorker();
     });
-    it('usePublicVapidKey should not error when called', () => {
+    it('usePublicVapidKey should not error when called', function() {
       firebase.messaging().usePublicVapidKey();
     });
   });
 
-  describe('getInitialNotification', () => {
-    it('returns null when no initial notification', async () => {
+  describe('getInitialNotification', function() {
+    it('returns null when no initial notification', async function() {
       should.equal(await firebase.messaging().getInitialNotification(), null);
     });
   });
 
-  describe('getToken()', () => {
-    it('throws if authorizedEntity is not a string', () => {
+  describe('getToken()', function() {
+    it('throws if authorizedEntity is not a string', function() {
       try {
         firebase.messaging().getToken(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -123,7 +123,7 @@ describe('messaging()', () => {
       }
     });
 
-    it('throws if scope is not a string', () => {
+    it('throws if scope is not a string', function() {
       try {
         firebase.messaging().getToken('123', 123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -134,8 +134,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('deleteToken()', () => {
-    it('throws if authorizedEntity is not a string', () => {
+  describe('deleteToken()', function() {
+    it('throws if authorizedEntity is not a string', function() {
       try {
         firebase.messaging().deleteToken(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -145,7 +145,7 @@ describe('messaging()', () => {
       }
     });
 
-    it('throws if scope is not a string', () => {
+    it('throws if scope is not a string', function() {
       try {
         firebase.messaging().deleteToken('123', 123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -155,7 +155,7 @@ describe('messaging()', () => {
       }
     });
 
-    xit('generate a new token after deleting', async () => {
+    xit('generate a new token after deleting', async function() {
       // const token1 = await firebase.messaging().getToken();
 
       await firebase.messaging().deleteToken();
@@ -164,8 +164,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('onMessage()', () => {
-    it('throws if listener is not a function', () => {
+  describe('onMessage()', function() {
+    it('throws if listener is not a function', function() {
       try {
         firebase.messaging().onMessage({});
         return Promise.reject(new Error('Did not throw Error.'));
@@ -175,7 +175,7 @@ describe('messaging()', () => {
       }
     });
 
-    xit('receives messages when the app is in the foreground', async () => {
+    xit('receives messages when the app is in the foreground', async function() {
       const spy = sinon.spy();
       const unsubscribe = firebase.messaging().onMessage(spy);
       if (device.getPlatform() === 'ios') {
@@ -196,8 +196,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('onTokenRefresh()', () => {
-    it('throws if listener is not a function', () => {
+  describe('onTokenRefresh()', function() {
+    it('throws if listener is not a function', function() {
       try {
         firebase.messaging().onTokenRefresh({});
         return Promise.reject(new Error('Did not throw Error.'));
@@ -208,8 +208,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('onDeletedMessages()', () => {
-    it('throws if listener is not a function', () => {
+  describe('onDeletedMessages()', function() {
+    it('throws if listener is not a function', function() {
       try {
         firebase.messaging().onDeletedMessages(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -220,8 +220,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('onMessageSent()', () => {
-    it('throws if listener is not a function', () => {
+  describe('onMessageSent()', function() {
+    it('throws if listener is not a function', function() {
       try {
         firebase.messaging().onMessageSent(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -232,8 +232,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('onSendError()', () => {
-    it('throws if listener is not a function', () => {
+  describe('onSendError()', function() {
+    it('throws if listener is not a function', function() {
       try {
         firebase.messaging().onSendError('123');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -244,8 +244,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('setBackgroundMessageHandler()', () => {
-    it('throws if handler is not a function', () => {
+  describe('setBackgroundMessageHandler()', function() {
+    it('throws if handler is not a function', function() {
       try {
         firebase.messaging().setBackgroundMessageHandler('123');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -282,8 +282,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('subscribeToTopic()', () => {
-    it('throws if topic is not a string', () => {
+  describe('subscribeToTopic()', function() {
+    it('throws if topic is not a string', function() {
       try {
         firebase.messaging().subscribeToTopic(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -293,7 +293,7 @@ describe('messaging()', () => {
       }
     });
 
-    it('throws if topic contains a /', () => {
+    it('throws if topic contains a /', function() {
       try {
         firebase.messaging().subscribeToTopic('foo/bar');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -304,8 +304,8 @@ describe('messaging()', () => {
     });
   });
 
-  describe('unsubscribeFromTopic()', () => {
-    it('throws if topic is not a string', () => {
+  describe('unsubscribeFromTopic()', function() {
+    it('throws if topic is not a string', function() {
       try {
         firebase.messaging().unsubscribeFromTopic(123);
         return Promise.reject(new Error('Did not throw Error.'));
@@ -315,7 +315,7 @@ describe('messaging()', () => {
       }
     });
 
-    it('throws if topic contains a /', () => {
+    it('throws if topic contains a /', function() {
       try {
         firebase.messaging().unsubscribeFromTopic('foo/bar');
         return Promise.reject(new Error('Did not throw Error.'));

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -74,12 +74,6 @@ describe('messaging()', function() {
     });
   });
 
-  describe('unregisterDeviceForRemoteMessages', function() {
-    android.it('resolves on android', async () => {
-      await firebase.messaging().unregisterDeviceForRemoteMessages();
-    });
-  });
-
   describe('requestPermission', function() {
     android.it('resolves 1 on android', async () => {
       should.equal(await firebase.messaging().requestPermission(), 1);

--- a/packages/messaging/e2e/remoteMessage.e2e.js
+++ b/packages/messaging/e2e/remoteMessage.e2e.js
@@ -47,7 +47,7 @@ describe('messaging().sendMessage(*)', function() {
   });
 
   android.describe('to', () => {
-    it('throws if not a string', function() {
+    it('throws if to is not a string', function() {
       try {
         firebase.messaging().sendMessage({
           to: 123,
@@ -59,7 +59,7 @@ describe('messaging().sendMessage(*)', function() {
       }
     });
 
-    it('accepts custom value', async function() {
+    it('accepts custom to value', async function() {
       await firebase.messaging().sendMessage({
         to: 'foobar',
       });
@@ -67,7 +67,7 @@ describe('messaging().sendMessage(*)', function() {
   });
 
   android.describe('messageId', () => {
-    it('throws if not a string', function() {
+    it('throws if messageId is not a string', function() {
       try {
         firebase.messaging().sendMessage({
           messageId: 123,
@@ -79,7 +79,7 @@ describe('messaging().sendMessage(*)', function() {
       }
     });
 
-    it('accepts custom value', async function() {
+    it('accepts custom messageId value', async function() {
       await firebase.messaging().sendMessage({
         messageId: 'foobar',
       });
@@ -123,7 +123,7 @@ describe('messaging().sendMessage(*)', function() {
       }
     });
 
-    it('accepts custom value', async function() {
+    it('accepts custom ttl value', async function() {
       await firebase.messaging().sendMessage({
         ttl: 123,
       });
@@ -131,7 +131,7 @@ describe('messaging().sendMessage(*)', function() {
   });
 
   android.describe('data', () => {
-    it('throws if not an object', function() {
+    it('throws if data not an object', function() {
       try {
         firebase.messaging().sendMessage({
           data: 123,
@@ -143,7 +143,7 @@ describe('messaging().sendMessage(*)', function() {
       }
     });
 
-    it('accepts custom value', async function() {
+    it('accepts custom data value', async function() {
       await firebase.messaging().sendMessage({
         data: {
           foo: 'bar',
@@ -153,7 +153,7 @@ describe('messaging().sendMessage(*)', function() {
   });
 
   android.describe('collapseKey', () => {
-    it('throws if not a string', function() {
+    it('throws if collapseKey is not a string', function() {
       try {
         firebase.messaging().sendMessage({
           collapseKey: 123,
@@ -165,7 +165,7 @@ describe('messaging().sendMessage(*)', function() {
       }
     });
 
-    it('accepts custom value', async function() {
+    it('accepts custom collapseKey value', async function() {
       await firebase.messaging().sendMessage({
         collapseKey: 'foobar',
       });
@@ -173,7 +173,7 @@ describe('messaging().sendMessage(*)', function() {
   });
 
   android.describe('messageType', () => {
-    it('throws if not a string', function() {
+    it('throws if messageType is not a string', function() {
       try {
         firebase.messaging().sendMessage({
           messageType: 123,
@@ -185,7 +185,7 @@ describe('messaging().sendMessage(*)', function() {
       }
     });
 
-    it('accepts custom value', async function() {
+    it('accepts custom messageType value', async function() {
       await firebase.messaging().sendMessage({
         messageType: 'foobar',
       });

--- a/packages/messaging/e2e/remoteMessage.e2e.js
+++ b/packages/messaging/e2e/remoteMessage.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('messaging().sendMessage(*)', () => {
-  it('throws if used on ios', () => {
+describe('messaging().sendMessage(*)', function() {
+  it('throws if used on ios', function() {
     if (device.getPlatform() === 'ios') {
       try {
         firebase.messaging().sendMessage(123);
@@ -47,7 +47,7 @@ describe('messaging().sendMessage(*)', () => {
   });
 
   android.describe('to', () => {
-    it('throws if not a string', () => {
+    it('throws if not a string', function() {
       try {
         firebase.messaging().sendMessage({
           to: 123,
@@ -59,7 +59,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('accepts custom value', async () => {
+    it('accepts custom value', async function() {
       await firebase.messaging().sendMessage({
         to: 'foobar',
       });
@@ -67,7 +67,7 @@ describe('messaging().sendMessage(*)', () => {
   });
 
   android.describe('messageId', () => {
-    it('throws if not a string', () => {
+    it('throws if not a string', function() {
       try {
         firebase.messaging().sendMessage({
           messageId: 123,
@@ -79,7 +79,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('accepts custom value', async () => {
+    it('accepts custom value', async function() {
       await firebase.messaging().sendMessage({
         messageId: 'foobar',
       });
@@ -87,7 +87,7 @@ describe('messaging().sendMessage(*)', () => {
   });
 
   android.describe('ttl', () => {
-    it('throws if not a number', () => {
+    it('throws if not a number', function() {
       try {
         firebase.messaging().sendMessage({
           ttl: '123',
@@ -99,7 +99,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('throws if negative number', () => {
+    it('throws if negative number', function() {
       try {
         firebase.messaging().sendMessage({
           ttl: -2,
@@ -111,7 +111,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('throws if float number', () => {
+    it('throws if float number', function() {
       try {
         firebase.messaging().sendMessage({
           ttl: 123.4,
@@ -123,7 +123,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('accepts custom value', async () => {
+    it('accepts custom value', async function() {
       await firebase.messaging().sendMessage({
         ttl: 123,
       });
@@ -131,7 +131,7 @@ describe('messaging().sendMessage(*)', () => {
   });
 
   android.describe('data', () => {
-    it('throws if not an object', () => {
+    it('throws if not an object', function() {
       try {
         firebase.messaging().sendMessage({
           data: 123,
@@ -143,7 +143,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('accepts custom value', async () => {
+    it('accepts custom value', async function() {
       await firebase.messaging().sendMessage({
         data: {
           foo: 'bar',
@@ -153,7 +153,7 @@ describe('messaging().sendMessage(*)', () => {
   });
 
   android.describe('collapseKey', () => {
-    it('throws if not a string', () => {
+    it('throws if not a string', function() {
       try {
         firebase.messaging().sendMessage({
           collapseKey: 123,
@@ -165,7 +165,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('accepts custom value', async () => {
+    it('accepts custom value', async function() {
       await firebase.messaging().sendMessage({
         collapseKey: 'foobar',
       });
@@ -173,7 +173,7 @@ describe('messaging().sendMessage(*)', () => {
   });
 
   android.describe('messageType', () => {
-    it('throws if not a string', () => {
+    it('throws if not a string', function() {
       try {
         firebase.messaging().sendMessage({
           messageType: 123,
@@ -185,7 +185,7 @@ describe('messaging().sendMessage(*)', () => {
       }
     });
 
-    it('accepts custom value', async () => {
+    it('accepts custom value', async function() {
       await firebase.messaging().sendMessage({
         messageType: 'foobar',
       });

--- a/packages/ml/e2e/documentText.e2e.js
+++ b/packages/ml/e2e/documentText.e2e.js
@@ -42,8 +42,8 @@ function documentTextBaseElementValidate(documentTextBase) {
 
 let testImageFile;
 
-describe('ml.document.text', () => {
-  before(async () => {
+describe('ml.document.text', function() {
+  before(async function() {
     testImageFile = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/text.png`;
     await firebase
       .storage()
@@ -51,8 +51,8 @@ describe('ml.document.text', () => {
       .writeToFile(testImageFile);
   });
 
-  describe('MLCloudDocumentTextRecognizerOptions', () => {
-    it('throws if not an object', async () => {
+  describe('MLCloudDocumentTextRecognizerOptions', function() {
+    it('throws if not an object', async function() {
       try {
         await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, 'foo');
         return Promise.reject(new Error('Did not throw Error.'));
@@ -64,7 +64,7 @@ describe('ml.document.text', () => {
       }
     });
 
-    it('throws if enforceCertFingerprintMatch is not a boolean', async () => {
+    it('throws if enforceCertFingerprintMatch is not a boolean', async function() {
       try {
         await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, {
           enforceCertFingerprintMatch: 'true',
@@ -78,13 +78,13 @@ describe('ml.document.text', () => {
       }
     });
 
-    it('sets enforceCertFingerprintMatch', async () => {
+    it('sets enforceCertFingerprintMatch', async function() {
       await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, {
         enforceCertFingerprintMatch: false,
       });
     });
 
-    it('throws if apiKeyOverride is not a string', async () => {
+    it('throws if apiKeyOverride is not a string', async function() {
       try {
         await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, {
           apiKeyOverride: true,
@@ -98,7 +98,7 @@ describe('ml.document.text', () => {
       }
     });
 
-    it('throws if languageHints is not an array', async () => {
+    it('throws if languageHints is not an array', async function() {
       try {
         await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, {
           languageHints: 'en',
@@ -112,7 +112,7 @@ describe('ml.document.text', () => {
       }
     });
 
-    it('throws if languageHints is empty array', async () => {
+    it('throws if languageHints is empty array', async function() {
       try {
         await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, {
           languageHints: [],
@@ -126,7 +126,7 @@ describe('ml.document.text', () => {
       }
     });
 
-    it('throws if languageHints contains non-string', async () => {
+    it('throws if languageHints contains non-string', async function() {
       try {
         await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, {
           languageHints: [123],
@@ -140,15 +140,15 @@ describe('ml.document.text', () => {
       }
     });
 
-    it('sets hinted languages', async () => {
+    it('sets hinted languages', async function() {
       await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile, {
         languageHints: ['fr'],
       });
     });
   });
 
-  describe('cloudDocumentTextRecognizerProcessImage()', () => {
-    it('should throw if image path is not a string', () => {
+  describe('cloudDocumentTextRecognizerProcessImage()', function() {
+    it('should throw if image path is not a string', function() {
       try {
         firebase.ml().cloudDocumentTextRecognizerProcessImage(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -158,7 +158,7 @@ describe('ml.document.text', () => {
       }
     });
 
-    it('should return a MLDocumentText representation for an image', async () => {
+    it('should return a MLDocumentText representation for an image', async function() {
       const res = await firebase.ml().cloudDocumentTextRecognizerProcessImage(testImageFile);
 
       res.text.should.be.a.String();

--- a/packages/ml/e2e/label.e2e.js
+++ b/packages/ml/e2e/label.e2e.js
@@ -17,8 +17,8 @@
 
 let testImageFile;
 
-describe('ml.label', () => {
-  before(async () => {
+describe('ml.label', function() {
+  before(async function() {
     testImageFile = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/crab.jpg`;
     await firebase
       .storage()
@@ -26,8 +26,8 @@ describe('ml.label', () => {
       .writeToFile(testImageFile);
   });
 
-  describe('cloudImageLabelerProcessImage()', () => {
-    it('should throw if image path is not a string', () => {
+  describe('cloudImageLabelerProcessImage()', function() {
+    it('should throw if image path is not a string', function() {
       try {
         firebase.ml().cloudImageLabelerProcessImage(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -37,7 +37,7 @@ describe('ml.label', () => {
       }
     });
 
-    xit('should return a cloud label array', async () => {
+    xit('should return a cloud label array', async function() {
       const res = await firebase.ml().cloudImageLabelerProcessImage(testImageFile);
 
       res.should.be.Array();
@@ -51,8 +51,8 @@ describe('ml.label', () => {
     });
   });
 
-  describe('MLCloudImageLabelerOptions', () => {
-    it('throws if not an object', async () => {
+  describe('MLCloudImageLabelerOptions', function() {
+    it('throws if not an object', async function() {
       try {
         await firebase.ml().cloudImageLabelerProcessImage(testImageFile, '123');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -62,8 +62,8 @@ describe('ml.label', () => {
       }
     });
 
-    describe('confidenceThreshold', () => {
-      it('should throw if confidence threshold is not a number', async () => {
+    describe('confidenceThreshold', function() {
+      it('should throw if confidence threshold is not a number', async function() {
         try {
           await firebase.ml().cloudImageLabelerProcessImage(testImageFile, {
             confidenceThreshold: '0.2',
@@ -77,7 +77,7 @@ describe('ml.label', () => {
         }
       });
 
-      it('should throw if confidence threshold is not between 0 & 1', async () => {
+      it('should throw if confidence threshold is not between 0 & 1', async function() {
         try {
           await firebase.ml().cloudImageLabelerProcessImage(testImageFile, {
             confidenceThreshold: 1.1,
@@ -91,7 +91,7 @@ describe('ml.label', () => {
         }
       });
 
-      xit('should accept options and return cloud labels', async () => {
+      xit('should accept options and return cloud labels', async function() {
         const res = await firebase.ml().cloudImageLabelerProcessImage(testImageFile, {
           confidenceThreshold: 0.8,
         });
@@ -107,8 +107,8 @@ describe('ml.label', () => {
       });
     });
 
-    describe('enforceCertFingerprintMatch', () => {
-      it('throws if not a boolean', async () => {
+    describe('enforceCertFingerprintMatch', function() {
+      it('throws if not a boolean', async function() {
         try {
           await firebase.ml().cloudImageLabelerProcessImage(testImageFile, {
             enforceCertFingerprintMatch: 'true',
@@ -122,15 +122,15 @@ describe('ml.label', () => {
         }
       });
 
-      xit('sets enforceCertFingerprintMatch', async () => {
+      xit('sets enforceCertFingerprintMatch', async function() {
         await firebase.ml().cloudImageLabelerProcessImage(testImageFile, {
           enforceCertFingerprintMatch: false,
         });
       });
     });
 
-    xdescribe('apiKeyOverride', () => {
-      it('throws if apiKeyOverride is not a string', async () => {
+    xdescribe('apiKeyOverride', function() {
+      it('throws if apiKeyOverride is not a string', async function() {
         try {
           await firebase.ml().cloudImageLabelerProcessImage(testImageFile, {
             apiKeyOverride: true,

--- a/packages/ml/e2e/landmark.e2e.js
+++ b/packages/ml/e2e/landmark.e2e.js
@@ -16,8 +16,8 @@
  */
 let testImageFile;
 
-describe('ml.landmark', () => {
-  before(async () => {
+describe('ml.landmark', function() {
+  before(async function() {
     testImageFile = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/landmark.jpg`;
     await firebase
       .storage()
@@ -25,8 +25,8 @@ describe('ml.landmark', () => {
       .writeToFile(testImageFile);
   });
 
-  describe('cloudLandmarkRecognizerProcessImage()', () => {
-    it('should throw if image path is not a string', () => {
+  describe('cloudLandmarkRecognizerProcessImage()', function() {
+    it('should throw if image path is not a string', function() {
       try {
         firebase.ml().cloudLandmarkRecognizerProcessImage(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -36,7 +36,7 @@ describe('ml.landmark', () => {
       }
     });
 
-    xit('should return an array of landmark information', async () => {
+    xit('should return an array of landmark information', async function() {
       const res = await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile);
 
       res.should.be.Array();
@@ -59,8 +59,8 @@ describe('ml.landmark', () => {
     });
   });
 
-  describe('MLCloudLandmarkRecognizerOptions', () => {
-    it('throws if not an object', async () => {
+  describe('MLCloudLandmarkRecognizerOptions', function() {
+    it('throws if not an object', async function() {
       try {
         await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, '123');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -72,8 +72,8 @@ describe('ml.landmark', () => {
       }
     });
 
-    describe('cloudLandmarkRecognizerOptions', () => {
-      it('throws if not a boolean', async () => {
+    describe('cloudLandmarkRecognizerOptions', function() {
+      it('throws if not a boolean', async function() {
         try {
           await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
             enforceCertFingerprintMatch: 'false',
@@ -87,13 +87,13 @@ describe('ml.landmark', () => {
         }
       });
 
-      xit('sets cloudLandmarkRecognizerOptions', async () => {
+      xit('sets cloudLandmarkRecognizerOptions', async function() {
         await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
           enforceCertFingerprintMatch: false,
         });
       });
 
-      it('throws if apiKeyOverride is not a string', async () => {
+      it('throws if apiKeyOverride is not a string', async function() {
         try {
           await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
             apiKeyOverride: true,
@@ -108,8 +108,8 @@ describe('ml.landmark', () => {
       });
     });
     // TODO temporarily disable test suite - is flakey on CI - needs investigating
-    describe('maxResults', () => {
-      it('throws if maxResults is not a number', async () => {
+    describe('maxResults', function() {
+      it('throws if maxResults is not a number', async function() {
         try {
           await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
             maxResults: '2',
@@ -123,7 +123,7 @@ describe('ml.landmark', () => {
         }
       });
 
-      xit('limits the maximum results', async () => {
+      xit('limits the maximum results', async function() {
         const res = await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
           maxResults: 3,
         });
@@ -135,8 +135,8 @@ describe('ml.landmark', () => {
       });
     });
 
-    describe('modelType', () => {
-      it('throws if model is invalid', async () => {
+    describe('modelType', function() {
+      it('throws if model is invalid', async function() {
         try {
           await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
             modelType: 3,
@@ -150,7 +150,7 @@ describe('ml.landmark', () => {
         }
       });
 
-      xit('sets modelType', async () => {
+      xit('sets modelType', async function() {
         await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
           modelType: firebase.ml.MLCloudLandmarkRecognizerModelType.STABLE_MODEL,
         });
@@ -160,7 +160,7 @@ describe('ml.landmark', () => {
         });
       });
 
-      xit('uses a latest model', async () => {
+      xit('uses a latest model', async function() {
         const res = await firebase.ml().cloudLandmarkRecognizerProcessImage(testImageFile, {
           modelType: firebase.ml.MLCloudLandmarkRecognizerModelType.LATEST_MODEL,
         });

--- a/packages/ml/e2e/ml.e2e.js
+++ b/packages/ml/e2e/ml.e2e.js
@@ -15,15 +15,15 @@
  *
  */
 
-describe('ml()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('ml()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.ml);
       app.ml().app.should.equal(app);
     });
 
-    it('supports multiple apps', async () => {
+    it('supports multiple apps', async function() {
       firebase.ml().app.name.should.equal('[DEFAULT]');
 
       firebase.ml(firebase.app('secondaryFromNative')).app.name.should.equal('secondaryFromNative');

--- a/packages/ml/e2e/text.e2e.js
+++ b/packages/ml/e2e/text.e2e.js
@@ -69,8 +69,8 @@ function textBaseElementValidate(textBase, cloud = false) {
 
 let testImageFile;
 
-describe('ml.text', () => {
-  before(async () => {
+describe('ml.text', function() {
+  before(async function() {
     testImageFile = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/text.png`;
     await firebase
       .storage()
@@ -78,8 +78,8 @@ describe('ml.text', () => {
       .writeToFile(testImageFile);
   });
 
-  describe('MLCloudTextRecognizerOptions', () => {
-    it('throws if not an object', async () => {
+  describe('MLCloudTextRecognizerOptions', function() {
+    it('throws if not an object', async function() {
       try {
         await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, '123');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -89,8 +89,8 @@ describe('ml.text', () => {
       }
     });
 
-    describe('enforceCertFingerprintMatch', () => {
-      it('throws if not a boolean', async () => {
+    describe('enforceCertFingerprintMatch', function() {
+      it('throws if not a boolean', async function() {
         try {
           await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
             enforceCertFingerprintMatch: 'false',
@@ -104,15 +104,15 @@ describe('ml.text', () => {
         }
       });
 
-      it('sets a value', async () => {
+      it('sets a value', async function() {
         await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
           enforceCertFingerprintMatch: false,
         });
       });
     });
 
-    describe('apiKeyOverride', () => {
-      it('throws if apiKeyOverride is not a string', async () => {
+    describe('apiKeyOverride', function() {
+      it('throws if apiKeyOverride is not a string', async function() {
         try {
           await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
             apiKeyOverride: true,
@@ -127,8 +127,8 @@ describe('ml.text', () => {
       });
     });
 
-    describe('languageHints', () => {
-      it('throws if not array', async () => {
+    describe('languageHints', function() {
+      it('throws if not array', async function() {
         try {
           await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
             languageHints: 'en',
@@ -142,7 +142,7 @@ describe('ml.text', () => {
         }
       });
 
-      it('throws if empty array', async () => {
+      it('throws if empty array', async function() {
         try {
           await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
             languageHints: [],
@@ -156,7 +156,7 @@ describe('ml.text', () => {
         }
       });
 
-      it('throws if array contains non-string values', async () => {
+      it('throws if array contains non-string values', async function() {
         try {
           await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
             languageHints: [123],
@@ -170,15 +170,15 @@ describe('ml.text', () => {
         }
       });
 
-      it('sets hintedLanguages', async () => {
+      it('sets hintedLanguages', async function() {
         await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
           languageHints: ['fr'],
         });
       });
     });
 
-    describe('modelType', () => {
-      it('throws if invalid type', async () => {
+    describe('modelType', function() {
+      it('throws if invalid type', async function() {
         try {
           await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
             modelType: 7,
@@ -190,7 +190,7 @@ describe('ml.text', () => {
         }
       });
 
-      it('sets modelType', async () => {
+      it('sets modelType', async function() {
         await firebase.ml().cloudTextRecognizerProcessImage(testImageFile, {
           modelType: firebase.ml.MLCloudTextRecognizerModelType.SPARSE_MODEL,
         });
@@ -198,8 +198,8 @@ describe('ml.text', () => {
     });
   });
 
-  describe('cloudTextRecognizerProcessImage()', () => {
-    it('should throw if image path is not a string', () => {
+  describe('cloudTextRecognizerProcessImage()', function() {
+    it('should throw if image path is not a string', function() {
       try {
         firebase.ml().cloudTextRecognizerProcessImage(123);
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -209,7 +209,7 @@ describe('ml.text', () => {
       }
     });
 
-    it('should return a VisionText representation for an image', async () => {
+    it('should return a VisionText representation for an image', async function() {
       const res = await firebase.ml().cloudTextRecognizerProcessImage(testImageFile);
       res.text.should.be.a.String();
       res.blocks.should.be.an.Array();

--- a/packages/perf/__tests__/perf.test.ts
+++ b/packages/perf/__tests__/perf.test.ts
@@ -1,16 +1,16 @@
 import perf, { firebase } from '../lib';
 
-describe('Performance Monitoring', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('Performance Monitoring', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       expect(app.perf).toBeDefined();
       expect(app.perf().app).toEqual(app);
     });
   });
 
-  describe('setPerformanceCollectionEnabled', () => {
-    it('errors if not boolean', () => {
+  describe('setPerformanceCollectionEnabled', function() {
+    it('errors if not boolean', function() {
       expect(() => {
         // @ts-ignore
         perf().setPerformanceCollectionEnabled();
@@ -18,8 +18,8 @@ describe('Performance Monitoring', () => {
     });
   });
 
-  describe('newTrace()', () => {
-    it('returns an instance of Trace', () => {
+  describe('newTrace()', function() {
+    it('returns an instance of Trace', function() {
       const trace = perf().newTrace('invertase');
       expect(trace.constructor.name).toEqual('Trace');
 
@@ -27,7 +27,7 @@ describe('Performance Monitoring', () => {
       expect(trace._identifier).toEqual('invertase');
     });
 
-    it('errors if identifier not a string', () => {
+    it('errors if identifier not a string', function() {
       try {
         // @ts-ignore
         perf().newTrace(1337);
@@ -40,7 +40,7 @@ describe('Performance Monitoring', () => {
       }
     });
 
-    it('errors if identifier length > 100', () => {
+    it('errors if identifier length > 100', function() {
       try {
         perf().newTrace(new Array(101).fill('i').join(''));
         return Promise.reject(new Error('Did not throw'));
@@ -53,8 +53,8 @@ describe('Performance Monitoring', () => {
     });
   });
 
-  describe('newHttpMetric()', () => {
-    it('returns an instance of HttpMetric', async () => {
+  describe('newHttpMetric()', function() {
+    it('returns an instance of HttpMetric', async function() {
       const metric = perf().newHttpMetric('https://invertase.io', 'GET');
       expect(metric.constructor.name).toEqual('HttpMetric');
 
@@ -65,7 +65,7 @@ describe('Performance Monitoring', () => {
       expect(metric._httpMethod).toEqual('GET');
     });
 
-    it('errors if url not a string', async () => {
+    it('errors if url not a string', async function() {
       try {
         // @ts-ignore
         perf().newHttpMetric(1337, 7331);
@@ -76,7 +76,7 @@ describe('Performance Monitoring', () => {
       }
     });
 
-    it('errors if httpMethod not a string', async () => {
+    it('errors if httpMethod not a string', async function() {
       try {
         // @ts-ignore
         perf().newHttpMetric('https://invertase.io', 1337);
@@ -89,7 +89,7 @@ describe('Performance Monitoring', () => {
       }
     });
 
-    it('errors if httpMethod not a valid type', async () => {
+    it('errors if httpMethod not a valid type', async function() {
       try {
         // @ts-ignore
         perf().newHttpMetric('https://invertase.io', 'FIRE');
@@ -103,8 +103,8 @@ describe('Performance Monitoring', () => {
     });
   });
 
-  describe('setPerformanceCollectionEnabled()', () => {
-    it('errors if not boolean', async () => {
+  describe('setPerformanceCollectionEnabled()', function() {
+    it('errors if not boolean', async function() {
       try {
         // @ts-ignore
         firebase.perf().setPerformanceCollectionEnabled();

--- a/packages/perf/e2e/HttpMetric.e2e.js
+++ b/packages/perf/e2e/HttpMetric.e2e.js
@@ -18,9 +18,9 @@
 const aCoolUrl = 'https://invertase.io';
 
 android.describe('perf()', () => {
-  describe('HttpMetric', () => {
-    describe('start()', () => {
-      it('correctly starts with internal flag ', async () => {
+  describe('HttpMetric', function() {
+    describe('start()', function() {
+      it('correctly starts with internal flag ', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         await httpMetric.start();
         httpMetric.setHttpResponseCode(200);
@@ -29,7 +29,7 @@ android.describe('perf()', () => {
         await httpMetric.stop();
       });
 
-      it('resolves null if already started', async () => {
+      it('resolves null if already started', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'POST');
         await httpMetric.start();
         should.equal(httpMetric._started, true);
@@ -40,8 +40,8 @@ android.describe('perf()', () => {
       });
     });
 
-    describe('stop()', () => {
-      it('correctly stops with internal flag ', async () => {
+    describe('stop()', function() {
+      it('correctly stops with internal flag ', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         await httpMetric.start();
         httpMetric.setHttpResponseCode(500);
@@ -55,7 +55,7 @@ android.describe('perf()', () => {
         should.equal(httpMetric._stopped, true);
       });
 
-      it('resolves null if already stopped', async () => {
+      it('resolves null if already stopped', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'POST');
         await httpMetric.start();
         await Utils.sleep(100);
@@ -63,7 +63,7 @@ android.describe('perf()', () => {
         should.equal(await httpMetric.stop(), null);
       });
 
-      it('handles floating point numbers', async () => {
+      it('handles floating point numbers', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'POST');
         await httpMetric.start();
         const floatingPoint = 500.447553;
@@ -101,21 +101,21 @@ android.describe('perf()', () => {
     //   });
     // });
 
-    describe('getAttribute()', async () => {
-      it('should return null if attribute does not exist', async () => {
+    describe('getAttribute()', function() {
+      it('should return null if attribute does not exist', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         const value = httpMetric.getAttribute('inver');
         should.equal(value, null);
       });
 
-      it('should return an attribute string value', async () => {
+      it('should return an attribute string value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.putAttribute('inver', 'tase');
         const value = httpMetric.getAttribute('inver');
         should.equal(value, 'tase');
       });
 
-      it('errors if attribute name is not a string', async () => {
+      it('errors if attribute name is not a string', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.getAttribute(1337);
@@ -127,15 +127,15 @@ android.describe('perf()', () => {
       });
     });
 
-    describe('putAttribute()', async () => {
-      it('sets an attribute string value', async () => {
+    describe('putAttribute()', function() {
+      it('sets an attribute string value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.putAttribute('inver', 'tase');
         const value = httpMetric.getAttribute('inver');
         value.should.equal('tase');
       });
 
-      it('errors if attribute name is not a string', async () => {
+      it('errors if attribute name is not a string', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.putAttribute(1337, 'invertase');
@@ -146,7 +146,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if attribute value is not a string', async () => {
+      it('errors if attribute value is not a string', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.putAttribute('invertase', 1337);
@@ -157,7 +157,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if attribute name is greater than 40 characters', async () => {
+      it('errors if attribute name is greater than 40 characters', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.putAttribute(new Array(41).fill('1').join(''), 1337);
@@ -168,7 +168,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if attribute value is greater than 100 characters', async () => {
+      it('errors if attribute value is greater than 100 characters', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.putAttribute('invertase', new Array(101).fill('1').join(''));
@@ -179,7 +179,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if more than 5 attributes are put', async () => {
+      it('errors if more than 5 attributes are put', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
 
         httpMetric.putAttribute('invertase1', '1337');
@@ -209,20 +209,20 @@ android.describe('perf()', () => {
     //   });
     // });
 
-    describe('setHttpResponseCode()', async () => {
-      it('sets number value', async () => {
+    describe('setHttpResponseCode()', function() {
+      it('sets number value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setHttpResponseCode(500);
         should.equal(httpMetric._httpResponseCode, 500);
       });
 
-      it('sets a null value to clear value', async () => {
+      it('sets a null value to clear value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setHttpResponseCode(null);
         should.equal(httpMetric._httpResponseCode, null);
       });
 
-      it('errors if not a number or null value', async () => {
+      it('errors if not a number or null value', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.setHttpResponseCode('500');
@@ -234,20 +234,20 @@ android.describe('perf()', () => {
       });
     });
 
-    describe('setRequestPayloadSize()', async () => {
-      it('sets number value', async () => {
+    describe('setRequestPayloadSize()', function() {
+      it('sets number value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setRequestPayloadSize(13377331);
         should.equal(httpMetric._requestPayloadSize, 13377331);
       });
 
-      it('sets a null value to clear value', async () => {
+      it('sets a null value to clear value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setRequestPayloadSize(null);
         should.equal(httpMetric._requestPayloadSize, null);
       });
 
-      it('errors if not a number or null value', async () => {
+      it('errors if not a number or null value', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.setRequestPayloadSize('1337');
@@ -259,20 +259,20 @@ android.describe('perf()', () => {
       });
     });
 
-    describe('setResponsePayloadSize()', async () => {
-      it('sets number value', async () => {
+    describe('setResponsePayloadSize()', function() {
+      it('sets number value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setResponsePayloadSize(13377331);
         should.equal(httpMetric._responsePayloadSize, 13377331);
       });
 
-      it('sets a null value to clear value', async () => {
+      it('sets a null value to clear value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setResponsePayloadSize(null);
         should.equal(httpMetric._responsePayloadSize, null);
       });
 
-      it('errors if not a number or null value', async () => {
+      it('errors if not a number or null value', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.setResponsePayloadSize('1337');
@@ -284,20 +284,20 @@ android.describe('perf()', () => {
       });
     });
 
-    describe('setResponseContentType()', async () => {
-      it('sets string value', async () => {
+    describe('setResponseContentType()', function() {
+      it('sets string value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setResponseContentType('application/invertase');
         should.equal(httpMetric._responseContentType, 'application/invertase');
       });
 
-      it('sets a null value to clear value', async () => {
+      it('sets a null value to clear value', async function() {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
         httpMetric.setResponseContentType(null);
         should.equal(httpMetric._responseContentType, null);
       });
 
-      it('errors if not a string or null value', async () => {
+      it('errors if not a string or null value', async function() {
         try {
           const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
           httpMetric.setResponseContentType(1337);

--- a/packages/perf/e2e/Trace.e2e.js
+++ b/packages/perf/e2e/Trace.e2e.js
@@ -16,9 +16,9 @@
  */
 
 android.describe('perf()', () => {
-  describe('Trace', () => {
-    describe('start()', () => {
-      it('correctly starts with internal flag ', async () => {
+  describe('Trace', function() {
+    describe('start()', function() {
+      it('correctly starts with internal flag ', async function() {
         const trace = firebase.perf().newTrace('invertase');
         await trace.start();
         should.equal(trace._started, true);
@@ -28,7 +28,7 @@ android.describe('perf()', () => {
         await trace.stop();
       });
 
-      it('resolves null if already started', async () => {
+      it('resolves null if already started', async function() {
         const trace = firebase.perf().newTrace('invertase');
         await trace.start();
         should.equal(trace._started, true);
@@ -38,8 +38,8 @@ android.describe('perf()', () => {
       });
     });
 
-    describe('stop()', () => {
-      it('correctly stops with internal flag ', async () => {
+    describe('stop()', function() {
+      it('correctly stops with internal flag ', async function() {
         const trace = firebase.perf().newTrace('invertase');
         await trace.start();
         trace.putAttribute('foo', 'bar');
@@ -51,7 +51,7 @@ android.describe('perf()', () => {
         should.equal(trace._stopped, true);
       });
 
-      it('resolves null if already stopped', async () => {
+      it('resolves null if already stopped', async function() {
         const trace = firebase.perf().newTrace('invertase');
         await trace.start();
         await Utils.sleep(100);
@@ -84,21 +84,21 @@ android.describe('perf()', () => {
     //   });
     // });
 
-    describe('getAttribute()', async () => {
-      it('should return null if attribute does not exist', async () => {
+    describe('getAttribute()', function() {
+      it('should return null if attribute does not exist', async function() {
         const trace = firebase.perf().newTrace('invertase');
         const value = trace.getAttribute('inver');
         should.equal(value, null);
       });
 
-      it('should return an attribute string value', async () => {
+      it('should return an attribute string value', async function() {
         const trace = firebase.perf().newTrace('invertase');
         trace.putAttribute('inver', 'tase');
         const value = trace.getAttribute('inver');
         should.equal(value, 'tase');
       });
 
-      it('errors if attribute name is not a string', async () => {
+      it('errors if attribute name is not a string', async function() {
         try {
           const trace = firebase.perf().newTrace('invertase');
           trace.getAttribute(1337);
@@ -110,15 +110,15 @@ android.describe('perf()', () => {
       });
     });
 
-    describe('putAttribute()', async () => {
-      it('sets an attribute string value', async () => {
+    describe('putAttribute()', function() {
+      it('sets an attribute string value', async function() {
         const trace = firebase.perf().newTrace('invertase');
         trace.putAttribute('inver', 'tase');
         const value = trace.getAttribute('inver');
         value.should.equal('tase');
       });
 
-      it('errors if attribute name is not a string', async () => {
+      it('errors if attribute name is not a string', async function() {
         try {
           const trace = firebase.perf().newTrace('invertase');
           trace.putAttribute(1337, 'invertase');
@@ -129,7 +129,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if attribute value is not a string', async () => {
+      it('errors if attribute value is not a string', async function() {
         try {
           const trace = firebase.perf().newTrace('invertase');
           trace.putAttribute('invertase', 1337);
@@ -140,7 +140,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if attribute name is greater than 40 characters', async () => {
+      it('errors if attribute name is greater than 40 characters', async function() {
         try {
           const trace = firebase.perf().newTrace('invertase');
           trace.putAttribute(new Array(41).fill('1').join(''), 1337);
@@ -151,7 +151,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if attribute value is greater than 100 characters', async () => {
+      it('errors if attribute value is greater than 100 characters', async function() {
         try {
           const trace = firebase.perf().newTrace('invertase');
           trace.putAttribute('invertase', new Array(101).fill('1').join(''));
@@ -162,7 +162,7 @@ android.describe('perf()', () => {
         }
       });
 
-      it('errors if more than 5 attributes are put', async () => {
+      it('errors if more than 5 attributes are put', async function() {
         const trace = firebase.perf().newTrace('invertase');
 
         trace.putAttribute('invertase1', '1337');
@@ -197,8 +197,8 @@ android.describe('perf()', () => {
   //   Metrics
   // -----------
 
-  describe('removeMetric()', async () => {
-    it('errors if name not a string', async () => {
+  describe('removeMetric()', function() {
+    it('errors if name not a string', async function() {
       const trace = firebase.perf().newTrace('invertase');
       try {
         trace.putMetric('likes', 1337);
@@ -210,7 +210,7 @@ android.describe('perf()', () => {
       }
     });
 
-    it('removes a metric', async () => {
+    it('removes a metric', async function() {
       const trace = firebase.perf().newTrace('invertase');
       trace.putMetric('likes', 1337);
       const value = trace.getMetric('likes');
@@ -221,21 +221,21 @@ android.describe('perf()', () => {
     });
   });
 
-  describe('getMetric()', async () => {
-    it('should return 0 if metric does not exist', async () => {
+  describe('getMetric()', function() {
+    it('should return 0 if metric does not exist', async function() {
       const trace = firebase.perf().newTrace('invertase');
       const value = trace.getMetric('likes');
       should.equal(value, 0);
     });
 
-    it('should return an metric number value', async () => {
+    it('should return an metric number value', async function() {
       const trace = firebase.perf().newTrace('invertase');
       trace.putMetric('likes', 7331);
       const value = trace.getMetric('likes');
       should.equal(value, 7331);
     });
 
-    it('errors if metric name is not a string', async () => {
+    it('errors if metric name is not a string', async function() {
       try {
         const trace = firebase.perf().newTrace('invertase');
         trace.getMetric(1337);
@@ -247,15 +247,15 @@ android.describe('perf()', () => {
     });
   });
 
-  describe('putMetric()', async () => {
-    it('sets a metric number value', async () => {
+  describe('putMetric()', function() {
+    it('sets a metric number value', async function() {
       const trace = firebase.perf().newTrace('invertase');
       trace.putMetric('likes', 9001);
       const value = trace.getMetric('likes');
       value.should.equal(9001);
     });
 
-    it('overwrites existing metric if it exists', async () => {
+    it('overwrites existing metric if it exists', async function() {
       const trace = firebase.perf().newTrace('invertase');
       trace.putMetric('likes', 1);
       trace.incrementMetric('likes', 9000);
@@ -266,7 +266,7 @@ android.describe('perf()', () => {
       value2.should.equal(1);
     });
 
-    it('errors if metric name is not a string', async () => {
+    it('errors if metric name is not a string', async function() {
       try {
         const trace = firebase.perf().newTrace('invertase');
         trace.putMetric(1337, 7331);
@@ -277,7 +277,7 @@ android.describe('perf()', () => {
       }
     });
 
-    it('errors if metric value is not a number', async () => {
+    it('errors if metric value is not a number', async function() {
       try {
         const trace = firebase.perf().newTrace('invertase');
         trace.putMetric('likes', '1337');
@@ -289,8 +289,8 @@ android.describe('perf()', () => {
     });
   });
 
-  describe('incrementMetric()', async () => {
-    it('increments a metric number value', async () => {
+  describe('incrementMetric()', function() {
+    it('increments a metric number value', async function() {
       const trace = firebase.perf().newTrace('invertase');
       trace.putMetric('likes', 9000);
       trace.incrementMetric('likes', 1);
@@ -298,14 +298,14 @@ android.describe('perf()', () => {
       value.should.equal(9001);
     });
 
-    it('increments a metric even if it does not already exist', async () => {
+    it('increments a metric even if it does not already exist', async function() {
       const trace = firebase.perf().newTrace('invertase');
       trace.incrementMetric('likes', 9001);
       const value = trace.getMetric('likes');
       value.should.equal(9001);
     });
 
-    it('errors if metric name is not a string', async () => {
+    it('errors if metric name is not a string', async function() {
       try {
         const trace = firebase.perf().newTrace('invertase');
         trace.incrementMetric(1337, 1);
@@ -316,7 +316,7 @@ android.describe('perf()', () => {
       }
     });
 
-    it('errors if incrementBy value is not a number', async () => {
+    it('errors if incrementBy value is not a number', async function() {
       try {
         const trace = firebase.perf().newTrace('invertase');
         trace.incrementMetric('likes', '1');
@@ -328,7 +328,7 @@ android.describe('perf()', () => {
     });
   });
 
-  it('getMetrics()', async () => {
+  it('getMetrics()', async function() {
     const trace = firebase.perf().newTrace('invertase');
     trace.putMetric('likes', 1337);
     trace.putMetric('stars', 6832);

--- a/packages/perf/e2e/perf.e2e.js
+++ b/packages/perf/e2e/perf.e2e.js
@@ -16,16 +16,16 @@
  */
 
 android.describe('perf()', () => {
-  describe('setPerformanceCollectionEnabled()', () => {
+  describe('setPerformanceCollectionEnabled()', function() {
     // TODO sometimes android launches with isPerformanceCollectionEnabled = false
-    xit('true', async () => {
+    xit('true', async function() {
       should.equal(firebase.perf().isPerformanceCollectionEnabled, true);
       await firebase.perf().setPerformanceCollectionEnabled(true);
       should.equal(firebase.perf().isPerformanceCollectionEnabled, true);
       await Utils.sleep(2000);
     });
 
-    it('false', async () => {
+    it('false', async function() {
       await device.launchApp();
       await firebase.perf().setPerformanceCollectionEnabled(false);
       should.equal(firebase.perf().isPerformanceCollectionEnabled, false);
@@ -36,8 +36,8 @@ android.describe('perf()', () => {
     });
   });
 
-  describe('startTrace()', () => {
-    it('resolves a started instance of Trace', async () => {
+  describe('startTrace()', function() {
+    it('resolves a started instance of Trace', async function() {
       const trace = await firebase.perf().startTrace('invertase');
       trace.constructor.name.should.be.equal('Trace');
       trace._identifier.should.equal('invertase');

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -15,15 +15,15 @@
  *
  */
 
-describe('remoteConfig()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('remoteConfig()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.remoteConfig);
       app.remoteConfig().app.should.equal(app);
     });
 
-    it('supports multiple apps', async () => {
+    it('supports multiple apps', async function() {
       firebase.firestore().app.name.should.equal('[DEFAULT]');
 
       firebase
@@ -37,8 +37,8 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('statics', () => {
-    it('LastFetchStatus', () => {
+  describe('statics', function() {
+    it('LastFetchStatus', function() {
       firebase.remoteConfig.LastFetchStatus.should.be.an.Object();
       firebase.remoteConfig.LastFetchStatus.FAILURE.should.equal('failure');
       firebase.remoteConfig.LastFetchStatus.SUCCESS.should.equal('success');
@@ -46,7 +46,7 @@ describe('remoteConfig()', () => {
       firebase.remoteConfig.LastFetchStatus.THROTTLED.should.equal('throttled');
     });
 
-    it('ValueSource', () => {
+    it('ValueSource', function() {
       firebase.remoteConfig.ValueSource.should.be.an.Object();
       firebase.remoteConfig.ValueSource.REMOTE.should.equal('remote');
       firebase.remoteConfig.ValueSource.STATIC.should.equal('static');
@@ -54,8 +54,8 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('fetch()', () => {
-    it('with expiration provided', async () => {
+  describe('fetch()', function() {
+    it('with expiration provided', async function() {
       const date = Date.now() - 30000;
       await firebase.remoteConfig().ensureInitialized();
 
@@ -73,8 +73,10 @@ describe('remoteConfig()', () => {
       console.log(firebase.remoteConfig().fetchTimeMillis, date);
       should.equal(firebase.remoteConfig().fetchTimeMillis >= date, true);
     });
-    it('without expiration provided', () => firebase.remoteConfig().fetch());
-    it('it throws if expiration is not a number', () => {
+    it('without expiration provided', function() {
+      return firebase.remoteConfig().fetch();
+    });
+    it('it throws if expiration is not a number', function() {
       try {
         firebase.remoteConfig().fetch('foo');
         return Promise.reject(new Error('Did not throw'));
@@ -85,37 +87,37 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('fetchAndActivate()', () => {
-    it('returns true/false if activated', async () => {
+  describe('fetchAndActivate()', function() {
+    it('returns true/false if activated', async function() {
       const activated = await firebase.remoteConfig().fetchAndActivate();
       activated.should.be.a.Boolean();
     });
   });
 
-  describe('activate()', () => {
-    it('with expiration provided', async () => {
+  describe('activate()', function() {
+    it('with expiration provided', async function() {
       await firebase.remoteConfig().fetch(0);
       const activated = await firebase.remoteConfig().activate();
       activated.should.be.a.Boolean();
     });
 
-    it('without expiration provided', async () => {
+    it('without expiration provided', async function() {
       await firebase.remoteConfig().fetch();
       const activated = await firebase.remoteConfig().activate();
       activated.should.be.a.Boolean();
     });
   });
 
-  describe('config settings', () => {
-    it('should be immediately available', async () => {
+  describe('config settings', function() {
+    it('should be immediately available', async function() {
       firebase.remoteConfig().lastFetchStatus.should.be.a.String();
       firebase.remoteConfig().lastFetchStatus.should.equal('success');
       firebase.remoteConfig().fetchTimeMillis.should.be.a.Number();
     });
   });
 
-  describe('setConfigSettings()', () => {
-    it('it throws if arg is not an object', async () => {
+  describe('setConfigSettings()', function() {
+    it('it throws if arg is not an object', async function() {
       try {
         firebase.remoteConfig().setConfigSettings('not an object');
 
@@ -126,13 +128,13 @@ describe('remoteConfig()', () => {
       }
     });
 
-    it('minimumFetchIntervalMillis sets correctly', async () => {
+    it('minimumFetchIntervalMillis sets correctly', async function() {
       await firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 3000 });
 
       firebase.remoteConfig().settings.minimumFetchIntervalMillis.should.be.equal(3000);
     });
 
-    it('throws if minimumFetchIntervalMillis is not a number', async () => {
+    it('throws if minimumFetchIntervalMillis is not a number', async function() {
       try {
         firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 'potato' });
 
@@ -143,13 +145,13 @@ describe('remoteConfig()', () => {
       }
     });
 
-    it('fetchTimeMillis sets correctly', async () => {
+    it('fetchTimeMillis sets correctly', async function() {
       await firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 3000 });
 
       firebase.remoteConfig().settings.fetchTimeMillis.should.be.equal(3000);
     });
 
-    it('throws if fetchTimeMillis is not a number', () => {
+    it('throws if fetchTimeMillis is not a number', function() {
       try {
         firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 'potato' });
 
@@ -161,8 +163,8 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('ensureInitialized()', () => {
-    it('should ensure remote config has been initialized and values are accessible', async () => {
+  describe('ensureInitialized()', function() {
+    it('should ensure remote config has been initialized and values are accessible', async function() {
       const ensure = await firebase.remoteConfig().ensureInitialized();
       const number = firebase.remoteConfig().getValue('number');
 
@@ -172,8 +174,8 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('getAll()', () => {
-    it('should return an object of all available values', () => {
+  describe('getAll()', function() {
+    it('should return an object of all available values', function() {
       const config = firebase.remoteConfig().getAll();
       config.number.asNumber().should.equal(1337);
       config.number.getSource().should.equal('remote');
@@ -185,8 +187,8 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('setDefaults()', () => {
-    it('sets default values from key values object', async () => {
+  describe('setDefaults()', function() {
+    it('sets default values from key values object', async function() {
       await firebase.remoteConfig().setDefaults({
         some_key: 'I do not exist',
         some_key_1: 1337,
@@ -203,7 +205,7 @@ describe('remoteConfig()', () => {
       values.some_key_2.getSource().should.equal('default');
     });
 
-    it('it throws if defaults object not provided', () => {
+    it('it throws if defaults object not provided', function() {
       try {
         firebase.remoteConfig().setDefaults('not an object');
         return Promise.reject(new Error('Did not throw'));
@@ -214,9 +216,9 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('getValue()', () => {
-    describe('getValue().asBoolean()', () => {
-      it("returns 'true' for the specified keys: '1', 'true', 't', 'yes', 'y', 'on'", async () => {
+  describe('getValue()', function() {
+    describe('getValue().asBoolean()', function() {
+      it("returns 'true' for the specified keys: '1', 'true', 't', 'yes', 'y', 'on'", async function() {
         //Boolean truthy values as defined by web sdk
         await firebase.remoteConfig().setDefaults({
           test1: '1',
@@ -261,7 +263,7 @@ describe('remoteConfig()', () => {
         test6.should.equal(true);
       });
 
-      it("returns 'false' for values that resolve to a falsy", async () => {
+      it("returns 'false' for values that resolve to a falsy", async function() {
         await firebase.remoteConfig().setDefaults({
           test1: '2',
           test2: 'foo',
@@ -281,7 +283,7 @@ describe('remoteConfig()', () => {
         test2.should.equal(false);
       });
 
-      it("returns 'false' if the source is static", () => {
+      it("returns 'false' if the source is static", function() {
         const unknownKey = firebase
           .remoteConfig()
           .getValue('unknownKey')
@@ -291,8 +293,8 @@ describe('remoteConfig()', () => {
       });
     });
 
-    describe('getValue().asString()', () => {
-      it('returns the value as a string', () => {
+    describe('getValue().asString()', function() {
+      it('returns the value as a string', function() {
         const config = firebase.remoteConfig().getAll();
 
         config.number.asString().should.equal('1337');
@@ -302,8 +304,8 @@ describe('remoteConfig()', () => {
       });
     });
 
-    describe('getValue().asNumber()', () => {
-      it('returns the value as a number if it can be evaluated as a number', () => {
+    describe('getValue().asNumber()', function() {
+      it('returns the value as a number if it can be evaluated as a number', function() {
         const config = firebase.remoteConfig().getAll();
 
         config.number.asNumber().should.equal(1337);
@@ -311,14 +313,14 @@ describe('remoteConfig()', () => {
         config.prefix_1.asNumber().should.equal(1);
       });
 
-      it('returns the value "0" if it cannot be evaluated as a number', () => {
+      it('returns the value "0" if it cannot be evaluated as a number', function() {
         const config = firebase.remoteConfig().getAll();
 
         config.bool.asNumber().should.equal(0);
         config.string.asNumber().should.equal(0);
       });
 
-      it("returns '0' if the source is static", () => {
+      it("returns '0' if the source is static", function() {
         const unknownKey = firebase
           .remoteConfig()
           .getValue('unknownKey')
@@ -328,8 +330,8 @@ describe('remoteConfig()', () => {
       });
     });
 
-    describe('getValue().getSource()', () => {
-      it('returns the correct source as default or remote', async () => {
+    describe('getValue().getSource()', function() {
+      it('returns the correct source as default or remote', async function() {
         await firebase.remoteConfig().setDefaults({
           test1: '2',
           test2: 'foo',
@@ -346,13 +348,13 @@ describe('remoteConfig()', () => {
       });
     });
 
-    it("returns an empty string for a static value for keys that doesn't exist", () => {
+    it("returns an empty string for a static value for keys that doesn't exist", function() {
       const configValue = firebase.remoteConfig().getValue('fourOhFour');
       configValue.getSource().should.equal('static');
       should.equal(configValue.asString(), '');
     });
 
-    it('errors if no key provided', async () => {
+    it('errors if no key provided', async function() {
       try {
         firebase.remoteConfig().getValue();
         return Promise.reject(new Error('Did not throw'));
@@ -362,7 +364,7 @@ describe('remoteConfig()', () => {
       }
     });
 
-    it('errors if key not a string', async () => {
+    it('errors if key not a string', async function() {
       try {
         firebase.remoteConfig().getValue(1234);
         return Promise.reject(new Error('Did not throw'));
@@ -373,8 +375,8 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('getAll()', () => {
-    it('gets all values', async () => {
+  describe('getAll()', function() {
+    it('gets all values', async function() {
       const config = firebase.remoteConfig().getAll();
 
       config.should.be.a.Object();
@@ -390,15 +392,15 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('setDefaultsFromResource()', () => {
-    it('sets defaults from remote_config_resource_test file', async () => {
+  describe('setDefaultsFromResource()', function() {
+    it('sets defaults from remote_config_resource_test file', async function() {
       await firebase.remoteConfig().setDefaultsFromResource('remote_config_resource_test');
       const config = firebase.remoteConfig().getAll();
       config.company.getSource().should.equal('default');
       config.company.asString().should.equal('invertase');
     });
 
-    it('rejects if resource not found', async () => {
+    it('rejects if resource not found', async function() {
       const [error] = await A2A(firebase.remoteConfig().setDefaultsFromResource('i_do_not_exist'));
       if (!error) {
         throw new Error('Did not reject');
@@ -408,7 +410,7 @@ describe('remoteConfig()', () => {
       error.message.should.containEql('was not found');
     });
 
-    it('throws if resourceName is not a string', () => {
+    it('throws if resourceName is not a string', function() {
       try {
         firebase.remoteConfig().setDefaultsFromResource(1337);
         return Promise.reject(new Error('Did not throw'));
@@ -419,7 +421,7 @@ describe('remoteConfig()', () => {
     });
   });
 
-  describe('reset()', () => {
+  describe('reset()', function() {
     android.it('resets all activated, fetched and default config', async () => {
       await firebase.remoteConfig().setDefaults({
         some_key: 'I do not exist',
@@ -438,7 +440,7 @@ describe('remoteConfig()', () => {
       should(configRetrieveAgain).not.have.properties(remoteProps);
     });
 
-    it('returns a "null" value as reset() API is not supported on iOS', async () => {
+    it('returns a "null" value as reset() API is not supported on iOS', async function() {
       if (device.getPlatform() === 'ios') {
         const reset = await firebase.remoteConfig().reset();
 

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -174,7 +174,7 @@ describe('remoteConfig()', function() {
     });
   });
 
-  describe('getAll()', function() {
+  describe('getAll() with remote', function() {
     it('should return an object of all available values', function() {
       const config = firebase.remoteConfig().getAll();
       config.number.asNumber().should.equal(1337);

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -15,9 +15,9 @@
  *
  */
 
-describe('storage() -> StorageReference', () => {
-  describe('toString()', () => {
-    it('returns the correct bucket path to the file', () => {
+describe('storage() -> StorageReference', function() {
+  describe('toString()', function() {
+    it('returns the correct bucket path to the file', function() {
       const app = firebase.app();
       firebase
         .storage()
@@ -27,9 +27,9 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('properties', () => {
-    describe('fullPath', () => {
-      it('returns the full path as a string', () => {
+  describe('properties', function() {
+    describe('fullPath', function() {
+      it('returns the full path as a string', function() {
         firebase
           .storage()
           .ref('/foo/uploadNope.jpeg')
@@ -41,8 +41,8 @@ describe('storage() -> StorageReference', () => {
       });
     });
 
-    describe('storage', () => {
-      it('returns the instance of storage', () => {
+    describe('storage', function() {
+      it('returns the instance of storage', function() {
         firebase
           .storage()
           .ref('/foo/uploadNope.jpeg')
@@ -50,8 +50,8 @@ describe('storage() -> StorageReference', () => {
       });
     });
 
-    describe('bucket', () => {
-      it('returns the storage bucket as a string', () => {
+    describe('bucket', function() {
+      it('returns the storage bucket as a string', function() {
         const app = firebase.app();
         firebase
           .storage()
@@ -60,29 +60,29 @@ describe('storage() -> StorageReference', () => {
       });
     });
 
-    describe('name', () => {
-      it('returns the file name as a string', () => {
+    describe('name', function() {
+      it('returns the file name as a string', function() {
         const ref = firebase.storage().ref('/foo/uploadNope.jpeg');
         ref.name.should.equal('uploadNope.jpeg');
       });
     });
 
-    describe('parent', () => {
-      it('returns the parent directory as a reference', () => {
+    describe('parent', function() {
+      it('returns the parent directory as a reference', function() {
         firebase
           .storage()
           .ref('/foo/uploadNope.jpeg')
           .parent.fullPath.should.equal('foo');
       });
 
-      it('returns null if already at root', () => {
+      it('returns null if already at root', function() {
         const ref = firebase.storage().ref('/');
         should.equal(ref.parent, null);
       });
     });
 
-    describe('root', () => {
-      it('returns a reference to the root of the bucket', () => {
+    describe('root', function() {
+      it('returns a reference to the root of the bucket', function() {
         firebase
           .storage()
           .ref('/foo/uploadNope.jpeg')
@@ -91,16 +91,16 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('child()', () => {
-    it('returns a reference to a child path', () => {
+  describe('child()', function() {
+    it('returns a reference to a child path', function() {
       const parentRef = firebase.storage().ref('/foo');
       const childRef = parentRef.child('someFile.json');
       childRef.fullPath.should.equal('foo/someFile.json');
     });
   });
 
-  describe('delete()', () => {
-    before(async () => {
+  describe('delete()', function() {
+    before(async function() {
       await firebase
         .storage()
         .ref('/ok.jpeg')
@@ -111,7 +111,7 @@ describe('storage() -> StorageReference', () => {
         .putFile(`${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/deleteMe.jpeg`);
     });
 
-    it('should delete a file', async () => {
+    it('should delete a file', async function() {
       const storageReference = firebase.storage().ref('/deleteMe.jpeg');
       await storageReference.delete();
 
@@ -127,7 +127,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('throws error if file does not exist', async () => {
+    it('throws error if file does not exist', async function() {
       const storageReference = firebase.storage().ref('/iDoNotExist.jpeg');
 
       try {
@@ -142,7 +142,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('throws error if no write permission', async () => {
+    it('throws error if no write permission', async function() {
       const storageReference = firebase.storage().ref('/uploadNope.jpeg');
 
       try {
@@ -158,8 +158,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('getDownloadURL', () => {
-    it('should return a download url for a file', async () => {
+  describe('getDownloadURL', function() {
+    it('should return a download url for a file', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       const downloadUrl = await storageReference.getDownloadURL();
       downloadUrl.should.be.a.String();
@@ -167,7 +167,7 @@ describe('storage() -> StorageReference', () => {
       downloadUrl.should.containEql(firebase.app().options.projectId);
     });
 
-    it('throws error if file does not exist', async () => {
+    it('throws error if file does not exist', async function() {
       const storageReference = firebase.storage().ref('/iDoNotExist.jpeg');
 
       try {
@@ -182,7 +182,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('throws error if no write permission', async () => {
+    it('throws error if no write permission', async function() {
       const storageReference = firebase.storage().ref('/writeOnly.jpeg');
 
       try {
@@ -198,8 +198,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('getMetadata', () => {
-    it('should return a metadata for a file', async () => {
+  describe('getMetadata', function() {
+    it('should return a metadata for a file', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       const metadata = await storageReference.getMetadata();
       metadata.generation.should.be.a.String();
@@ -221,8 +221,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('list', () => {
-    it('should return list results', async () => {
+  describe('list', function() {
+    it('should return list results', async function() {
       const storageReference = firebase.storage().ref('/list');
       const result = await storageReference.list();
 
@@ -238,7 +238,7 @@ describe('storage() -> StorageReference', () => {
       result.prefixes[0].constructor.name.should.eql('StorageReference');
     });
 
-    it('throws if options is not an object', () => {
+    it('throws if options is not an object', function() {
       try {
         const storageReference = firebase.storage().ref('/');
         storageReference.list(123);
@@ -249,8 +249,8 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    describe('maxResults', () => {
-      it('should limit with maxResults are passed', async () => {
+    describe('maxResults', function() {
+      it('should limit with maxResults are passed', async function() {
         const storageReference = firebase.storage().ref('/list');
         const result = await storageReference.list({
           maxResults: 1,
@@ -266,7 +266,7 @@ describe('storage() -> StorageReference', () => {
         // todo length?
       });
 
-      it('throws if maxResults is not a number', () => {
+      it('throws if maxResults is not a number', function() {
         try {
           const storageReference = firebase.storage().ref('/list');
           storageReference.list({
@@ -279,7 +279,7 @@ describe('storage() -> StorageReference', () => {
         }
       });
 
-      it('throws if maxResults is not a valid number', () => {
+      it('throws if maxResults is not a valid number', function() {
         try {
           const storageReference = firebase.storage().ref('/list');
           storageReference.list({
@@ -295,8 +295,8 @@ describe('storage() -> StorageReference', () => {
       });
     });
 
-    describe('pageToken', () => {
-      it('throws if pageToken is not a string', () => {
+    describe('pageToken', function() {
+      it('throws if pageToken is not a string', function() {
         try {
           const storageReference = firebase.storage().ref('/list');
           storageReference.list({
@@ -309,7 +309,7 @@ describe('storage() -> StorageReference', () => {
         }
       });
 
-      it('should return and use a page token', async () => {
+      it('should return and use a page token', async function() {
         const storageReference = firebase.storage().ref('/list');
         const result1 = await storageReference.list({
           maxResults: 1,
@@ -331,8 +331,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('listAll', () => {
-    it('should return all results', async () => {
+  describe('listAll', function() {
+    it('should return all results', async function() {
       const storageReference = firebase.storage().ref('/list');
       const result = await storageReference.listAll();
 
@@ -348,8 +348,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('updateMetadata', () => {
-    it('should return the updated metadata for a file', async () => {
+  describe('updateMetadata', function() {
+    it('should return the updated metadata for a file', async function() {
       const storageReference = firebase.storage().ref('/writeOnly.jpeg');
       const metadata = await storageReference.updateMetadata({
         contentType: 'image/jpeg',
@@ -377,7 +377,7 @@ describe('storage() -> StorageReference', () => {
       metadata.customMetadata.should.be.an.Object();
     });
 
-    it('should remove customMetadata properties by setting the value to null', async () => {
+    it('should remove customMetadata properties by setting the value to null', async function() {
       const storageReference = firebase.storage().ref('/writeOnly.jpeg');
       const metadata = await storageReference.updateMetadata({
         contentType: 'image/jpeg',
@@ -399,8 +399,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('putFile', () => {
-    it('errors if file path is not a string', async () => {
+  describe('putFile', function() {
+    it('errors if file path is not a string', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putFile(1337);
@@ -411,7 +411,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata is not an object', async () => {
+    it('errors if metadata is not an object', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putFile('foo', 123);
@@ -422,7 +422,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata contains an unsupported property', async () => {
+    it('errors if metadata contains an unsupported property', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putFile('foo', { foo: true });
@@ -433,7 +433,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata property value is not a string or null value', async () => {
+    it('errors if metadata property value is not a string or null value', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putFile('foo', { contentType: true });
@@ -444,7 +444,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata.customMetadata is not an object', async () => {
+    it('errors if metadata.customMetadata is not an object', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putFile('foo', { customMetadata: true });
@@ -458,8 +458,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('putString', () => {
-    it('errors if metadata is not an object', async () => {
+  describe('putString', function() {
+    it('errors if metadata is not an object', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putString('foo', 'raw', 123);
@@ -470,7 +470,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata contains an unsupported property', async () => {
+    it('errors if metadata contains an unsupported property', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putString('foo', 'raw', { foo: true });
@@ -481,7 +481,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata property value is not a string or null value', async () => {
+    it('errors if metadata property value is not a string or null value', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putString('foo', 'raw', { contentType: true });
@@ -492,7 +492,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata.customMetadata is not an object', async () => {
+    it('errors if metadata.customMetadata is not an object', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.putString('foo', 'raw', { customMetadata: true });
@@ -506,8 +506,8 @@ describe('storage() -> StorageReference', () => {
     });
   });
 
-  describe('put', () => {
-    it('errors if metadata is not an object', async () => {
+  describe('put', function() {
+    it('errors if metadata is not an object', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.put(new jet.context.window.ArrayBuffer(), 123);
@@ -518,7 +518,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata contains an unsupported property', async () => {
+    it('errors if metadata contains an unsupported property', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.put(new jet.context.window.ArrayBuffer(), { foo: true });
@@ -529,7 +529,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata property value is not a string or null value', async () => {
+    it('errors if metadata property value is not a string or null value', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.put(new jet.context.window.ArrayBuffer(), { contentType: true });
@@ -540,7 +540,7 @@ describe('storage() -> StorageReference', () => {
       }
     });
 
-    it('errors if metadata.customMetadata is not an object', async () => {
+    it('errors if metadata.customMetadata is not an object', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         storageReference.put(new jet.context.window.ArrayBuffer(), { customMetadata: true });

--- a/packages/storage/e2e/StorageStatics.e2e.js
+++ b/packages/storage/e2e/StorageStatics.e2e.js
@@ -15,8 +15,8 @@
  *
  */
 
-describe('storage()', () => {
-  describe('statics', () => {
+describe('storage()', function() {
+  describe('statics', function() {
     // TODO test statics correctly exported
   });
 });

--- a/packages/storage/e2e/StorageTask.e2e.js
+++ b/packages/storage/e2e/StorageTask.e2e.js
@@ -24,7 +24,7 @@ function snapshotProperties(snapshot) {
   snapshot.should.have.property('bytesTransferred');
 }
 
-describe.only('storage() -> StorageTask', () => {
+describe('storage() -> StorageTask', () => {
   describe('writeToFile()', () => {
     it('errors if permission denied', async () => {
       try {

--- a/packages/storage/e2e/StorageTask.e2e.js
+++ b/packages/storage/e2e/StorageTask.e2e.js
@@ -24,9 +24,9 @@ function snapshotProperties(snapshot) {
   snapshot.should.have.property('bytesTransferred');
 }
 
-describe('storage() -> StorageTask', () => {
-  describe('writeToFile()', () => {
-    it('errors if permission denied', async () => {
+describe('storage() -> StorageTask', function() {
+  describe('writeToFile()', function() {
+    it('errors if permission denied', async function() {
       try {
         await firebase
           .storage()
@@ -40,7 +40,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('downloads a file', async () => {
+    it('downloads a file', async function() {
       const meta = await firebase
         .storage()
         .ref('/ok.jpeg')
@@ -51,8 +51,8 @@ describe('storage() -> StorageTask', () => {
     });
   });
 
-  describe('putString()', () => {
-    it('uploads a raw string', async () => {
+  describe('putString()', function() {
+    it('uploads a raw string', async function() {
       const jsonDerulo = JSON.stringify({ foo: 'bar' });
 
       const uploadTaskSnapshot = await firebase
@@ -67,7 +67,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('uploads a data_url formatted string', async () => {
+    it('uploads a data_url formatted string', async function() {
       const dataUrl = 'data:application/json;base64,eyJmb28iOiJiYXNlNjQifQ==';
       const uploadTaskSnapshot = await firebase
         .storage()
@@ -79,7 +79,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('uploads a url encoded data_url formatted string', async () => {
+    it('uploads a url encoded data_url formatted string', async function() {
       const dataUrl = 'data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E';
       const uploadTaskSnapshot = await firebase
         .storage()
@@ -91,7 +91,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('when using data_url it still sets the content type if metadata is provided', async () => {
+    it('when using data_url it still sets the content type if metadata is provided', async function() {
       const dataUrl = 'data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E';
 
       const uploadTaskSnapshot = await firebase
@@ -109,7 +109,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('uploads a base64 string', async () => {
+    it('uploads a base64 string', async function() {
       const base64String = 'eyJmb28iOiJiYXNlNjQifQ==';
 
       const uploadTaskSnapshot = await firebase
@@ -124,7 +124,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('uploads a base64url string', async () => {
+    it('uploads a base64url string', async function() {
       const base64UrlString = 'eyJmb28iOiJiYXNlNjQifQ';
 
       const uploadTaskSnapshot = await firebase
@@ -139,7 +139,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('throws an error on invalid data_url', async () => {
+    it('throws an error on invalid data_url', async function() {
       const dataUrl = '';
       try {
         await firebase
@@ -153,7 +153,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('throws if string arg is not a valid string', async () => {
+    it('throws if string arg is not a valid string', async function() {
       try {
         await firebase
           .storage()
@@ -166,7 +166,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('throws an error on invalid string format', async () => {
+    it('throws an error on invalid string format', async function() {
       try {
         await firebase
           .storage()
@@ -179,7 +179,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('throws an error if metadata is not an object', async () => {
+    it('throws an error if metadata is not an object', async function() {
       try {
         await firebase
           .storage()
@@ -193,8 +193,8 @@ describe('storage() -> StorageTask', () => {
     });
   });
 
-  describe('put()', () => {
-    it('uploads a Blob', async () => {
+  describe('put()', function() {
+    it('uploads a Blob', async function() {
       const jsonDerulo = JSON.stringify({ foo: 'bar' });
 
       const bob = new jet.context.Blob([jsonDerulo], {
@@ -211,7 +211,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('uploads an ArrayBuffer', async () => {
+    it('uploads an ArrayBuffer', async function() {
       const jsonDerulo = JSON.stringify({ foo: 'bar' });
 
       const arrayBuffer = new jet.context.window.ArrayBuffer(jsonDerulo.length);
@@ -233,7 +233,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('uploads an Uint8Array', async () => {
+    it('uploads an Uint8Array', async function() {
       const jsonDerulo = JSON.stringify({ foo: 'bar' });
 
       const arrayBuffer = new jet.context.window.ArrayBuffer(jsonDerulo.length);
@@ -255,7 +255,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('should have access to the snapshot values outside of the Task thennable', async () => {
+    it('should have access to the snapshot values outside of the Task thennable', async function() {
       const jsonDerulo = JSON.stringify({ foo: 'bar' });
 
       const bob = new jet.context.Blob([jsonDerulo], {
@@ -275,8 +275,8 @@ describe('storage() -> StorageTask', () => {
     });
   });
 
-  describe('putFile()', () => {
-    before(async () => {
+  describe('putFile()', function() {
+    before(async function() {
       await firebase
         .storage()
         .ref('/ok.jpeg')
@@ -291,7 +291,7 @@ describe('storage() -> StorageTask', () => {
         .writeToFile(`${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/hei.heic`);
     });
 
-    it('errors if permission denied', async () => {
+    it('errors if permission denied', async function() {
       try {
         await firebase
           .storage()
@@ -305,7 +305,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('supports thenable .catch()', async () => {
+    it('supports thenable .catch()', async function() {
       const out = await firebase
         .storage()
         .ref('/uploadNope.jpeg')
@@ -318,7 +318,7 @@ describe('storage() -> StorageTask', () => {
       should.equal(out, 1);
     });
 
-    it('uploads a file', async () => {
+    it('uploads a file', async function() {
       let uploadTaskSnapshot = await firebase
         .storage()
         .ref('/uploadOk.jpeg')
@@ -349,7 +349,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('uploads a file without read permission', async () => {
+    it('uploads a file without read permission', async function() {
       const uploadTaskSnapshot = await firebase
         .storage()
         .ref('/writeOnly.jpeg')
@@ -360,7 +360,7 @@ describe('storage() -> StorageTask', () => {
       uploadTaskSnapshot.metadata.should.be.an.Object();
     });
 
-    it('should have access to the snapshot values outside of the Task thennable', async () => {
+    it('should have access to the snapshot values outside of the Task thennable', async function() {
       const uploadTaskSnapshot = firebase
         .storage()
         .ref('/putStringBlob.json')
@@ -373,7 +373,7 @@ describe('storage() -> StorageTask', () => {
       snapshotProperties(snapshot);
     });
 
-    it('should have access to the snapshot values outside of the event subscriber', async () => {
+    it('should have access to the snapshot values outside of the event subscriber', async function() {
       const uploadTaskSnapshot = firebase
         .storage()
         .ref('/putStringBlob.json')
@@ -393,15 +393,15 @@ describe('storage() -> StorageTask', () => {
     });
   });
 
-  describe('on()', () => {
-    before(async () => {
+  describe('on()', function() {
+    before(async function() {
       await firebase
         .storage()
         .ref('/ok.jpeg')
         .writeToFile(`${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/ok.jpeg`);
     });
 
-    it('throws an Error if event is invalid', async () => {
+    it('throws an Error if event is invalid', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         const task = storageReference.putFile('abc');
@@ -415,7 +415,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('throws an Error if nextOrObserver is invalid', async () => {
+    it('throws an Error if nextOrObserver is invalid', async function() {
       const storageReference = firebase.storage().ref('/ok.jpeg');
       try {
         const task = storageReference.putFile('abc');
@@ -427,7 +427,7 @@ describe('storage() -> StorageTask', () => {
       }
     });
 
-    it('observer calls error callback', async () => {
+    it('observer calls error callback', async function() {
       const ref = firebase.storage().ref('/uploadOk.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/notFoundFooFile.bar`;
@@ -449,7 +449,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('observer: calls next callback', async () => {
+    it('observer: calls next callback', async function() {
       const ref = firebase.storage().ref('/ok.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/onDownload.jpeg`;
@@ -467,7 +467,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('observer: calls completion callback', async () => {
+    it('observer: calls completion callback', async function() {
       const ref = firebase.storage().ref('/ok.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/onDownload.jpeg`;
@@ -484,7 +484,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('calls error callback', async () => {
+    it('calls error callback', async function() {
       const ref = firebase.storage().ref('/uploadOk.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/notFoundFooFile.bar`;
@@ -509,7 +509,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('calls next callback', async () => {
+    it('calls next callback', async function() {
       const ref = firebase.storage().ref('/ok.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/onDownload.jpeg`;
@@ -525,7 +525,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('calls completion callback', async () => {
+    it('calls completion callback', async function() {
       const ref = firebase.storage().ref('/ok.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/onDownload.jpeg`;
@@ -540,7 +540,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('returns a subscribe fn', async () => {
+    it('returns a subscribe fn', async function() {
       const ref = firebase.storage().ref('/ok.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/onDownload.jpeg`;
@@ -558,7 +558,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('returns a subscribe fn supporting observer usage syntax', async () => {
+    it('returns a subscribe fn supporting observer usage syntax', async function() {
       const ref = firebase.storage().ref('/ok.jpeg');
       const { resolve, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/onDownload.jpeg`;
@@ -578,7 +578,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('listens to download state', async () => {
+    it('listens to download state', async function() {
       const ref = firebase.storage().ref('/cat.gif');
       const { resolve, reject, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/onDownload.gif`;
@@ -599,7 +599,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('listens to upload state', async () => {
+    it('listens to upload state', async function() {
       const { resolve, reject, promise } = Promise.defer();
       const path = `${firebase.utils.FilePath.DOCUMENT_DIRECTORY}/ok.jpeg`;
       const ref = firebase.storage().ref('/uploadOk.jpeg');
@@ -621,7 +621,7 @@ describe('storage() -> StorageTask', () => {
     });
   });
 
-  describe('pause() resume()', () => {
+  describe('pause() resume()', function() {
     it('successfully pauses and resumes an upload', async function testRunner() {
       this.timeout(100 * 1000);
 
@@ -687,7 +687,7 @@ describe('storage() -> StorageTask', () => {
       await promise;
     });
 
-    it('successfully pauses and resumes a download', async () => {
+    it('successfully pauses and resumes a download', async function() {
       const ref = firebase
         .storage()
         .ref(device.getPlatform() === 'ios' ? '/1mbTestFile.gif' : '/cat.gif');
@@ -747,8 +747,8 @@ describe('storage() -> StorageTask', () => {
     });
   });
 
-  describe('cancel()', async () => {
-    it('successfully cancels an upload', async () => {
+  describe('cancel()', function() {
+    it('successfully cancels an upload', async function() {
       await firebase
         .storage()
         .ref('/1mbTestFile.gif')
@@ -801,7 +801,7 @@ describe('storage() -> StorageTask', () => {
     });
   });
 
-  it('successfully cancels a download', async () => {
+  it('successfully cancels a download', async function() {
     await Utils.sleep(10000);
     const ref = firebase.storage().ref('/1mbTestFile.gif');
     const { resolve, reject, promise } = Promise.defer();

--- a/packages/storage/e2e/storage.e2e.js
+++ b/packages/storage/e2e/storage.e2e.js
@@ -15,15 +15,15 @@
  *
  */
 
-describe('storage()', () => {
-  describe('namespace', () => {
-    it('accessible from firebase.app()', () => {
+describe('storage()', function() {
+  describe('namespace', function() {
+    it('accessible from firebase.app()', function() {
       const app = firebase.app();
       should.exist(app.storage);
       app.storage().app.should.equal(app);
     });
 
-    it('supports multiple apps', async () => {
+    it('supports multiple apps', async function() {
       firebase.storage().app.name.should.equal('[DEFAULT]');
 
       firebase
@@ -36,7 +36,7 @@ describe('storage()', () => {
         .app.name.should.equal('secondaryFromNative');
     });
 
-    it('supports specifying a bucket', async () => {
+    it('supports specifying a bucket', async function() {
       const bucket = 'gs://react-native-firebase-testing';
       const defaultInstance = firebase.storage();
       defaultInstance.app.name.should.equal('[DEFAULT]');
@@ -49,7 +49,7 @@ describe('storage()', () => {
       instanceForBucket._customUrlOrRegion.should.equal(bucket);
     });
 
-    it('throws an error if an invalid bucket url is provided', async () => {
+    it('throws an error if an invalid bucket url is provided', async function() {
       const bucket = 'invalid://react-native-firebase-testing';
       try {
         firebase.app().storage(bucket);
@@ -60,7 +60,7 @@ describe('storage()', () => {
       }
     });
 
-    it('uploads to a custom bucket when specified', async () => {
+    it('uploads to a custom bucket when specified', async function() {
       const jsonDerulo = JSON.stringify({ foo: 'bar' });
       const bucket = 'gs://react-native-firebase-testing';
 
@@ -78,23 +78,23 @@ describe('storage()', () => {
     });
   });
 
-  describe('ref', () => {
-    it('uses default path if none provided', async () => {
+  describe('ref', function() {
+    it('uses default path if none provided', async function() {
       const ref = firebase.storage().ref();
       ref.fullPath.should.equal('/');
     });
 
-    it('accepts a custom path', async () => {
+    it('accepts a custom path', async function() {
       const ref = firebase.storage().ref('foo/bar/baz.png');
       ref.fullPath.should.equal('foo/bar/baz.png');
     });
 
-    it('strips leading / from custom path', async () => {
+    it('strips leading / from custom path', async function() {
       const ref = firebase.storage().ref('/foo/bar/baz.png');
       ref.fullPath.should.equal('foo/bar/baz.png');
     });
 
-    it('throws an error if custom path not a string', async () => {
+    it('throws an error if custom path not a string', async function() {
       try {
         firebase.storage().ref({ derp: true });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -105,14 +105,14 @@ describe('storage()', () => {
     });
   });
 
-  describe('refFromURL', () => {
-    it('accepts a gs url', async () => {
+  describe('refFromURL', function() {
+    it('accepts a gs url', async function() {
       const url = 'gs://foo/bar/baz.png';
       const ref = firebase.storage().refFromURL(url);
       ref.toString().should.equal(url);
     });
 
-    it('accepts a https url', async () => {
+    it('accepts a https url', async function() {
       const url =
         'https://firebasestorage.googleapis.com/v0/b/react-native-firebase-testing.appspot.com/o/1mbTestFile.gif?alt=media';
       const ref = firebase.storage().refFromURL(url);
@@ -121,7 +121,7 @@ describe('storage()', () => {
       ref.toString().should.equal('gs://react-native-firebase-testing.appspot.com/1mbTestFile.gif');
     });
 
-    it('accepts a https encoded url', async () => {
+    it('accepts a https encoded url', async function() {
       const url =
         'https%3A%2F%2Ffirebasestorage.googleapis.com%2Fv0%2Fb%2Freact-native-firebase-testing.appspot.com%2Fo%2F1mbTestFile.gif%3Falt%3Dmedia';
       const ref = firebase.storage().refFromURL(url);
@@ -130,7 +130,7 @@ describe('storage()', () => {
       ref.toString().should.equal('gs://react-native-firebase-testing.appspot.com/1mbTestFile.gif');
     });
 
-    it('throws an error if https url could not be parsed', async () => {
+    it('throws an error if https url could not be parsed', async function() {
       try {
         firebase.storage().refFromURL('https://invertase.io');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -140,13 +140,13 @@ describe('storage()', () => {
       }
     });
 
-    it('accepts a gs url without a fullPath', async () => {
+    it('accepts a gs url without a fullPath', async function() {
       const url = 'gs://some-bucket';
       const ref = firebase.storage().refFromURL(url);
       ref.toString().should.equal(url);
     });
 
-    it('throws an error if url is not a string', async () => {
+    it('throws an error if url is not a string', async function() {
       try {
         firebase.storage().refFromURL({ derp: true });
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -156,7 +156,7 @@ describe('storage()', () => {
       }
     });
 
-    it('throws an error if url does not start with gs:// or https://', async () => {
+    it('throws an error if url does not start with gs:// or https://', async function() {
       try {
         firebase.storage().refFromURL('bs://foo/bar/cat.gif');
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -167,14 +167,14 @@ describe('storage()', () => {
     });
   });
 
-  describe('setMaxOperationRetryTime', () => {
-    it('should set', async () => {
+  describe('setMaxOperationRetryTime', function() {
+    it('should set', async function() {
       firebase.storage().maxOperationRetryTime.should.equal(120000);
       await firebase.storage().setMaxOperationRetryTime(100000);
       firebase.storage().maxOperationRetryTime.should.equal(100000);
     });
 
-    it('throws if time is not a number value', async () => {
+    it('throws if time is not a number value', async function() {
       try {
         await firebase.storage().setMaxOperationRetryTime('im a teapot');
         return Promise.reject(new Error('Did not throw'));
@@ -185,14 +185,14 @@ describe('storage()', () => {
     });
   });
 
-  describe('setMaxUploadRetryTime', () => {
-    it('should set', async () => {
+  describe('setMaxUploadRetryTime', function() {
+    it('should set', async function() {
       firebase.storage().maxUploadRetryTime.should.equal(600000);
       await firebase.storage().setMaxUploadRetryTime(120000);
       firebase.storage().maxUploadRetryTime.should.equal(120000);
     });
 
-    it('throws if time is not a number value', async () => {
+    it('throws if time is not a number value', async function() {
       try {
         await firebase.storage().setMaxUploadRetryTime('im a teapot');
         return Promise.reject(new Error('Did not throw'));
@@ -203,14 +203,14 @@ describe('storage()', () => {
     });
   });
 
-  describe('setMaxDownloadRetryTime', () => {
-    it('should set', async () => {
+  describe('setMaxDownloadRetryTime', function() {
+    it('should set', async function() {
       firebase.storage().maxDownloadRetryTime.should.equal(600000);
       await firebase.storage().setMaxDownloadRetryTime(120000);
       firebase.storage().maxDownloadRetryTime.should.equal(120000);
     });
 
-    it('throws if time is not a number value', async () => {
+    it('throws if time is not a number value', async function() {
       try {
         await firebase.storage().setMaxDownloadRetryTime('im a teapot');
         return Promise.reject(new Error('Did not throw'));

--- a/tests/e2e/init.js
+++ b/tests/e2e/init.js
@@ -25,7 +25,7 @@ const { detox: config } = require('../package.json');
 config.configurations['android.emu.debug'].device.avdName =
   process.env.ANDROID_AVD_NAME || config.configurations['android.emu.debug'].device.avdName;
 
-before(async () => {
+before(async function() {
   await detox.init(config);
   await jet.init();
 });
@@ -49,7 +49,7 @@ beforeEach(async function beforeEach() {
   }
 });
 
-after(async () => {
+after(async function() {
   console.log(' ✨ Tests Complete ✨ ');
   await device.terminateApp();
 });

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -2,7 +2,7 @@ platform :ios, '10.0'
 $RNFirebaseAsStaticFramework = false
 
 # Version override testing
-$FirebaseSDKVersion = '7.2.0'
+$FirebaseSDKVersion = '7.3.0'
 
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -228,69 +228,69 @@ PODS:
     - React-Core (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/turbomodule/core (= 0.62.2)
-  - Firebase/AdMob (7.2.0):
+  - Firebase/AdMob (7.3.0):
     - Firebase/CoreOnly
     - Google-Mobile-Ads-SDK (~> 7.66)
-  - Firebase/Analytics (7.2.0):
+  - Firebase/Analytics (7.3.0):
     - Firebase/Core
-  - Firebase/Auth (7.2.0):
+  - Firebase/Auth (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 7.2.0)
-  - Firebase/Core (7.2.0):
+    - FirebaseAuth (~> 7.3.0)
+  - Firebase/Core (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 7.2.0)
-  - Firebase/CoreOnly (7.2.0):
-    - FirebaseCore (= 7.2.0)
-  - Firebase/Crashlytics (7.2.0):
+    - FirebaseAnalytics (= 7.3.0)
+  - Firebase/CoreOnly (7.3.0):
+    - FirebaseCore (= 7.3.0)
+  - Firebase/Crashlytics (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 7.2.0)
-  - Firebase/Database (7.2.0):
+    - FirebaseCrashlytics (~> 7.3.0)
+  - Firebase/Database (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 7.2.0)
-  - Firebase/DynamicLinks (7.2.0):
+    - FirebaseDatabase (~> 7.3.0)
+  - Firebase/DynamicLinks (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 7.2.0)
-  - Firebase/Firestore (7.2.0):
+    - FirebaseDynamicLinks (~> 7.3.0)
+  - Firebase/Firestore (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 7.2.0)
-  - Firebase/Functions (7.2.0):
+    - FirebaseFirestore (~> 7.3.0)
+  - Firebase/Functions (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 7.2.0)
-  - Firebase/InAppMessaging (7.2.0):
+    - FirebaseFunctions (~> 7.3.0)
+  - Firebase/InAppMessaging (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 7.2.0-beta)
-  - Firebase/Messaging (7.2.0):
+    - FirebaseInAppMessaging (~> 7.3.0-beta)
+  - Firebase/Messaging (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 7.2.0)
-  - Firebase/MLVision (7.2.0):
+    - FirebaseMessaging (~> 7.3.0)
+  - Firebase/MLVision (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseMLVision (~> 7.2.0-beta)
-  - Firebase/Performance (7.2.0):
+    - FirebaseMLVision (~> 7.3.0-beta)
+  - Firebase/Performance (7.3.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 7.2.0)
-  - Firebase/RemoteConfig (7.2.0):
+    - FirebasePerformance (~> 7.3.0)
+  - Firebase/RemoteConfig (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 7.2.0)
-  - Firebase/Storage (7.2.0):
+    - FirebaseRemoteConfig (~> 7.3.0)
+  - Firebase/Storage (7.3.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 7.2.0)
+    - FirebaseStorage (~> 7.3.0)
   - FirebaseABTesting (7.3.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseAnalytics (7.2.0):
+  - FirebaseAnalytics (7.3.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
-    - GoogleAppMeasurement (= 7.2.0)
+    - GoogleAppMeasurement (= 7.3.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30906.0)
-  - FirebaseAuth (7.2.0):
+  - FirebaseAuth (7.3.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
-  - FirebaseCore (7.2.0):
+  - FirebaseCore (7.3.0):
     - FirebaseCoreDiagnostics (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
@@ -299,18 +299,18 @@ PODS:
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
     - nanopb (~> 2.30906.0)
-  - FirebaseCrashlytics (7.2.0):
+  - FirebaseCrashlytics (7.3.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleDataTransport (~> 8.0)
     - nanopb (~> 2.30906.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseDatabase (7.2.0):
+  - FirebaseDatabase (7.3.0):
     - FirebaseCore (~> 7.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (7.2.0):
+  - FirebaseDynamicLinks (7.3.1):
     - FirebaseCore (~> 7.0)
-  - FirebaseFirestore (7.2.0):
+  - FirebaseFirestore (7.3.0):
     - abseil/algorithm (= 0.20200225.0)
     - abseil/base (= 0.20200225.0)
     - abseil/memory (= 0.20200225.0)
@@ -322,10 +322,10 @@ PODS:
     - "gRPC-C++ (~> 1.28.0)"
     - leveldb-library (~> 1.22)
     - nanopb (~> 2.30906.0)
-  - FirebaseFunctions (7.2.0):
+  - FirebaseFunctions (7.3.0):
     - FirebaseCore (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
-  - FirebaseInAppMessaging (7.2.0-beta):
+  - FirebaseInAppMessaging (7.3.0-beta):
     - FirebaseABTesting (~> 7.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
@@ -341,7 +341,7 @@ PODS:
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseMessaging (7.2.0):
+  - FirebaseMessaging (7.3.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstanceID (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
@@ -357,7 +357,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.12)
-  - FirebaseMLVision (7.2.0-beta):
+  - FirebaseMLVision (7.3.0-beta):
     - FirebaseCore (~> 7.0)
     - FirebaseMLCommon (~> 7.0-beta)
     - GoogleAPIClientForREST/Core (~> 1.3)
@@ -366,11 +366,11 @@ PODS:
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.12)
-  - FirebasePerformance (7.2.0):
+  - FirebasePerformance (7.3.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - FirebaseRemoteConfig (~> 7.0)
-    - GoogleDataTransport (~> 8.0)
+    - GoogleDataTransport (~> 8.1)
     - GoogleToolboxForMac/Logger (~> 2.1)
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
     - GoogleUtilities/Environment (~> 7.0)
@@ -378,13 +378,13 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.12)
-  - FirebaseRemoteConfig (7.2.0):
+  - FirebaseRemoteConfig (7.3.0):
     - FirebaseABTesting (~> 7.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
-  - FirebaseStorage (7.2.0):
+  - FirebaseStorage (7.3.0):
     - FirebaseCore (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
   - Folly (2018.10.22.00):
@@ -405,7 +405,7 @@ PODS:
   - GoogleAPIClientForREST/Vision (1.5.1):
     - GoogleAPIClientForREST/Core
     - GTMSessionFetcher (>= 1.1.7)
-  - GoogleAppMeasurement (7.2.0):
+  - GoogleAppMeasurement (7.3.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
@@ -708,70 +708,70 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
     - ReactCommon/callinvoker (= 0.62.2)
-  - RNFBAdMob (10.1.1):
-    - Firebase/AdMob (= 7.2.0)
+  - RNFBAdMob (10.2.0):
+    - Firebase/AdMob (= 7.3.0)
     - PersonalizedAdConsent (~> 1.0.4)
     - React-Core
     - RNFBApp
-  - RNFBAnalytics (10.1.1):
-    - Firebase/Analytics (= 7.2.0)
+  - RNFBAnalytics (10.2.0):
+    - Firebase/Analytics (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (10.1.0):
-    - Firebase/CoreOnly (= 7.2.0)
+  - RNFBApp (10.2.0):
+    - Firebase/CoreOnly (= 7.3.0)
     - React-Core
-  - RNFBAuth (10.1.1):
-    - Firebase/Auth (= 7.2.0)
-    - React-Core
-    - RNFBApp
-  - RNFBCrashlytics (10.1.1):
-    - Firebase/Crashlytics (= 7.2.0)
+  - RNFBAuth (10.2.0):
+    - Firebase/Auth (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (10.1.1):
-    - Firebase/Database (= 7.2.0)
+  - RNFBCrashlytics (10.2.0):
+    - Firebase/Crashlytics (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (10.1.1):
-    - Firebase/DynamicLinks (= 7.2.0)
+  - RNFBDatabase (10.2.0):
+    - Firebase/Database (= 7.3.0)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (10.2.0):
+    - Firebase/DynamicLinks (= 7.3.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (10.1.1):
-    - Firebase/Firestore (= 7.2.0)
+  - RNFBFirestore (10.2.0):
+    - Firebase/Firestore (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (10.1.1):
-    - Firebase/Functions (= 7.2.0)
+  - RNFBFunctions (10.2.0):
+    - Firebase/Functions (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBIid (10.1.1):
-    - Firebase/CoreOnly (= 7.2.0)
+  - RNFBIid (10.2.0):
+    - Firebase/CoreOnly (= 7.3.0)
     - FirebaseInstanceID
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (10.1.1):
-    - Firebase/InAppMessaging (= 7.2.0)
+  - RNFBInAppMessaging (10.2.0):
+    - Firebase/InAppMessaging (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (10.1.1):
-    - Firebase/Messaging (= 7.2.0)
+  - RNFBMessaging (10.2.0):
+    - Firebase/Messaging (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBML (10.1.1):
-    - Firebase/MLVision (= 7.2.0)
+  - RNFBML (10.2.0):
+    - Firebase/MLVision (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBPerf (10.1.1):
-    - Firebase/Performance (= 7.2.0)
+  - RNFBPerf (10.2.0):
+    - Firebase/Performance (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (10.1.1):
-    - Firebase/RemoteConfig (= 7.2.0)
+  - RNFBRemoteConfig (10.2.0):
+    - Firebase/RemoteConfig (= 7.3.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (10.1.1):
-    - Firebase/Storage (= 7.2.0)
+  - RNFBStorage (10.2.0):
+    - Firebase/Storage (= 7.3.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -957,31 +957,31 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
-  Firebase: 456eeacc158d8c58586b7871619a81bb9f27d4ae
+  Firebase: 26223c695fe322633274198cb19dca8cb7e54416
   FirebaseABTesting: 303b5366c0c75be479424e8935e2f475cf24ce21
-  FirebaseAnalytics: 2673264e482b428df13786b59165ebf420881d7a
-  FirebaseAuth: e6a214cc897d2eab7635b1e5dd6b4298fd1e776b
-  FirebaseCore: c959e8a598f83125c01c1700d9161b236ab3833c
+  FirebaseAnalytics: 2580c2d62535ae7b644143d48941fcc239ea897a
+  FirebaseAuth: c224a0cf1afa0949bd5c7bfcf154b4f5ce8ddef2
+  FirebaseCore: 4d3c72622ce0e2106aaa07bb4b2935ba2c370972
   FirebaseCoreDiagnostics: d50e11039e5984d92c8a512be2395f13df747350
-  FirebaseCrashlytics: 8afbf6e9c3731adee0e721870c9e7b40b0e8fd44
-  FirebaseDatabase: efb4d986413f55f7d9a05e621bd86ca1589e6ca7
-  FirebaseDynamicLinks: b3e9fc531227f6f35c7e7109cfef2026327d9cad
-  FirebaseFirestore: 526c70e247f550206e5c02a7bafc264588847499
-  FirebaseFunctions: 64d08fe979f2c5b38cb80f19ed99bbe08e952708
-  FirebaseInAppMessaging: 6a136aee1c49a12d8f63d8eb73c0799188f1a9ca
+  FirebaseCrashlytics: d31325312c92e2cb2f0386d589b9aa44e303d99b
+  FirebaseDatabase: 22199cb121a527ae59df646d61426fbb12f5627a
+  FirebaseDynamicLinks: a6df95d6dbc746c2bbf7d511343cda1344e2cf70
+  FirebaseFirestore: 1906bf163afdb7c432d2e3b5c40ceb9dd2df5820
+  FirebaseFunctions: 56b7275ad46d936b77b64ecacd306e77db7be251
+  FirebaseInAppMessaging: 9436b16bbd1fd02bcb50c25ed485150b3269d611
   FirebaseInstallations: 971df89b48ae5ee4cc2bf6935f3857a525d28550
   FirebaseInstanceID: 5ccdee6a84e6b4bb5316de0a8cd88bc749ba490d
-  FirebaseMessaging: 7091222bfac24ca89c569c3c59e58390311e487f
+  FirebaseMessaging: 68d1bcb14880189558a8ae57167abe0b7e417232
   FirebaseMLCommon: 9915d9cf10be6611cbae16e8586aaf76e232ed2b
-  FirebaseMLVision: 0221749767755b38577e84e7f283bb2dc039a19c
-  FirebasePerformance: 43ae90c227bd48956f7a115951ebf21bb22894f5
-  FirebaseRemoteConfig: 73cad38920c491ea81c5c66f9e94a87f265b85a4
-  FirebaseStorage: 4c2cdd98dfe5f6b3fae02db0da72105ac5554bbd
+  FirebaseMLVision: 8fb6dced9cc214c61d2b22026e3456c8e0e08a75
+  FirebasePerformance: 7915b7dfc8258030d5fac9544d7fa6b55fbe3e57
+  FirebaseRemoteConfig: 826fad8bec5ce1912ef97a124d6ec0ce4dcf6ec1
+  FirebaseStorage: 5002b1895bfe74a5ce92ad54f966e6162d0da2e5
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAPIClientForREST: 4bb409633efcc2e1b3f945afe7e35039b5a61db2
-  GoogleAppMeasurement: 57a0df93dc2feb5176b1bac06012dbd725191ba5
+  GoogleAppMeasurement: 8d3c0aeede16ab7764144b5a4ca8e1d4323841b7
   GoogleDataTransport: 116c84c4bdeb76be2a7a46de51244368f9794eab
   GoogleToolboxForMac: 1350d40e86a76f7863928d63bcb0b89c84c521c5
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
@@ -1014,24 +1014,24 @@ SPEC CHECKSUMS:
   React-RCTText: fae545b10cfdb3d247c36c56f61a94cfd6dba41d
   React-RCTVibration: 4356114dbcba4ce66991096e51a66e61eda51256
   ReactCommon: ed4e11d27609d571e7eee8b65548efc191116eb3
-  RNFBAdMob: e8c6e14d5e38c34c01be2bad88953ab8c2286137
-  RNFBAnalytics: dfe01d15618d97868d26d7fdf4581003fa105e9a
-  RNFBApp: b75256740b3df4685209720bad7571314d8e9f4e
-  RNFBAuth: e93318d7cd8dad0596bae53a9c65b510e109a884
-  RNFBCrashlytics: dfd341b95a392f0161858afeb39052449536b5ee
-  RNFBDatabase: 939489aa27d5fa9758e9f83b582548b52ba5add3
-  RNFBDynamicLinks: 3e73967210c0c621fe7da85e909df055c17d6b68
-  RNFBFirestore: 2d1328e8f24e29c1f051f3b80ecb74c356485eec
-  RNFBFunctions: a03a1f27f4040001a1073ba67820d155feb35eaf
-  RNFBIid: 379ffc359419ce01c318bd6e766a20c3119bbe0f
-  RNFBInAppMessaging: 314c4788e4cd3058dbf467247c43636772fe6968
-  RNFBMessaging: aa397d1c2c08deab1018f4493f094af581daa947
-  RNFBML: 46098d2dc457da69c251b20ccb4b858db7a9608c
-  RNFBPerf: f679f47370640ab3c256505502d8c37af2457b6b
-  RNFBRemoteConfig: 383e00a31d00f95661355dc867f3b7e7bdb248c7
-  RNFBStorage: c37fe3e67a53e3a1942d805a279fb766ad4d7e31
+  RNFBAdMob: 9f2e2623a0cb4b75a548c1cac47c334547e9082a
+  RNFBAnalytics: bf045edef2f269bcf31d81007037afb57c8d7371
+  RNFBApp: fd4be67593ac21e42ad9abfba81cabd79227e094
+  RNFBAuth: 9171930995d3fa83b34c365a1553387f23c5f8e8
+  RNFBCrashlytics: fca30344cb30b042bc9fddb5d86c05ff57c4124b
+  RNFBDatabase: d1136592fba24b7972658f2d94f77f0db470f293
+  RNFBDynamicLinks: 676811143fd3601e75825fd4cc6eac61433aa34b
+  RNFBFirestore: 3c58f168e437c78200598c5945774397a1df24d1
+  RNFBFunctions: 08efed83f47320dfff52ecaa7dd48c91119059b6
+  RNFBIid: c3745573da38815e38b558104a88c5a9b19499ea
+  RNFBInAppMessaging: 028ca02ab5ffafcc88605fd9044bd84788d0d48f
+  RNFBMessaging: 13cd5384534e09454bcc74913a05e06598d6a18c
+  RNFBML: 6d77faa1249971a636c4256d009ccd56442cf15a
+  RNFBPerf: e3bf8a350f081f2ee2603dca3bd6f8c56aea7a2c
+  RNFBRemoteConfig: c7fe7222a5c8e4f214cca3a727337722642bbfe6
+  RNFBStorage: dc9df0544ccea1cdad00239423966ef438461516
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
 
-PODFILE CHECKSUM: 47acc3d334a0a65c3f8600d5375f0d6fcf6aa137
+PODFILE CHECKSUM: 25cda5a14df5322182a3bad4876faa9b94aafd3b
 
 COCOAPODS: 1.10.0


### PR DESCRIPTION
### Description

This increases firebase-android-sdk to 26.2.0 and firebase-ios-sdk to 7.3.0

It also fixes a mistake in storage e2e where I left an `.only` in place (luckily I don't think anything regressed in the couple days it was in)

This also fixes an error-handling change in firebase-ios-sdk for dynamic links in that do not exist in resolveLink which was caught by and is supported by e2e testing of the success and failure conditions of the resolveLink API

### Related issues

#4668 was the PR that had my incorrect `.only` inclusion

### Release Summary

PR title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
