### PR TITLE
test(e2e, ios): deterministically exclude leveldb

### DIFF
--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -11,10 +11,6 @@ Pod::UI.puts "react-native-firebase/tests: Using Firebase SDK version '#{$Fireba
 # See: https://firebase.google.com/support/release-notes/ios#analytics - requires firebase-ios-sdk 7.11.0+
 #$RNFirebaseAnalyticsWithoutAdIdSupport = true # toggle this to true for the no-ad-tracking Analytics subspec
 
-# This is needed to reduce flakiness where leveldb is transitively included by database, and packed as framework
-# from the pre-compiled firestore-ios-sdk-frameworks
-$FirebaseFirestoreExcludeLeveldb = true
-
 # Versions used below, for quick reference / outdated+upgrade checks
 $iOSMinimumDeployVersion = '10.0'
 
@@ -35,8 +31,11 @@ target 'testing' do
     :hermes_enabled => false
   )
 
-  # Use pre-compiled firestore frameworks to optimize compile time. But make sure there are not leveldb conflicts.
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => $FirebaseSDKVersion
+  # Use pre-compiled firestore frameworks to optimize compile time. Auto-includes leveldb if needed.
+  # pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => $FirebaseSDKVersion
+
+  # If leveldb auto-inclusion fails and build fails with leveldb symbol conflicts, use this subspec:
+  pod 'FirebaseFirestore/WithoutLeveldb', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :commit => 'af5c7177c896d69d73acb173c265d7efe8886126'
 
   # Enables Flipper.
   #

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -109,7 +109,13 @@ PODS:
     - leveldb-library (~> 1.22)
   - FirebaseDynamicLinks (7.11.0):
     - FirebaseCore (~> 7.0)
-  - FirebaseFirestore (7.11.0)
+  - FirebaseFirestore (7.11.0):
+    - FirebaseFirestore/AutodetectLeveldb (= 7.11.0)
+  - FirebaseFirestore/AutodetectLeveldb (7.11.0):
+    - FirebaseFirestore/Base
+  - FirebaseFirestore/Base (7.11.0)
+  - FirebaseFirestore/WithoutLeveldb (7.11.0):
+    - FirebaseFirestore/Base
   - FirebaseFunctions (7.11.0):
     - FirebaseCore (~> 7.0)
     - GTMSessionFetcher/Core (~> 1.4)
@@ -505,69 +511,69 @@ PODS:
     - React-cxxreact (= 0.64.0)
     - React-jsi (= 0.64.0)
     - React-perflogger (= 0.64.0)
-  - RNFBAdMob (11.3.3):
+  - RNFBAdMob (11.4.1):
     - Firebase/AdMob (= 7.11.0)
     - PersonalizedAdConsent (~> 1.0.5)
     - React-Core
     - RNFBApp
