### PR TITLE
feat(analytics, ATT): allow use of AnalyticsWithoutAdIdSupport pod

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -8,6 +8,8 @@ APIs
 APIs.
 APNs
 async
+ATT
+ATT-compatible
 auth
 Auth
 authenticator
@@ -46,6 +48,7 @@ Fastlane
 FCM
 firebase
 Firebase
+firebase-ios-sdk
 Firestore
 GDPR
 globals
@@ -55,6 +58,7 @@ Hesp
 Homebrew
 HTTP
 HTTPS
+IDFA
 installable
 Interstitials
 interstitials

--- a/docs/analytics/usage/index.md
+++ b/docs/analytics/usage/index.md
@@ -132,6 +132,27 @@ import analytics from '@react-native-firebase/analytics';
 const appInstanceId = await analytics().getAppInstanceId();
 ```
 
+# Disable Ad Id usage on iOS
+
+Apple has a strict ban on the usage of Ad Ids ("IDFA") in Kids Category apps. They will not accept any app
+in the Kids category if the app accesses the IDFA iOS symbols.
+
+Additionally, apps must implement Apples "App Tracking Transparency" (or "ATT") requirements if they access IDFA symbols.
+However, if an app does not use IDFA and otherwise handles data in an ATT-compatible way, it eliminates this ATT requirement.
+
+If avoiding the usage of IDFA is a requirement for your app, you must use firebase-ios-sdk 7.11.0 or greater, then you may define a variable in your Podfile like this:
+
+```ruby
+$RNFirebaseAnalyticsWithoutAdIdSupport = true
+```
+
+During `pod install`, using that variable installs a new
+["Analytics With No Ad Ids"](https://firebase.google.com/support/release-notes/ios#version_7110_-_april_20_2021)
+pod the firebase-ios-sdk team has created, and allows both the use of Firebase Analytics in Kids Category apps,
+and use of Firebase Analytics without needing the App Tracking Transparency handling (assuming no other parts
+of your app handle data in a way that requires ATT)
+
+Note that for obvious reasons, configuring Firebase Analytics for use without IDFA is incompatible with AdMob
 # firebase.json
 
 ## Disable Auto-Initialization

--- a/packages/admob/RNFBAdMob.podspec
+++ b/packages/admob/RNFBAdMob.podspec
@@ -37,6 +37,11 @@ Pod::Spec.new do |s|
     firebase_sdk_version = $FirebaseSDKVersion
   end
 
+  if defined?($RNFirebaseAnalyticsWithoutAdIdSupport)
+    # Trying to use AdMob *and* AnalyticsWIthoutAdIdSupport is not a valid combination
+    raise "#{s.name} and Firebase/AnalyticsWithoutAdIdSupport are not compatible. Ad Ids are required for #{s.name}"
+  end
+
   # Firebase dependencies
   s.dependency          'Firebase/AdMob', firebase_sdk_version
 

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -34,7 +34,20 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Analytics', firebase_sdk_version
+  if defined?($RNFirebaseAnalyticsWithoutAdIdSupport)
+    Pod::UI.puts "#{s.name}: Using Firebase/AnalyticsWithoutAdIdSupport pod in place of default Firebase/Analytics"
+
+    # Releasing as non-breaking change as it is optional but it raises minimum requirements, validate just in case
+    if (Gem::Version.new(firebase_sdk_version) < Gem::Version.new("7.11.0"))
+      raise "Firebase/AnalyticsWithoutAdIdSupport requires firebase-ios-sdk 7.11.0 or greater."
+    end
+
+    s.dependency          'Firebase/AnalyticsWithoutAdIdSupport', firebase_sdk_version
+  else
+    Pod::UI.puts "#{s.name}: Using default Firebase/Analytics with Ad Ids. May require App Tracking Transparency. Not allowed for Kids apps."
+    Pod::UI.puts "#{s.name}: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids."
+    s.dependency          'Firebase/Analytics', firebase_sdk_version
+  end
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "7.10.0"
+      "firebase": "7.11.0"
     },
     "android": {
       "minSdk": 16,

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -7,6 +7,14 @@ $FirebaseSDKVersion = appPackage['sdkVersions']['ios']['firebase']
 Pod::UI.puts "react-native-firebase/tests: Using Firebase SDK version '#{$FirebaseSDKVersion}'"
 #$RNFirebaseAsStaticFramework = false # toggle this to true (and set 'use_frameworks!' below to test static frameworks)
 
+# Toggle this to true for the no-ad-tracking Analytics subspec. Useful at minimum for Kids category apps.
+# See: https://firebase.google.com/support/release-notes/ios#analytics - requires firebase-ios-sdk 7.11.0+
+#$RNFirebaseAnalyticsWithoutAdIdSupport = true # toggle this to true for the no-ad-tracking Analytics subspec
+
+# This is needed to reduce flakiness where leveldb is transitively included by database, and packed as framework
+# from the pre-compiled firestore-ios-sdk-frameworks
+$FirebaseFirestoreExcludeLeveldb = true
+
 # Versions used below, for quick reference / outdated+upgrade checks
 $iOSMinimumDeployVersion = '10.0'
 
@@ -28,7 +36,6 @@ target 'testing' do
   )
 
   # Use pre-compiled firestore frameworks to optimize compile time. But make sure there are not leveldb conflicts.
-  $FirebaseFirestoreExcludeLeveldb = true
   pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => $FirebaseSDKVersion
 
   # Enables Flipper.

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -9,110 +9,118 @@ PODS:
     - React-Core (= 0.64.0)
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
-  - Firebase/AdMob (7.10.0):
+  - Firebase/AdMob (7.11.0):
     - Firebase/CoreOnly
     - Google-Mobile-Ads-SDK (~> 7.66)
-  - Firebase/Analytics (7.10.0):
-    - Firebase/Core
-  - Firebase/Auth (7.10.0):
+  - Firebase/AnalyticsWithoutAdIdSupport (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 7.10.0)
-  - Firebase/Core (7.10.0):
+    - FirebaseAnalytics/WithoutAdIdSupport (~> 7.11.0)
+  - Firebase/Auth (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 7.10.0)
-  - Firebase/CoreOnly (7.10.0):
-    - FirebaseCore (= 7.10.0)
-  - Firebase/Crashlytics (7.10.0):
+    - FirebaseAuth (~> 7.11.0)
+  - Firebase/CoreOnly (7.11.0):
+    - FirebaseCore (= 7.11.0)
+  - Firebase/Crashlytics (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 7.10.0)
-  - Firebase/Database (7.10.0):
+    - FirebaseCrashlytics (~> 7.11.0)
+  - Firebase/Database (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 7.10.0)
-  - Firebase/DynamicLinks (7.10.0):
+    - FirebaseDatabase (~> 7.11.0)
+  - Firebase/DynamicLinks (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 7.10.0)
-  - Firebase/Firestore (7.10.0):
+    - FirebaseDynamicLinks (~> 7.11.0)
+  - Firebase/Firestore (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 7.10.0)
-  - Firebase/Functions (7.10.0):
+    - FirebaseFirestore (~> 7.11.0)
+  - Firebase/Functions (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 7.10.0)
-  - Firebase/InAppMessaging (7.10.0):
+    - FirebaseFunctions (~> 7.11.0)
+  - Firebase/InAppMessaging (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 7.10.0-beta)
-  - Firebase/Messaging (7.10.0):
+    - FirebaseInAppMessaging (~> 7.11.0-beta)
+  - Firebase/Messaging (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 7.10.0)
-  - Firebase/MLVision (7.10.0):
+    - FirebaseMessaging (~> 7.11.0)
+  - Firebase/MLVision (7.11.0):
     - Firebase/CoreOnly
     - FirebaseMLVision (~> 7.6.0-beta)
-  - Firebase/Performance (7.10.0):
+  - Firebase/Performance (7.11.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 7.10.0)
-  - Firebase/RemoteConfig (7.10.0):
+    - FirebasePerformance (~> 7.11.0)
+  - Firebase/RemoteConfig (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 7.10.0)
-  - Firebase/Storage (7.10.0):
+    - FirebaseRemoteConfig (~> 7.11.0)
+  - Firebase/Storage (7.11.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 7.10.0)
-  - FirebaseABTesting (7.10.0):
+    - FirebaseStorage (~> 7.11.0)
+  - FirebaseABTesting (7.11.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseAnalytics (7.10.0):
+  - FirebaseAnalytics/Base (7.11.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
-    - GoogleAppMeasurement (= 7.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAuth (7.10.0):
+  - FirebaseAnalytics/WithoutAdIdSupport (7.11.0):
+    - FirebaseAnalytics/Base (= 7.11.0)
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 7.11.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/MethodSwizzler (~> 7.0)
+    - GoogleUtilities/Network (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAuth (7.11.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
-  - FirebaseCore (7.10.0):
+  - FirebaseCore (7.11.0):
     - FirebaseCoreDiagnostics (~> 7.4)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
-  - FirebaseCoreDiagnostics (7.10.0):
+  - FirebaseCoreDiagnostics (7.11.0):
     - GoogleDataTransport (~> 8.4)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/Logger (~> 7.0)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (7.10.0):
+  - FirebaseCrashlytics (7.11.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleDataTransport (~> 8.4)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseDatabase (7.10.0):
+  - FirebaseDatabase (7.11.0):
     - FirebaseCore (~> 7.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (7.10.0):
+  - FirebaseDynamicLinks (7.11.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseFirestore (7.10.0)
-  - FirebaseFunctions (7.10.0):
+  - FirebaseFirestore (7.11.0)
+  - FirebaseFunctions (7.11.0):
     - FirebaseCore (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
-  - FirebaseInAppMessaging (7.10.0-beta):
+  - FirebaseInAppMessaging (7.11.0-beta):
     - FirebaseABTesting (~> 7.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (7.10.0):
+  - FirebaseInstallations (7.11.0):
     - FirebaseCore (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseInstanceID (7.10.0):
+  - FirebaseInstanceID (7.11.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - GoogleUtilities/UserDefaults (~> 7.0)
-  - FirebaseMessaging (7.10.0):
+  - FirebaseMessaging (7.11.0):
     - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
     - FirebaseInstanceID (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
@@ -136,7 +144,7 @@ PODS:
     - "GoogleToolboxForMac/NSData+zlib (~> 2.1)"
     - GTMSessionFetcher/Core (~> 1.1)
     - Protobuf (~> 3.12)
-  - FirebasePerformance (7.10.0):
+  - FirebasePerformance (7.11.0):
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - FirebaseRemoteConfig (~> 7.0)
@@ -145,13 +153,13 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - Protobuf (~> 3.12)
-  - FirebaseRemoteConfig (7.10.0):
+  - FirebaseRemoteConfig (7.11.0):
     - FirebaseABTesting (~> 7.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/Environment (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
-  - FirebaseStorage (7.10.0):
+  - FirebaseStorage (7.11.0):
     - FirebaseCore (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
   - glog (0.3.5)
@@ -163,7 +171,20 @@ PODS:
   - GoogleAPIClientForREST/Vision (1.5.2):
     - GoogleAPIClientForREST/Core
     - GTMSessionFetcher (>= 1.1.7)
-  - GoogleAppMeasurement (7.10.0):
+  - GoogleAppMeasurement (7.11.0):
+    - GoogleAppMeasurement/AdIdSupport (= 7.11.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/MethodSwizzler (~> 7.0)
+    - GoogleUtilities/Network (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (7.11.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/MethodSwizzler (~> 7.0)
+    - GoogleUtilities/Network (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (7.11.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
@@ -479,70 +500,70 @@ PODS:
     - React-cxxreact (= 0.64.0)
     - React-jsi (= 0.64.0)
     - React-perflogger (= 0.64.0)
-  - RNFBAdMob (11.2.0):
-    - Firebase/AdMob (= 7.10.0)
+  - RNFBAdMob (11.3.3):
+    - Firebase/AdMob (= 7.11.0)
     - PersonalizedAdConsent (~> 1.0.5)
     - React-Core
     - RNFBApp
-  - RNFBAnalytics (11.2.0):
-    - Firebase/Analytics (= 7.10.0)
+  - RNFBAnalytics (11.3.3):
+    - Firebase/AnalyticsWithoutAdIdSupport (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (11.2.0):
-    - Firebase/CoreOnly (= 7.10.0)
+  - RNFBApp (11.3.3):
+    - Firebase/CoreOnly (= 7.11.0)
     - React-Core
-  - RNFBAuth (11.2.0):
-    - Firebase/Auth (= 7.10.0)
-    - React-Core
-    - RNFBApp
-  - RNFBCrashlytics (11.2.0):
-    - Firebase/Crashlytics (= 7.10.0)
+  - RNFBAuth (11.3.3):
+    - Firebase/Auth (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (11.2.0):
-    - Firebase/Database (= 7.10.0)
+  - RNFBCrashlytics (11.3.3):
+    - Firebase/Crashlytics (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (11.2.0):
-    - Firebase/DynamicLinks (= 7.10.0)
+  - RNFBDatabase (11.3.3):
+    - Firebase/Database (= 7.11.0)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (11.3.3):
+    - Firebase/DynamicLinks (= 7.11.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (11.2.0):
-    - Firebase/Firestore (= 7.10.0)
+  - RNFBFirestore (11.3.3):
+    - Firebase/Firestore (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (11.2.0):
-    - Firebase/Functions (= 7.10.0)
+  - RNFBFunctions (11.3.3):
+    - Firebase/Functions (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBIid (11.2.0):
-    - Firebase/CoreOnly (= 7.10.0)
+  - RNFBIid (11.3.3):
+    - Firebase/CoreOnly (= 7.11.0)
     - FirebaseInstanceID
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (11.2.0):
-    - Firebase/InAppMessaging (= 7.10.0)
+  - RNFBInAppMessaging (11.3.3):
+    - Firebase/InAppMessaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (11.2.0):
-    - Firebase/Messaging (= 7.10.0)
+  - RNFBMessaging (11.3.3):
+    - Firebase/Messaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBML (11.2.0):
-    - Firebase/MLVision (= 7.10.0)
+  - RNFBML (11.3.3):
+    - Firebase/MLVision (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBPerf (11.2.0):
-    - Firebase/Performance (= 7.10.0)
+  - RNFBPerf (11.3.3):
+    - Firebase/Performance (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (11.2.0):
-    - Firebase/RemoteConfig (= 7.10.0)
+  - RNFBRemoteConfig (11.3.3):
+    - Firebase/RemoteConfig (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (11.2.0):
-    - Firebase/Storage (= 7.10.0)
+  - RNFBStorage (11.3.3):
+    - Firebase/Storage (= 7.11.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -551,7 +572,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `7.10.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `7.11.0`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Jet (from `../node_modules/jet/ios`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -642,7 +663,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 7.10.0
+    :tag: 7.11.0
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Jet:
@@ -731,37 +752,37 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 7.10.0
+    :tag: 7.11.0
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
   FBReactNativeSpec: ea750e746c463712a67a3ad0d8c73f68ae5c6ffe
-  Firebase: fffddd0bab8677d07376538365faa93ff3889b39
-  FirebaseABTesting: 457bc058cf6de8bcffc6fd9a2a4c933b24bfc264
-  FirebaseAnalytics: 4641d7ae4220174f6ca5626163ffc5de2e90391e
-  FirebaseAuth: 675f2c4eb4426e7c58a78a89965a6530e7863535
-  FirebaseCore: ec566d917b2195fc2610aeb148dae99f57a788f9
-  FirebaseCoreDiagnostics: 5662a3823ffcc0acbaa9a21ba5ed302fac634705
-  FirebaseCrashlytics: e7669d368a22d202f1d0c7546ffdfdff496e1a8c
-  FirebaseDatabase: ed9c5fc2568e92a22a40cab1ccaf4e0e9e9c8ae6
-  FirebaseDynamicLinks: 5f898580358c4d65430a85ae96dd779efb26b098
-  FirebaseFirestore: d090696b64d79461618bde32774c25152d0256f0
-  FirebaseFunctions: 542c0b41a4b0d298e48f9b7996aad59600b64f53
-  FirebaseInAppMessaging: 8d1e3f0b332180c8c82f394db0cb4b19162fb7f7
-  FirebaseInstallations: bf2ec8dbf36ff4c91af6b9a003d15855757680c1
-  FirebaseInstanceID: 5ad92c898e1328b66e8dd58811964d6fe4d334c3
-  FirebaseMessaging: 76b3058cef7f339cf10db196e03bbbb2165fb5d7
+  Firebase: c121feb35e4126c0b355e3313fa9b487d47319fd
+  FirebaseABTesting: e66f1f80747792630d9b292966de206d5df9853b
+  FirebaseAnalytics: cd3bd84d722a24a8923918af8af8e5236f615d77
+  FirebaseAuth: 5fe4585c2ed847319f0ea68bd1d82c77e49ff9a0
+  FirebaseCore: 907447d8917a4d3eb0cce2829c5a0ad21d90b432
+  FirebaseCoreDiagnostics: 68ad972f99206cef818230f3f3179d52ccfb7f8c
+  FirebaseCrashlytics: 272b675aa9d1e9bae1f9e1449fcc1f2cf6042806
+  FirebaseDatabase: 6c39fbf1c8514a2f32e610f9bf9ef30c535dc15a
+  FirebaseDynamicLinks: 07f101c20bb40fd39f6b3e5278a64a5f2f660dc1
+  FirebaseFirestore: 783538aced1557a6b817ee121593561127a00244
+  FirebaseFunctions: cf3d041e5292b1c4bda868d542071a0f8291a4d4
+  FirebaseInAppMessaging: 03f39409c6f5ce5fb2d0db9cc99e043c0a538ba0
+  FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
+  FirebaseInstanceID: ad5135045a498d7775903efd39762d2cdfa1be27
+  FirebaseMessaging: 163435fb6db065e3b6228f1e577b10ed2cc506d2
   FirebaseMLCommon: cbab07a0cfa19b982819fc9e030e6f3d569c23a6
   FirebaseMLVision: 68439dbb81881116a87c0e469af9f55b53e9648c
-  FirebasePerformance: 4dc33e0b7baa36b88474c9edb439088ef1b17f3c
-  FirebaseRemoteConfig: 2841e353accfe688150781deebeb245e3fe16c2f
-  FirebaseStorage: d88ef8e9f152c6a17e44540ae2b93c3be74e9b60
+  FirebasePerformance: 3166d0c16b359b1ef92be774f46f2768b98c8993
+  FirebaseRemoteConfig: 0ea30de5fb0231df8c1bdcdf3b6c23bdc5066131
+  FirebaseStorage: 8542711850ca181a3931c0ed483006a7b46039e7
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Google-Mobile-Ads-SDK: 2f288748a42920d1c744946a460896a95b0e9110
   GoogleAPIClientForREST: 538a8ad0014fd88b78894e77100775a6b0a4f7ed
-  GoogleAppMeasurement: 1c863b1161fc3c8cf614a7460d1be6a7c262aab3
+  GoogleAppMeasurement: fd19169c3034975cb934e865e5667bfdce59df7f
   GoogleDataTransport: cd9db2180fcecd8da1b561aea31e3e56cf834aa7
   GoogleToolboxForMac: 471e0c05d39506e50e6398f46fa9a12ae0efeff9
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
@@ -796,24 +817,24 @@ SPEC CHECKSUMS:
   React-RCTVibration: 0fd6b21751a33cb72fce1a4a33ab9678416d307a
   React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
-  RNFBAdMob: 4b5355f7c8cef0f833e9b696e35f95b274716d02
-  RNFBAnalytics: 5fb6895296e01b4847f627e13888b3f6e3cc8aef
-  RNFBApp: 4a65422000f36c9973e76f19ca104283296841b7
-  RNFBAuth: d322e629ef1c1d2d23197ed0b45f3b14ceeb2596
-  RNFBCrashlytics: 31a039911500bf1a3a7fd15c5df3c4a413a542d6
-  RNFBDatabase: a4ce18794239c2082bd71156f8b3112dc4c2179c
-  RNFBDynamicLinks: dc131812ecfbd48c4359046a957b1f38348d53de
-  RNFBFirestore: 71230fa71c84232b0b112420f9d49ffe365b8338
-  RNFBFunctions: 54c06803197c1b34f44bdf27e820bfdf59b759e9
-  RNFBIid: 8408f47ad269f3ecef3f8c20b7472068d941e670
-  RNFBInAppMessaging: 1b5ef506173578994acbc8b8c9c505714e0a8e36
-  RNFBMessaging: dc27880b65a2e19a49a97781bc3837dece9f5535
-  RNFBML: 160435a205304258ae610b2b7eaa8c5c7b56a51b
-  RNFBPerf: 35a424771cf3712390cb4acf054455279e8583e8
-  RNFBRemoteConfig: 7ee9f8cb4cc762551be2bb69c16d14230df742a1
-  RNFBStorage: 9676c876b01c72438e625cf3737df7c1478925aa
+  RNFBAdMob: 7d5a6b026782a1b5f91bd863d2299e4a328cade0
+  RNFBAnalytics: 45e0aaa4919d5dc82a2605f01984cd4dfff706c8
+  RNFBApp: 097a73b10972939bade8ad720ef92c3867baf2e5
+  RNFBAuth: e554b8c1d3cddcb1ead741794be055acc1defcda
+  RNFBCrashlytics: a045da0758ed559db99ed049a11ffc995fececb9
+  RNFBDatabase: de7c902da929d8b170930f23e2787ee3f5e75c4b
+  RNFBDynamicLinks: 135501c3922e49e4e7e00d1a0a1777b2fba1f042
+  RNFBFirestore: 9c7fc9c42de2cc91d9b70cfc12ed00aa25ddb250
+  RNFBFunctions: c2af986961d28a74f1383b0e53f4e4d20a95098a
+  RNFBIid: 585215475e5dec2e0565360b77fb8a33fe33d081
+  RNFBInAppMessaging: f7ac052f565200549d1fc187b4b86bec611eab03
+  RNFBMessaging: 747dbfebbe827241a9819884cbba2cb35ce5dc90
+  RNFBML: 8f7b5e256a0224bfc862d6e85d42db8a19d02d70
+  RNFBPerf: fb34154674ad8b13effe52a0ab4a51bdb9992b7a
+  RNFBRemoteConfig: fd88e45c151427ef9f75534da31c86dba1e28da3
+  RNFBStorage: af7814531e503ea094f65f24fc5aa98491823bb8
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: 1a823bd84dc58905bf4b883bf4804355a2a6881d
+PODFILE CHECKSUM: 425de7af0490cb14d4d9a6f7f39d3eb34cd31fb6
 
 COCOAPODS: 1.10.1

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -12,12 +12,14 @@ PODS:
   - Firebase/AdMob (7.11.0):
     - Firebase/CoreOnly
     - Google-Mobile-Ads-SDK (~> 7.66)
-  - Firebase/AnalyticsWithoutAdIdSupport (7.11.0):
-    - Firebase/CoreOnly
-    - FirebaseAnalytics/WithoutAdIdSupport (~> 7.11.0)
+  - Firebase/Analytics (7.11.0):
+    - Firebase/Core
   - Firebase/Auth (7.11.0):
     - Firebase/CoreOnly
     - FirebaseAuth (~> 7.11.0)
+  - Firebase/Core (7.11.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (~> 7.11.0)
   - Firebase/CoreOnly (7.11.0):
     - FirebaseCore (= 7.11.0)
   - Firebase/Crashlytics (7.11.0):
@@ -55,7 +57,8 @@ PODS:
     - FirebaseStorage (~> 7.11.0)
   - FirebaseABTesting (7.11.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseAnalytics/Base (7.11.0):
+  - FirebaseAnalytics (7.11.0):
+    - FirebaseAnalytics/AdIdSupport (= 7.11.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
@@ -63,11 +66,19 @@ PODS:
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/WithoutAdIdSupport (7.11.0):
+  - FirebaseAnalytics/AdIdSupport (7.11.0):
     - FirebaseAnalytics/Base (= 7.11.0)
     - FirebaseCore (~> 7.0)
     - FirebaseInstallations (~> 7.0)
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 7.11.0)
+    - GoogleAppMeasurement/AdIdSupport (= 7.11.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
+    - GoogleUtilities/MethodSwizzler (~> 7.0)
+    - GoogleUtilities/Network (~> 7.0)
+    - "GoogleUtilities/NSData+zlib (~> 7.0)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAnalytics/Base (7.11.0):
+    - FirebaseCore (~> 7.0)
+    - FirebaseInstallations (~> 7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
     - GoogleUtilities/MethodSwizzler (~> 7.0)
     - GoogleUtilities/Network (~> 7.0)
@@ -184,12 +195,6 @@ PODS:
     - GoogleUtilities/Network (~> 7.0)
     - "GoogleUtilities/NSData+zlib (~> 7.0)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (7.11.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.0)
-    - GoogleUtilities/MethodSwizzler (~> 7.0)
-    - GoogleUtilities/Network (~> 7.0)
-    - "GoogleUtilities/NSData+zlib (~> 7.0)"
-    - nanopb (~> 2.30908.0)
   - GoogleDataTransport (8.4.0):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
@@ -207,25 +212,25 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.1)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.3.1)"
   - GoogleUserMessagingPlatform (1.4.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.3.1):
+  - GoogleUtilities/AppDelegateSwizzler (7.4.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.3.1):
+  - GoogleUtilities/Environment (7.4.0):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/ISASwizzler (7.3.1)
-  - GoogleUtilities/Logger (7.3.1):
+  - GoogleUtilities/ISASwizzler (7.4.0)
+  - GoogleUtilities/Logger (7.4.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.3.1):
+  - GoogleUtilities/MethodSwizzler (7.4.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.3.1):
+  - GoogleUtilities/Network (7.4.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.3.1)"
-  - GoogleUtilities/Reachability (7.3.1):
+  - "GoogleUtilities/NSData+zlib (7.4.0)"
+  - GoogleUtilities/Reachability (7.4.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.3.1):
+  - GoogleUtilities/UserDefaults (7.4.0):
     - GoogleUtilities/Logger
   - GTMSessionFetcher (1.5.0):
     - GTMSessionFetcher/Full (= 1.5.0)
@@ -506,7 +511,7 @@ PODS:
     - React-Core
     - RNFBApp
   - RNFBAnalytics (11.3.3):
-    - Firebase/AnalyticsWithoutAdIdSupport (= 7.11.0)
+    - Firebase/Analytics (= 7.11.0)
     - React-Core
     - RNFBApp
   - RNFBApp (11.3.3):
@@ -786,7 +791,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: cd9db2180fcecd8da1b561aea31e3e56cf834aa7
   GoogleToolboxForMac: 471e0c05d39506e50e6398f46fa9a12ae0efeff9
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
-  GoogleUtilities: e1d9ed4e544fc32a93e00e721400cbc3f377200d
+  GoogleUtilities: 284cddc7fffc14ae1907efb6f78ab95c1fccaedc
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Jet: 84fd0e2e9d49457fc04bc79b5d8857737a01c507
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
@@ -818,7 +823,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
   RNFBAdMob: 7d5a6b026782a1b5f91bd863d2299e4a328cade0
-  RNFBAnalytics: 45e0aaa4919d5dc82a2605f01984cd4dfff706c8
+  RNFBAnalytics: 4747ea51be1b2f003c889aad0207bf3fcc8309ad
   RNFBApp: 097a73b10972939bade8ad720ef92c3867baf2e5
   RNFBAuth: e554b8c1d3cddcb1ead741794be055acc1defcda
   RNFBCrashlytics: a045da0758ed559db99ed049a11ffc995fececb9
@@ -835,6 +840,6 @@ SPEC CHECKSUMS:
   RNFBStorage: af7814531e503ea094f65f24fc5aa98491823bb8
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: 425de7af0490cb14d4d9a6f7f39d3eb34cd31fb6
+PODFILE CHECKSUM: 89dba385c805fb62e8343576922b9b86427aa683
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
### Description

Allow use of new Analytics subspec that gets you Analytics without the Ad Id usage (thus no need for Apple App Transparency Tracking)

### Related issues

Discussion here https://github.com/invertase/react-native-firebase/discussions/5223

### Release Summary

2 conventional commits, can be rebase merged

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- test with firebase-ios-sdk 7.10.0 and using new podspec variable (should fail, does fail :heavy_check_mark: )
- test with firebase-ios-sdk 7.11.0, using new variable, with admob too (should fail, does fail :heavy_check_mark: )
- test with firebase-ios-sdk 7.11.0 using new variable, no admob (should use new subspec, works :heavy_check_mark:  )

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
