### PR TITLE
fix(android, dependencies): remove vestigial ml dependencies, add browser dep to auth

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -50,6 +50,7 @@ Firestore
 GDPR
 globals
 Gradle
+gradle
 Hesp
 Homebrew
 HTTP

--- a/docs/in-app-messaging/usage/index.md
+++ b/docs/in-app-messaging/usage/index.md
@@ -24,6 +24,8 @@ yarn add @react-native-firebase/in-app-messaging
 cd ios/ && pod install
 ```
 
+Note: in-app-messaging requires a minimum android gradle plugin version of 3.5.4 to compile or you will see `AAPT` errors regarding unexpected XML with `<queries>` elements. However, `react-native@0.63.4` still ships with a default of 3.5.3. If you have not already, you must update the line `classpath("com.android.tools.build:gradle:3.5.3")`in `android/build.gradle` to a minimum of `3.5.4` for android builds to work.
+
 If you're using an older version of React Native without autolinking support, or wish to integrate into an existing project,
 you can follow the manual installation steps for [iOS](/in-app-messaging/usage/installation/ios) and [Android](/in-app-messaging/usage/installation/android).
 

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -81,10 +81,21 @@ repositories {
   jcenter()
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+def BROWSER_VERSION = safeExtGet('androidxBrowserVersion', '[1.0.0, 2.0.0)')
+
 dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-auth"
+
+  // This is needed for the reCAPTCHA flow but is incorrectly missing as a transitive dependency upstream
+  // https://github.com/invertase/react-native-firebase/issues/4744
+  // https://github.com/firebase/firebase-android-sdk/issues/2164
+  implementation "androidx.browser:browser:${BROWSER_VERSION}"
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/ml/android/build.gradle
+++ b/packages/ml/android/build.gradle
@@ -94,8 +94,6 @@ dependencies {
 
   implementation 'com.google.android.gms:play-services-vision:20.1.1'
   implementation 'com.google.android.gms:play-services-vision-common:19.1.1'
-  implementation 'com.google.android.gms:play-services-vision-image-labeling-internal:16.0.5'
-  implementation 'com.google.android.gms:play-services-vision-image-label:18.0.5'
   implementation 'com.google.firebase:firebase-ml-model-interpreter:22.0.4'
 }
 


### PR DESCRIPTION
### Description

Android dependencies in ML were still pulling in an on-device library, unnecessarily bloating APKs, #4750 / #4871 

Auth module depends on androidx.browser for reCAPTCHA flow but it is not included transitively from upstream, this leads to crashes so including a workaround here while upstream issue resolves seems reasonable, #4744 / https://github.com/firebase/firebase-android-sdk/issues/2164

### Release Summary

This should be re-base merged, each commit has a correct commit title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
