### PR TITLE
feat(crashlytics): flag fatal errors for crashlytics and analytics

### DIFF
--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -40,7 +40,7 @@ const ReservedEventNames = [
   'ad_reward',
   'app_background',
   'app_clear_data',
-  'app_exception',
+  // 'app_exception',
   'app_remove',
   'app_store_refund',
   'app_store_subscription_cancel',


### PR DESCRIPTION
### Description

Crashlytics backend is working on better integration with interpreted languages

This change should work with changes in the backend to transform errors to a style that enables better reporting in both crashlytics and analytics

### Release Summary

The commit title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

There is a specific `__DEV__` test which means this will never work in dev mode.
Analytics and Crashlytics must both be installed for a full test.
There is no easy way to mock out the functions and verify the attribute is correct

So a manual unhandled javascript crash should be attempted in release mode and then the results should be verified in the crashlytics and analytics consoles on the web I think

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
