### PR TITLE
fix(messaging, android): repair crash handling remote notifications

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -83,7 +83,7 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
             } else {
               remoteMessageMap = ReactNativeFirebaseMessagingSerializer.remoteMessageToWritableMap(remoteMessage);
             }
-            if (remoteMessageMap != null){
+            if (remoteMessageMap != null) {
               promise.resolve(remoteMessageMap);
               initialNotificationMap.put(messageId, true);
               return;
@@ -228,9 +228,10 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
         } else {
           remoteMessageMap = ReactNativeFirebaseMessagingSerializer.remoteMessageToWritableMap(remoteMessage);
         }
-        
-        if (remoteMessageMap != null){
-          initialNotification = remoteMessageMap;
+
+        if (remoteMessageMap != null) {
+          // WritableNativeMap not be consumed twice. But it is resolved in future and in event below. Make a copy - issue #5231
+          initialNotification = remoteMessageMap.copy();
           ReactNativeFirebaseMessagingReceiver.notifications.remove(messageId);
 
           ReactNativeFirebaseEventEmitter emitter = ReactNativeFirebaseEventEmitter.getSharedInstance();


### PR DESCRIPTION

### Description

WritableNativeMap has a check to see if it is consumed or not when it is used,
to prevent resolving a Promise in native code then attempting to modify it.

We may use the same WritableNativeMap object twice though when handling deferred
initial notifications. Crash repair is to store a copy so the Maps are distinct

### Related issues

Fixes #5231

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Hard to test - will rely on @xxsnakerxx for reports on whether it happens or not, they appear to have a customer with a reproduction case

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
