### PR TITLE
fix(database, update): allow empty objects in ref.update()

### DIFF
--- a/packages/database/e2e/reference/update.e2e.js
+++ b/packages/database/e2e/reference/update.e2e.js
@@ -34,16 +34,6 @@ describe('database().ref().update()', function () {
     }
   });
 
-  it('throws if values does not contain any values', async function () {
-    try {
-      await firebase.database().ref(TEST_PATH).update({});
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql("'values' must be an object containing multiple values");
-      return Promise.resolve();
-    }
-  });
-
   it('throws if update paths are not valid', async function () {
     try {
       await firebase.database().ref(TEST_PATH).update({
@@ -79,6 +69,14 @@ describe('database().ref().update()', function () {
     });
     const snapshot = await ref.once('value');
     snapshot.val().should.eql(
+      jet.contextify({
+        foo: value,
+      }),
+    );
+
+    await ref.update({}); // empty update should pass, but no side effects
+    const snapshot2 = await ref.once('value');
+    snapshot2.val().should.eql(
       jet.contextify({
         foo: value,
       }),

--- a/packages/database/lib/DatabaseReference.js
+++ b/packages/database/lib/DatabaseReference.js
@@ -112,12 +112,6 @@ export default class DatabaseReference extends DatabaseQuery {
       throw new Error("firebase.database().ref().update(*) 'values' must be an object.");
     }
 
-    if (!Object.keys(values).length) {
-      throw new Error(
-        "firebase.database().ref().update(*) 'values' must be an object containing multiple values.",
-      );
-    }
-
     const keys = Object.keys(values);
     for (let i = 0; i < keys.length; i++) {
       if (!isValidPath(keys[i])) {


### PR DESCRIPTION
### Description

As pointed out by @daveGregorian firebase-js-sdk allows empty objects
while the code here was enforcing that the objects had at least one key

### Related issues

Fixes #5218

### Release Summary

Conventional commit message

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Verified (with investigation in linked issue) that firebase-js-sdk allows empty objects through), added an e2e test that verifies firebase-ios-sdk and firebase-android-sdk handle empty objects, and those work, so removing the check in our javascript layer should be fine

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
