### PR TITLE
fix(dynamic-links, dependencies): analytics is optional

### DIFF
--- a/packages/dynamic-links/package.json
+++ b/packages/dynamic-links/package.json
@@ -23,7 +23,6 @@
     "dynamic link"
   ],
   "peerDependencies": {
-    "@react-native-firebase/analytics": "10.7.0",
     "@react-native-firebase/app": "10.7.0"
   },
   "publishConfig": {


### PR DESCRIPTION
Per @nfcampos analytics is actually optional for dynamic links
This information is not mentioned in main documentation but present in some supporting docs
https://github.com/invertase/react-native-firebase/pull/4850#issuecomment-776516887

### Related issues

#4850

### Release Summary

PR title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
