### PR TITLE
fix(app, android): require default firebase.json boolean key

### DIFF
--- a/packages/admob/android/build.gradle
+++ b/packages/admob/android/build.gradle
@@ -74,7 +74,7 @@ def firebaseJSONAdmobDelayAppMeasurementInitBool = false
 
 if (rootProject.ext.firebaseJson) {
   firebaseJSONAdmobAppIDString = rootProject.ext.firebaseJson.getStringValue("admob_android_app_id", "")
-  firebaseJSONAdmobDelayAppMeasurementInitBool = rootProject.ext.firebaseJson.isFlagEnabled("admob_delay_app_measurement_init")
+  firebaseJSONAdmobDelayAppMeasurementInitBool = rootProject.ext.firebaseJson.isFlagEnabled("admob_delay_app_measurement_init", false)
 }
 
 if (!firebaseJSONAdmobAppIDString) {

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -68,7 +68,7 @@ apply from: file("./../../app/android/firebase-json.gradle")
 def autoCollectionEnabled = "true"
 
 if (rootProject.ext && rootProject.ext.firebaseJson) {
-  if (rootProject.ext.firebaseJson.isFlagEnabled("analytics_auto_collection_enabled") == false) {
+  if (rootProject.ext.firebaseJson.isFlagEnabled("analytics_auto_collection_enabled", true) == false) {
     autoCollectionEnabled = "false"
   }
 }

--- a/packages/app/android/firebase-json.gradle
+++ b/packages/app/android/firebase-json.gradle
@@ -32,8 +32,9 @@ if (jsonFile != null && jsonFile.exists()) {
 
     rootProject.ext.firebaseJson = [
       raw: json[jsonRoot],
-      isFlagEnabled: { key ->
-        return json[jsonRoot] != null && json[jsonRoot][key] == true
+      isFlagEnabled: { key, defaultValue ->
+        if (json[jsonRoot] == null || json[jsonRoot][key] == null) return defaultValue
+        return json[jsonRoot][key] == true ? true : false
       },
       getStringValue: { key, defaultValue ->
         if (json[jsonRoot] == null) return defaultValue

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -72,7 +72,7 @@ def notificationColor = defaultNotificationColor
 
 
 if (rootProject.ext && rootProject.ext.firebaseJson) {
-  if (rootProject.ext.firebaseJson.isFlagEnabled("messaging_auto_init_enabled") == false) {
+  if (rootProject.ext.firebaseJson.isFlagEnabled("messaging_auto_init_enabled", true) == false) {
     autoInitEnabled = "false"
   }
   notificationChannelId = rootProject.ext.firebaseJson.getStringValue("messaging_android_notification_channel_id", "")


### PR DESCRIPTION
### Description

This fixes the case where firebase.json existed but the key being
query was missing. Previously the config system would silently fail on
the missing key and return false even though the default for some keys
should be true

In particular this caused analytics auto collection to be disabled
if you had a firebase.json but no analytics_auto_collection_enabled = true entry,
even though the default should have been true

Credit to @WadhahEssam for discovery, diagnosis, and general solution

### Related issues

Fixes #4784 
Obsoletes #4786 (different API shape, same solution though)

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I tested:
- firebase.json present, key missing, default value false: got false
- firebase.json present, key missing, default value true: got true
- firebase.json present, key present and true, default value false: got true
- firebase.json present, key present and false, default value true: got false

Seems to work fine although I did discover some problems and was able to break my tests - the tests I was doing were testing it and I proved it locally by toggling back and forth

the logic is not engaged if firebase.json is not present

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
