### PR TITLE
fix(dynamic-links,android): getInitialLink returned more than once, and sometimes returned null

### DIFF
--- a/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
+++ b/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
@@ -47,8 +47,8 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
    */
   private boolean gotInitialLink = false;
   /**
-   *  Used by getInitialLink to check if the activity has been resumed.
-   * "host" here refers to the host activity.
+   * Used by getInitialLink to check if the activity has been resumed.
+   * "host" refers to the host activity, in terms of {@link LifeCycleEventListener#onHostResume()}
    */
   private boolean hostResumed = false;
   /**
@@ -134,7 +134,7 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
 
     // Check for the case where getInitialLink
     // runs before the LifeCycleState is RESUMED (e.g. BEFORE_CREATE or BEFORE_RESUME).
-    if(!hostResumed) {
+    if (!hostResumed) {
       // Use initialPromise to store the Promise that was passed and
       // run it when LifeCycleState changes to RESUMED in onHostResume.
       initialPromise = promise;
@@ -150,7 +150,7 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
 
     Intent currentIntent = currentActivity.getIntent();
     // Verify if the app was resumed from the Overview (history) screen.
-    launchedFromHistory = currentIntent != null && (currentIntent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0;
+    launchedFromHistory = (currentIntent != null) && ((currentIntent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0);
 
     FirebaseDynamicLinks.getInstance().getDynamicLink(currentIntent)
       .addOnCompleteListener(task -> {
@@ -438,7 +438,7 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
     hostResumed = true;
     // Check if getInitialLink was called before LifeCycleState was RESUMED
     // and there's a pending Promise.
-    if(initialPromise != null) {
+    if (initialPromise != null) {
       // Call getInitialLink getInitialLink with the Promise that was passed in the original call.
       getInitialLink(initialPromise);
       // Clear the Promise

--- a/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
+++ b/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
@@ -118,6 +118,7 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
       promise.resolve(null);
       return;
     }
+    
     Intent currentIntent = currentActivity.getIntent();
     launchedFromHistory = currentIntent != null && (currentIntent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0;
 


### PR DESCRIPTION
### Description

This PR addresses two issue:
1. `getInitialLink ` link is returned more than once.
2. `getInitialLink ` returns null.
* The Android SDK doesn't seem to clear the dynamic link after calling getDynamicLink in `getInitialLink`.  
(as stated in the official docs: `Calling getDynamicLink() retrieves the link and clears that data so it is only processed once by your app.`)  
This causes the link to be retrieved even when returning to the app from the Overview screen after backgrounding the app using the back button, which leads to unwanted results such as deep links being handled more than once.
* When `getInitialLink` is called before the host is resumed, `getCurrentActivity` will be null and `getInitialLink` will return null instead of trying to `getDynamicLink`.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #3990 
Fixes #3027 
### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire: