### PR TITLE
docs: Add code marks around the transaction's set method

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1549,7 +1549,7 @@ export namespace FirebaseFirestoreTypes {
    * A reference to a transaction. The `Transaction` object passed to a transaction's updateFunction provides the methods to
    * read and write data within the transaction context. See `Firestore.runTransaction()`.
    *
-   * A transaction consists of any number of `get()` operations followed by any number of write operations such as set(),
+   * A transaction consists of any number of `get()` operations followed by any number of write operations such as `set()`,
    * `update()`, or `delete()`. In the case of a concurrent edit, Cloud Firestore runs the entire transaction again. For example,
    * if a transaction reads documents and another client modifies any of those documents, Cloud Firestore retries the transaction.
    * This feature ensures that the transaction runs on up-to-date and consistent data.


### PR DESCRIPTION
They were missing, and since all other methods stand out thanks to markup, I was wondering if I could call `set()` on my transaction

### Description
This PR adds backticks around the `set()` method in the `Transaction` documentation introduction

### Related issues


### Release Summary
DOC: Add code marks around the transaction's set method

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests - N/A
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
N/A

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
