### PR TITLE
fix(app, types): initializeApp returns Promise<FirebaseApp>

### DIFF
--- a/packages/app/lib/index.d.ts
+++ b/packages/app/lib/index.d.ts
@@ -159,7 +159,7 @@ export namespace ReactNativeFirebase {
      * @param options Options to configure the services used in the App.
      * @param config The optional config for your firebase app
      */
-    initializeApp(options: FirebaseAppOptions, config?: FirebaseAppConfig): FirebaseApp;
+    initializeApp(options: FirebaseAppOptions, config?: FirebaseAppConfig): Promise<FirebaseApp>;
 
     /**
      * Create (and initialize) a FirebaseApp.
@@ -168,7 +168,7 @@ export namespace ReactNativeFirebase {
      * @param name The optional name of the app to initialize ('[DEFAULT]' if
      * omitted)
      */
-    initializeApp(options: FirebaseAppOptions, name?: string): FirebaseApp;
+    initializeApp(options: FirebaseAppOptions, name?: string): Promise<FirebaseApp>;
 
     /**
      * Retrieve an instance of a FirebaseApp.


### PR DESCRIPTION
### Description

previously was `FirebaseApp` so it seemed sync vs async

### Related issues

Fixes #4979 

### Release Summary

PR title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

All of the E2E tests in the area have been enabled and tested
(by purposefully modifying expected output to not match) to fail
as expected, and pass with correct expected output

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
