### PR TITLE
feat(crashlytics, native): add non-fatal exception logger for 3rd party native code use

### DIFF
--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -233,3 +233,37 @@ React Native Crashlytics module is generating additional non-fatal issues on Jav
   }
 }
 ```
+
+## Crashlytics non-fatal exceptions native handling
+
+In case you need to log non-fatal (handled) exceptions on the native side (e.g from `try catch` block), you may use the following static methods:
+<br />
+### Android
+
+```
+try {
+  //...
+} catch (Exception e) {
+  ReactNativeFirebaseCrashlyticsNativeHelper.recordNativeException(e);
+  return null;
+}
+```
+
+### iOS
+
+```
+@try {
+  //...
+} @catch (NSException *exception) {
+  NSMutableDictionary * info = [NSMutableDictionary dictionary];
+  [info setValue:exception.name forKey:@"ExceptionName"];
+  [info setValue:exception.reason forKey:@"ExceptionReason"];
+  [info setValue:exception.callStackReturnAddresses forKey:@"ExceptionCallStackReturnAddresses"];
+  [info setValue:exception.callStackSymbols forKey:@"ExceptionCallStackSymbols"];
+  [info setValue:exception.userInfo forKey:@"ExceptionUserInfo"];
+
+  NSError *error = [[NSError alloc] initWithDomain:yourdomain code:errorcode userInfo:info];
+  [RNFBCrashlyticsNativeHelper recordNativeError:error];
+}
+
+```

--- a/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsNativeHelper.java
+++ b/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsNativeHelper.java
@@ -1,0 +1,11 @@
+package io.invertase.firebase.crashlytics;
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
+public class ReactNativeFirebaseCrashlyticsNativeHelper {
+
+  public static void recordNativeException(Throwable throwable) {
+    FirebaseCrashlytics.getInstance().recordException(throwable);
+  }
+
+}

--- a/packages/crashlytics/ios/RNFBCrashlytics.xcodeproj/project.pbxproj
+++ b/packages/crashlytics/ios/RNFBCrashlytics.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		2744B98621F45429004F8E3F /* RNFBCrashlyticsModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 2744B98521F45429004F8E3F /* RNFBCrashlyticsModule.m */; };
 		2748D82422371C1C00FC8DC8 /* RNFBCrashlyticsInitProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 2748D82322371C1C00FC8DC8 /* RNFBCrashlyticsInitProvider.m */; };
+		C66637BB25FA560700DCAA51 /* RNFBCrashlyticsNativeHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = C66637BA25FA560700DCAA51 /* RNFBCrashlyticsNativeHelper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,6 +30,8 @@
 		2744B98521F45429004F8E3F /* RNFBCrashlyticsModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = RNFBCrashlyticsModule.m; path = RNFBCrashlytics/RNFBCrashlyticsModule.m; sourceTree = SOURCE_ROOT; };
 		2748D82222371C0900FC8DC8 /* RNFBCrashlyticsInitProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFBCrashlyticsInitProvider.h; sourceTree = "<group>"; };
 		2748D82322371C1C00FC8DC8 /* RNFBCrashlyticsInitProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFBCrashlyticsInitProvider.m; sourceTree = "<group>"; };
+		C66637BA25FA560700DCAA51 /* RNFBCrashlyticsNativeHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNFBCrashlyticsNativeHelper.m; sourceTree = "<group>"; };
+		C66637BD25FA561D00DCAA51 /* RNFBCrashlyticsNativeHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNFBCrashlyticsNativeHelper.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,6 +60,8 @@
 				2744B98521F45429004F8E3F /* RNFBCrashlyticsModule.m */,
 				2748D82222371C0900FC8DC8 /* RNFBCrashlyticsInitProvider.h */,
 				2748D82322371C1C00FC8DC8 /* RNFBCrashlyticsInitProvider.m */,
+				C66637BD25FA561D00DCAA51 /* RNFBCrashlyticsNativeHelper.h */,
+				C66637BA25FA560700DCAA51 /* RNFBCrashlyticsNativeHelper.m */,
 			);
 			path = RNFBCrashlytics;
 			sourceTree = "<group>";
@@ -127,6 +132,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C66637BB25FA560700DCAA51 /* RNFBCrashlyticsNativeHelper.m in Sources */,
 				2748D82422371C1C00FC8DC8 /* RNFBCrashlyticsInitProvider.m in Sources */,
 				2744B98621F45429004F8E3F /* RNFBCrashlyticsModule.m in Sources */,
 			);

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface RNFBCrashlyticsNativeHelper
+@interface RNFBCrashlyticsNativeHelper : NSObject 
 
 + (void)recordNativeError:(NSError *)error;
 

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
@@ -18,7 +18,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface RNFBCrashlyticsNativeHelper : NSObject <FIRLibrary>
+@interface RNFBCrashlyticsNativeHelper
 
 + (void)recordNativeError:(NSError *)error;
 

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
@@ -1,0 +1,26 @@
+//
+/**
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RNFBCrashlyticsNativeHelper : NSObject <FIRLibrary>
+
++ (void)recordNativeError:(NSError *)error;
+
+@end
+

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.m
@@ -1,0 +1,28 @@
+//
+/**
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import <Firebase/Firebase.h>
+#import "RNFBCrashlyticsNativeHelper.h"
+
+@implementation RNFBCrashlyticsNativeHelper
+
++ (void)recordNativeError:(NSError *)error {
+  [[FIRCrashlytics crashlytics] recordError:error];
+}
+
+@end


### PR DESCRIPTION
### Description

This change allows to log non-fatal exception in Firebase Crashlytics, handled on the native side.

### Related issues

[Discussion](https://github.com/invertase/react-native-firebase/discussions/5010)

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

🔥 

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
