### PR TITLE
docs(messaging, v6-migration): subscribeToTopic must not include '/'

### DIFF
--- a/docs/migrating-to-v6.md
+++ b/docs/migrating-to-v6.md
@@ -418,7 +418,7 @@ How to migrate: If you use device-local notification APIs and user-visible notif
 - [android] The manually added `RNFirebaseMessagingService` service in your `AndroidManifest.xml` file is no longer required - you can safely remove it.
 - [iOS] The manually added `RNFirebaseMessaging` usages in your `AppDelegate` files are no longer required - you can safely remove them.
 - The _builder_ syntax has been deprecated in favor of simple objects. See `newRemoteMessage()` documentation for an example.
-- subscribeToTopic('some-topic') method must not include "/" in topic.
+- `subscribeToTopic('some-topic')` method must not include "/" in topic.
 - [iOS] The minimum supported iOS version is now 10
 - iOS 9 or lower only accounts for 0.% of all iPhone devices.
 - To see a detailed device versions breakdown see [this link](https://david-smith.org/iosversionstats/).

--- a/docs/migrating-to-v6.md
+++ b/docs/migrating-to-v6.md
@@ -418,6 +418,7 @@ How to migrate: If you use device-local notification APIs and user-visible notif
 - [android] The manually added `RNFirebaseMessagingService` service in your `AndroidManifest.xml` file is no longer required - you can safely remove it.
 - [iOS] The manually added `RNFirebaseMessaging` usages in your `AppDelegate` files are no longer required - you can safely remove them.
 - The _builder_ syntax has been deprecated in favor of simple objects. See `newRemoteMessage()` documentation for an example.
+- subscribeToTopic('some-topic') method must not include "/" in topic.
 - [iOS] The minimum supported iOS version is now 10
 - iOS 9 or lower only accounts for 0.% of all iPhone devices.
 - To see a detailed device versions breakdown see [this link](https://david-smith.org/iosversionstats/).


### PR DESCRIPTION
add note about subscribeToTopic not including "/" in topic

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
