### PR TITLE
fix(analytics, android): change param access from ITEMS to ITEM_LIST to fix crash

### DIFF
--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -125,7 +125,7 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
     if (bundle == null) {
       return null;
     }
-    ArrayList itemsArray = (ArrayList) bundle.getSerializable(FirebaseAnalytics.Param.ITEMS);
+    ArrayList itemsArray = (ArrayList) bundle.getSerializable(FirebaseAnalytics.Param.ITEM_LIST);
     for (Object item : itemsArray != null ? itemsArray : new ArrayList()) {
       if (item instanceof Bundle && ((Bundle) item).containsKey(FirebaseAnalytics.Param.QUANTITY)) {
         double number = ((Bundle) item).getDouble(FirebaseAnalytics.Param.QUANTITY);


### PR DESCRIPTION
### Description
The application crashes while running on android in React Native and changing this to ITEM_LIST fix the issue

