### PR TITLE
docs(app): fix typo in expo integration docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -257,4 +257,4 @@ $RNFirebaseAsStaticFramework = true
 
 ### Expo
 
-Expo does not support integration with native modules via it's ["Managed workflow"](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/#managed-workflow). Integration is only possible when used with the ["Bare workflow"](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/#bare-workflow).
+Expo does not support integration with native modules via its ["Managed workflow"](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/#managed-workflow). Integration is only possible when used with the ["Bare workflow"](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/#bare-workflow).


### PR DESCRIPTION
### Description

Fixed a type in the documentation. `its` instead of `it's`.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests; 
  -  n/a
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No