### PR TITLE
feat(functions): support to set tenantID for firebase auth

### DIFF
--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -43,4 +43,13 @@ describe('Auth', function () {
       expect(bar).toEqual(['10.0.2.2', 9099]);
     });
   });
+
+  describe('tenantId', function () {
+    it('should can set tenantId ', function () {
+      const auth = firebase.app().auth();
+      auth.setTenantId('test-id').then(() => {
+        expect(auth.tenantId).toBe('test-id');
+      });
+    });
+  });
 });

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1628,6 +1628,19 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   /**
+   * setTenantId
+   *
+   * @param appName
+   * @param tenantId
+   */
+  @ReactMethod
+  public void setTenantId(String appName, String tenantId) {
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+    firebaseAuth.setTenantId(tenantId);
+  }
+
+  /**
    * useDeviceLanguage
    *
    * @param appName

--- a/packages/auth/e2e/auth.e2e.js
+++ b/packages/auth/e2e/auth.e2e.js
@@ -47,6 +47,12 @@ describe('auth()', function () {
       app.auth().app.should.equal(app);
     });
 
+    it('supports set tenantId', function () {
+      const app = firebase.app().auth();
+      should.exist(app.auth);
+      app.auth().app.should.equal(app);
+    });
+
     // removing as pending if module.options.hasMultiAppSupport = true
     it('supports multiple apps', async function () {
       firebase.auth().app.name.should.equal('[DEFAULT]');

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -900,6 +900,15 @@ RCT_EXPORT_METHOD(setLanguageCode:
   
 }
 
+RCT_EXPORT_METHOD(setTenantID:
+  (FIRApp *) firebaseApp
+    :(NSString *) tenantID
+) {
+    if(tenantID){
+        [FIRAuth authWithApp:firebaseApp].tenantID = tenantID;
+    }
+}
+
 RCT_EXPORT_METHOD(useDeviceLanguage:
   (FIRApp *) firebaseApp
 ) {

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1202,6 +1202,16 @@ export namespace FirebaseAuthTypes {
    */
   export class Module extends FirebaseModule {
     /**
+     * Returns the current tenant Id.
+     *
+     * #### Example
+     *
+     * ```js
+     * const tenantId = firebase.auth().tenantId;
+     * ```
+     */
+    tenantId: string;
+    /**
      * Returns the current language code.
      *
      * #### Example
@@ -1228,6 +1238,20 @@ export namespace FirebaseAuthTypes {
      * > It is recommended to use {@link auth#onAuthStateChanged} to track whether the user is currently signed in.
      */
     currentUser: User | null;
+
+    /**
+     * Sets the tenant id.
+     *
+     * #### Example
+     *
+     * ```js
+     * await firebase.auth().setTenantId('tenant-123');
+     * ```
+     *
+     * @param tenantId the tenantID current app bind to.
+     */
+    setTenantId(tenantId: string | null): Promise<void>;
+
     /**
      * Sets the language code.
      *

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -69,6 +69,7 @@ class FirebaseAuthModule extends FirebaseModule {
     this._settings = null;
     this._authResult = false;
     this._languageCode = this.native.APP_LANGUAGE[this.app._name];
+    this._tenantId = null;
 
     if (!this.languageCode) {
       this._languageCode = this.native.APP_LANGUAGE['[DEFAULT]'];
@@ -99,6 +100,10 @@ class FirebaseAuthModule extends FirebaseModule {
 
   get languageCode() {
     return this._languageCode;
+  }
+
+  get tenantId() {
+    return this._tenantId;
   }
 
   get settings() {
@@ -148,6 +153,16 @@ class FirebaseAuthModule extends FirebaseModule {
     } else {
       this._languageCode = code;
     }
+  }
+
+  async setTenantId(tenantId) {
+    if (!isString(tenantId) && !isNull(tenantId)) {
+      throw new Error(
+        "firebase.auth().setTenantId(*) expected 'tenantId' to be a string or null value",
+      );
+    }
+    await this.native.setTenantId(tenantId);
+    this._tenantId = tenantId;
   }
 
   _parseListener(listenerOrObserver) {


### PR DESCRIPTION
### Description
When I working on the firebase auth, I found I can't set tenant id which is quite critical for working with Google Identity platform. In the repository discussion channel. there are 2 questions related with this also.

1. https://github.com/invertase/react-native-firebase/discussions/4462
2. https://github.com/invertase/react-native-firebase/discussions/4462

Then  I checked the[ Firebase iOS SDK,](https://github.com/firebase/firebase-ios-sdk/pull/6142) which actually provided tenantId for user to set it. So I created this PR to open this capability to React native Lib users.

### Related issues

No

### Release Summary

Support set tenant it in Firebase auth module.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
`yarn tests:jest`

Test Suites: 8 passed, 8 total
Tests:       1 skipped, 94 passed, 95 total
Snapshots:   0 total
Time:        7.393 s, estimated 14 s

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
