### PR TITLE
docs(app, secondary-apps): fix links to other modules

### DIFF
--- a/docs/app/usage.md
+++ b/docs/app/usage.md
@@ -21,14 +21,14 @@ for manually initializing secondary Firebase app instances.
 
 Currently, the native Firebase SDKs only provide functionality for creating secondary apps on the following services:
 
-- [Authentication](/auth).
-- [Realtime Database](/database).
-- [Cloud Firestore](/firestore).
-- [Cloud Functions](/functions)
-- [Cloud Storage](/storage).
-- [Instance ID](/iid).
-- [ML](/ml).
-- [Remote Config](/remote-config).
+- [Authentication](/auth/usage).
+- [Realtime Database](/database/usage).
+- [Cloud Firestore](/firestore/usage).
+- [Cloud Functions](/functions/usage)
+- [Cloud Storage](/storage/usage).
+- [Instance ID](/iid/usage).
+- [ML](/ml/usage).
+- [Remote Config](/remote-config/usage).
 
 ## Initializing secondary apps
 


### PR DESCRIPTION
### Description

The raw links to modules do not work but if you add usage to the URL the links should work

### Related issues

No issue logged, noticed while troubleshooting #5134

### Release Summary

conventional commit message

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Check vercel test build after it renders

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
