### PR TITLE
docs(admob, consent): admob_app_id config key gone, note platform-specific keys

### DIFF
--- a/docs/admob/european-user-consent.md
+++ b/docs/admob/european-user-consent.md
@@ -42,7 +42,8 @@ Within your projects `firebase.json` file, set the `admob_delay_app_measurement_
 ```json
 {
   "react-native": {
-    "admob_app_id": "YOUR_APP_ID",
+    "admob_android_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
+    "admob_ios_app_id": "ca-app-pub-xxxxxxxx~xxxxxxxx",
     "admob_delay_app_measurement_init": true
   }
 }
@@ -251,7 +252,7 @@ non-personalized ad.
 
 This is a common error which occurs on both Android & iOS when making a request to display a Google-rendered consent form. Unfortunately the reasoning for this error is generic, making it hard to debug. There are a number of steps to check which are usually the cause for this error:
 
-- The AdMob App ID is incorrect: Ensure you have entered the correct ID into the `firebase.json` file under the `admob_app_id` key in the `react-native` config.
+- The AdMob App ID is incorrect: Ensure you have entered the correct ID into the `firebase.json` file under the `admob_android_app_id` or `admob_ios_app_id` key in the `react-native` config.
 - A publisher ID is incorrect: Ensure your entered publisher IDs are correct.
   - The publisher ID needs to be available on the same account as your AdMob App ID.
 - The user is outside of the EEA: If a user does not need to provide consent, the form request will error. Ensure you have checked the users status via `requestInfoUpdate`. If using an emulator, ensure you set a debug location via `setDebugGeography`.


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

The Admob [European User Consent](https://rnfirebase.io/admob/european-user-consent#delaying-app-measurement) still include the `admob_app_id` config key which  has been replaced with `admob_android_app_id` and `admob_ios_app_id`. This PR fixes the usage of the outdated config keys. (I made sure this was the last place they were used).

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

- Related to #2611

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

I formatted the edited file and looked at the compiled the docs.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
