### PR TITLE
docs(dynamic-links): URL-encoding for iOS

### DIFF
--- a/docs/dynamic-links/usage/index.md
+++ b/docs/dynamic-links/usage/index.md
@@ -133,6 +133,8 @@ The iOS Notes app is a good place to paste your dynamic link and test it opens y
 
 5. There is a known bug that you can follow [here](http://bit.ly/2y8gey4) that stops Apple from downloading the app site association file. The work around is to uninstall your app, restart your device and reinstall your app.
 
+6. Make sure your [deep link parameter](https://firebase.google.com/docs/dynamic-links/create-manually?authuser=0#parameters) is properly URL-encoded, especially if it contains a query string.
+
 ## Android Setup
 
 1. Create a SHA-256 fingerprint using these [instructions](https://developers.google.com/android/guides/client-auth) for your app, and add to your app in your Firebase console.


### PR DESCRIPTION
### Description

Update iOS troubleshooting section for Dynamic Links doc to explicitly mention the necessity of URL-encoding for deep link parameter. Seems like Android works fine even with unencoded deep link, which makes this problem trickier to catch, hence the explicit mention.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Should help with some cases of #3450

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

:fire: