### PR TITLE
docs(functions): updated instructions for using useFunctionsEmulator

### DIFF
--- a/docs/functions/usage/index.md
+++ b/docs/functions/usage/index.md
@@ -99,6 +99,7 @@ import functions from '@react-native-firebase/functions';
 
 // Use a local emulator in development
 if (__DEV__) {
+  // If you are running on a physical device, replace http://localhost with the local ip of your PC. (http://192.168.x.x)
   functions().useFunctionsEmulator('http://localhost:5000');
 }
 ```


### PR DESCRIPTION
### Description

The documentation shows the usage of `useFunctionsEmulator` as `functions().useFunctionsEmulator('http://localhost:5000');` however this will only work when the phone is running on an emulator. Added a comment reminding that when used on a real device, non localhost URLs should be used.

### Related issues

Fixes (Solves)  #4827 
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
