### PR TITLE
fix(storage, ios): resolve listAll promise once and only once on error

### DIFF
--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -346,6 +346,20 @@ describe('storage() -> StorageReference', function() {
       result.prefixes.length.should.be.greaterThan(0);
       result.prefixes[0].constructor.name.should.eql('StorageReference');
     });
+
+    it('should not crash if the user is not allowed to list the directory', async function() {
+      const storageReference = firebase.storage().ref('/forbidden');
+      try {
+        await storageReference.listAll();
+        return Promise.reject(new Error('listAll on a forbidden directory succeeded'));
+      } catch (error) {
+        error.code.should.equal('storage/unauthorized');
+        error.message.should.equal(
+          '[storage/unauthorized] User is not authorized to perform the desired action.',
+        );
+        return Promise.resolve();
+      }
+    });
   });
 
   describe('updateMetadata', function() {

--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -199,8 +199,8 @@ RCT_EXPORT_METHOD(listAll:
   id completionBlock = ^(FIRStorageListResult *result, NSError *error) {
     // This may be called multiple times if an error occurs
     // Make sure we won't try to resolve the promise twice in this case
-    // See https://github.com/firebase/firebase-ios-sdk/blob/14764b8d60a6ad023d8fa5b7f81d42378d92e6fe/FirebaseStorage/Sources/FIRStorageReference.m#L417
-    if(alreadyCompleted) {
+    // TODO - remove pending resolution of https://github.com/firebase/firebase-ios-sdk/issues/7197
+    if (alreadyCompleted) {
       return;
     }
     alreadyCompleted = true;

--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -194,7 +194,16 @@ RCT_EXPORT_METHOD(listAll:
 ) {
   FIRStorageReference *storageReference = [self getReferenceFromUrl:url app:firebaseApp];
 
+  __block bool alreadyCompleted = false;
+
   id completionBlock = ^(FIRStorageListResult *result, NSError *error) {
+    // This may be called multiple times if an error occurs
+    // Make sure we won't try to resolve the promise twice in this case
+    // See https://github.com/firebase/firebase-ios-sdk/blob/14764b8d60a6ad023d8fa5b7f81d42378d92e6fe/FirebaseStorage/Sources/FIRStorageReference.m#L417
+    if(alreadyCompleted) {
+      return;
+    }
+    alreadyCompleted = true;
     if (error != nil) {
       [self promiseRejectStorageException:reject error:error];
     } else {


### PR DESCRIPTION
### Description

When calling `listAll` on a forbidden directory, the promise is rejected then RNFirebase tries to resolve it with an empty result, which leads to the following Exception (which I believe would crash the app in production):
```
Invariant Violation: No callback found with cbID 256 and callID 128 for  RNFBStorageModule.listAll - most likely the callback was already invoked. Args: '[{"nextPageToken":null,"items":[],"prefixes":[]}]'
2020-12-18 11:45:24.318162+0100 ExampleApp[40550:189312] [native] Running surface LogBox ({
    initialProps =     {
    };
    rootTag = 11;
})
```
The root cause is the lack of a `return`on this line of the Firebase iOS SDK : https://github.com/firebase/firebase-ios-sdk/blob/14764b8d60a6ad023d8fa5b7f81d42378d92e6fe/FirebaseStorage/Sources/FIRStorageReference.m#L417

This issue does not occur on Android

### Related issues
Upstream issue: https://github.com/firebase/firebase-ios-sdk/issues/7197

### Release Summary

* [Storage] FIX: Avoid a crash if listAll fails

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Try it on your project !
<details>
<summary>Storage rules</summary>

```
rules_version = '2';
service firebase.storage {
  match /b/{bucket}/o {
    match /stuff/{userId} {
      allow read: if false;
    }
  }
}
```
</details>

<details>
<summary>JS Code</summary>

```
import storage from "@react-native-firebase/storage";
storage().ref('stuff').listAll(console.log, console.warn);
```
</details>

The app will crash without this change on iOS.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
