### PR TITLE
fix(app, json-schema): admob_delay_app_measurement_init type is boolean

### DIFF
--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -15,7 +15,7 @@
         },
         "admob_delay_app_measurement_init": {
           "description": "By default, the Google Mobile Ads SDK initializes app measurement and begins sending user-level event data to Google immediately when the app starts. This initialization behavior ensures you can enable AdMob user metricswithout making additional code changes.\n If you require your app users to provide consent before collecting data, setting the value to `true` will preventdata being sent until the `firebase.admob().initialize()` method has been called.",
-          "type": "string"
+          "type": "boolean"
         },
         "analytics_auto_collection_enabled": {
           "description": "Disable or enable auto collection of analytics data.\n This is useful for opt-in-first data flows, for example when dealing with GDPR compliance. This can be overridden in JavaScript. \n Re-enable analytics data collection, e.g. once user has granted permission.",


### PR DESCRIPTION
### Description

Fixes #5295 - credit @DoctorJohn thanks!

Commit message says it all, more details in linked issue if needed

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
