### PR TITLE
fix(crashlytics, debug): Disable Crashlytics in debug mode by default

### DIFF
--- a/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsInitProvider.java
+++ b/packages/crashlytics/android/src/main/java/io/invertase/firebase/crashlytics/ReactNativeFirebaseCrashlyticsInitProvider.java
@@ -42,6 +42,10 @@ public class ReactNativeFirebaseCrashlyticsInitProvider extends ReactNativeFireb
     } else {
       enabled = meta.getBooleanValue(KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED, true);
     }
+    
+    if (!json.getBooleanValue(KEY_CRASHLYTICS_DEBUG_ENABLED, false) && BuildConfig.DEBUG) {
+      enabled = false;
+    }
 
     return enabled;
   }

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
@@ -47,6 +47,13 @@ NSString *const KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED = @"cras
     enabled = [RNFBMeta getBooleanValue:KEY_CRASHLYTICS_AUTO_COLLECTION_ENABLED defaultValue:YES];
     DLog(@"isCrashlyticsCollectionEnabled via RNFBMeta: %d", enabled);
   }
+  
+#ifdef DEBUG
+  enabled = NO;
+  if ([[RNFBJSON shared] contains:KEY_CRASHLYTICS_DEBUG_ENABLED]) {
+    enabled = [[RNFBJSON shared] getBooleanValue:KEY_CRASHLYTICS_DEBUG_ENABLED defaultValue:NO];
+  }
+#endif
 
   DLog(@"isCrashlyticsCollectionEnabled: %d", enabled);
 

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
@@ -49,10 +49,10 @@ NSString *const KEY_CRASHLYTICS_IS_ERROR_GENERATION_ON_JS_CRASH_ENABLED = @"cras
   }
   
 #ifdef DEBUG
-  enabled = NO;
-  if ([[RNFBJSON shared] contains:KEY_CRASHLYTICS_DEBUG_ENABLED]) {
-    enabled = [[RNFBJSON shared] getBooleanValue:KEY_CRASHLYTICS_DEBUG_ENABLED defaultValue:NO];
+  if (![[RNFBJSON shared] getBooleanValue:KEY_CRASHLYTICS_DEBUG_ENABLED defaultValue:NO]) {
+    enabled = NO;
   }
+  DLog(@"isCrashlyticsCollectionEnabled after checking RNFBJSON %@: %d", KEY_CRASHLYTICS_DEBUG_ENABLED, enabled);
 #endif
 
   DLog(@"isCrashlyticsCollectionEnabled: %d", enabled);


### PR DESCRIPTION
### Description

This is a continuation of the good work from @waqas19921 - I tried to do a polishing commit on PR #5113 and inadvertently pushed incorrect contents, requiring a new PR to fix

### Related issues

Related #5113 
Fixes #4793

### Release Summary

PR title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Verified via inspection of newly added DLog commands in iOS it worked, code inspection on android

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
