### PR TITLE
fix(app, firebase-ios-sdk): bump to firebase-ios-sdk v7.8.1 for analytics fix

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "7.8.0"
+      "firebase": "7.8.1"
     },
     "android": {
       "minSdk": 16,


### PR DESCRIPTION
### Description

https://firebase.google.com/support/release-notes/ios#version_781_-_march_12_2021

Analytics fixed an issue where references to retrieveAdTrackingConsentStatus caused kids' apps to be rejected during App Store review


### Release Summary

commit message

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Just CI, if it passes I'll release v11.1.1

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
