### PR TITLE
fix(all, android): purge jcenter() from android build

### DIFF
--- a/packages/admob/android/build.gradle
+++ b/packages/admob/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -101,7 +101,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -97,7 +97,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -73,7 +73,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -78,7 +78,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 def safeExtGet(prop, fallback) {

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -79,7 +79,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/database/android/build.gradle
+++ b/packages/database/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -84,7 +84,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/dynamic-links/android/build.gradle
+++ b/packages/dynamic-links/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -79,7 +79,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -84,7 +84,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -84,7 +84,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/iid/android/build.gradle
+++ b/packages/iid/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -86,7 +86,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -84,7 +84,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -100,7 +100,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/ml/android/build.gradle
+++ b/packages/ml/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -84,7 +84,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -97,7 +97,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -84,7 +84,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   if (project == rootProject) {
     repositories {
       google()
-      jcenter()
+      mavenCentral()
     }
 
     dependencies {
@@ -79,7 +79,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/scripts/_TEMPLATE_/android/build.gradle
+++ b/scripts/_TEMPLATE_/android/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:4.1.0'
+    classpath 'com.android.tools.build:gradle:4.1.3'
   }
 }
 
@@ -25,7 +25,7 @@ project.ext {
       ],
 
       firebase          : [
-        bom: "26.0.0"
+        bom: "26.8.0"
       ],
     ],
   ])
@@ -47,7 +47,7 @@ android {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   ext.targetSdkVersion = 30
   ext.ndkVersion = "20.1.5948944"
 
-  ext.kotlinVersion = '1.4.31' // https://kotlinlang.org/releases.html
+  ext.kotlinVersion = '1.4.32' // https://kotlinlang.org/releases.html
   ext.supportLibVersion = "1.3.2" // this maps to androidx.core https://developer.android.com/jetpack/androidx/releases/core
   ext.appCompatVersion = "1.2.0" // this maps to androidx.appcompat https://developer.android.com/jetpack/androidx/releases/appcompat
   ext.supportVersion = ext.supportLibVersion
@@ -25,7 +25,6 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
     mavenCentral()
   }
   dependencies {
@@ -55,9 +54,9 @@ allprojects {
     //   // Detox as an .aar file (we're going to use it as a compile dependency though, to patch it)
     //   url "$rootDir/../node_modules/detox/Detox-android"
     // }
-    jcenter()
+    mavenCentral()
+    jcenter() // com.facebook.yoa:proguard-annotations not published elsewhere yet, and react-native needs new flipper+fbjni-java-only
   }
-
 }
 
 subprojects {


### PR DESCRIPTION
### Description

Only remaining jcenter usage is in our tests app, not used by
library consumers, where we must retain it until react-native itself
is jcenter-free

Also bumped everything in the template to current and bumped kotlin in tests app to 1.4.32 from 1.4.31 but no one will notice or care ;-)

### Related issues

Tracking remaining usage: https://github.com/react-native-community/releases/issues/221#issuecomment-822024961

### Release Summary

It's a conventional commit message


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

I ran `yarn tests:build:test` to make sure everything still built after. It still builds, unless you comment out the final jcenter line, then it fails on known problems (link above).

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
