### PR TITLE
fix(android, utils): fix rare crash getting documents directory

### DIFF
--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/ReactNativeFirebaseUtilsModule.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/ReactNativeFirebaseUtilsModule.java
@@ -159,10 +159,16 @@ public class ReactNativeFirebaseUtilsModule extends ReactNativeFirebaseModule {
     constants.put(KEY_TEMP_DIRECTORY, context.getCacheDir().getAbsolutePath());
     constants.put(KEY_CACHE_DIRECTORY, context.getCacheDir().getAbsolutePath());
 
+    File externalDirectory = context.getExternalFilesDir(null);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      File externalDirectory = context.getExternalFilesDir(null);
       if (externalDirectory != null) {
         constants.put(KEY_DOCUMENT_DIRECTORY, externalDirectory.getAbsolutePath());
+      } else {
+        // The external directory may be null if it is truly external *and*
+        // the device's external storage environment changes. We will use the regular
+        // Files directory as a backup and note in the documentation that the directory may
+        // vary under rare conditions
+        constants.put(KEY_DOCUMENT_DIRECTORY, context.getFilesDir().getAbsolutePath());
       }
     }
 

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/ReactNativeFirebaseUtilsModule.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/ReactNativeFirebaseUtilsModule.java
@@ -159,12 +159,14 @@ public class ReactNativeFirebaseUtilsModule extends ReactNativeFirebaseModule {
     constants.put(KEY_TEMP_DIRECTORY, context.getCacheDir().getAbsolutePath());
     constants.put(KEY_CACHE_DIRECTORY, context.getCacheDir().getAbsolutePath());
 
-    File externalDirectory = context.getExternalFilesDir(null);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      if ( externalDirectory != null ) {
+      File externalDirectory = context.getExternalFilesDir(null);
+      if (externalDirectory != null) {
         constants.put(KEY_DOCUMENT_DIRECTORY, externalDirectory.getAbsolutePath());
       }
-    } else {
+    }
+
+    if (!constants.containsKey(KEY_DOCUMENT_DIRECTORY))  {
       constants.put(KEY_DOCUMENT_DIRECTORY, context.getFilesDir().getAbsolutePath());
     }
 

--- a/packages/app/lib/index.d.ts
+++ b/packages/app/lib/index.d.ts
@@ -284,6 +284,11 @@ export namespace Utils {
      *
      * Use this directory to place documents that have been created by the user.
      *
+     * Normally this is the external files directory on Android but if no external storage directory found,
+     * e.g. removable media has been ejected by the user, it will fall back to internal storage. This may
+     * under rare circumstances where device storage environment changes cause the directory to be different
+     * between runs of the application
+     *
      * ```js
      * firebase.utils.FilePath.DOCUMENT_DIRECTORY;
      * ```


### PR DESCRIPTION
[NullPointerException Firebase Crashlytics](https://github.com/invertase/react-native-firebase/issues/4706)

### Description

The exported constant value for key KEY_DOCUMENT_DIRECTORY will be missed in ReactNativeFirebaseUtilsModule when Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT and  externalDirectory == null

### Related issues

Fixes [#4706](https://github.com/invertase/react-native-firebase/issues/4706)

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
