### PR TITLE
fix(admob, android): force admob dependency to compatible v19

### DIFF
--- a/packages/admob/android/build.gradle
+++ b/packages/admob/android/build.gradle
@@ -106,8 +106,7 @@ repositories {
 
 dependencies {
   api appProject
-  implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
-  implementation "com.google.firebase:firebase-ads"
+  implementation("com.google.android.gms:play-services-ads:19.8.0") { force = true; }
   implementation "com.google.android.ads.consent:consent-library:${ReactNative.ext.getVersion("ads", "consent")}"
 }
 


### PR DESCRIPTION
### Description

With the BoM it was apparently still possible for the admob library
to go across the breaking change v19->v20 boundary

Example was seen in #5127 and https://stackoverflow.com/questions/67114004/app-is-crashing-while-calling-interstitialad-load-method-in-react-native/67137688

This uses a gradle forced dependency until we forward-port

### Related issues

Related is #5150 - tracks the actual forward port, it will be breaking though as it will require a new BoM

### Release Summary

Conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I tried a few things and my success criteria was that `./gradlew :app:dependencies` output could be examined and ads 19.8.0 dependency was seen (not 20+)

Removing the BoM here and putting the range in appeared to do the trick

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
