### PR TITLE
fix(firestore): GeoPoint latitude error message incorrectly used 'longitude'

### DIFF
--- a/packages/firestore/e2e/GeoPoint.e2e.js
+++ b/packages/firestore/e2e/GeoPoint.e2e.js
@@ -55,7 +55,7 @@ describe('firestore.GeoPoint', function () {
       new firebase.firestore.GeoPoint(-100, 0);
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {
-      error.message.should.containEql("'longitude' must be a number between -90 and 90");
+      error.message.should.containEql("'latitude' must be a number between -90 and 90");
       return Promise.resolve();
     }
   });

--- a/packages/firestore/lib/FirestoreGeoPoint.js
+++ b/packages/firestore/lib/FirestoreGeoPoint.js
@@ -35,7 +35,7 @@ export default class FirestoreGeoPoint {
 
     if (!isFinite(latitude) || latitude < -90 || latitude > 90) {
       throw new Error(
-        `firebase.firestore.GeoPoint 'longitude' must be a number between -90 and 90, but was: ${latitude}.`,
+        `firebase.firestore.GeoPoint 'latitude' must be a number between -90 and 90, but was: ${latitude}.`,
       );
     }
 


### PR DESCRIPTION
…range

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
