### PR TITLE
test: improve caching in workflows

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -32,8 +32,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          restore-keys: ${{ runner.os }}-yarn
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:
@@ -81,8 +80,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          restore-keys: ${{ runner.os }}-yarn
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:
@@ -116,8 +114,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-with-website
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          restore-keys: ${{ runner.os }}-yarn
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -52,7 +52,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v1
+          key: firebase-emulators-${{ github.run_id }}-v1
+          restore-key: firebase-emulators
 
       - name: Start Firestore Emulator
         run: yarn tests:emulator:start-ci
@@ -67,12 +68,14 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-v1
+          restore-keys: ${{ runner.os }}-yarn
 
       - uses: actions/cache@v2
         name: Gradle Cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-v1
+          restore-keys: ${{ runner.os }}-gradle
 
       - name: Yarn Install
         uses: nick-invision/retry@v2

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -36,6 +36,12 @@ jobs:
         with:
           fetch-depth: 50
 
+      - uses: mikehardy/buildcache-action@v1
+        name: Buildcache
+        with:
+          cache_key: ${{ runner.os }}-v1
+          upload_buildcache_log: true
+
       - uses: actions/setup-node@v2
         with:
           node-version: 14
@@ -75,7 +81,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-v1
-          restore-keys: ${{ runner.os }}-yarn-
+          restore-keys: ${{ runner.os }}-yarn
 
       - uses: actions/cache@v2
         name: Cache Pods
@@ -83,7 +89,7 @@ jobs:
         with:
           path: tests/ios/Pods
           key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}-v1
-          restore-keys: ${{ runner.os }}-pods-
+          restore-keys: ${{ runner.os }}-pods
 
       - uses: actions/cache@v2
         name: Detox Framework Cache
@@ -115,11 +121,6 @@ jobs:
           retry_wait_seconds: 60
           max_attempts: 3
           command: yarn tests:ios:pod:install
-
-      - uses: mikehardy/buildcache-action@v1
-        name: Buildcache
-        with:
-          key: ${{ runner.os }}-v1
 
       - name: Build iOS App
         run: |

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -44,8 +44,7 @@ jobs:
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          restore-keys: ${{ runner.os }}-yarn
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:


### PR DESCRIPTION
### Description

The workflows were not uploading fresh caches after runs

I learned a lot about github caching while working on buildcache-action,
implementing better caching key usage here to implement the knowledge...

It turns out github caches are immutable so if there might be updates of any kind you
really want to specify a deterministically unique key as the cache key, with a generic fallback

If your key is generic in any way, then even if the directory contents change a fresh cache won't
upload because the key is the comparison for "should it upload or not", as opposed to "are the directory
contents fresh or not" - directory contents are not taken into account


### Related issues

None

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The whole thing is made of tests ;-) - but visual inspecting of cache steps in the workflows is how to verify, we should see the cache Post steps uploading now every time even if there were hits on base keys

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
