### PR TITLE
test(e2e, android): sleep a bit / use right path for coverage file

### DIFF
--- a/tests/e2e/init.js
+++ b/tests/e2e/init.js
@@ -56,13 +56,15 @@ after(async function () {
 
   // emits 'cleanup' across socket, which goes native, terminates Detox test Looper
   // This returns control to the java code in our instrumented test, and then Instrumentation lifecycle finishes cleanly
+  await Utils.sleep(5000); // give async processes (like Firestore writes) time to complete
   await detox.cleanup();
+  await Utils.sleep(5000); // give client app time to dump coverage report
 
   // Get the file off the device, into standard location for JaCoCo binary report
   // It will still need processing via gradle jacocoAndroidTestReport task for codecov, but it's available now
   if (isAndroid) {
     const pkg = 'com.invertase.testing';
-    const emuOrig = `/data/data/${pkg}/files/coverage.ec`;
+    const emuOrig = `/data/user/0/${pkg}/files/coverage.ec`;
     const emuDest = '/data/local/tmp/detox/coverage.ec';
     const localDestDir = './android/app/build/output/coverage/';
 


### PR DESCRIPTION
currently Detox is force killing the app before Firestore finishes and returns

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
