### PR TITLE
docs(common): Improve paragraph readability

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -57,7 +57,6 @@
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
-    "nodegit": "^0.26.5",
     "postcss-nested": "^4.2.1",
     "postcss-nesting": "^7.0.1",
     "prettier": "^2.0.4",

--- a/website/src/components/Mdx.tsx
+++ b/website/src/components/Mdx.tsx
@@ -29,7 +29,7 @@ type Props = {
   body: string;
 };
 
-const text = 'font-thin leading-loose';
+const text = 'leading-loose';
 
 const components = {
   // Headings
@@ -66,7 +66,7 @@ const components = {
 
   // Text
   p: ({ children }: any) => {
-    return <p className={cx('my-4 font-light', text)}>{children}</p>;
+    return <p className={cx('my-4', text)}>{children}</p>;
   },
 
   // Code
@@ -76,9 +76,9 @@ const components = {
   },
 
   // Lists
-  ul: (props: any) => <ul {...props} className="list-disc list-inside pl-4 font-light" />,
-  ol: (props: any) => <ul {...props} className="list-decimal list-inside pl-4 font-light" />,
-  li: (props: any) => <li {...props} className={cx('mb-2 font-light', text)} />,
+  ul: (props: any) => <ul {...props} className="list-disc list-inside pl-4" />,
+  ol: (props: any) => <ul {...props} className="list-decimal list-inside pl-4" />,
+  li: (props: any) => <li {...props} className={cx('mb-2', text)} />,
 
   // Table
   table: (props: any) => (

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -22,7 +22,7 @@ main a:hover {
 
 main p,
 main li {
-  @apply text-gray-600;
+  @apply text-gray-800;
 }
 
 li code,
@@ -70,7 +70,6 @@ h6 code {
   font-size: 0.9em;
   padding: 0 6px;
 }
-
 
 .parameter {
   @apply text-blue-500;


### PR DESCRIPTION
### Description

Paragraph readability is poor in documentation. It is to light, so contrast is not enough for good readability. Also font weight is too thin to be used for a paragraph text.

Also I removed `nodegit` from dependencies, because it is not used in documentation. 

### Related issues

Fixes #4908 

### Release Summary

Improve Readability of documentation website

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes

- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Below are screenshots of website, before and after changes

Before, Win10 Surface pro
![image](https://user-images.githubusercontent.com/2746150/108398166-6477eb80-7221-11eb-8346-2c003933b11c.png)

Before, Macbook
![image](https://user-images.githubusercontent.com/2746150/108398217-722d7100-7221-11eb-8dfd-c7991950fb2d.png)

After, Win10 Surface pro
![image](https://user-images.githubusercontent.com/2746150/108398397-a012b580-7221-11eb-9a34-fd46e8c7f1ee.png)

After, Macbook
![image](https://user-images.githubusercontent.com/2746150/108398445-b02a9500-7221-11eb-9265-f9c71487ca43.png)

🔥 