### PR TITLE
feat(firestore)!: add ignoreUndefinedProperties setting, throw on undefined if false

### DIFF
--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -136,8 +136,8 @@ describe('firestore()', function () {
         return Promise.reject(new Error('Snapshot not saved'));
       }
 
-      snapData.field1.should.equal(1);
-      should.not.exist(snapData.field2);
+      snapData.field1.should.eql(1);
+      snapData.hasOwnProperty('field2').should.eql(false);
     });
 
     it('filters out nested undefined properties when setting enabled', async function () {
@@ -157,28 +157,46 @@ describe('firestore()', function () {
         return Promise.reject(new Error('Snapshot not saved'));
       }
 
-      snapData.field1.should.equal(1);
-      should.exist(snapData.field2);
-      should.not.exist(snapData.field2.shouldBeMissing);
+      snapData.field1.should.eql(1);
+      snapData.hasOwnProperty('field2').should.eql(true);
+
+      snapData.field2.hasOwnProperty('shouldBeMissing').should.eql(false);
     });
 
-    it('filters out undefined properties when setting disabled', async function () {
+    it('throws when undefined value provided and ignored undefined is false', async function () {
       await firebase.firestore().settings({ ignoreUndefinedProperties: false });
 
       const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      await docRef.set({
-        field1: 1,
-        field2: undefined,
-      });
 
-      const snap = await docRef.get();
-      const snapData = snap.data();
-      if (!snapData) {
-        return Promise.reject(new Error('Snapshot not saved'));
+      try {
+        await docRef.set({
+          field1: 1,
+          field2: undefined,
+        });
+
+        return Promise.reject(new Error('Expected set() to throw'));
+      } catch (e) {
+        return Promise.resolve();
       }
+    });
 
-      snapData.field1.should.equal(1);
-      should.equal(snapData.field2, null);
+    it('throws when nested undefined value provided and ignored undefined is false', async function () {
+      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
+
+      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+
+      try {
+        await docRef.set({
+          field1: 1,
+          field2: {
+            shouldNotWork: undefined,
+          },
+        });
+
+        return Promise.reject(new Error('Expected set() to throw'));
+      } catch (e) {
+        return Promise.resolve();
+      }
     });
   });
 

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -120,6 +120,25 @@ describe('firestore()', function () {
       should.equal(docRef.constructor.name, 'FirestoreDocumentReference');
       docRef.path.should.eql(`${COLLECTION}/bar`);
     });
+
+    it('filters out undefined properties when setting enabled', async function () {
+      await firebase.firestore().settings({ ignoreUndefinedProperties: true });
+
+      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+      await docRef.set({
+        field1: 1,
+        field2: undefined,
+      });
+
+      const snap = await docRef.get();
+      const snapData = snap.data();
+      if (!snapData) {
+        return Promise.reject(new Error('Snapshot not saved'));
+      }
+
+      snapData.field1.should.equal(1);
+      snapData.field2.should.not.exist();
+    });
   });
 
   describe('collectionGroup()', function () {
@@ -318,6 +337,18 @@ describe('firestore()', function () {
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql("'settings.persistence' must be a boolean value");
+        return Promise.resolve();
+      }
+    });
+
+    it('throws if ignoreUndefinedProperties is not a boolean', function () {
+      try {
+        firebase.firestore().settings({ ignoreUndefinedProperties: 'true' });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql(
+          "'settings.ignoreUndefinedProperties' must be a boolean value",
+        );
         return Promise.resolve();
       }
     });

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -17,7 +17,7 @@
 const COLLECTION = 'firestore';
 const COLLECTION_GROUP = 'collectionGroup';
 
-describe('firestore()', function () {
+describe.only('firestore()', function () {
   describe('namespace', function () {
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
@@ -137,7 +137,26 @@ describe('firestore()', function () {
       }
 
       snapData.field1.should.equal(1);
-      snapData.field2.should.not.exist();
+      should.not.exist(snapData.field2);
+    });
+
+    it('filters out undefined properties when setting disabled', async function () {
+      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
+
+      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+      await docRef.set({
+        field1: 1,
+        field2: undefined,
+      });
+
+      const snap = await docRef.get();
+      const snapData = snap.data();
+      if (!snapData) {
+        return Promise.reject(new Error('Snapshot not saved'));
+      }
+
+      snapData.field1.should.equal(1);
+      should.equal(snapData.field2, null);
     });
   });
 

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -17,7 +17,7 @@
 const COLLECTION = 'firestore';
 const COLLECTION_GROUP = 'collectionGroup';
 
-describe.only('firestore()', function () {
+describe('firestore()', function () {
   describe('namespace', function () {
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
@@ -138,6 +138,28 @@ describe.only('firestore()', function () {
 
       snapData.field1.should.equal(1);
       should.not.exist(snapData.field2);
+    });
+
+    it('filters out nested undefined properties when setting enabled', async function () {
+      await firebase.firestore().settings({ ignoreUndefinedProperties: true });
+
+      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+      await docRef.set({
+        field1: 1,
+        field2: {
+          shouldBeMissing: undefined,
+        },
+      });
+
+      const snap = await docRef.get();
+      const snapData = snap.data();
+      if (!snapData) {
+        return Promise.reject(new Error('Snapshot not saved'));
+      }
+
+      snapData.field1.should.equal(1);
+      should.exist(snapData.field2);
+      should.not.exist(snapData.field2.shouldBeMissing);
     });
 
     it('filters out undefined properties when setting disabled', async function () {

--- a/packages/firestore/lib/FirestoreDocumentReference.js
+++ b/packages/firestore/lib/FirestoreDocumentReference.js
@@ -185,7 +185,11 @@ export default class FirestoreDocumentReference {
       throw new Error(`firebase.firestore().doc().set(_, *) ${e.message}.`);
     }
 
-    return this._firestore.native.documentSet(this.path, buildNativeMap(data), setOptions);
+    return this._firestore.native.documentSet(
+      this.path,
+      buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
+      setOptions,
+    );
   }
 
   update(...args) {
@@ -202,7 +206,10 @@ export default class FirestoreDocumentReference {
       throw new Error(`firebase.firestore().doc().update(*) ${e.message}`);
     }
 
-    return this._firestore.native.documentUpdate(this.path, buildNativeMap(data));
+    return this._firestore.native.documentUpdate(
+      this.path,
+      buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
+    );
   }
 }
 

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -204,7 +204,7 @@ export default class FirestoreQueryModifiers {
     const filter = {
       fieldPath,
       operator: OPERATORS[opStr],
-      value: generateNativeData(value),
+      value: generateNativeData(value, true),
     };
 
     this._filters = this._filters.concat(filter);

--- a/packages/firestore/lib/FirestoreTransaction.js
+++ b/packages/firestore/lib/FirestoreTransaction.js
@@ -85,7 +85,7 @@ export default class FirestoreTransaction {
     this._commandBuffer.push({
       type: 'SET',
       path: documentRef.path,
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
       options: setOptions,
     });
 
@@ -111,7 +111,7 @@ export default class FirestoreTransaction {
     this._commandBuffer.push({
       type: 'UPDATE',
       path: documentRef.path,
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
     });
 
     return this;

--- a/packages/firestore/lib/FirestoreWriteBatch.js
+++ b/packages/firestore/lib/FirestoreWriteBatch.js
@@ -94,7 +94,7 @@ export default class FirestoreWriteBatch {
     this._writes.push({
       path: documentRef.path,
       type: 'SET',
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
       options: setOptions,
     });
 
@@ -131,7 +131,7 @@ export default class FirestoreWriteBatch {
     this._writes.push({
       path: documentRef.path,
       type: 'UPDATE',
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
     });
 
     return this;

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1419,6 +1419,11 @@ export namespace FirebaseFirestoreTypes {
      * Whether to use SSL when connecting.
      */
     ssl?: boolean;
+
+    /**
+     * When this parameter is set, Cloud Firestore ignores undefined properties inside objects.
+     */
+    ignoreUndefinedProperties?: boolean;
   }
 
   /**

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -185,7 +185,7 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
     const keys = Object.keys(settings);
 
-    const opts = ['cacheSizeBytes', 'host', 'persistence', 'ssl'];
+    const opts = ['cacheSizeBytes', 'host', 'persistence', 'ssl', 'ignoreUndefinedProperties'];
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
@@ -250,6 +250,18 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
     if (!isUndefined(settings.ssl) && !isBoolean(settings.ssl)) {
       throw new Error("firebase.firestore().settings(*) 'settings.ssl' must be a boolean value.");
+    }
+
+    if (!isUndefined(settings.ignoreUndefinedProperties)) {
+      if (!isBoolean(settings.ignoreUndefinedProperties)) {
+        throw new Error(
+          "firebase.firestore().settings(*) 'settings.ignoreUndefinedProperties' must be a boolean value.",
+        );
+      } else {
+        this._settings.ignoreUndefined = settings.ignoreUndefined;
+      }
+
+      delete settings.ignoreUndefinedProperties;
     }
 
     return this.native.settings(settings);

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -262,7 +262,7 @@ class FirebaseFirestoreModule extends FirebaseModule {
           "firebase.firestore().settings(*) 'settings.ignoreUndefinedProperties' must be a boolean value.",
         );
       } else {
-        this._settings.ignoreUndefinedProperties = settings.ignoreUndefined;
+        this._settings.ignoreUndefinedProperties = settings.ignoreUndefinedProperties;
       }
 
       delete settings.ignoreUndefinedProperties;

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -74,6 +74,10 @@ class FirebaseFirestoreModule extends FirebaseModule {
         event,
       );
     });
+
+    this._settings = {
+      ignoreUndefinedProperties: false,
+    };
   }
 
   batch() {
@@ -258,7 +262,7 @@ class FirebaseFirestoreModule extends FirebaseModule {
           "firebase.firestore().settings(*) 'settings.ignoreUndefinedProperties' must be a boolean value.",
         );
       } else {
-        this._settings.ignoreUndefined = settings.ignoreUndefined;
+        this._settings.ignoreUndefinedProperties = settings.ignoreUndefined;
       }
 
       delete settings.ignoreUndefinedProperties;

--- a/packages/firestore/lib/utils/serialize.js
+++ b/packages/firestore/lib/utils/serialize.js
@@ -49,15 +49,22 @@ export function provideFieldValueClass(fieldValue) {
  * @param data
  * @param ignoreUndefined
  */
-export function buildNativeMap(data, ignoreUndefined = false) {
+export function buildNativeMap(data, ignoreUndefined) {
   const nativeData = {};
   if (data) {
     const keys = Object.keys(data);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      const typeMap = generateNativeData(data[key], ignoreUndefined);
-      if (typeMap) {
-        nativeData[key] = typeMap;
+
+      if (typeof data[key] === 'undefined') {
+        if (!ignoreUndefined) {
+          throw new Error('firebase.firestore() undefined values cannot be saved');
+        }
+      } else {
+        const typeMap = generateNativeData(data[key], ignoreUndefined);
+        if (typeMap) {
+          nativeData[key] = typeMap;
+        }
       }
     }
   }
@@ -94,7 +101,7 @@ export function buildNativeArray(array) {
  * @param ignoreUndefined
  * @returns {*}
  */
-export function generateNativeData(value, ignoreUndefined = false) {
+export function generateNativeData(value, ignoreUndefined) {
   if (Number.isNaN(value)) {
     return getTypeMapInt('nan');
   }

--- a/packages/firestore/lib/utils/serialize.js
+++ b/packages/firestore/lib/utils/serialize.js
@@ -47,14 +47,15 @@ export function provideFieldValueClass(fieldValue) {
 /**
  *
  * @param data
+ * @param ignoreUndefined
  */
-export function buildNativeMap(data) {
+export function buildNativeMap(data, ignoreUndefined = false) {
   const nativeData = {};
   if (data) {
     const keys = Object.keys(data);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      const typeMap = generateNativeData(data[key]);
+      const typeMap = generateNativeData(data[key], ignoreUndefined);
       if (typeMap) {
         nativeData[key] = typeMap;
       }
@@ -90,9 +91,10 @@ export function buildNativeArray(array) {
  * Example: [7, 'some string'];
  *
  * @param value
+ * @param ignoreUndefined
  * @returns {*}
  */
-export function generateNativeData(value) {
+export function generateNativeData(value, ignoreUndefined = false) {
   if (Number.isNaN(value)) {
     return getTypeMapInt('nan');
   }
@@ -165,7 +167,7 @@ export function generateNativeData(value) {
       return getTypeMapInt('fieldvalue', [value._type, value._elements]);
     }
 
-    return getTypeMapInt('object', buildNativeMap(value));
+    return getTypeMapInt('object', buildNativeMap(value, ignoreUndefined));
   }
 
   // eslint-disable-next-line no-console

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -218,25 +218,25 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.1)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.3.1)"
   - GoogleUserMessagingPlatform (1.4.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.4.1):
+  - GoogleUtilities/AppDelegateSwizzler (7.4.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.4.1):
+  - GoogleUtilities/Environment (7.4.0):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/ISASwizzler (7.4.1)
-  - GoogleUtilities/Logger (7.4.1):
+  - GoogleUtilities/ISASwizzler (7.4.0)
+  - GoogleUtilities/Logger (7.4.0):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.4.1):
+  - GoogleUtilities/MethodSwizzler (7.4.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.4.1):
+  - GoogleUtilities/Network (7.4.0):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.4.1)"
-  - GoogleUtilities/Reachability (7.4.1):
+  - "GoogleUtilities/NSData+zlib (7.4.0)"
+  - GoogleUtilities/Reachability (7.4.0):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.4.1):
+  - GoogleUtilities/UserDefaults (7.4.0):
     - GoogleUtilities/Logger
   - GTMSessionFetcher (1.5.0):
     - GTMSessionFetcher/Full (= 1.5.0)
@@ -253,7 +253,7 @@ PODS:
   - nanopb/encode (2.30908.0)
   - PersonalizedAdConsent (1.0.5)
   - PromisesObjC (1.2.12)
-  - Protobuf (3.17.0)
+  - Protobuf (3.15.8)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -511,69 +511,69 @@ PODS:
     - React-cxxreact (= 0.64.1)
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
-  - RNFBAdMob (11.5.0):
+  - RNFBAdMob (11.4.1):
     - Firebase/AdMob (= 7.11.0)
     - PersonalizedAdConsent (~> 1.0.5)
     - React-Core
     - RNFBApp
-  - RNFBAnalytics (11.5.0):
+  - RNFBAnalytics (11.4.1):
     - Firebase/Analytics (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (11.5.0):
+  - RNFBApp (11.4.1):
     - Firebase/CoreOnly (= 7.11.0)
     - React-Core
-  - RNFBAuth (11.5.0):
+  - RNFBAuth (11.4.1):
     - Firebase/Auth (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (11.5.0):
+  - RNFBCrashlytics (11.4.1):
     - Firebase/Crashlytics (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (11.5.0):
+  - RNFBDatabase (11.4.1):
     - Firebase/Database (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (11.5.0):
+  - RNFBDynamicLinks (11.4.1):
     - Firebase/DynamicLinks (= 7.11.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (11.5.0):
+  - RNFBFirestore (11.4.1):
     - Firebase/Firestore (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (11.5.0):
+  - RNFBFunctions (11.4.1):
     - Firebase/Functions (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBIid (11.5.0):
+  - RNFBIid (11.4.1):
     - Firebase/CoreOnly (= 7.11.0)
     - FirebaseInstanceID
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (11.5.0):
+  - RNFBInAppMessaging (11.4.1):
     - Firebase/InAppMessaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (11.5.0):
+  - RNFBMessaging (11.4.1):
     - Firebase/Messaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBML (11.5.0):
+  - RNFBML (11.4.1):
     - Firebase/MLVision (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBPerf (11.5.0):
+  - RNFBPerf (11.4.1):
     - Firebase/Performance (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (11.5.0):
+  - RNFBRemoteConfig (11.4.1):
     - Firebase/RemoteConfig (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (11.5.0):
+  - RNFBStorage (11.4.1):
     - Firebase/Storage (= 7.11.0)
     - React-Core
     - RNFBApp
@@ -769,7 +769,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 8ee9855fae2e86ec6628f8243a32ab3cd91dc0d9
+  FBReactNativeSpec: 61ae6bc80c7c2b86b5491427cc0eab2af9b84135
   Firebase: c121feb35e4126c0b355e3313fa9b487d47319fd
   FirebaseABTesting: e66f1f80747792630d9b292966de206d5df9853b
   FirebaseAnalytics: cd3bd84d722a24a8923918af8af8e5236f615d77
@@ -797,14 +797,14 @@ SPEC CHECKSUMS:
   GoogleDataTransport: cd9db2180fcecd8da1b561aea31e3e56cf834aa7
   GoogleToolboxForMac: 471e0c05d39506e50e6398f46fa9a12ae0efeff9
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
-  GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20
+  GoogleUtilities: 284cddc7fffc14ae1907efb6f78ab95c1fccaedc
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Jet: 84fd0e2e9d49457fc04bc79b5d8857737a01c507
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PersonalizedAdConsent: dbecabb3467df967c16d9cebc2ef4a8890e4bbd8
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  Protobuf: 7327d4444215b5f18e560a97f879ff5503c4581c
+  Protobuf: adb85cd18a15bd1a777c158af9fd6e612a0e6d69
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: ec2ebc96b7bfba3ca5c32740f5a0c6a014a274d2
   RCTTypeSafety: 22567f31e67c3e088c7ac23ea46ab6d4779c0ea5
@@ -828,22 +828,22 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
-  RNFBAdMob: a2b5f148468b16d02543707d4627bc9a19016bf3
-  RNFBAnalytics: 3e250066a98d6ea0a7816c52de75f2633f726580
-  RNFBApp: 9c90f9d576861947ba75fe0830567c570bcbcf6d
-  RNFBAuth: 99fdbce04ff3d39e57a7a3956d632ee69145685b
-  RNFBCrashlytics: 8eafacfe3dc4aeb7733c3c3d65228f4e75861e72
-  RNFBDatabase: 64aaecd9e48c6378864ef7d0fe65cc5f312987ed
-  RNFBDynamicLinks: 53f5621a2ab44b6f967f2240f1b7d56f8b6c74de
-  RNFBFirestore: bedb9727c0df9a1f1ec23b5e23988075a4cbea78
-  RNFBFunctions: 570969b0b7a104066374d4f6e840d6d8a217e3ad
-  RNFBIid: e3a0c5de29ab0d414f6b186963066b4d34884d59
-  RNFBInAppMessaging: beddb2f5f10d6e691c3125af6194437e10d85ae9
-  RNFBMessaging: c873e6c37f69d22de22cab134413030a9c6330a9
-  RNFBML: 552169e3c048e34f5bb8842b5ae63e86bb6b2cf3
-  RNFBPerf: 27e85a7451cb366b75bd6ade8a2b912749d0a165
-  RNFBRemoteConfig: d2c532f1fee5862a7518190211ea2a28123167c5
-  RNFBStorage: 052a32c5af38b106e4d6b0a296df304d97be995e
+  RNFBAdMob: bbc64554e13d019d37fbc981f5f48ba4c6ea5889
+  RNFBAnalytics: 1190435dcd25d7403d28ceb4342c0d1e050843de
+  RNFBApp: 996860ad6832996faba79ef3f6ec2d3ea5870dd9
+  RNFBAuth: 3726f7f9bc9e9efb80cd1f5b2e65c4b04dc53760
+  RNFBCrashlytics: 59d9ecfaacddbe10819d9071ee3b9921b79b8c6b
+  RNFBDatabase: 026067d3ce9d65c96146f7f32c1f044f27665f29
+  RNFBDynamicLinks: e6c9cd9cba02cc65f8b76fbd22cf50a66d473bdd
+  RNFBFirestore: 7fa546e352aad031a78b934a67435e55b32cba49
+  RNFBFunctions: 4838dd472870e5941908eabc48d1711dacdda558
+  RNFBIid: 6003e884d8479e9d14ecbb6dbaa3939aaab40984
+  RNFBInAppMessaging: 84a265c8ac2d4fbce01c13cd5d22946389c6926e
+  RNFBMessaging: 8d84ceadc705ca6b6047c37376d2e2aaabcb8e3d
+  RNFBML: 80dccd04dcea208eb96eb6d1b1f38975a0f3a274
+  RNFBPerf: d54d3ab9a11fb319074de3d4714168052ac225cd
+  RNFBRemoteConfig: 3035dd5d7b2a903f822505f04a5cd01752d5bc37
+  RNFBStorage: 519ea44ccd27418d4bffbc9cd088a72697b5cb98
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
 
 PODFILE CHECKSUM: 207309c3bddb2e511bc745f32898e130e30eb1c6

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -218,25 +218,25 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.3.1)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.3.1)"
   - GoogleUserMessagingPlatform (1.4.0)
-  - GoogleUtilities/AppDelegateSwizzler (7.4.0):
+  - GoogleUtilities/AppDelegateSwizzler (7.4.1):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.4.0):
+  - GoogleUtilities/Environment (7.4.1):
     - PromisesObjC (~> 1.2)
-  - GoogleUtilities/ISASwizzler (7.4.0)
-  - GoogleUtilities/Logger (7.4.0):
+  - GoogleUtilities/ISASwizzler (7.4.1)
+  - GoogleUtilities/Logger (7.4.1):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.4.0):
+  - GoogleUtilities/MethodSwizzler (7.4.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.4.0):
+  - GoogleUtilities/Network (7.4.1):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.4.0)"
-  - GoogleUtilities/Reachability (7.4.0):
+  - "GoogleUtilities/NSData+zlib (7.4.1)"
+  - GoogleUtilities/Reachability (7.4.1):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.4.0):
+  - GoogleUtilities/UserDefaults (7.4.1):
     - GoogleUtilities/Logger
   - GTMSessionFetcher (1.5.0):
     - GTMSessionFetcher/Full (= 1.5.0)
@@ -253,7 +253,7 @@ PODS:
   - nanopb/encode (2.30908.0)
   - PersonalizedAdConsent (1.0.5)
   - PromisesObjC (1.2.12)
-  - Protobuf (3.15.8)
+  - Protobuf (3.17.0)
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
     - DoubleConversion
@@ -511,69 +511,69 @@ PODS:
     - React-cxxreact (= 0.64.1)
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
-  - RNFBAdMob (11.4.1):
+  - RNFBAdMob (11.5.0):
     - Firebase/AdMob (= 7.11.0)
     - PersonalizedAdConsent (~> 1.0.5)
     - React-Core
     - RNFBApp
-  - RNFBAnalytics (11.4.1):
+  - RNFBAnalytics (11.5.0):
     - Firebase/Analytics (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (11.4.1):
+  - RNFBApp (11.5.0):
     - Firebase/CoreOnly (= 7.11.0)
     - React-Core
-  - RNFBAuth (11.4.1):
+  - RNFBAuth (11.5.0):
     - Firebase/Auth (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (11.4.1):
+  - RNFBCrashlytics (11.5.0):
     - Firebase/Crashlytics (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (11.4.1):
+  - RNFBDatabase (11.5.0):
     - Firebase/Database (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (11.4.1):
+  - RNFBDynamicLinks (11.5.0):
     - Firebase/DynamicLinks (= 7.11.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (11.4.1):
+  - RNFBFirestore (11.5.0):
     - Firebase/Firestore (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (11.4.1):
+  - RNFBFunctions (11.5.0):
     - Firebase/Functions (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBIid (11.4.1):
+  - RNFBIid (11.5.0):
     - Firebase/CoreOnly (= 7.11.0)
     - FirebaseInstanceID
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (11.4.1):
+  - RNFBInAppMessaging (11.5.0):
     - Firebase/InAppMessaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (11.4.1):
+  - RNFBMessaging (11.5.0):
     - Firebase/Messaging (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBML (11.4.1):
+  - RNFBML (11.5.0):
     - Firebase/MLVision (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBPerf (11.4.1):
+  - RNFBPerf (11.5.0):
     - Firebase/Performance (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (11.4.1):
+  - RNFBRemoteConfig (11.5.0):
     - Firebase/RemoteConfig (= 7.11.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (11.4.1):
+  - RNFBStorage (11.5.0):
     - Firebase/Storage (= 7.11.0)
     - React-Core
     - RNFBApp
@@ -769,7 +769,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 61ae6bc80c7c2b86b5491427cc0eab2af9b84135
+  FBReactNativeSpec: 8ee9855fae2e86ec6628f8243a32ab3cd91dc0d9
   Firebase: c121feb35e4126c0b355e3313fa9b487d47319fd
   FirebaseABTesting: e66f1f80747792630d9b292966de206d5df9853b
   FirebaseAnalytics: cd3bd84d722a24a8923918af8af8e5236f615d77
@@ -797,14 +797,14 @@ SPEC CHECKSUMS:
   GoogleDataTransport: cd9db2180fcecd8da1b561aea31e3e56cf834aa7
   GoogleToolboxForMac: 471e0c05d39506e50e6398f46fa9a12ae0efeff9
   GoogleUserMessagingPlatform: b168e8c46cd8f92aa3e34b584c4ca78a411ce367
-  GoogleUtilities: 284cddc7fffc14ae1907efb6f78ab95c1fccaedc
+  GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Jet: 84fd0e2e9d49457fc04bc79b5d8857737a01c507
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PersonalizedAdConsent: dbecabb3467df967c16d9cebc2ef4a8890e4bbd8
   PromisesObjC: 3113f7f76903778cf4a0586bd1ab89329a0b7b97
-  Protobuf: adb85cd18a15bd1a777c158af9fd6e612a0e6d69
+  Protobuf: 7327d4444215b5f18e560a97f879ff5503c4581c
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: ec2ebc96b7bfba3ca5c32740f5a0c6a014a274d2
   RCTTypeSafety: 22567f31e67c3e088c7ac23ea46ab6d4779c0ea5
@@ -828,22 +828,22 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
-  RNFBAdMob: bbc64554e13d019d37fbc981f5f48ba4c6ea5889
-  RNFBAnalytics: 1190435dcd25d7403d28ceb4342c0d1e050843de
-  RNFBApp: 996860ad6832996faba79ef3f6ec2d3ea5870dd9
-  RNFBAuth: 3726f7f9bc9e9efb80cd1f5b2e65c4b04dc53760
-  RNFBCrashlytics: 59d9ecfaacddbe10819d9071ee3b9921b79b8c6b
-  RNFBDatabase: 026067d3ce9d65c96146f7f32c1f044f27665f29
-  RNFBDynamicLinks: e6c9cd9cba02cc65f8b76fbd22cf50a66d473bdd
-  RNFBFirestore: 7fa546e352aad031a78b934a67435e55b32cba49
-  RNFBFunctions: 4838dd472870e5941908eabc48d1711dacdda558
-  RNFBIid: 6003e884d8479e9d14ecbb6dbaa3939aaab40984
-  RNFBInAppMessaging: 84a265c8ac2d4fbce01c13cd5d22946389c6926e
-  RNFBMessaging: 8d84ceadc705ca6b6047c37376d2e2aaabcb8e3d
-  RNFBML: 80dccd04dcea208eb96eb6d1b1f38975a0f3a274
-  RNFBPerf: d54d3ab9a11fb319074de3d4714168052ac225cd
-  RNFBRemoteConfig: 3035dd5d7b2a903f822505f04a5cd01752d5bc37
-  RNFBStorage: 519ea44ccd27418d4bffbc9cd088a72697b5cb98
+  RNFBAdMob: a2b5f148468b16d02543707d4627bc9a19016bf3
+  RNFBAnalytics: 3e250066a98d6ea0a7816c52de75f2633f726580
+  RNFBApp: 9c90f9d576861947ba75fe0830567c570bcbcf6d
+  RNFBAuth: 99fdbce04ff3d39e57a7a3956d632ee69145685b
+  RNFBCrashlytics: 8eafacfe3dc4aeb7733c3c3d65228f4e75861e72
+  RNFBDatabase: 64aaecd9e48c6378864ef7d0fe65cc5f312987ed
+  RNFBDynamicLinks: 53f5621a2ab44b6f967f2240f1b7d56f8b6c74de
+  RNFBFirestore: bedb9727c0df9a1f1ec23b5e23988075a4cbea78
+  RNFBFunctions: 570969b0b7a104066374d4f6e840d6d8a217e3ad
+  RNFBIid: e3a0c5de29ab0d414f6b186963066b4d34884d59
+  RNFBInAppMessaging: beddb2f5f10d6e691c3125af6194437e10d85ae9
+  RNFBMessaging: c873e6c37f69d22de22cab134413030a9c6330a9
+  RNFBML: 552169e3c048e34f5bb8842b5ae63e86bb6b2cf3
+  RNFBPerf: 27e85a7451cb366b75bd6ade8a2b912749d0a165
+  RNFBRemoteConfig: d2c532f1fee5862a7518190211ea2a28123167c5
+  RNFBStorage: 052a32c5af38b106e4d6b0a296df304d97be995e
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
 
 PODFILE CHECKSUM: 207309c3bddb2e511bc745f32898e130e30eb1c6


### PR DESCRIPTION
### Description

Firestore web / node SDKs support an "ignoreUndefinedProperties" field which will automatically filter out undefined properties.  This PR adds support for this.  They will throw by default if undefined is passed in.

Followed the pattern suggested in in #5304 with one exception, I have not added a `settings` getter because the Firestore API already uses `settings` as a setter and it proxies directly to native for over half of the settings.  I can modify the setter to be a getter when no arguments are provided and to save / return all settings if desired.  

This is a breaking change in the current iteration: we mimic the node / web SDKs - we throw when we encounter `undefined` by default

### Related issues

Fixes #5304

### Release Summary

Adds Firestore support for ignoreUndefinedProperties config value

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No


### Test Plan

```
      ✓ returns a new WriteBatch instance
    collection()
      ✓ throws if path is not a string
      ✓ throws if path is empty string
      ✓ throws if path does not point to a collection
      ✓ returns a new CollectionReference
    doc()
      ✓ throws if path is not a string
      ✓ throws if path is empty string
      ✓ throws if path does not point to a document
      ✓ returns a new DocumentReference
      ✓ filters out undefined properties when setting enabled
      ✓ filters out nested undefined properties when setting enabled
      ✓ throws when undefined value provided and ignored undefined is false
      ✓ throws when nested undefined value provided and ignored undefined is false
    collectionGroup()
      ✓ throws if id is not a string
      ✓ throws if id is empty
      ✓ throws if id contains forward-slash
      ✓ returns a new query instance
      ✓ performs a collection group query
      ✓ performs a collection group query with cursor queries
    disableNetwork() & enableNetwork()
      ✓ disables and enables with no errors
    runTransaction()
      ✓ throws if updateFunction is not a function
    settings()
      ✓ throws if settings is not an object
      ✓ throws if passing an incorrect setting key
      ✓ throws if cacheSizeBytes is not a number
      ✓ throws if cacheSizeBytes is less than 1MB
      - accepts an unlimited cache size
      ✓ throws if host is not a string
      ✓ throws if host is an empty string
      ✓ throws if persistence is not a boolean
      ✓ throws if ignoreUndefinedProperties is not a boolean
      ✓ throws if ssl is not a boolean
    Clear cached data persistence
      - should clear any cached data
    wait for pending writes
      - waits for pending writes

```
