### PR TITLE
feat(app, android): support list of Activities to ignore when detecting AppState

### DIFF
--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseJSON.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseJSON.java
@@ -68,6 +68,26 @@ public class ReactNativeFirebaseJSON {
     return jsonObject.optString(key, defaultValue);
   }
 
+  public ArrayList<String> getArrayValue(String key) {
+    if (jsonObject == null) return new ArrayList<String>();
+
+    try {
+      ArrayList<String> result = new ArrayList<String>();
+      
+      JSONArray array = jsonObject.optJSONArray(key);
+      if(array != null){
+        for (int i=0;i<array.length();i++) {
+          result.add(array.getString(i));
+        }
+      }
+
+      return result;
+    }
+    catch (JSONException e) {
+      return new ArrayList<String>();
+    }
+  }
+
   public String getRawJSON() {
     return BuildConfig.FIREBASE_JSON_RAW;
   }

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseJSON.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseJSON.java
@@ -69,23 +69,22 @@ public class ReactNativeFirebaseJSON {
   }
 
   public ArrayList<String> getArrayValue(String key) {
-    if (jsonObject == null) return new ArrayList<String>();
+    ArrayList<String> result = new ArrayList<String>();
+    if (jsonObject == null) return result;
 
-    try {
-      ArrayList<String> result = new ArrayList<String>();
-      
+    try {      
       JSONArray array = jsonObject.optJSONArray(key);
-      if(array != null){
-        for (int i=0;i<array.length();i++) {
+      if (array != null) {
+        for (int i = 0; i < array.length(); i++) {
           result.add(array.getString(i));
         }
       }
-
-      return result;
     }
     catch (JSONException e) {
-      return new ArrayList<String>();
+      // do nothing
     }
+    
+    return result;
   }
 
   public String getRawJSON() {

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseJSON.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseJSON.java
@@ -24,6 +24,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+
 import io.invertase.firebase.BuildConfig;
 
 public class ReactNativeFirebaseJSON {

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -131,8 +131,7 @@ public class SharedUtils {
     if (appProcesses == null) return false;
 
     // Check if current activity is a background activity
-    if(json.contains("background_activity_names"))
-    {
+    if (json.contains("android_background_activity_names")) {
       ArrayList<String> backgroundActivities = json.getArrayValue("background_activity_names");
 
       if(backgroundActivities.size() != 0) {

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -144,7 +144,7 @@ public class SharedUtils {
           }
         } else {
           List<ActivityManager.RunningTaskInfo> taskInfo = activityManager.getRunningTasks(1);
-          if(taskInfo.size() > 0) {
+          if (taskInfo.size() > 0) {
             currentActivity = taskInfo.get(0).topActivity.getShortClassName();
           }
         }

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -137,7 +137,7 @@ public class SharedUtils {
       if (backgroundActivities.size() != 0) {
         List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();
 
-        if(taskInfo.size() > 0) {
+        if (taskInfo.size() > 0) {
           String currentActivity = taskInfo.get(0).getTaskInfo().baseActivity.getShortClassName();
           if(backgroundActivities.contains(currentActivity)) {
             return false;

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -149,7 +149,7 @@ public class SharedUtils {
           }
         }
 
-        if (currentActivity != "" && backgroundActivities.contains(currentActivity)) {
+        if (!"".equals(currentActivity) && backgroundActivities.contains(currentActivity)) {
           return false;
         }
       }

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -130,6 +130,23 @@ public class SharedUtils {
     List<ActivityManager.RunningAppProcessInfo> appProcesses = activityManager.getRunningAppProcesses();
     if (appProcesses == null) return false;
 
+    // Check if current activity is a background activity
+    if(json.contains("background_activity_names"))
+    {
+      ArrayList<String> backgroundActivities = json.getArrayValue("background_activity_names");
+
+      if(backgroundActivities.size() != 0) {
+        List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();
+
+        if(taskInfo.size() > 0) {
+          String currentActivity = taskInfo.get(0).getTaskInfo().baseActivity.getShortClassName();
+          if(backgroundActivities.contains(currentActivity)) {
+            return false;
+          }
+        }
+      }
+    }
+
     final String packageName = context.getPackageName();
     for (ActivityManager.RunningAppProcessInfo appProcess : appProcesses) {
       if (

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -131,17 +131,26 @@ public class SharedUtils {
     if (appProcesses == null) return false;
 
     // Check if current activity is a background activity
+    ReactNativeFirebaseJSON json = ReactNativeFirebaseJSON.getSharedInstance();
     if (json.contains("android_background_activity_names")) {
       ArrayList<String> backgroundActivities = json.getArrayValue("android_background_activity_names");
-
+      
       if (backgroundActivities.size() != 0) {
-        List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();
-
-        if (taskInfo.size() > 0) {
-          String currentActivity = taskInfo.get(0).getTaskInfo().baseActivity.getShortClassName();
-          if (backgroundActivities.contains(currentActivity)) {
-            return false;
+        String currentActivity = "";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+          List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();
+          if(taskInfo.size() > 0) {
+            currentActivity = taskInfo.get(0).getTaskInfo().baseActivity.getShortClassName();
           }
+        } else {
+          List<ActivityManager.RunningTaskInfo> taskInfo = activityManager.getRunningTasks(1);
+          if(taskInfo.size() > 0) {
+            currentActivity = taskInfo.get(0).topActivity.getShortClassName();
+          }
+        }
+
+        if (currentActivity != "" && backgroundActivities.contains(currentActivity)) {
+          return false;
         }
       }
     }

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -139,7 +139,7 @@ public class SharedUtils {
 
         if (taskInfo.size() > 0) {
           String currentActivity = taskInfo.get(0).getTaskInfo().baseActivity.getShortClassName();
-          if(backgroundActivities.contains(currentActivity)) {
+          if (backgroundActivities.contains(currentActivity)) {
             return false;
           }
         }

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.net.Uri;
+import android.os.Build;
 import android.util.Log;
 import com.facebook.react.bridge.*;
 import com.facebook.react.common.LifecycleState;

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -139,7 +139,7 @@ public class SharedUtils {
         String currentActivity = "";
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
           List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();
-          if(taskInfo.size() > 0) {
+          if (taskInfo.size() > 0) {
             currentActivity = taskInfo.get(0).getTaskInfo().baseActivity.getShortClassName();
           }
         } else {

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -134,7 +134,7 @@ public class SharedUtils {
     if (json.contains("android_background_activity_names")) {
       ArrayList<String> backgroundActivities = json.getArrayValue("background_activity_names");
 
-      if(backgroundActivities.size() != 0) {
+      if (backgroundActivities.size() != 0) {
         List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();
 
         if(taskInfo.size() > 0) {

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -135,13 +135,20 @@ public class SharedUtils {
     ReactNativeFirebaseJSON json = ReactNativeFirebaseJSON.getSharedInstance();
     if (json.contains("android_background_activity_names")) {
       ArrayList<String> backgroundActivities = json.getArrayValue("android_background_activity_names");
-      
+
       if (backgroundActivities.size() != 0) {
         String currentActivity = "";
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
           List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();
           if (taskInfo.size() > 0) {
-            currentActivity = taskInfo.get(0).getTaskInfo().baseActivity.getShortClassName();
+            ActivityManager.RecentTaskInfo task = taskInfo.get(0).getTaskInfo();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+              currentActivity = task.baseActivity.getShortClassName();
+            } else {
+              currentActivity = task.origActivity != null ?
+                task.origActivity.getShortClassName() :
+                task.baseIntent.getComponent().getShortClassName();
+            }
           }
         } else {
           List<ActivityManager.RunningTaskInfo> taskInfo = activityManager.getRunningTasks(1);

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -132,7 +132,7 @@ public class SharedUtils {
 
     // Check if current activity is a background activity
     if (json.contains("android_background_activity_names")) {
-      ArrayList<String> backgroundActivities = json.getArrayValue("background_activity_names");
+      ArrayList<String> backgroundActivities = json.getArrayValue("android_background_activity_names");
 
       if (backgroundActivities.size() != 0) {
         List<ActivityManager.AppTask> taskInfo = activityManager.getAppTasks();

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -81,6 +81,10 @@
         "android_task_executor_keep_alive_seconds": {
           "description": "Keep-alive time of ThreadPoolExecutor used by RNFirebase for Android, in seconds. Defaults to `3`.\n Excess threads in the pool executor will be terminated if they have been idle for more than the keep-alive time.",
           "type": "number"
+        },
+        "background_activity_names": {
+          "description": "On Android, list the names of additional native activities which are used outside the context of the react native application",
+          "type": "array"
         }
       }
     }

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -83,7 +83,7 @@
           "type": "number"
         },
         "android_background_activity_names": {
-          "description": "The names of Activities used outside the context of react native, to be ignored when determining if foreground or background javascript handlers should be called",
+          "description": "The names (as returned by `getShortClassName()` of Activities used outside the context of react native.\nThese are ignored when determining if the app is in foreground for purposes of calling javascript background handlers",
           "type": "array"
         }
       }

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -83,7 +83,7 @@
           "type": "number"
         },
         "android_background_activity_names": {
-          "description": "On Android, list the names of additional native activities which are used outside the context of the react native application",
+          "description": "The names of Activities used outside the context of react native, to be ignored when determining if foreground or background javascript handlers should be called",
           "type": "array"
         }
       }

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -82,7 +82,7 @@
           "description": "Keep-alive time of ThreadPoolExecutor used by RNFirebase for Android, in seconds. Defaults to `3`.\n Excess threads in the pool executor will be terminated if they have been idle for more than the keep-alive time.",
           "type": "number"
         },
-        "background_activity_names": {
+        "android_background_activity_names": {
           "description": "On Android, list the names of additional native activities which are used outside the context of the react native application",
           "type": "array"
         }

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -1,5 +1,7 @@
 {
   "react-native": {
+    "android_background_activity_names": "NotActuallyAnActivity",
+
     "admob_delay_app_measurement_init": true,
     "admob_ios_app_id": "ca-app-pub-4406399463942824~1625911479",
     "admob_android_app_id": "ca-app-pub-4406399463942824~1625911479",


### PR DESCRIPTION
### Description

This is entirely based off the good work from @danwhite-ipc on #5228 - just doing a branch here so I can push one final change to it - I don't have write powers on that branch

From that PR:

> Allow for configuration of background native activities to allow for the handling of background messages when a native activity is visible and the react native app is dead.

### Related issues

Supercedes #5228 but verified the CLA was signed.
Fixes #5219

### Release Summary

PR title is conventional, squash merge

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Relying on @danwhite-ipc to indicate it works for them :-), I added a test array key to the test app firebase.json and it gets a background message during E2E testing, so that should at least exercise the JSON parse code

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
