### PR TITLE
chore: bump action versions and build toolchain versions

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -30,7 +30,9 @@ jobs:
       # - make into an action, parameterize directories to pack, and package names to install
       # - name patches w/PR as "semver prerelease" and SHA as "semver build info". Needs patch-package enhancement.
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,7 @@ jobs:
     name: 'Spelling & Grammar'
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.8.0
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,9 +14,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.8.0
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
@@ -63,9 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.8.0
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
@@ -98,9 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.8.0
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,9 +18,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -65,9 +65,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -98,9 +98,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v2.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      - uses: amannn/action-semantic-pull-request@v3.4.0
+        with:
+          validateSingleCommit: true

--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -83,10 +83,15 @@ jobs:
           max_attempts: 3
           command: DETOX_DISABLE_POSTINSTALL=1 yarn --no-audit --prefer-offline
 
-      - name: Verify JDK 1.8
-        # OpenJDK1.8 is the default in GitHub macOS 10.15 runner, setup is not required
-        # Run a check that exits with error unless it is 1.8 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '1.8'
+      - name: Configure JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11" # ubuntu-latest is about to default to 11, force it everywhere
+
+      - name: Verify JDK11
+        # Default JDK varies depending on different runner flavors, make sure we are on 11
+        # Run a check that exits with error unless it is 11 version to future-proof against unexpected upgrades
+        run: java -fullversion 2>&1 | grep '11.0'
         shell: bash
 
       - name: Build Android App
@@ -117,10 +122,10 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-30;google_apis;x86_64"
+          command: echo "y" | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --install "system-images;android-30;google_apis;x86_64"
 
       - name: Create Emulator
-        run: echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd --force --name TestingAVD --device "Nexus 5X" -k 'system-images;android-30;google_apis;x86_64' -g google_apis
+        run: echo "no" | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --force --name TestingAVD --device "Nexus 5X" -k 'system-images;android-30;google_apis;x86_64' -g google_apis
 
       # These Emulator start steps are the current best practice to do retries on multi-line commands with persistent (nohup) processes
       - name: Start Android Emulator

--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -38,8 +38,9 @@ jobs:
         with:
           fetch-depth: 50
 
-      - uses: actions/setup-node@v2-beta
-
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Install firebase CLI
         uses: nick-invision/retry@v2
         with:
@@ -217,7 +218,9 @@ jobs:
         with:
           fetch-depth: 50
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/tests_e2e.yml
+++ b/.github/workflows/tests_e2e.yml
@@ -32,9 +32,7 @@ jobs:
       EMULATOR_COMMAND: "-avd TestingAVD -noaudio -gpu swiftshader_indirect -camera-back none -no-snapshot -no-window -no-boot-anim -nojni -memory 2048 -timezone 'Europe/London' -cores 2"
       EMULATOR_EXECUTABLE: qemu-system-x86_64-headless
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.8.0
 
       - uses: actions/checkout@v2
         with:
@@ -213,9 +211,7 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.8.0
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -26,9 +26,7 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
+      - uses: styfle/cancel-workflow-action@0.8.0
       - uses: actions/checkout@v2
         with:
           fetch-depth: 50

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -30,9 +30,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 50
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
### Description

This updates to node v14 and JDK11 to track ecosystem minimum requirements that are coming into force, and updates action versions in the process


### Release Summary

Each commit is conventional, rebase merge should work

### Test Plan

It's all github actions work, CI passes or it doesn't :-)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
