### PR TITLE
fix(analytics): added missing price parameter to the Item structure

### DIFF
--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -376,7 +376,7 @@ describe('analytics()', function () {
             item_location_id: 'foo',
             price: 123,
           },
-        ]
+        ],
       });
     });
   });

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -368,6 +368,15 @@ describe('analytics()', function () {
     it('calls logViewItemList', async function () {
       await firebase.analytics().logViewItemList({
         item_list_name: 'foo',
+        items: [
+          {
+            item_id: 'foo',
+            item_name: 'foo',
+            item_category: 'foo',
+            item_location_id: 'foo',
+            price: 123,
+          },
+        ]
       });
     });
   });

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -105,6 +105,8 @@ export namespace FirebaseAnalyticsTypes {
     quantity?: number;
     /**
      * The Item price.
+     * Note that firebase analytics will display this as an integer with trailing zeros, due to some firebase-internal conversion.
+     * See https://github.com/invertase/react-native-firebase/issues/4578#issuecomment-771703420 for more information
      */
     price?: number;
   }

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -103,6 +103,10 @@ export namespace FirebaseAnalyticsTypes {
      * The Item quantity.
      */
     quantity?: number;
+    /**
+     * The Item price.
+     */
+    price?: number;
   }
 
   export interface AddPaymentInfoEventParameters {

--- a/packages/analytics/lib/structs.js
+++ b/packages/analytics/lib/structs.js
@@ -29,6 +29,7 @@ const Item = struct({
   item_location_id: 'string?',
   item_variant: 'string?',
   quantity: 'number?',
+  price: 'number?',
 });
 
 export const ScreenView = struct({


### PR DESCRIPTION
### Description

This pull request addresses the problem of not being able to pass the price parameter when trying to log `view_item_list`

But as described in the official [documentation](https://firebase.google.com/docs/analytics/measure-ecommerce#web-v8_1) it must be possible.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
- My change includes tests;
  - [X] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

🔥 