### PR TITLE
improvement(crashlytics): Make additional non-fatal error generation on JS exception optional

### DIFF
--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -220,3 +220,16 @@ React Native. You can disable Crashlytics NDK in your `firebase.json` config.
   }
 }
 ```
+
+## Crashlytics additional non-fatal issue generation
+
+React Native Crashlytics module is generating additional non-fatal issues on JavaScript exceptions by default. Sometimes it is not desirable behavior since it might duplicate issues and hide original exceptions logs. You can disable this behavior by setting appropriate option to false:
+
+```json
+// <project-root>/firebase.json
+{
+  "react-native": {
+    "crashlytics_is_error_generation_on_js_crash_enabled": false
+  }
+}
+```

--- a/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/Constants.java
+++ b/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/Constants.java
@@ -21,4 +21,5 @@ class Constants {
   final static String KEY_CRASHLYTICS_NDK_ENABLED = "crashlytics_ndk_enabled";
   final static String KEY_CRASHLYTICS_DEBUG_ENABLED = "crashlytics_debug_enabled";
   final static String KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED = "crashlytics_auto_collection_enabled";
+  final static String KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED = "crashlytics_is_error_generation_on_js_crash_enabled";
 }

--- a/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsInitProvider.java
+++ b/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsInitProvider.java
@@ -46,6 +46,23 @@ public class ReactNativeFirebaseCrashlyticsInitProvider extends ReactNativeFireb
     return enabled;
   }
 
+  static boolean isErrorGenerationOnJSCrashEnabled() {
+    boolean enabled;
+    ReactNativeFirebaseJSON json = ReactNativeFirebaseJSON.getSharedInstance();
+    ReactNativeFirebaseMeta meta = ReactNativeFirebaseMeta.getSharedInstance();
+    ReactNativeFirebasePreferences prefs = ReactNativeFirebasePreferences.getSharedInstance();
+
+    if (prefs.contains(KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED)) {
+      enabled = prefs.getBooleanValue(KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED, true);
+    } else if (json.contains(KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED)) {
+      enabled = json.getBooleanValue(KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED, true);
+    } else {
+      enabled = meta.getBooleanValue(KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED, true);
+    }
+
+    return enabled;
+  }
+
   @Override
   public boolean onCreate() {
     super.onCreate();

--- a/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsModule.java
+++ b/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsModule.java
@@ -185,6 +185,10 @@ public class ReactNativeFirebaseCrashlyticsModule extends ReactNativeFirebaseMod
       "isCrashlyticsCollectionEnabled",
       ReactNativeFirebaseCrashlyticsInitProvider.isCrashlyticsCollectionEnabled()
     );
+    constants.put(
+      "isErrorGenerationOnJSCrashEnabled",
+      ReactNativeFirebaseCrashlyticsInitProvider.isErrorGenerationOnJSCrashEnabled()
+    );
     return constants;
   }
 }

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.h
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.h
@@ -22,6 +22,8 @@
 
 + (BOOL)isCrashlyticsCollectionEnabled;
 
++ (BOOL)isErrorGenerationOnJSCrashEnabled;
+
 /// Returns one or more FIRComponents that will be registered in
 /// FIRApp and participate in dependency resolution and injection.
 + (NSArray<FIRComponent *> *)componentsToRegister;

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
@@ -25,6 +25,7 @@
 
 NSString *const KEY_CRASHLYTICS_DEBUG_ENABLED = @"crashlytics_debug_enabled";
 NSString *const KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED = @"crashlytics_auto_collection_enabled";
+NSString *const KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED = @"crashlytics_is_error_generation_on_js_crash_enabled";
 
 @implementation RNFBCrashlyticsInitProvider
 
@@ -48,6 +49,26 @@ NSString *const KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED = @"crashlytics_auto_col
   }
 
   DLog(@"isCrashlyticsCollectionEnabled: %d", enabled);
+
+  return enabled;
+}
+
++ (BOOL)isErrorGenerationOnJSCrashEnabled {
+  BOOL enabled;
+
+  if ([[RNFBPreferences shared] contains:KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED]) {
+    enabled = [[RNFBPreferences shared] getBooleanValue:KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED defaultValue:YES];
+    DLog(@"isErrorGenerationOnJSCrashEnabled via RNFBPreferences: %d", enabled);
+  } else if ([[RNFBJSON shared] contains:KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED]) {
+    enabled = [[RNFBJSON shared] getBooleanValue:KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED defaultValue:YES];
+    DLog(@"isErrorGenerationOnJSCrashEnabled via RNFBJSON: %d", enabled);
+  } else {
+    // Note that if we're here, and the key is not set on the app's bundle, we default to "YES"
+    enabled = [RNFBMeta getBooleanValue:KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED defaultValue:YES];
+    DLog(@"isErrorGenerationOnJSCrashEnabled via RNFBMeta: %d", enabled);
+  }
+
+  DLog(@"isErrorGenerationOnJSCrashEnabled: %d", enabled);
 
   return enabled;
 }

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -32,6 +32,7 @@ RCT_EXPORT_MODULE();
 - (NSDictionary *)constantsToExport {
   NSMutableDictionary *constants = [NSMutableDictionary new];
   constants[@"isCrashlyticsCollectionEnabled"] = @([RCTConvert BOOL:@([RNFBCrashlyticsInitProvider isCrashlyticsCollectionEnabled])]);
+  constants[@"isErrorGenerationOnJSCrashEnabled"] = @([RCTConvert BOOL:@([RNFBCrashlyticsInitProvider isErrorGenerationOnJSCrashEnabled])]);
   return constants;
 }
 

--- a/packages/crashlytics/lib/handlers.js
+++ b/packages/crashlytics/lib/handlers.js
@@ -75,11 +75,13 @@ export const setGlobalErrorHandler = once(nativeModule => {
       return originalHandler(error, fatal);
     }
 
-    try {
-      const stackFrames = await StackTrace.fromError(error, { offline: true });
-      await nativeModule.recordErrorPromise(createNativeErrorObj(error, stackFrames, false));
-    } catch (_) {
-      // do nothing
+    if (nativeModule.isErrorGenerationOnJSCrashEnabled) {
+      try {
+        const stackFrames = await StackTrace.fromError(error, {offline: true});
+        await nativeModule.recordErrorPromise(createNativeErrorObj(error, stackFrames, false));
+      } catch (_) {
+        // do nothing
+      }
     }
     return originalHandler(error, fatal);
   }

--- a/packages/crashlytics/lib/handlers.js
+++ b/packages/crashlytics/lib/handlers.js
@@ -77,7 +77,7 @@ export const setGlobalErrorHandler = once(nativeModule => {
 
     if (nativeModule.isErrorGenerationOnJSCrashEnabled) {
       try {
-        const stackFrames = await StackTrace.fromError(error, {offline: true});
+        const stackFrames = await StackTrace.fromError(error, { offline: true });
         await nativeModule.recordErrorPromise(createNativeErrorObj(error, stackFrames, false));
       } catch (_) {
         // do nothing

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -8,6 +8,7 @@
     "crashlytics_debug_enabled": true,
     "crashlytics_disable_auto_disabler": false,
     "crashlytics_auto_collection_enabled": true,
+    "crashlytics_is_error_generation_on_js_crash_enabled": true,
 
     "messaging_auto_init_enabled": true,
     "messaging_android_headless_task_timeout": 30000,


### PR DESCRIPTION
### Description

Currently, the crashlytics react-native package generates an additional non-fatal issue on JS crashes that might cause issues duplication and absence of collected logs for original exceptions. This PR introduces an option in firebase.json to prevent the module from generating that additional error.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

Fixes #4772 
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
