### PR TITLE
fix(admob): mark BannerAd callbacks as optional

### DIFF
--- a/packages/admob/lib/index.d.ts
+++ b/packages/admob/lib/index.d.ts
@@ -1132,27 +1132,27 @@ export namespace FirebaseAdMobTypes {
     /**
      * When an ad has finished loading.
      */
-    onAdLoaded: () => void;
+    onAdLoaded?: () => void;
 
     /**
      * When an ad has failed to load. Callback contains an Error.
      */
-    onAdFailedToLoad: (error: Error) => void;
+    onAdFailedToLoad?: (error: Error) => void;
 
     /**
      * The ad is now visible to the user.
      */
-    onAdOpened: () => void;
+    onAdOpened?: () => void;
 
     /**
      * Called when the user is about to return to the app after tapping on an ad.
      */
-    onAdClosed: () => void;
+    onAdClosed?: () => void;
 
     /**
      * Called when the user has left the application (e.g. clicking an advert).
      */
-    onAdLeftApplication: () => void;
+    onAdLeftApplication?: () => void;
   }
 
   /**


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

BannerAd callbacks were not marked optional in Typescript. However, they are presented as optional in the documentation and the implementation checks for their existance before attempting calls.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
- Fixes #5180 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
I tested this minor change locally and made sure `yarn lint` and `yarn tests:jest` pass.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
