### PR TITLE
test(e2e): detect redbox in ci

### DIFF
--- a/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
+++ b/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
@@ -17,9 +17,10 @@ package io.invertase.firebase.common;
  *
  */
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionHandler;
@@ -96,12 +97,14 @@ public class TaskExecutorService {
   }
 
   public void shutdown() {
-    Set<String> existingExecutorNames = executors.keySet();
-    for (String executorName : existingExecutorNames) {
-      if (!executorName.startsWith(name)) {
-        existingExecutorNames.remove(executorName);
-      } else {
-        removeExecutor(executorName);
+    synchronized(executors) {
+      List<String> existingExecutorNames = new ArrayList<>(executors.keySet());
+      for (String executorName : existingExecutorNames) {
+        if (!executorName.startsWith(name)) {
+          executors.remove(executorName);
+        } else {
+          removeExecutor(executorName);
+        }
       }
     }
   }

--- a/packages/app/e2e/config.e2e.js
+++ b/packages/app/e2e/config.e2e.js
@@ -26,7 +26,7 @@ describe('config', function () {
   });
 
   describe('json', function () {
-    xit('should read firebase.json data', async function () {
+    it('should read firebase.json data', async function () {
       const jsonData = await NativeModules.RNFBAppModule.jsonGetAll();
       jsonData.rnfirebase_json_testing_string.should.equal('abc');
       jsonData.rnfirebase_json_testing_boolean_false.should.equal(false);

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -91,5 +91,10 @@ describe('firestore()', function () {
         }
       });
     });
+
+    it('issue 5225 - app reloads successfully', async function () {
+      // Reload causes the TaskExecutor to shut down, make sure it does not error
+      await device.reloadReactNative();
+    });
   });
 });

--- a/tests/app.js
+++ b/tests/app.js
@@ -53,14 +53,17 @@ function Root() {
       style={{ flex: 1, paddingTop: 20, justifyContent: 'center', alignItems: 'center' }}
     >
       <Text style={{ fontSize: 25, marginBottom: 30 }}>React Native Firebase</Text>
-      <Text style={{ fontSize: 25, marginBottom: 30 }}>End-to-End Testing App2</Text>
+      <Text style={{ fontSize: 25, marginBottom: 30 }}>End-to-End Testing App</Text>
       <Button
+        style={{ flex: 1, marginTop: 20 }}
         title={'Test Native Crash Now.'}
         onPress={() => {
           firebase.crashlytics().crash();
         }}
       />
+      <View testId="spacer" style={{ height: 20 }} />
       <Button
+        style={{ flex: 1, marginTop: 20 }}
         title={'Test Javascript Crash Now.'}
         onPress={() => {
           undefinedVariable.notAFunction();

--- a/tests/e2e/init.js
+++ b/tests/e2e/init.js
@@ -49,6 +49,13 @@ beforeEach(async function beforeEach() {
   }
 });
 
+// Make sure we the app is still visible (that is, no redbox) after each test
+afterEach(async function afterEach() {
+  await waitFor(element(by.id('welcome')).atIndex(0)) // the testID for the Root View in app.js
+    .toBeVisible()
+    .withTimeout(20000); // If app reloads, it takes some time to re-display
+});
+
 after(async function () {
   console.log(' ✨ Tests Complete ✨ ');
   await device.terminateApp();


### PR DESCRIPTION
### Description

Attempt to verify after each test that the main app is still displaying, to make sure we don't have a redbox in place or similar

This is a WIP at the moment as it has E2E flakiness noted below, but I have it working locally so I wanted to make sure it was at least posted on github just in case.

### Related issues

Related - #5225 - issue generated a redbox and CI is blind to redboxes

### Release Summary

Conventional commits - rebase merge

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The whole PR is a test. That said, you should have a test that triggers a redbox to verify redbox detection is working

Note that right now this is flaky on CI, unknown reasons why but it appears to be that the heuristic-based Espresso Root View detector (used by Detox under the covers to do layout matching and determine main app visibility) is sometimes picking the wrong RootView so we aren't matching against the app layout. It's possible the screen is locked or that there is an ANR or welcome dialog or similar confusing it.

Related information:
- https://github.com/travis-ci/travis-ci/issues/6340
- https://github.com/autyzm-pg/friendly-plans/pull/112/files
- https://developer.android.com/reference/androidx/test/espresso/matcher/RootMatchers

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
