### PR TITLE
test: more cache key/restore-keys work

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -47,7 +47,8 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-v1
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
 
       - name: Yarn Install
         uses: nick-invision/retry@v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,8 +31,8 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: ${{ runner.os }}-yarn
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:
@@ -79,8 +79,8 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: ${{ runner.os }}-yarn
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:
@@ -113,8 +113,8 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-with-website
-          restore-keys: ${{ runner.os }}-yarn
+          key: ${{ runner.os }}-yarn-with-website-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-with-website-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -52,8 +52,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-${{ github.run_id }}-v1
-          restore-key: firebase-emulators
+          key: firebase-emulators-v1-${{ github.run_id }}
+          restore-keys: firebase-emulators-v1
 
       - name: Start Firestore Emulator
         run: yarn tests:emulator:start-ci
@@ -67,15 +67,15 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-v1
-          restore-keys: ${{ runner.os }}-yarn
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
 
       - uses: actions/cache@v2
         name: Gradle Cache
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-v1
-          restore-keys: ${{ runner.os }}-gradle
+          key: ${{ runner.os }}-gradle-v1-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-v1
 
       - name: Yarn Install
         uses: nick-invision/retry@v2

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -66,7 +66,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v1
+          key: firebase-emulators-v1-${{ github.run_id }}
+          restore-keys: firebase-emulators-v1
 
       - name: Start Firestore Emulator
         run: yarn tests:emulator:start-ci
@@ -80,8 +81,8 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}-v1
-          restore-keys: ${{ runner.os }}-yarn
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
 
       - uses: actions/cache@v2
         name: Cache Pods

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -43,8 +43,8 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/package.json') }}
-          restore-keys: ${{ runner.os }}-yarn
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2
         with:


### PR DESCRIPTION
### Description

- had a typo in one of the usages: restore-key -> restore-keys
- the versioning in the cache key should be before disambiguating key components
- all keys need something disambiguating or they never update (e.g., ios firestore emulator)

### Related issues

No related issues - just a stream of quite a few PRs recently...

### Release Summary

conventional commit


### Test Plan


I'm discovering these things by actually reading the action run output, that's the continued test plan - checking output

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