-  - RNFBAnalytics (11.3.3):
+  - RNFBAnalytics (11.4.1):
     - Firebase/Analytics (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (11.3.3):
+  - RNFBApp (11.4.1):
     - Firebase/CoreOnly (= 7.11.0)
     - React-Core
-  - RNFBAuth (11.3.3):
+  - RNFBAuth (11.4.1):
     - Firebase/Auth (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (11.3.3):
+  - RNFBCrashlytics (11.4.1):
     - Firebase/Crashlytics (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (11.3.3):
+  - RNFBDatabase (11.4.1):
     - Firebase/Database (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (11.3.3):
+  - RNFBDynamicLinks (11.4.1):
     - Firebase/DynamicLinks (= 7.11.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (11.3.3):
+  - RNFBFirestore (11.4.1):
     - Firebase/Firestore (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (11.3.3):
+  - RNFBFunctions (11.4.1):
     - Firebase/Functions (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBIid (11.3.3):
+  - RNFBIid (11.4.1):
     - Firebase/CoreOnly (= 7.11.0)
     - FirebaseInstanceID
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (11.3.3):
+  - RNFBInAppMessaging (11.4.1):
     - Firebase/InAppMessaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (11.3.3):
+  - RNFBMessaging (11.4.1):
     - Firebase/Messaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBML (11.3.3):
+  - RNFBML (11.4.1):
     - Firebase/MLVision (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBPerf (11.3.3):
+  - RNFBPerf (11.4.1):
     - Firebase/Performance (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (11.3.3):
+  - RNFBRemoteConfig (11.4.1):
     - Firebase/RemoteConfig (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (11.3.3):
+  - RNFBStorage (11.4.1):
     - Firebase/Storage (= 7.11.0)
     - React-Core
     - RNFBApp
@@ -577,7 +583,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `7.11.0`)
+  - FirebaseFirestore/WithoutLeveldb (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, commit `af5c7177c896d69d73acb173c265d7efe8886126`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Jet (from `../node_modules/jet/ios`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -667,8 +673,8 @@ EXTERNAL SOURCES:
   FBReactNativeSpec:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   FirebaseFirestore:
+    :commit: af5c7177c896d69d73acb173c265d7efe8886126
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 7.11.0
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Jet:
@@ -756,8 +762,8 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   FirebaseFirestore:
+    :commit: af5c7177c896d69d73acb173c265d7efe8886126
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 7.11.0
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
@@ -773,7 +779,7 @@ SPEC CHECKSUMS:
   FirebaseCrashlytics: 272b675aa9d1e9bae1f9e1449fcc1f2cf6042806
   FirebaseDatabase: 6c39fbf1c8514a2f32e610f9bf9ef30c535dc15a
   FirebaseDynamicLinks: 07f101c20bb40fd39f6b3e5278a64a5f2f660dc1
-  FirebaseFirestore: 783538aced1557a6b817ee121593561127a00244
+  FirebaseFirestore: 782bf8a23c53bddf8fbbf6059c90fabe08768107
   FirebaseFunctions: cf3d041e5292b1c4bda868d542071a0f8291a4d4
   FirebaseInAppMessaging: 03f39409c6f5ce5fb2d0db9cc99e043c0a538ba0
   FirebaseInstallations: a58d4f72ec5861840b84df489f2668d970df558a
@@ -822,24 +828,24 @@ SPEC CHECKSUMS:
   React-RCTVibration: 0fd6b21751a33cb72fce1a4a33ab9678416d307a
   React-runtimeexecutor: cad74a1eaa53ee6e7a3620231939d8fe2c6afcf0
   ReactCommon: cfe2b7fd20e0dbd2d1185cd7d8f99633fbc5ff05
-  RNFBAdMob: 7d5a6b026782a1b5f91bd863d2299e4a328cade0
-  RNFBAnalytics: 4747ea51be1b2f003c889aad0207bf3fcc8309ad
-  RNFBApp: 097a73b10972939bade8ad720ef92c3867baf2e5
-  RNFBAuth: e554b8c1d3cddcb1ead741794be055acc1defcda
-  RNFBCrashlytics: a045da0758ed559db99ed049a11ffc995fececb9
-  RNFBDatabase: de7c902da929d8b170930f23e2787ee3f5e75c4b
-  RNFBDynamicLinks: 135501c3922e49e4e7e00d1a0a1777b2fba1f042
-  RNFBFirestore: 9c7fc9c42de2cc91d9b70cfc12ed00aa25ddb250
-  RNFBFunctions: c2af986961d28a74f1383b0e53f4e4d20a95098a
-  RNFBIid: 585215475e5dec2e0565360b77fb8a33fe33d081
-  RNFBInAppMessaging: f7ac052f565200549d1fc187b4b86bec611eab03
-  RNFBMessaging: 747dbfebbe827241a9819884cbba2cb35ce5dc90
-  RNFBML: 8f7b5e256a0224bfc862d6e85d42db8a19d02d70
-  RNFBPerf: fb34154674ad8b13effe52a0ab4a51bdb9992b7a
-  RNFBRemoteConfig: fd88e45c151427ef9f75534da31c86dba1e28da3
-  RNFBStorage: af7814531e503ea094f65f24fc5aa98491823bb8
+  RNFBAdMob: bbc64554e13d019d37fbc981f5f48ba4c6ea5889
+  RNFBAnalytics: 1190435dcd25d7403d28ceb4342c0d1e050843de
+  RNFBApp: 996860ad6832996faba79ef3f6ec2d3ea5870dd9
+  RNFBAuth: 3726f7f9bc9e9efb80cd1f5b2e65c4b04dc53760
+  RNFBCrashlytics: 59d9ecfaacddbe10819d9071ee3b9921b79b8c6b
+  RNFBDatabase: 026067d3ce9d65c96146f7f32c1f044f27665f29
+  RNFBDynamicLinks: e6c9cd9cba02cc65f8b76fbd22cf50a66d473bdd
+  RNFBFirestore: 7fa546e352aad031a78b934a67435e55b32cba49
+  RNFBFunctions: 4838dd472870e5941908eabc48d1711dacdda558
+  RNFBIid: 6003e884d8479e9d14ecbb6dbaa3939aaab40984
+  RNFBInAppMessaging: 84a265c8ac2d4fbce01c13cd5d22946389c6926e
+  RNFBMessaging: 8d84ceadc705ca6b6047c37376d2e2aaabcb8e3d
+  RNFBML: 80dccd04dcea208eb96eb6d1b1f38975a0f3a274
+  RNFBPerf: d54d3ab9a11fb319074de3d4714168052ac225cd
+  RNFBRemoteConfig: 3035dd5d7b2a903f822505f04a5cd01752d5bc37
+  RNFBStorage: 519ea44ccd27418d4bffbc9cd088a72697b5cb98
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 
-PODFILE CHECKSUM: 89dba385c805fb62e8343576922b9b86427aa683
+PODFILE CHECKSUM: 207309c3bddb2e511bc745f32898e130e30eb1c6
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
### Description

Auto-detection of whether to include or exclude leveldb is flaky for me
Use the deterministic exclude-leveldb subspec

### Related issues

 invertase/firestore-ios-sdk-frameworks#32

### Release Summary

This is based on #5239 and will be rebased once that lands
Then it's a single conventional commit and should be rebase-merged

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The linked issue has the full test plan, but for the purposes of RNFB, if CI passes while using this, it's good to go

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
