### PR TITLE
feat(auth, multi-tenant): add multi-tenant (tenantID) support

### DIFF
--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -300,6 +300,7 @@ jobs:
           export SKIP_BUNDLING=1
           export RCT_NO_LAUNCH_PACKAGER=1
           cd tests
+          set -o pipefail
           ./node_modules/.bin/detox build --configuration ios.ci
         shell: bash
 

--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -43,4 +43,23 @@ describe('Auth', function () {
       expect(bar).toEqual(['10.0.2.2', 9099]);
     });
   });
+
+  describe('tenantId', function () {
+    it('should be able to set tenantId ', function () {
+      const auth = firebase.app().auth();
+      auth.setTenantId('test-id').then(() => {
+        expect(auth.tenantId).toBe('test-id');
+      });
+    });
+
+    it('should throw error when tenantId is a non string object ', async function () {
+      try {
+        await firebase.app().auth().setTenantId(Object());
+        return Promise.reject('It should throw an error');
+      } catch (e) {
+        expect(e.message).toBe("firebase.auth().setTenantId(*) expected 'tenantId' to be a string");
+        return Promise.resolve('Error catched');
+      }
+    });
+  });
 });

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1628,6 +1628,19 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   /**
+   * setTenantId
+   *
+   * @param appName
+   * @param tenantId
+   */
+  @ReactMethod
+  public void setTenantId(String appName, String tenantId) {
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+    firebaseAuth.setTenantId(tenantId);
+  }
+
+  /**
    * useDeviceLanguage
    *
    * @param appName

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1970,6 +1970,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     final String provider = user.getProviderId();
     final boolean verified = user.isEmailVerified();
     final String phoneNumber = user.getPhoneNumber();
+    final String tenantId = user.getTenantId();
 
     userMap.putString("uid", uid);
     userMap.putString("providerId", provider);
@@ -1998,6 +1999,12 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       userMap.putString("phoneNumber", phoneNumber);
     } else {
       userMap.putNull("phoneNumber");
+    }
+
+    if (tenantId != null && !"".equals(tenantId)) {
+      userMap.putString("tenantId", tenantId);
+    } else {
+      userMap.putNull("tenantId");
     }
 
     userMap.putArray("providerData", convertProviderData(user.getProviderData(), user));

--- a/packages/auth/e2e/auth.e2e.js
+++ b/packages/auth/e2e/auth.e2e.js
@@ -1071,4 +1071,25 @@ describe('auth()', function () {
       }
     });
   });
+
+  describe('setTenantId()', function () {
+    it('should return null if tenantId unset', function () {
+      should.not.exist(firebase.auth().tenantId);
+    });
+
+    // multi-tenant is not supported by the firebase auth emulator, and requires a valid multi-tenant tenantid
+    // After setting this, next user creation will result in internal error on emulator, or auth/invalid-tenant-id live
+    // it('should return tenantId correctly after setting', async function () {
+    //   await firebase.auth().setTenantId('testTenantId');
+    //   firebase.auth().tenantId.should.equal('testTenantId');
+    // });
+    // it('user should have tenant after setting tenantId', async function () {
+    //   await firebase.auth().setTenantId('userTestTenantId');
+    //   firebase.auth().tenantId.should.equal('userTestTenantId');
+    //   const random = Utils.randString(12, '#a');
+    //   const email = `${random}@${random}.com`;
+    //   const userCredential = await firebase.auth().createUserWithEmailAndPassword(email, random);
+    //   userCredential.user.tenantId.should.equal('userTestTenantId');
+    // });
+  });
 });

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -904,7 +904,7 @@ RCT_EXPORT_METHOD(setTenantId:
   (FIRApp *) firebaseApp
     :(NSString *) tenantID
 ) {
-    FIRAuth authWithApp:firebaseApp].tenantID = tenantID;
+    [FIRAuth authWithApp:firebaseApp].tenantID = tenantID;
 }
 
 RCT_EXPORT_METHOD(useDeviceLanguage:

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1210,6 +1210,7 @@ RCT_EXPORT_METHOD(useEmulator:
       @"providerData": [self convertProviderData:user.providerData],
       keyProviderId: [user.providerID lowercaseString],
       @"refreshToken": user.refreshToken,
+      @"tenantId": user.tenantID ? (id) user.tenantID : [NSNull null],
       keyUid: user.uid
   };
 }

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -900,6 +900,13 @@ RCT_EXPORT_METHOD(setLanguageCode:
   
 }
 
+RCT_EXPORT_METHOD(setTenantId:
+  (FIRApp *) firebaseApp
+    :(NSString *) tenantID
+) {
+    FIRAuth authWithApp:firebaseApp].tenantID = tenantID;
+}
+
 RCT_EXPORT_METHOD(useDeviceLanguage:
   (FIRApp *) firebaseApp
 ) {

--- a/packages/auth/lib/User.js
+++ b/packages/auth/lib/User.js
@@ -52,6 +52,10 @@ export default class User {
     return this._user.phoneNumber || null;
   }
 
+  get tenantId() {
+    return this._user.tenantId || null;
+  }
+
   get photoURL() {
     return this._user.photoURL || null;
   }

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1202,6 +1202,16 @@ export namespace FirebaseAuthTypes {
    */
   export class Module extends FirebaseModule {
     /**
+     * Returns the current tenant Id or null if it has never been set
+     *
+     * #### Example
+     *
+     * ```js
+     * const tenantId = firebase.auth().tenantId;
+     * ```
+     */
+    tenantId: string | null;
+    /**
      * Returns the current language code.
      *
      * #### Example
@@ -1228,6 +1238,18 @@ export namespace FirebaseAuthTypes {
      * > It is recommended to use {@link auth#onAuthStateChanged} to track whether the user is currently signed in.
      */
     currentUser: User | null;
+    /**
+     * Sets the tenant id.
+     *
+     * #### Example
+     *
+     * ```js
+     * await firebase.auth().setTenantId('tenant-123');
+     * ```
+     *
+     * @param tenantId the tenantID current app bind to.
+     */
+    setTenantId(tenantId: string): Promise<void>;
     /**
      * Sets the language code.
      *

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -398,6 +398,10 @@ export namespace FirebaseAuthTypes {
      */
     providerId: string;
     /**
+     * Returns a string representing the multi-tenant tenant id. This is null if the user is not associated with a tenant.
+     */
+    tenantId?: string;
+    /**
      * Returns a user identifier as specified by the authentication provider.
      */
     uid: string;
@@ -1247,6 +1251,7 @@ export namespace FirebaseAuthTypes {
      * await firebase.auth().setTenantId('tenant-123');
      * ```
      *
+     * @error auth/invalid-tenant-id if the tenant id is invalid for some reason
      * @param tenantId the tenantID current app bind to.
      */
     setTenantId(tenantId: string): Promise<void>;

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -69,6 +69,7 @@ class FirebaseAuthModule extends FirebaseModule {
     this._settings = null;
     this._authResult = false;
     this._languageCode = this.native.APP_LANGUAGE[this.app._name];
+    this._tenantId = null;
 
     if (!this.languageCode) {
       this._languageCode = this.native.APP_LANGUAGE['[DEFAULT]'];
@@ -99,6 +100,10 @@ class FirebaseAuthModule extends FirebaseModule {
 
   get languageCode() {
     return this._languageCode;
+  }
+
+  get tenantId() {
+    return this._tenantId;
   }
 
   get settings() {
@@ -148,6 +153,14 @@ class FirebaseAuthModule extends FirebaseModule {
     } else {
       this._languageCode = code;
     }
+  }
+
+  async setTenantId(tenantId) {
+    if (!isString(tenantId)) {
+      throw new Error("firebase.auth().setTenantId(*) expected 'tenantId' to be a string");
+    }
+    this._tenantId = tenantId;
+    await this.native.setTenantId(tenantId);
   }
 
   _parseListener(listenerOrObserver) {

--- a/tests/package.json
+++ b/tests/package.json
@@ -52,7 +52,7 @@
     "configurations": {
       "ios.sim.debug": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/testing.app",
-        "build": "xcodebuild -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=YES -quiet | xcpretty -k",
+        "build": "set -o pipefail && xcodebuild -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=YES -quiet | xcpretty -k",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 8"
@@ -60,7 +60,7 @@
       },
       "ios.ci": {
         "binaryPath": "ios/build/Build/Products/Debug-iphonesimulator/testing.app",
-        "build": "xcodebuild -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=YES | xcpretty -k",
+        "build": "set -o pipefail && xcodebuild -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=YES | xcpretty -k",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 11"
@@ -76,7 +76,7 @@
       },
       "ios.sim.release": {
         "binaryPath": "ios/build/Build/Products/Release-iphonesimulator/testing.app",
-        "build": "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/testing.xcworkspace -scheme testing -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=YES -quiet | xcpretty -k",
+        "build": "set -o pipefail && export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -workspace ios/testing.xcworkspace -scheme testing -configuration Release -sdk iphonesimulator -derivedDataPath ios/build -UseModernBuildSystem=YES -quiet | xcpretty -k",
         "type": "ios.simulator",
         "device": {
           "type": "iPhone X"


### PR DESCRIPTION
### Description
When I working on the firebase auth, I found I can't set tenant id which is quite critical for working with Google Identity platform. In the repository discussion channel. there are 2 questions related with this also.

1. https://github.com/invertase/react-native-firebase/discussions/4462
2. https://github.com/invertase/react-native-firebase/discussions/4964

Then  I checked the[ Firebase iOS SDK,](https://github.com/firebase/firebase-ios-sdk/pull/6142) which actually provided tenantId for user to set it. So I created this PR to open this capability to React native Lib users.

### Related issues

No

### Release Summary

Support set tenant it in Firebase auth module.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
`yarn tests:jest`

Test Suites: 8 passed, 8 total
Tests:       1 skipped, 95 passed, 96 total
Snapshots:   0 total
Time:        20.6 s

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
