### PR TITLE
docs(auth): note sendPasswordResetEmail resolves true even if SMTP settings invalid

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1468,6 +1468,8 @@ export namespace FirebaseAuthTypes {
      * Sends a password reset email to the given email address.
      * Unlike the web SDK, the email will contain a password reset link rather than a code.
      *
+     * (Warning: if you're using custom SMTP settings for your password reset emails on the Firebase console, the promise will resolve even if the SMTP settings are invalid and the email fails to send.)
+     *
      * #### Example
      *
      * ```js


### PR DESCRIPTION
Mentions that sendPasswordResetEmail will resolve even if the email fails to send when custom SMTP settings are configured on the Firebase console.

### Description

Little side note on the documentation to mention that invalid SMTP credentials on the firebase console still cause the `sendPasswordResetEmail` promise to **resolve**, even though the email fails to send.

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

### Test Plan

