### PR TITLE
fix(analytics): import using package name not relative path

### DIFF
--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -31,7 +31,7 @@ import {
   FirebaseModule,
   getFirebaseRoot,
 } from '@react-native-firebase/app/lib/internal';
-import { isBoolean } from '../../app/lib/common';
+import { isBoolean } from '@react-native-firebase/app/lib/common';
 
 import version from './version';
 import * as structs from './structs';


### PR DESCRIPTION
### Description
This is an easy PR. I updated `../../app/lib/common` by '@react-native-firebase/app/lib/common'
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
- App does not crash when it's opened
<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
