### PR TITLE
test(e2e, ios): buildcache via an action vs in situ

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -116,45 +116,18 @@ jobs:
           max_attempts: 3
           command: yarn tests:ios:pod:install
 
-      - uses: actions/cache@v2
-        name: Buildcache Cache
-        id: buildcache-cache
+      - uses: mikehardy/buildcache-action@v1
+        name: Buildcache
         with:
-          path: ~/.buildcache
           key: ${{ runner.os }}-v1
-
-      - name: Fetch buildcache
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: cd $HOME && curl -s https://api.github.com/repos/mbitsnbites/buildcache/releases/latest | grep -o "https://.*macos\.zip" | xargs curl -fsLJO
-
-      - name: Install buildcache
-        run: |
-          pwd
-          cd $HOME
-          ls -la
-          unzip buildcache-macos.zip
-          ln -s $HOME/buildcache/bin/buildcache $HOME/buildcache/bin/clang
-          ln -s $HOME/buildcache/bin/buildcache $HOME/buildcache/bin/clang++
-          echo "BUILDCACHE_MAX_CACHE_SIZE=525288000" >> $GITHUB_ENV
-          echo "BUILDCACHE_DEBUG=2" >> $GITHUB_ENV
-          echo "BUILDCACHE_LOG_FILE=$HOME/buildcache.log" >> $GITHUB_ENV
-          echo $HOME/buildcache/bin >> $GITHUB_PATH
 
       - name: Build iOS App
         run: |
-          $HOME/buildcache/bin/buildcache -c
-          $HOME/buildcache/bin/buildcache -s
-          which clang
           export SKIP_BUNDLING=1
           export RCT_NO_LAUNCH_PACKAGER=1
           cd tests
           set -o pipefail
           ./node_modules/.bin/detox build --configuration ios.sim.debug
-          $HOME/buildcache/bin/buildcache -s
         shell: bash
 
       - name: Install applesimutils
@@ -194,7 +167,7 @@ jobs:
         if: always()
         with:
           name: buildcache_log
-          path: $BUILDCACHE_LOG_FILE
+          path: ./.buildcache/buildcache.log
 
       - name: Compress Simulator Log
         if: always()


### PR DESCRIPTION
### Description

This was my hoped-for goal with the buildcache work - to have it be a trivial-to-use action that could span across all the Xcode builds Invertase touches. I think it's all working and here is the test integration

### Related issues

#5239 

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The whole thing is a test :-), but the action itself is well-tested during development, and was based on the well-tested proof of concept here

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
