### PR TITLE
fix(admob): improve defense logic to prevent multiple calls

### DIFF
--- a/packages/admob/lib/ads/InterstitialAd.js
+++ b/packages/admob/lib/ads/InterstitialAd.js
@@ -45,11 +45,11 @@ export default class InterstitialAd extends MobileAd {
 
   load() {
     // Prevent multiple load calls
-    if (this._loaded) {
+    if (this._loaded || this._isLoadCalled) {
       return;
     }
 
-    this._loaded = true;
+    this._isLoadCalled = true;
     this._admob.native.interstitialLoad(this._requestId, this._adUnitId, this._requestOptions);
   }
 

--- a/packages/admob/lib/ads/MobileAd.js
+++ b/packages/admob/lib/ads/MobileAd.js
@@ -28,6 +28,7 @@ export default class MobileAd {
     this._requestOptions = requestOptions;
 
     this._loaded = false;
+    this._isLoadCalled = false;
     this._onAdEventHandler = null;
 
     this._nativeListener = admob.emitter.addListener(
@@ -45,6 +46,7 @@ export default class MobileAd {
 
     if (type === AdEventType.CLOSED || type === RewardedAdEventType.CLOSED) {
       this._loaded = false;
+      this._isLoadCalled = false;
     }
 
     if (this._onAdEventHandler) {

--- a/packages/admob/lib/ads/RewardedAd.js
+++ b/packages/admob/lib/ads/RewardedAd.js
@@ -45,11 +45,11 @@ export default class RewardedAd extends MobileAd {
 
   load() {
     // Prevent multiple load calls
-    if (this._loaded) {
+    if (this._loaded || this._isLoadCalled) {
       return;
     }
 
-    this._loaded = true;
+    this._isLoadCalled = true;
     this._admob.native.rewardedLoad(this._requestId, this._adUnitId, this._requestOptions);
   }
 


### PR DESCRIPTION
### Description

**`loaded: Whether the advert is loaded and can be shown.`**

If `_loaded` is changed to `true` when `load()` is called, the meaning of `loaded` getter becomes ambiguous.

If the goal is to prevent multiple calls, it would be better to use other variables for this.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No
