### PR TITLE
fix(app, ios): formally note cocoapods v1.10+ requirement in podspec

### DIFF
--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.source              = { :git => "https://github.com/invertase/react-native-firebase.git", :tag => "v#{s.version}" }
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "10.0"
+  s.cocoapods_version   = '>= 1.10.0'
   s.source_files        = "ios/**/*.{h,m}"
 
   # React Native dependencies


### PR DESCRIPTION

### Description

cocoapods has needed a minimum version of 1.10 for quite some time, so this
is not actually a breaking change, the breaking change was before v10 I think,
this just makes it much more obvious with good messaging, versus previous subtle
error behavior

### Related issues

Related #5070 - where cocoapods minimum version was not being enforced and complicated troubleshooting

### Release Summary

PR and commit are conventional, rebase merge should work

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
