### PR TITLE
fix(admob): AdEventHandler returns javascript (not native) unsubscribe function

### DIFF
--- a/packages/admob/lib/ads/MobileAd.js
+++ b/packages/admob/lib/ads/MobileAd.js
@@ -61,7 +61,7 @@ export default class MobileAd {
 
   _setAdEventHandler(handler) {
     this._onAdEventHandler = handler;
-    return () => this._onAdEventHandler = null;
+    return () => (this._onAdEventHandler = null);
   }
 
   get adUnitId() {

--- a/packages/admob/lib/ads/MobileAd.js
+++ b/packages/admob/lib/ads/MobileAd.js
@@ -61,7 +61,7 @@ export default class MobileAd {
 
   _setAdEventHandler(handler) {
     this._onAdEventHandler = handler;
-    return () => this._nativeListener.remove();
+    return () => this._onAdEventHandler = null;
   }
 
   get adUnitId() {


### PR DESCRIPTION
`_setAdEventHandler` method return a wrong unsubscribe function. It should remove js listener, but instead it unsubscribe ad instance from native events and _onAdEventHandler is still could be used by the instance

### Description

RewardedAd instance onAdEvent method uses _setAdEventHandler of it's superclass. Logically it should return function that will unsubscribe listener that we add, but instead it unsubscribe instance from native events.
### Related issues

It's not possible to use different listeners for load and show ad because after first unsubscribe ad intance doesn't receive any native events anymore

```
const rewarded = RewardedAd.createForAdRequest(TestIds.REWARDED, {
  requestNonPersonalizedAdsOnly: true,
})

const loadAd = () => {
  if ([AdLoadStatus.InProgress, AdLoadStatus.Loaded].includes(adLoadStatus)) {
    return
  }
  const eventListener = rewarded.onAdEvent((type, error) => {
    if (type === RewardedAdEventType.LOADED) {
      adLoadStatus = AdLoadStatus.Loaded
      eventListener()
    } else if (type === AdEventType.ERROR) {
      adLoadStatus = AdLoadStatus.Failed
      eventListener()
    }
  })
  rewarded.load()
}

const showAd = (callback: () => void) => {
  const eventListener = rewarded.onAdEvent((type, error) => {
    console.log('SHow Ad error ', error, type)
    if (type === RewardedAdEventType.EARNED_REWARD) {
      adLoadStatus = AdLoadStatus.Idle
      eventListener()
      callback()
    }
  })
  rewarded.show()
}
```

When we call loadAd on app start and then we want to call showAd at some moment it won't receive any native events

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ x ] Yes
- My change supports the following platforms;
  - [ x ] `Android`
  - [ x ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ x ] I have updated TypeScript types that are affected by my change. (there is no changes in types)
- This is a breaking change;
  - [ ] Yes
  - [ x ] No

