### PR TITLE
feat(firestore): add OnSnapshotsInSync support

### DIFF
--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreEvent.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreEvent.java
@@ -23,6 +23,7 @@ import io.invertase.firebase.interfaces.NativeEvent;
 
 public class ReactNativeFirebaseFirestoreEvent implements NativeEvent {
 
+  static final String SNAPSHOTS_IN_SYNC_EVENT = "firestore_snapshots_in_sync_event";
   static final String COLLECTION_EVENT_SYNC = "firestore_collection_sync_event";
   static final String DOCUMENT_EVENT_SYNC = "firestore_document_sync_event";
   static final String TRANSACTION_EVENT_SYNC = "firestore_transaction_event";

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1964,6 +1964,32 @@ export namespace FirebaseFirestoreTypes {
     enableNetwork(): Promise<void>;
 
     /**
+     * Attaches a listener for a snapshots-in-sync event.
+     *
+     * The snapshots-in-sync event indicates that all listeners affected by a given change have fired, even
+     * if a single server-generated change affects multiple listeners.
+     *
+     * NOTE: The snapshots-in-sync event only indicates that listeners are in sync with each other, but does not relate
+     * to whether those snapshots are in sync with the server. Use SnapshotMetadata in the individual listeners to determine
+     * if a snapshot is from the cache or the server.
+     *
+     * Returns an unsubscribe function.
+     *
+     * @param observer A callback to listen to in-sync events.
+     *
+     * #### Example
+     *
+     * ```js
+     * const unsubscribe = firebase.firestore().onSnapshotsInSync(() => {
+     *   // in-sync event
+     * });
+     *
+     * unsubscribe();
+     * ```
+     */
+    onSnapshotsInSync(observer: (error?: Error) => void): () => void;
+
+    /**
      * Executes the given `updateFunction` and then attempts to commit the changes applied within the transaction.
      * If any document read within the transaction has changed, Cloud Firestore retries the `updateFunction`.
      * If it fails to commit after 5 attempts, the transaction fails.


### PR DESCRIPTION
### Description

Adds support for `onSnapshotsInSync` API.

### Related issues

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
