### PR TITLE
fix(messaging): Missing notification on restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "react-native-firebase",
   "private": true,
   "scripts": {
-//    "version": "node ./scripts/version.js",
     "version": "11.2.0",
     "prepare": "yarn run lerna:link && lerna run prepare --parallel",
     "build:all:clean": "lerna run build:clean",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "react-native-firebase",
   "private": true,
+  "version": "11.2.0",
   "scripts": {
-    "version": "11.2.0",
+    "version": "node ./scripts/version.js",
     "prepare": "yarn run lerna:link && lerna run prepare --parallel",
     "build:all:clean": "lerna run build:clean",
     "build:all:build": "lerna run build",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "react-native-firebase",
   "private": true,
-  "version": "11.2.0",
   "scripts": {
     "version": "node ./scripts/version.js",
     "prepare": "yarn run lerna:link && lerna run prepare --parallel",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "react-native-firebase",
   "private": true,
   "scripts": {
-    "version": "node ./scripts/version.js",
+//    "version": "node ./scripts/version.js",
+    "version": "11.2.0",
     "prepare": "yarn run lerna:link && lerna run prepare --parallel",
     "build:all:clean": "lerna run build:clean",
     "build:all:build": "lerna run build",

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -73,7 +73,7 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
           // messageId can be either one...
           String messageId = intent.getExtras().getString("google.message_id");
           if (messageId == null) messageId = intent.getExtras().getString("message_id");
-          
+
           // only handle non-consumed initial notifications
           if (messageId != null && initialNotificationMap.get(messageId) == null) {
             WritableMap remoteMessageMap;

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
@@ -2,8 +2,8 @@ package io.invertase.firebase.messaging;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.WritableMap;
 import com.google.firebase.messaging.RemoteMessage;
 import io.invertase.firebase.common.ReactNativeFirebaseEvent;
 import io.invertase.firebase.common.SharedUtils;

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
@@ -2,8 +2,8 @@ package io.invertase.firebase.messaging;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.google.firebase.messaging.RemoteMessage;
 import io.invertase.firebase.common.ReactNativeFirebaseEvent;
 import io.invertase.firebase.common.SharedUtils;
@@ -48,6 +48,10 @@ public class ReactNativeFirebaseMessagingSerializer {
 
   public static ReactNativeFirebaseEvent remoteMessageToEvent(RemoteMessage remoteMessage, Boolean openEvent) {
     return new ReactNativeFirebaseEvent(openEvent ? EVENT_NOTIFICATION_OPENED : EVENT_MESSAGE_RECEIVED, remoteMessageToWritableMap(remoteMessage));
+  }
+
+  public static ReactNativeFirebaseEvent remoteMessageMapToEvent(WritableMap remoteMessageMap, Boolean openEvent) {
+    return new ReactNativeFirebaseEvent(openEvent ? EVENT_NOTIFICATION_OPENED : EVENT_MESSAGE_RECEIVED, remoteMessageMap);
   }
 
   public static ReactNativeFirebaseEvent newTokenToTokenEvent(String newToken) {

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStore.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStore.java
@@ -2,10 +2,12 @@ package io.invertase.firebase.messaging;
 
 import com.google.firebase.messaging.RemoteMessage;
 
+import com.facebook.react.bridge.WritableMap;
+
 public interface ReactNativeFirebaseMessagingStore {
   void storeFirebaseMessage(RemoteMessage remoteMessage);
 
-  RemoteMessage getFirebaseMessage(String remoteMessageId);
+  WritableMap getFirebaseMessage(String remoteMessageId);
 
   void clearFirebaseMessage(String remoteMessageId);
 }

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStore.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStore.java
@@ -7,7 +7,10 @@ import com.facebook.react.bridge.WritableMap;
 public interface ReactNativeFirebaseMessagingStore {
   void storeFirebaseMessage(RemoteMessage remoteMessage);
 
-  WritableMap getFirebaseMessage(String remoteMessageId);
+  @Deprecated
+  RemoteMessage getFirebaseMessage(String remoteMessageId);
+
+  WritableMap getFirebaseMessageMap(String remoteMessageId);
 
   void clearFirebaseMessage(String remoteMessageId);
 }

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -48,15 +48,15 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
   }
 
   @Override
-  public RemoteMessage getFirebaseMessage(String remoteMessageId) {
+  public WritableMap getFirebaseMessage(String remoteMessageId) {
     String remoteMessageString = UniversalFirebasePreferences.getSharedInstance().getStringValue(remoteMessageId, null);
     if (remoteMessageString != null) {
 //      Log.d("getFirebaseMessage", remoteMessageString);
       try {
-        WritableMap readableMap = jsonToReact(new JSONObject(remoteMessageString));
-        readableMap.putString("to", remoteMessageId);//fake to
-        return remoteMessageFromReadableMap(readableMap);
-      } catch (JSONException e) {
+        WritableMap remoteMessageMap = jsonToReact(new JSONObject(remoteMessageString));
+        remoteMessageMap.putString("to", remoteMessageId);//fake to
+        return remoteMessageMap;
+       } catch (JSONException e) {
         e.printStackTrace();
       }
     }

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -50,7 +50,7 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
   @Deprecated
   @Override
   public RemoteMessage getFirebaseMessage(String remoteMessageId) {
-    WritableMap messageMap = getFirebaseMessageMap(remoteMessageId);
+    ReadableMap messageMap = getFirebaseMessageMap(remoteMessageId);
     if (messageMap != null){
       return remoteMessageFromReadableMap(messageMap);
     }

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -47,8 +47,18 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
     }
   }
 
+  @Deprecated
   @Override
-  public WritableMap getFirebaseMessage(String remoteMessageId) {
+  public RemoteMessage getFirebaseMessage(String remoteMessageId) {
+    WritableMap messageMap = getFirebaseMessageMap(remoteMessageId);
+    if (messageMap != null){
+      return remoteMessageFromReadableMap(messageMap);
+    }
+    return null;
+  }
+
+  @Override
+  public WritableMap getFirebaseMessageMap(String remoteMessageId) {
     String remoteMessageString = UniversalFirebasePreferences.getSharedInstance().getStringValue(remoteMessageId, null);
     if (remoteMessageString != null) {
 //      Log.d("getFirebaseMessage", remoteMessageString);

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -1,5 +1,6 @@
 package io.invertase.firebase.messaging;
 
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.firebase.messaging.RemoteMessage;
 


### PR DESCRIPTION
### Description

When deserializing saved notifications from the store on Android, this pull will include the notification object as well.  Previously the code used the Firebase RemoteMessage class, but that does not allow setting the notification object.  This uses writablemaps instead.

This is an Android only issue.

### Related issues

Fixes #5167

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

After following the reproduction steps in the linked issue, I can now get the notification object on start:

LOG  {"ttl":2419200,"from":"557990742577","to":"0:1618554006404925%26d15a5d26d15a5d","data":{},"sentTime":2147483647,"messageId":"0:1618554006404925%26d15a5d26d15a5d","collapseKey":"com.repromessagingbug","notification":{"android":{},"title":"test","body":"test"}}

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
