### PR TITLE
docs(firestore): remove await before transaction.update

### DIFF
--- a/docs/firestore/usage/index.md
+++ b/docs/firestore/usage/index.md
@@ -546,7 +546,7 @@ function onPostLike(postId) {
       throw 'Post does not exist!';
     }
 
-    await transaction.update(postReference, {
+    transaction.update(postReference, {
       likes: postSnapshot.data().likes + 1,
     });
   });


### PR DESCRIPTION
### Description

`transaction.set` does not return a promise, there is no need to `await` it. This could lead to a confusion among users since `await` usually indicates a promise.

### Related issues
#5087 

### Release Summary
doc(firestore): remove await before transaction.set

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
This is a doc-only change, no need for testing