### PR TITLE
chore(*): bumped test app to v7.7.0

### DIFF
--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -2,7 +2,7 @@ platform :ios, '10.0'
 $RNFirebaseAsStaticFramework = false
 
 # Version override - uncomment to test, otherwise take value from `@react-native-firebase/app`
-#$FirebaseSDKVersion = '7.5.0'
+$FirebaseSDKVersion = '7.7.0'
 
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'


### PR DESCRIPTION
### Description

The current build fails for the projects test app when rebuilding iOS pods. Bumping the version to the recently updated 7.7.0 fixes this.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
