### PR TITLE
fix(admob, android): unity ads require Activity Context

### DIFF
--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
@@ -17,7 +17,7 @@ package io.invertase.firebase.admob;
  *
  */
 
-import android.content.Context;
+import android.app.Activity;
 import android.util.SparseArray;
 
 import com.facebook.react.bridge.Arguments;
@@ -64,19 +64,16 @@ public class ReactNativeFirebaseAdMobInterstitialModule extends ReactNativeFireb
 
   @ReactMethod
   public void interstitialLoad(int requestId, String adUnitId, ReadableMap adRequestOptions) {
-    if (getCurrentActivity() == null) {
+    Activity currentActivity = getCurrentActivity();
+    if (currentActivity == null) {
       WritableMap error = Arguments.createMap();
       error.putString("code", "null-activity");
       error.putString("message", "Interstitial ad attempted to load but the current Activity was null.");
       sendInterstitialEvent(AD_ERROR, requestId, adUnitId, error);
       return;
     }
-    getCurrentActivity().runOnUiThread(() -> {
-      Context adContext = getCurrentActivity();
-      if (adContext == null) {
-        adContext = getApplicationContext();
-      }
-      InterstitialAd interstitialAd = new InterstitialAd(adContext);
+    currentActivity.runOnUiThread(() -> {
+      InterstitialAd interstitialAd = new InterstitialAd(currentActivity);
       interstitialAd.setAdUnitId(adUnitId);
 
       // Apply AdRequest builder

--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobInterstitialModule.java
@@ -17,6 +17,7 @@ package io.invertase.firebase.admob;
  *
  */
 
+import android.content.Context;
 import android.util.SparseArray;
 
 import com.facebook.react.bridge.Arguments;
@@ -71,7 +72,11 @@ public class ReactNativeFirebaseAdMobInterstitialModule extends ReactNativeFireb
       return;
     }
     getCurrentActivity().runOnUiThread(() -> {
-      InterstitialAd interstitialAd = new InterstitialAd(getApplicationContext());
+      Context adContext = getCurrentActivity();
+      if (adContext == null) {
+        adContext = getApplicationContext();
+      }
+      InterstitialAd interstitialAd = new InterstitialAd(adContext);
       interstitialAd.setAdUnitId(adUnitId);
 
       // Apply AdRequest builder

--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
@@ -59,7 +59,7 @@ public class ReactNativeFirebaseAdMobRewardedModule extends ReactNativeFirebaseM
       return;
     }
     getCurrentActivity().runOnUiThread(() -> {
-      RewardedAd rewardedAd = new RewardedAd(getApplicationContext(), adUnitId);
+      RewardedAd rewardedAd = new RewardedAd(getCurrentActivity(), adUnitId);
 
       RewardedAdLoadCallback adLoadCallback = new RewardedAdLoadCallback() {
         @Override

--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
@@ -1,6 +1,6 @@
 package io.invertase.firebase.admob;
 
-import android.content.Context;
+import android.app.Activity;
 import android.util.SparseArray;
 
 import androidx.annotation.NonNull;
@@ -52,20 +52,16 @@ public class ReactNativeFirebaseAdMobRewardedModule extends ReactNativeFirebaseM
 
   @ReactMethod
   public void rewardedLoad(int requestId, String adUnitId, ReadableMap adRequestOptions) {
-    if (getCurrentActivity() == null) {
+    Activity activity = getCurrentActivity();
+    if (activity == null) {
       WritableMap error = Arguments.createMap();
       error.putString("code", "null-activity");
       error.putString("message", "Rewarded ad attempted to load but the current Activity was null.");
       sendRewardedEvent(AD_ERROR, requestId, adUnitId, error, null);
       return;
     }
-    getCurrentActivity().runOnUiThread(() -> {
-
-      Context adContext = getCurrentActivity();
-      if (adContext == null) {
-        adContext = getApplicationContext();
-      }
-      RewardedAd rewardedAd = new RewardedAd(adContext, adUnitId);
+    activity.runOnUiThread(() -> {
+      RewardedAd rewardedAd = new RewardedAd(activity, adUnitId);
 
       RewardedAdLoadCallback adLoadCallback = new RewardedAdLoadCallback() {
         @Override

--- a/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
+++ b/packages/admob/android/src/main/java/io/invertase/firebase/admob/ReactNativeFirebaseAdMobRewardedModule.java
@@ -1,5 +1,6 @@
 package io.invertase.firebase.admob;
 
+import android.content.Context;
 import android.util.SparseArray;
 
 import androidx.annotation.NonNull;
@@ -59,7 +60,12 @@ public class ReactNativeFirebaseAdMobRewardedModule extends ReactNativeFirebaseM
       return;
     }
     getCurrentActivity().runOnUiThread(() -> {
-      RewardedAd rewardedAd = new RewardedAd(getCurrentActivity(), adUnitId);
+
+      Context adContext = getCurrentActivity();
+      if (adContext == null) {
+        adContext = getApplicationContext();
+      }
+      RewardedAd rewardedAd = new RewardedAd(adContext, adUnitId);
 
       RewardedAdLoadCallback adLoadCallback = new RewardedAdLoadCallback() {
         @Override


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Fix Admob crash from UnityAds with Admob Mediation.

Seems like a regression from https://github.com/invertase/react-native-firebase/pull/1892

Fixes https://github.com/invertase/react-native-firebase/issues/1792

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
#1792 
#1892

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
