### PR TITLE
docs(links, android): added intent block for url scheme for android

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -116,6 +116,7 @@ SDKs.
 SHA1
 SHA-256
 SMS
+src
 SVG
 TestLab
 TFUA

--- a/docs/dynamic-links/usage/index.md
+++ b/docs/dynamic-links/usage/index.md
@@ -139,8 +139,34 @@ The iOS Notes app is a good place to paste your dynamic link and test it opens y
 
 2. Test the domain you created in your Firebase console (first step in `Firebase Setup`). Go to the following location in your browser `[your-domain]/.well-known/assetlinks.json`. The response will have a `target` object containing a `package_name` which ought to have your app's package name. Please
    do not proceed until you see this, it may take a while to register.
+   
+3. Add your domains to the android/app/src/main/AndroidManifest.xml so that your app knows what links to open in the app. Below is the example code:
 
-3. Test the dynamic link works via your emulator by pasting it into in a text message, notepad or email, and checking that it does open your application (ensure the app is installed on the emulator).
+```xml
+    .
+    .
+    .
+      <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+         <!-- Add code below here  -->
+         <intent-filter>
+          <action android:name="android.intent.action.VIEW"/>
+          <category android:name="android.intent.category.DEFAULT"/>
+          <category android:name="android.intent.category.BROWSABLE"/>
+          <data  android:host="rnfbtestapplication.page.link" android:scheme="https"/>
+         <data  android:host="rnfbtestapplication.page.link" android:scheme="http"/>
+        </intent-filter>
+         <!-- Add code above from here.  -->
+      </activity>
+  <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+  .
+  .
+  .
+```
+
+4. Test the dynamic link works via your emulator by pasting it into in a text message, notepad or email, and checking that it does open your application (ensure the app is installed on the emulator).
 
 ## Create a Link
 

--- a/docs/dynamic-links/usage/index.md
+++ b/docs/dynamic-links/usage/index.md
@@ -140,7 +140,7 @@ The iOS Notes app is a good place to paste your dynamic link and test it opens y
 2. Test the domain you created in your Firebase console (first step in `Firebase Setup`). Go to the following location in your browser `[your-domain]/.well-known/assetlinks.json`. The response will have a `target` object containing a `package_name` which ought to have your app's package name. Please
    do not proceed until you see this, it may take a while to register.
    
-3. Add your domains to the android/app/src/main/AndroidManifest.xml so that your app knows what links to open in the app. Refer [the official docs](https://firebase.google.com/docs/dynamic-links/android/receive#add-an-intent-filter-for-deep-links) for example code.
+3. Add your domains to the android/app/src/main/AndroidManifest.xml so that your app knows what links to open in the app. Refer to [the official docs](https://firebase.google.com/docs/dynamic-links/android/receive#add-an-intent-filter-for-deep-links) for example code.
 
 4. Test the dynamic link works via your emulator by pasting it into in a text message, notepad or email, and checking that it does open your application (ensure the app is installed on the emulator).
 

--- a/docs/dynamic-links/usage/index.md
+++ b/docs/dynamic-links/usage/index.md
@@ -140,31 +140,7 @@ The iOS Notes app is a good place to paste your dynamic link and test it opens y
 2. Test the domain you created in your Firebase console (first step in `Firebase Setup`). Go to the following location in your browser `[your-domain]/.well-known/assetlinks.json`. The response will have a `target` object containing a `package_name` which ought to have your app's package name. Please
    do not proceed until you see this, it may take a while to register.
    
-3. Add your domains to the android/app/src/main/AndroidManifest.xml so that your app knows what links to open in the app. Below is the example code:
-
-```xml
-    .
-    .
-    .
-      <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-         <!-- Add code below here  -->
-         <intent-filter>
-          <action android:name="android.intent.action.VIEW"/>
-          <category android:name="android.intent.category.DEFAULT"/>
-          <category android:name="android.intent.category.BROWSABLE"/>
-          <data  android:host="rnfbtestapplication.page.link" android:scheme="https"/>
-         <data  android:host="rnfbtestapplication.page.link" android:scheme="http"/>
-        </intent-filter>
-         <!-- Add code above from here.  -->
-      </activity>
-  <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-  .
-  .
-  .
-```
+3. Add your domains to the android/app/src/main/AndroidManifest.xml so that your app knows what links to open in the app. Refer [the official docs](https://firebase.google.com/docs/dynamic-links/android/receive#add-an-intent-filter-for-deep-links) for example code.
 
 4. Test the dynamic link works via your emulator by pasting it into in a text message, notepad or email, and checking that it does open your application (ensure the app is installed on the emulator).
 


### PR DESCRIPTION
I added a missing step in the documentation, where the user has to add the URLs scheme in the AndroidManifest.xml file.

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
