### PR TITLE
feat(analytics): add support for analytics_auto_collection_enabled in firebase.json

### DIFF
--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -63,9 +63,22 @@ project.ext {
   ])
 }
 
+apply from: file("./../../app/android/firebase-json.gradle")
+
+def autoCollectionEnabled = "true"
+
+if (rootProject.ext && rootProject.ext.firebaseJson) {
+  if (rootProject.ext.firebaseJson.isFlagEnabled("analytics_auto_collection_enabled") == false) {
+    autoCollectionEnabled = "false"
+  }
+}
+
 android {
   defaultConfig {
     multiDexEnabled true
+    manifestPlaceholders = [
+      firebaseJsonAutoCollectionEnabled: autoCollectionEnabled
+    ]
   }
   lintOptions {
     disable 'GradleCompatible'

--- a/packages/analytics/android/src/main/AndroidManifest.xml
+++ b/packages/analytics/android/src/main/AndroidManifest.xml
@@ -5,4 +5,10 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+  <application>
+    <meta-data
+      android:name="firebase_analytics_collection_enabled"
+      android:value="${firebaseJsonAutoCollectionEnabled}"/>
+  </application>
 </manifest>

--- a/packages/app/ios_config.sh
+++ b/packages/app/ios_config.sh
@@ -86,6 +86,14 @@ if [[ ${_SEARCH_RESULT} ]]; then
   _PLIST_ENTRY_TYPES+=("string")
   _PLIST_ENTRY_VALUES+=("$_JSON_OUTPUT_BASE64")
 
+  # config.analytics_auto_collection_enabled
+  _ANALYTICS_AUTO_COLLECTION=$(getFirebaseJsonKeyValue "$_JSON_OUTPUT_RAW" "analytics_auto_collection_enabled")
+  if [[ $_ANALYTICS_AUTO_COLLECTION ]]; then
+    _PLIST_ENTRY_KEYS+=("FIREBASE_ANALYTICS_COLLECTION_ENABLED")
+    _PLIST_ENTRY_TYPES+=("bool")
+    _PLIST_ENTRY_VALUES+=("$(jsonBoolToYesNo "$_ANALYTICS_AUTO_COLLECTION")")
+  fi
+
   # config.messaging_auto_init_enabled
   _MESSAGING_AUTO_INIT=$(getFirebaseJsonKeyValue "$_JSON_OUTPUT_RAW" "messaging_auto_init_enabled")
   if [[ $_MESSAGING_AUTO_INIT ]]; then

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -15,7 +15,8 @@
     "messaging_android_notification_color": "@color/hotpink",
     "messaging_ios_auto_register_for_remote_messages": true,
 
-    "TODO_analytics_auto_collection_enabled": true,
+    "analytics_auto_collection_enabled": true,
+
     "TODO_perf_auto_collection_enabled": true,
     "TODO_in_app_messaging_auto_collection_enabled": true,
     "TODO_database_persistence_enabled": true,


### PR DESCRIPTION
### Description
This adds support for the [documented](analytics_auto_collection_enabled) but not implemented `analytics_auto_collection_enabled` in `firabase.json`.

I've aligned this with how `messaging_auto_init_enabled` is implemented.

### Related issues
Fixes #4473

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
I've asserted that both platforms log that analytics collection gets disabled:
* iOS: `[Firebase/Analytics][I-ACS023013] Analytics collection disabled`
* Android: `FA` `Event not sent since app measurement is disabled`


#### :fire: Thanks for all the hard work you've put into these great and very valuable packages!