### PR TITLE
fix(auth, android): do not timezone offset when getting UTC timestamp

### DIFF
--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -97,12 +97,10 @@ public class SharedUtils {
   }
 
   public static String timestampToUTC(long timestamp) {
-    Calendar calendar = Calendar.getInstance();
     long millisTimestamp = timestamp * 1000;
-    Date date = new Date(millisTimestamp + calendar.getTimeZone().getOffset(millisTimestamp));
-    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
     format.setTimeZone(TimeZone.getTimeZone("UTC"));
-    return format.format(date);
+    return format.format(millisTimestamp);
   }
 
   /**

--- a/packages/auth/e2e/user.e2e.js
+++ b/packages/auth/e2e/user.e2e.js
@@ -51,8 +51,8 @@ describe('auth().currentUser', function () {
   });
 
   describe('getIdTokenResult()', function () {
-    it("should return a valid IdTokenResult Object", async function() {
-      const random = Utils.randString(12, "#aA");
+    it('should return a valid IdTokenResult Object', async function () {
+      const random = Utils.randString(12, '#aA');
       const email = `${random}@${random}.com`;
 
       const { user } = await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -65,9 +65,9 @@ describe('auth().currentUser', function () {
       tokenResult.issuedAtTime.should.be.a.String();
       tokenResult.expirationTime.should.be.a.String();
 
-      new Date(tokenResult.authTime).toString().should.not.equal("Invalid Date");
-      new Date(tokenResult.issuedAtTime).toString().should.not.equal("Invalid Date");
-      new Date(tokenResult.expirationTime).toString().should.not.equal("Invalid Date");
+      new Date(tokenResult.authTime).toString().should.not.equal('Invalid Date');
+      new Date(tokenResult.issuedAtTime).toString().should.not.equal('Invalid Date');
+      new Date(tokenResult.expirationTime).toString().should.not.equal('Invalid Date');
 
       tokenResult.claims.should.be.a.Object();
       tokenResult.claims.iat.should.be.a.Number();
@@ -77,7 +77,7 @@ describe('auth().currentUser', function () {
       new Date(tokenResult.issuedAtTime).getTime().should.equal(tokenResult.claims.iat * 1000);
       new Date(tokenResult.expirationTime).getTime().should.equal(tokenResult.claims.exp * 1000);
 
-      tokenResult.signInProvider.should.equal("password");
+      tokenResult.signInProvider.should.equal('password');
       tokenResult.token.length.should.be.greaterThan(24);
 
       // Clean up

--- a/packages/auth/e2e/user.e2e.js
+++ b/packages/auth/e2e/user.e2e.js
@@ -51,8 +51,8 @@ describe('auth().currentUser', function () {
   });
 
   describe('getIdTokenResult()', function () {
-    it('should return a valid IdTokenResult Object', async function () {
-      const random = Utils.randString(12, '#aA');
+    it.only("should return a valid IdTokenResult Object", async function() {
+      const random = Utils.randString(12, "#aA");
       const email = `${random}@${random}.com`;
 
       const { user } = await firebase.auth().createUserWithEmailAndPassword(email, random);
@@ -65,15 +65,19 @@ describe('auth().currentUser', function () {
       tokenResult.issuedAtTime.should.be.a.String();
       tokenResult.expirationTime.should.be.a.String();
 
-      new Date(tokenResult.authTime).toString().should.not.equal('Invalid Date');
-      new Date(tokenResult.issuedAtTime).toString().should.not.equal('Invalid Date');
-      new Date(tokenResult.expirationTime).toString().should.not.equal('Invalid Date');
+      new Date(tokenResult.authTime).toString().should.not.equal("Invalid Date");
+      new Date(tokenResult.issuedAtTime).toString().should.not.equal("Invalid Date");
+      new Date(tokenResult.expirationTime).toString().should.not.equal("Invalid Date");
 
       tokenResult.claims.should.be.a.Object();
       tokenResult.claims.iat.should.be.a.Number();
+      tokenResult.claims.exp.should.be.a.Number();
       tokenResult.claims.iss.should.be.a.String();
 
-      tokenResult.signInProvider.should.equal('password');
+      new Date(tokenResult.issuedAtTime).getTime().should.equal(tokenResult.claims.iat * 1000);
+      new Date(tokenResult.expirationTime).getTime().should.equal(tokenResult.claims.exp * 1000);
+
+      tokenResult.signInProvider.should.equal("password");
       tokenResult.token.length.should.be.greaterThan(24);
 
       // Clean up

--- a/packages/auth/e2e/user.e2e.js
+++ b/packages/auth/e2e/user.e2e.js
@@ -51,7 +51,7 @@ describe('auth().currentUser', function () {
   });
 
   describe('getIdTokenResult()', function () {
-    it.only("should return a valid IdTokenResult Object", async function() {
+    it("should return a valid IdTokenResult Object", async function() {
       const random = Utils.randString(12, "#aA");
       const email = `${random}@${random}.com`;
 


### PR DESCRIPTION
### Description

In Android, JWT's iat and exp are now converted to correctly UTC time in strings.
Unnecessary offsets were being added to the timestamps, causing them to be converted to the wrong UTC time in strings.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I have tested the following:

- The JWT iat was correctly converted to UTC time.
- The JWT exp was correctly converted to UTC time.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
