### PR TITLE
test(iOS): avoid intermittent leveldb duplicate symbol build failure

### DIFF
--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -5,7 +5,7 @@ appPackage = JSON.parse(File.read(File.join('..', '..', 'node_modules', '@react-
 $FirebaseSDKVersion = appPackage['sdkVersions']['ios']['firebase']
 #$FirebaseSDKVersion = '7.7.0' # https://firebase.google.com/support/release-notes/ios
 Pod::UI.puts "react-native-firebase/tests: Using Firebase SDK version '#{$FirebaseSDKVersion}'"
-$RNFirebaseAsStaticFramework = false # toggle this to true (and set 'use_frameworks!' below to test static frameworks)
+#$RNFirebaseAsStaticFramework = false # toggle this to true (and set 'use_frameworks!' below to test static frameworks)
 
 # Versions used below, for quick reference / outdated+upgrade checks
 $iOSMinimumDeployVersion = '10.0'
@@ -26,6 +26,9 @@ target 'testing' do
     # to enable hermes on iOS, change `false` to `true` and then install pods
     :hermes_enabled => false
   )
+
+  # Use pre-compiled firestore frameworks to optimize compile time. But make sure there are not leveldb conflicts.
+  $FirebaseFirestoreExcludeLeveldb = true
   pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => $FirebaseSDKVersion
 
   # Enables Flipper.

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -55,7 +55,7 @@ PODS:
   - Firebase/Storage (7.9.0):
     - Firebase/CoreOnly
     - FirebaseStorage (~> 7.9.0)
-  - FirebaseABTesting (7.9.0):
+  - FirebaseABTesting (7.10.0):
     - FirebaseCore (~> 7.0)
   - FirebaseAnalytics (7.9.0):
     - FirebaseCore (~> 7.0)
@@ -101,12 +101,12 @@ PODS:
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - nanopb (~> 2.30907.0)
-  - FirebaseInstallations (7.9.0):
+  - FirebaseInstallations (7.10.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (7.9.0):
+  - FirebaseInstanceID (7.10.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
@@ -169,7 +169,7 @@ PODS:
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30907.0)
-  - GoogleDataTransport (8.3.0):
+  - GoogleDataTransport (8.3.1):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30907.0)
     - PromisesObjC (~> 1.2)
@@ -479,69 +479,69 @@ PODS:
     - React-cxxreact (= 0.64.0)
     - React-jsi (= 0.64.0)
     - React-perflogger (= 0.64.0)
-  - RNFBAdMob (11.1.2):
+  - RNFBAdMob (11.2.0):
     - Firebase/AdMob (= 7.9.0)
-    - PersonalizedAdConsent (~> 1.0.4)
+    - PersonalizedAdConsent (~> 1.0.5)
     - React-Core
     - RNFBApp
-  - RNFBAnalytics (11.1.2):
+  - RNFBAnalytics (11.2.0):
     - Firebase/Analytics (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (11.1.2):
+  - RNFBApp (11.2.0):
     - Firebase/CoreOnly (= 7.9.0)
     - React-Core
-  - RNFBAuth (11.1.2):
+  - RNFBAuth (11.2.0):
     - Firebase/Auth (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (11.1.2):
+  - RNFBCrashlytics (11.2.0):
     - Firebase/Crashlytics (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (11.1.2):
+  - RNFBDatabase (11.2.0):
     - Firebase/Database (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (11.1.2):
+  - RNFBDynamicLinks (11.2.0):
     - Firebase/DynamicLinks (= 7.9.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (11.1.2):
+  - RNFBFirestore (11.2.0):
     - Firebase/Firestore (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (11.1.2):
+  - RNFBFunctions (11.2.0):
     - Firebase/Functions (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBIid (11.1.2):
+  - RNFBIid (11.2.0):
     - Firebase/CoreOnly (= 7.9.0)
     - FirebaseInstanceID
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (11.1.2):
+  - RNFBInAppMessaging (11.2.0):
     - Firebase/InAppMessaging (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (11.1.2):
+  - RNFBMessaging (11.2.0):
     - Firebase/Messaging (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBML (11.1.2):
+  - RNFBML (11.2.0):
     - Firebase/MLVision (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBPerf (11.1.2):
+  - RNFBPerf (11.2.0):
     - Firebase/Performance (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (11.1.2):
+  - RNFBRemoteConfig (11.2.0):
     - Firebase/RemoteConfig (= 7.9.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (11.1.2):
+  - RNFBStorage (11.2.0):
     - Firebase/Storage (= 7.9.0)
     - React-Core
     - RNFBApp
@@ -739,7 +739,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: ea750e746c463712a67a3ad0d8c73f68ae5c6ffe
   Firebase: d8bd6bd34b4c7ed57bfdd056c66ff5adcdde53ab
-  FirebaseABTesting: f6853447dc61fa785df777748747c845f40fa7cd
+  FirebaseABTesting: 457bc058cf6de8bcffc6fd9a2a4c933b24bfc264
   FirebaseAnalytics: 31b1269830dfe16687db3c60b76082c12bd6d527
   FirebaseAuth: 20625f04fdd213995249a82375b3dab39b1c136c
   FirebaseCore: 0798738ad1ae0fda67e17c7b9081241c431c6859
@@ -747,11 +747,11 @@ SPEC CHECKSUMS:
   FirebaseCrashlytics: 73cfa8d24d573ed1ff648acce3900df39ca32d77
   FirebaseDatabase: b62e6e05aac439fe603d7ba68a2c764ca7357a58
   FirebaseDynamicLinks: d1af109c92606bacfc144406883bcae5a4ed215d
-  FirebaseFirestore: 93eb1bb94f1e5864130dfc8efaa7d549f0f1f00d
+  FirebaseFirestore: bbe3379a849d492ae2b56570294a1f562a6d2b2e
   FirebaseFunctions: 1bf9aa5435378d091bf495a5db83249ddca4b13e
   FirebaseInAppMessaging: bb400ae6c860425d6185eddd1a2f9aac58bf7349
-  FirebaseInstallations: 5e777e6640fa060405cc7632447b6c5ca5af4742
-  FirebaseInstanceID: 53140c03b9f6136f890d7901399f85a4c90ab2d0
+  FirebaseInstallations: bf2ec8dbf36ff4c91af6b9a003d15855757680c1
+  FirebaseInstanceID: 5ad92c898e1328b66e8dd58811964d6fe4d334c3
   FirebaseMessaging: 5f83f200a251c44f647f36cb43e557be09889e8d
   FirebaseMLCommon: cbab07a0cfa19b982819fc9e030e6f3d569c23a6
   FirebaseMLVision: 68439dbb81881116a87c0e469af9f55b53e9648c
@@ -762,7 +762,7 @@ SPEC CHECKSUMS:
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAPIClientForREST: 538a8ad0014fd88b78894e77100775a6b0a4f7ed
   GoogleAppMeasurement: 120eec8803fe65a4a7475fb3d3d59a61d0e1a866
-  GoogleDataTransport: b006084b73915a42c28a3466961a4edda3065da6
+  GoogleDataTransport: 8b0e733ea77c9218778e5a9e34ba9508b8328939
   GoogleToolboxForMac: 471e0c05d39506e50e6398f46fa9a12ae0efeff9
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
   GoogleUtilities: e1d9ed4e544fc32a93e00e721400cbc3f377200d
@@ -796,24 +796,24 @@ SPEC CHECKSUMS:
   React-RCTVibration: 0fd6b21751a33cb72fce1a4a33ab9678416d307a
   React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
-  RNFBAdMob: 77357704e470a6f84f174f55b184ae1115d97109
-  RNFBAnalytics: ee68739494c353a985457a07636040e5a2221db8
-  RNFBApp: 8bffaa3ca5d16daddb5f76b88e3729fe03055f72
-  RNFBAuth: 3bda63aa77a98a193ec583f7d384eab5c86e721f
-  RNFBCrashlytics: 79a418dd2ed3fd1c797df319313d8ed3cd73b828
-  RNFBDatabase: caf0589faf19c08d948b18bd8151829c3e364fbd
-  RNFBDynamicLinks: a0eda9df246aa2fa0c303d1998455e48826f3119
-  RNFBFirestore: 1d74b9bc18d7a742ce55f8c4cc9226a58b03ba48
-  RNFBFunctions: d3ce440c7e8e0ab62ab37432bee2ff30a0f07f06
-  RNFBIid: 91cc97a07083190c80b015553a5e926df05a11bd
-  RNFBInAppMessaging: b5adc9d0a4cd489a7ff061d3468a8de4888059c4
-  RNFBMessaging: 3d5bb4258650e6c111bf368ebf52559af7acae55
-  RNFBML: 0ff88756acd9c9d078a1a5aea3363ecdc5969f4f
-  RNFBPerf: 596e1c78d1e5d423a32d4e6508a60f09ff7def9e
-  RNFBRemoteConfig: d34f58ed9e56bb3ae6de327c4d3b10ea9534ecff
-  RNFBStorage: ee41952adea1a49e45f56b67bf620baeb506dbe5
+  RNFBAdMob: 479e3bfb7b13c0e1d9338c4ba03a20c687d23ba3
+  RNFBAnalytics: 11873c6dccab66da20fc1c75fc47c88244845410
+  RNFBApp: 48979858eb18ef53f8dfcb21b1d91a963bc80e4d
+  RNFBAuth: 73ef569faa4618624313fbc969dfaba66bb6d0ed
+  RNFBCrashlytics: d7dd4c9660bb10ae60978707540c61dc092b01f0
+  RNFBDatabase: 3bcb3fbcebc7bcd550124374d794cc8291dc32b1
+  RNFBDynamicLinks: 323c5a9a2c7c3d63de0b16c37fceb9c863738ad2
+  RNFBFirestore: 49898b75f0684b56f77b7464eb46c539b015a54c
+  RNFBFunctions: dded5e4b76dfd0aad3252a1f15edca383c80b358
+  RNFBIid: 12d40979e7b96458c5d9af2e8a3048212febab2f
+  RNFBInAppMessaging: 267522a1efa7f28c9962e06da5618a10a02c5926
+  RNFBMessaging: bab6a3073a3ac1ecff593c74b4f797cbc6cca562
+  RNFBML: 0174a0bd8b99ec6f88872bad1a64f7bfd5eac0b3
+  RNFBPerf: 4910c40298294bd3faef64271171456e48966d27
+  RNFBRemoteConfig: b8817825c9bf4df921ff7065f10ed8c4a531634b
+  RNFBStorage: 1e7dfba28c08d10dddbfa38b6474fcf8c0ecd3c0
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: d340e01560ce9c849236066ad7678a54b512f4fe
+PODFILE CHECKSUM: 1a823bd84dc58905bf4b883bf4804355a2a6881d
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
### Description

The tests project would sometimes fail to build on iOS because the pre-compiled firestore-ios-sdk-frameworks podspec could not determine whether leveldb should be included or not

I diagnosed that in the other repo as the Pod::Config.instance being nil and it seemed racy so I just added a flag in that repo to make it explicit, and I use that flag here.

### Related issues

https://github.com/invertase/firestore-ios-sdk-frameworks/issues/2
https://github.com/invertase/firestore-ios-sdk-frameworks/pull/30


### Release Summary

test-only, but commit message is conventional

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
