### PR TITLE
fix(database, types): harmonize on/once/off types with firebase-js-sdk

### DIFF
--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -599,7 +599,11 @@ export namespace FirebaseDatabaseTypes {
      * @param callback The callback function that was passed to `on()` or `undefined` to remove all callbacks.
      * @param context The context that was passed to `on()`.
      */
-    off(eventType?: EventType, callback?: () => void, context?: Record<string, any>): void;
+    off(
+      eventType?: EventType,
+      callback?: (a: DataSnapshot, b?: string | null) => void,
+      context?: Record<string, any>,
+    ): void;
 
     /**
      * Listens for data changes at a particular location.
@@ -656,9 +660,9 @@ export namespace FirebaseDatabaseTypes {
     on(
       eventType?: EventType,
       callback?: (data: DataSnapshot, previousChildKey?: string) => void,
-      cancelCallbackOrContext?: Record<string, any>,
+      cancelCallbackOrContext?: ((a: Error) => void) | Record<string, any> | null,
       context?: Record<string, any> | null,
-    ): () => void;
+    ): (a: DataSnapshot, b?: string | null) => void;
 
     /**
      * Listens for exactly one event of the specified event type, and then stops listening.


### PR DESCRIPTION
### Description

This does not change the underlying implementation which should still be correct with
the updated types, it only copies in the type definitions from firebase-js-sdk so we
stay in sync with them

### Related issues

Related #5027 - the type-related part of that issue

### Release Summary

PR title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

`yarn tsc:compile`, `yarn tests:jest` plus comparison to firebase-js-sdk and code inspection of the underlying DatabaseQuery.js implementation

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
