### PR TITLE
fix(android): Resolve a crash under Android 7

### DIFF
--- a/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
+++ b/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
@@ -101,12 +101,13 @@ public class TaskExecutorService {
 
   public void shutdown() {
     Set<String> existingExecutorNames = executors.keySet();
-    existingExecutorNames.removeIf((executorName) -> {
-      return executorName.startsWith(name) == false;
-    });
-    existingExecutorNames.forEach((executorName) -> {
-      removeExecutor(executorName);
-    });
+    for (String executorName : existingExecutorNames) {
+      if (executorName.startsWith(name) == false) {
+        existingExecutorNames.remove(executorName);
+      } else {
+        removeExecutor(executorName);  
+      }
+    }
   }
 
   public void removeExecutor(String executorName) {


### PR DESCRIPTION
### Description

Related to : #4981 

[TaskExecutorService](https://github.com/invertase/react-native-firebase/blob/v11.3.2/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java#L104) is using API level 24 Collection functions such as `removeIf`, `forEach`.
This can cause build failure or crash under Android 7.

I'm sure it needs to be modified to work with the lower minSdkVersion.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

None
