### PR TITLE
docs(crashlytics, install): add link to crashlytics install/verify blog

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -32,6 +32,7 @@ CocoaPods
 codebase
 config
 Config
+crashlytics
 Crashlytics
 datastore
 deprecations

--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -29,6 +29,8 @@ Once installed, you must complete the following additional setup steps for Andro
 If you're using an older version of React Native without autolinking support, or wish to integrate into an existing project,
 you can follow the manual installation steps for [iOS](/crashlytics/usage/installation/ios) and [Android](/crashlytics/usage/installation/android).
 
+> You may like reading a short article we wrote that explains how to configure and _most importantly_ verify your crashlytics installation so you are sure it is working. https://invertase.io/blog/react-native-firebase-crashlytics-configuration
+
 # What does it do
 
 Crashlytics helps you to collect analytics and details about crashes and errors that occur in your app. It does this through three aspects:


### PR DESCRIPTION
### Description

I write a blog post on how to verify crashlytics installations but never linked it in the crashlytics docs

### Related issues

https://github.com/invertase/react-native-firebase/discussions/5318

### Release Summary

conventional commit title / PR title

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
