### PR TITLE
docs(app, android): suggest 4.3.8 of google-play-services plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ First, add the `google-services` plugin as a dependency inside of your `/android
 buildscript {
   dependencies {
     // ... other dependencies
-    classpath 'com.google.gms:google-services:4.3.6'
+    classpath 'com.google.gms:google-services:4.3.8'
     // Add me --- /\
   }
 }


### PR DESCRIPTION

### Description

4.3.6 was non-functional, code was updated but docs weren't
Credit to @marqroldan for spotting it, thanks!

### Related issues

https://github.com/invertase/react-native-firebase/commit/d97587b33aa4c092a0d34291e24491ca66f9bcaa#r50879443

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Tests already using suggested version, known working

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
