### PR TITLE
fix(app, ios-plist): make sure Info.plist exists before processing

### DIFF
--- a/packages/app/react-native.config.js
+++ b/packages/app/react-native.config.js
@@ -10,6 +10,7 @@ module.exports = {
             name: '[RNFB] Core Configuration',
             path: './ios_config.sh',
             execution_position: 'after_compile',
+            input_files: ['$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)'],
           },
         ],
       },


### PR DESCRIPTION
### Description

Previously there was no dependency stated on Info.plist, so occasionally we would "lose the race"
and attempt to interpolate values prior to it existing

Since ads requires the Info.plist admob ids in the Info.plist, this resulted in crashes on startup occasionally
for users of the admob module

Noticed this occasionally in CI E2E plus during local testing it was very frustrating!

### Related issues

Fixes #5152

### Release Summary

conventional commit message

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
