### PR TITLE
fix(app, android): fix TaskExecutor ConcurrentModificationException

### DIFF
--- a/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
+++ b/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
@@ -17,9 +17,10 @@ package io.invertase.firebase.common;
  *
  */
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionHandler;
@@ -96,12 +97,14 @@ public class TaskExecutorService {
   }
 
   public void shutdown() {
-    Set<String> existingExecutorNames = executors.keySet();
-    for (String executorName : existingExecutorNames) {
-      if (!executorName.startsWith(name)) {
-        existingExecutorNames.remove(executorName);
-      } else {
-        removeExecutor(executorName);
+    synchronized(executors) {
+      List<String> existingExecutorNames = new ArrayList<>(executors.keySet());
+      for (String executorName : existingExecutorNames) {
+        if (!executorName.startsWith(name)) {
+          executors.remove(executorName);
+        } else {
+          removeExecutor(executorName);
+        }
       }
     }
   }

--- a/packages/app/e2e/config.e2e.js
+++ b/packages/app/e2e/config.e2e.js
@@ -26,7 +26,7 @@ describe('config', function () {
   });
 
   describe('json', function () {
-    xit('should read firebase.json data', async function () {
+    it('should read firebase.json data', async function () {
       const jsonData = await NativeModules.RNFBAppModule.jsonGetAll();
       jsonData.rnfirebase_json_testing_string.should.equal('abc');
       jsonData.rnfirebase_json_testing_boolean_false.should.equal(false);

--- a/tests/app.js
+++ b/tests/app.js
@@ -53,14 +53,17 @@ function Root() {
       style={{ flex: 1, paddingTop: 20, justifyContent: 'center', alignItems: 'center' }}
     >
       <Text style={{ fontSize: 25, marginBottom: 30 }}>React Native Firebase</Text>
-      <Text style={{ fontSize: 25, marginBottom: 30 }}>End-to-End Testing App2</Text>
+      <Text style={{ fontSize: 25, marginBottom: 30 }}>End-to-End Testing App</Text>
       <Button
+        style={{ flex: 1, marginTop: 20 }}
         title={'Test Native Crash Now.'}
         onPress={() => {
           firebase.crashlytics().crash();
         }}
       />
+      <View testId="spacer" style={{ height: 20 }} />
       <Button
+        style={{ flex: 1, marginTop: 20 }}
         title={'Test Javascript Crash Now.'}
         onPress={() => {
           undefinedVariable.notAFunction();


### PR DESCRIPTION
### Description

The new TaskExecutor code in #4981 is great but it is new and had a concurrency issue causing a redbox on CatalystInstance shutdown, which shows up as a redbox in dev when you reload the app

### Related issues

Fixes #5225
Related #5233 - redbox detection was flaky and I don't want to delay this fix, split it to separate PR

### Release Summary

Each commit is separate with a conventional commit message

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Redbox was reproducible in E2E suite after Detox reloaded the app, but the tests continued running under the redbox, so it passed CI. Fixed root cause of the initial bug and locally have redbox detection working but needs de-flaking

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
