### PR TITLE
feat(analytics): Adding default event parameters

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -164,6 +164,15 @@ describe('Analytics', function () {
     });
   });
 
+  describe('setDefaultEventParameters()', function () {
+    it('errors if params is not a object', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().setDefaultEventParameters('123')).toThrowError(
+        "firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value.",
+      );
+    });
+  });
+
   describe('logAddToCart()', function () {
     it('errors if param is not an object', function () {
       // @ts-ignore test

--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -168,7 +168,7 @@ describe('Analytics', function () {
     it('errors if params is not a object', function () {
       // @ts-ignore test
       expect(() => firebase.analytics().setDefaultEventParameters('123')).toThrowError(
-        "firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value.",
+        "firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value when it is defined.",
       );
     });
   });

--- a/packages/analytics/android/src/main/java/io/invertase/firebase/analytics/UniversalFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/main/java/io/invertase/firebase/analytics/UniversalFirebaseAnalyticsModule.java
@@ -96,4 +96,11 @@ public class UniversalFirebaseAnalyticsModule extends UniversalFirebaseModule {
       return null;
     });
   }
+
+  Task<Void> setDefaultEventParameters(Bundle parameters) {
+    return Tasks.call(() -> {
+      FirebaseAnalytics.getInstance(getContext()).setDefaultEventParameters(parameters);
+      return null;
+    });
+  }
 }

--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -131,6 +131,17 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
     });
   }
 
+  @ReactMethod
+  public void setDefaultEventParameters(@Nullable ReadableMap params, Promise promise) {
+    module.setDefaultEventParameters(toBundle(params)).addOnCompleteListener(task -> {
+      if (task.isSuccessful()) {
+        promise.resolve(task.getResult());
+      } else {
+        rejectPromiseWithExceptionMap(promise, task.getException());
+      }
+    });
+  }
+
   private Bundle toBundle(ReadableMap readableMap) {
     Bundle bundle = Arguments.toBundle(readableMap);
     if (bundle == null) {

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -418,4 +418,18 @@ describe('analytics()', function () {
       });
     });
   });
+
+  describe('setDefaultEventParameters()', function () {
+    it('set null default parameter', async function () {
+      await firebase.analytics().setDefaultEventParameters(null);
+    });
+
+    it('set undefined default parameter', async function () {
+      await firebase.analytics().setDefaultEventParameters(undefined);
+    });
+
+    it('log an event with parameters', async function () {
+      await firebase.analytics().setDefaultEventParameters({ number: 1, stringn: '123' });
+    });
+  });
 });

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -428,7 +428,7 @@ describe('analytics()', function () {
       await firebase.analytics().setDefaultEventParameters(undefined);
     });
 
-    it('log an event with parameters', async function () {
+    it('set default parameters', async function () {
       await firebase.analytics().setDefaultEventParameters({ number: 1, stringn: '123' });
     });
   });

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -142,6 +142,22 @@
       return resolve([FIRAnalytics appInstanceID]);
   }
 
+  RCT_EXPORT_METHOD(setDefaultEventParameters:
+    params:
+        (NSDictionary *) params
+        resolver:
+        (RCTPromiseResolveBlock) resolve
+        rejecter:
+        (RCTPromiseRejectBlock) reject) {
+    @try {
+      [FIRAnalytics setDefaultEventParameters:parameters:[self cleanJavascriptParams:params]];
+    } @catch (NSException *exception) {
+      return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
+    }
+
+    return resolve([NSNull null]);
+  }
+
 #pragma mark -
 #pragma mark Private methods
 

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -143,7 +143,6 @@
   }
 
   RCT_EXPORT_METHOD(setDefaultEventParameters:
-    params:
         (NSDictionary *) params
         resolver:
         (RCTPromiseResolveBlock) resolve

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -150,7 +150,7 @@
         rejecter:
         (RCTPromiseRejectBlock) reject) {
     @try {
-      [FIRAnalytics setDefaultEventParameters:parameters:[self cleanJavascriptParams:params]];
+      [FIRAnalytics setDefaultEventParameters:[self cleanJavascriptParams:params]];
     } @catch (NSException *exception) {
       return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
     }

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -1487,7 +1487,7 @@ export namespace FirebaseAnalyticsTypes {
      * Setting a key's value to null will clear that parameter. Passing in a null bundle
      * will clear all parameters.
      */
-     setDefaultEventParameters(params?: { [key: string]: any }): Promise<void>;
+    setDefaultEventParameters(params?: { [key: string]: any }): Promise<void>;
   }
 }
 

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -1468,6 +1468,26 @@ export namespace FirebaseAnalyticsTypes {
      * @param params See {@link analytics.ViewSearchResultsParameters}.
      */
     logViewSearchResults(params: ViewSearchResultsParameters): Promise<void>;
+
+    /**
+     * Adds parameters that will be set on every event logged from the SDK, including automatic ones.
+     *
+     * #### Example
+     *
+     * ```js
+     * await firebase.analytics().setDefaultEventParameters({
+     *   userId: '1234',
+     * });
+     * ```
+     *
+     *
+     * @param params Parameters to be added to the map of parameters added to every event.
+     * They will be added to the map of default event parameters, replacing any existing
+     * parameter with the same name. Valid parameter values are String, long, and double.
+     * Setting a key's value to null will clear that parameter. Passing in a null bundle
+     * will clear all parameters.
+     */
+     setDefaultEventParameters(params?: { [key: string]: any }): Promise<void>;
   }
 }
 

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -668,8 +668,10 @@ class FirebaseAnalyticsModule extends FirebaseModule {
   }
 
   setDefaultEventParameters(params) {
-    if (!isObject(params) && (!isNull(params) && !isUndefined(params))) {
-      throw new Error("firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value when it is defined.");
+    if (!isObject(params) && !isNull(params) && !isUndefined(params)) {
+      throw new Error(
+        "firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value when it is defined.",
+      );
     }
 
     return this.native.setDefaultEventParameters(params);

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -666,6 +666,14 @@ class FirebaseAnalyticsModule extends FirebaseModule {
       ),
     );
   }
+
+  setDefaultEventParameters(params = {}) {
+    if (!isObject(params)) {
+      throw new Error("firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value.");
+    }
+
+    return this.native.setDefaultEventParameters(params);
+  }
 }
 
 // import { SDK_VERSION } from '@react-native-firebase/analytics';

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -667,9 +667,9 @@ class FirebaseAnalyticsModule extends FirebaseModule {
     );
   }
 
-  setDefaultEventParameters(params = {}) {
-    if (!isObject(params)) {
-      throw new Error("firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value.");
+  setDefaultEventParameters(params) {
+    if (!isObject(params) && (!isNull(params) && !isUndefined(params))) {
+      throw new Error("firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value when it is defined.");
     }
 
     return this.native.setDefaultEventParameters(params);


### PR DESCRIPTION
### Description
Adding feature for setting default event parameters. As described [here](https://firebase.google.com/docs/reference/kotlin/com/google/firebase/analytics/FirebaseAnalytics#setdefaulteventparameters) in Firebase docs.

### Release Summary

Added `setDefaultEventParameters`. It adds default event parameters that will be send in every event.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
