### PR TITLE
fix(dynamic-links, ios): remove double-reject on resolveLink

### DIFF
--- a/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
+++ b/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
@@ -206,14 +206,7 @@ RCT_EXPORT_METHOD(resolveLink:
     }
   };
 
-  NSURL *linkURL = [NSURL URLWithString:link];
-  BOOL success = [[FIRDynamicLinks dynamicLinks] handleUniversalLink:linkURL completion:completion];
-  if (!success) {
-    [RNFBSharedUtils rejectPromiseWithUserInfo:reject userInfo:(NSMutableDictionary *) @{
-        @"code": @"not-found",
-        @"message": @"Dynamic link not found"
-    }];
-  }
+  [[FIRDynamicLinks dynamicLinks] handleUniversalLink:[NSURL URLWithString:link] completion:completion];
 }
 
 - (FIRDynamicLinkComponents *)createDynamicLinkComponents:(NSDictionary *)dynamicLinkDict {


### PR DESCRIPTION
the iOS firebase-ios-sdk handleUniversalLink completion handler
correctly handles all of the error conditions by resolving or rejecting
the passed in react-native promise as needed, but was incorrectly
then testing success status and rejecting again on unfound links

e2e tests were already probing this case to verify correct behavior
at the javascript level but the native-level double-reject went
unnoticed until now

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Ironically resolveLink was my own code and it demonstrates exactly why I am so cautious around Objective-C. The tests I wrote at least already covered the case to expose the error, I suppose a react-native upgrade added the native double-reject test as it's unclear how that could have been missed during resolveLink method implementation

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
