### PR TITLE
feat(perf): support "perf_auto_collection_enabled" flag in firebase.json

### DIFF
--- a/packages/app/ios_config.sh
+++ b/packages/app/ios_config.sh
@@ -94,6 +94,14 @@ if [[ ${_SEARCH_RESULT} ]]; then
     _PLIST_ENTRY_VALUES+=("$(jsonBoolToYesNo "$_ANALYTICS_AUTO_COLLECTION")")
   fi
 
+  # config.perf_auto_collection_enabled
+  _PERF_AUTO_COLLECTION=$(getFirebaseJsonKeyValue "$_JSON_OUTPUT_RAW" "perf_auto_collection_enabled")
+  if [[ $_PERF_AUTO_COLLECTION ]]; then
+    _PLIST_ENTRY_KEYS+=("firebase_performance_collection_enabled")
+    _PLIST_ENTRY_TYPES+=("bool")
+    _PLIST_ENTRY_VALUES+=("$(jsonBoolToYesNo "$_PERF_AUTO_COLLECTION")")
+  fi
+
   # config.messaging_auto_init_enabled
   _MESSAGING_AUTO_INIT=$(getFirebaseJsonKeyValue "$_JSON_OUTPUT_RAW" "messaging_auto_init_enabled")
   if [[ $_MESSAGING_AUTO_INIT ]]; then

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -63,9 +63,22 @@ project.ext {
   ])
 }
 
+apply from: file("./../../app/android/firebase-json.gradle")
+
+def autoCollectionEnabled = "true"
+
+if (rootProject.ext && rootProject.ext.firebaseJson) {
+  if (rootProject.ext.firebaseJson.isFlagEnabled("perf_auto_collection_enabled", true) == false) {
+    autoCollectionEnabled = "false"
+  }
+}
+
 android {
   defaultConfig {
     multiDexEnabled true
+    manifestPlaceholders = [
+      firebaseJsonAutoCollectionEnabled: autoCollectionEnabled
+    ]
   }
   lintOptions {
     disable 'GradleCompatible'

--- a/packages/perf/android/src/main/AndroidManifest.xml
+++ b/packages/perf/android/src/main/AndroidManifest.xml
@@ -1,2 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.invertase.firebase.perf" />
+
+<manifest package="io.invertase.firebase.perf"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <meta-data
+        android:name="firebase_performance_collection_enabled"
+        android:value="${firebaseJsonAutoCollectionEnabled}" />
+  </application>
+</manifest>

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -17,7 +17,8 @@
 
     "analytics_auto_collection_enabled": true,
 
-    "TODO_perf_auto_collection_enabled": true,
+    "perf_auto_collection_enabled": true,
+
     "TODO_in_app_messaging_auto_collection_enabled": true,
     "TODO_database_persistence_enabled": true,
     "TODO_firestore_persistence_enabled": true,


### PR DESCRIPTION
### Description

More or less clones https://github.com/invertase/react-native-firebase/commit/9a24ecd2826bfa8ab30657287432ccaeff8b7c7c
 
### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [X] Yes - Theoretically if someone had this flag set beforehand, it would not have been accurately reflected. This could be a breaking change in the sense that it would change someone's app configuration.
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Checking that firebase performance is disabled on app start when this flag is set.