### PR TITLE
feat(firestore)!: ignore undefined properties setting, with tests

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -45,6 +45,9 @@ jest.doMock('react-native', () => {
           on: jest.fn(),
           useEmulator: jest.fn(),
         },
+        RNFBFirestoreModule: {
+          settings: jest.fn(),
+        },
         RNFBPerfModule: {},
       },
     },

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -1,0 +1,266 @@
+import firestore, { firebase } from '../lib';
+
+const COLLECTION = 'firestore';
+
+describe('Storage', function () {
+  describe('namespace', function () {
+    it('accessible from firebase.app()', function () {
+      const app = firebase.app();
+      expect(app.firestore).toBeDefined();
+      expect(app.firestore().settings).toBeDefined();
+    });
+  });
+
+  describe('batch()', function () {
+    it('returns a new WriteBatch instance', function () {
+      const instance = firebase.firestore().batch();
+      return expect(instance.constructor.name).toEqual('FirestoreWriteBatch');
+    });
+  });
+
+  describe('settings', function () {
+    it('throws if settings is not an object', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firebase.firestore().settings('foo');
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings' must be an object");
+      }
+    });
+
+    it('throws if passing an incorrect setting key', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firebase.firestore().settings({ foo: 'bar' });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings.foo' is not a valid settings field");
+      }
+    });
+
+    it('throws if cacheSizeBytes is not a number', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firebase.firestore().settings({ cacheSizeBytes: 'foo' });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings.cacheSizeBytes' must be a number value");
+      }
+    });
+
+    it('throws if cacheSizeBytes is less than 1MB', async function () {
+      try {
+        await firebase.firestore().settings({ cacheSizeBytes: 123 });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings.cacheSizeBytes' the minimum cache size");
+      }
+    });
+
+    it('accepts an unlimited cache size', async function () {
+      await firebase
+        .firestore()
+        .settings({ cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED });
+    });
+
+    it('throws if host is not a string', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firebase.firestore().settings({ host: 123 });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings.host' must be a string value");
+      }
+    });
+
+    it('throws if host is an empty string', async function () {
+      try {
+        await firebase.firestore().settings({ host: '' });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings.host' must not be an empty string");
+      }
+    });
+
+    it('throws if persistence is not a boolean', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firebase.firestore().settings({ persistence: 'true' });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings.persistence' must be a boolean value");
+      }
+    });
+
+    it('throws if ssl is not a boolean', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firebase.firestore().settings({ ssl: 'true' });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'settings.ssl' must be a boolean value");
+      }
+    });
+
+    it('throws if ignoreUndefinedProperties is not a boolean', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firestore().settings({ ignoreUndefinedProperties: 'bogus' });
+        return Promise.reject(new Error('Should throw'));
+      } catch (e) {
+        return expect(e.message).toContain("ignoreUndefinedProperties' must be a boolean value.");
+      }
+    });
+  });
+
+  describe('runTransaction()', function () {
+    it('throws if updateFunction is not a function', async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firebase.firestore().runTransaction('foo');
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'updateFunction' must be a function");
+      }
+    });
+  });
+
+  describe('collectionGroup()', function () {
+    it('returns a new query instance', function () {
+      const query = firebase.firestore().collectionGroup(COLLECTION);
+      expect(query.constructor.name).toEqual('FirestoreQuery');
+    });
+
+    it('throws if id is not a string', function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        firebase.firestore().collectionGroup(123);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'collectionId' must be a string value");
+      }
+    });
+
+    it('throws if id is empty', function () {
+      try {
+        firebase.firestore().collectionGroup('');
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'collectionId' must be a non-empty string");
+      }
+    });
+
+    it('throws if id contains forward-slash', function () {
+      try {
+        firebase.firestore().collectionGroup(`someCollection/bar`);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'collectionId' must not contain '/'");
+      }
+    });
+  });
+
+  describe('collection()', function () {
+    it('throws if path is not a string', function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        firebase.firestore().collection(123);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'collectionPath' must be a string value");
+      }
+    });
+
+    it('throws if path is empty string', function () {
+      try {
+        firebase.firestore().collection('');
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'collectionPath' must be a non-empty string");
+      }
+    });
+
+    it('throws if path does not point to a collection', function () {
+      try {
+        firebase.firestore().collection(`firestore/bar`);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'collectionPath' must point to a collection");
+      }
+    });
+
+    it('returns a new CollectionReference', function () {
+      const collectionReference = firebase.firestore().collection('firestore');
+      expect(collectionReference.constructor.name).toEqual('FirestoreCollectionReference');
+      expect(collectionReference.path).toEqual('firestore');
+    });
+  });
+
+  describe('doc()', function () {
+    it('throws if path is not a string', function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        firebase.firestore().doc(123);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'documentPath' must be a string value");
+      }
+    });
+
+    it('throws if path is empty string', function () {
+      try {
+        firebase.firestore().doc('');
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'documentPath' must be a non-empty string");
+      }
+    });
+
+    it('throws if path does not point to a document', function () {
+      try {
+        firebase.firestore().doc(`${COLLECTION}/bar/baz`);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (e) {
+        return expect(e.message).toContain("'documentPath' must point to a document");
+      }
+    });
+
+    it('returns a new DocumentReference', function () {
+      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+      expect(docRef.constructor.name).toEqual('FirestoreDocumentReference');
+      expect(docRef.path).toEqual(`${COLLECTION}/bar`);
+    });
+
+    it('throws when undefined value provided and ignored undefined is false', async function () {
+      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
+      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+      try {
+        await docRef.set({
+          field1: 1,
+          field2: undefined,
+        });
+
+        return Promise.reject(new Error('Expected set() to throw'));
+      } catch (e) {
+        return expect(e.message).toEqual('Unsupported field value: undefined');
+      }
+    });
+
+    it('throws when nested undefined value provided and ignored undefined is false', async function () {
+      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
+      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+      try {
+        await docRef.set({
+          field1: 1,
+          field2: {
+            shouldNotWork: undefined,
+          },
+        });
+        return Promise.reject(new Error('Expected set() to throw'));
+      } catch (e) {
+        return expect(e.message).toEqual('Unsupported field value: undefined');
+      }
+    });
+  });
+});

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -19,12 +19,6 @@ const COLLECTION_GROUP = 'collectionGroup';
 
 describe('firestore()', function () {
   describe('namespace', function () {
-    it('accessible from firebase.app()', function () {
-      const app = firebase.app();
-      should.exist(app.firestore);
-      app.firestore().app.should.equal(app);
-    });
-
     // removing as pending if module.options.hasMultiAppSupport = true
     it('supports multiple apps', async function () {
       firebase.firestore().app.name.should.equal('[DEFAULT]');
@@ -37,90 +31,13 @@ describe('firestore()', function () {
     });
   });
 
-  describe('batch()', function () {
-    it('returns a new WriteBatch instance', function () {
-      const instance = firebase.firestore().batch();
-      instance.constructor.name.should.eql('FirestoreWriteBatch');
-    });
-  });
+  describe('batch()', function () {});
 
   describe('clearPersistence()', function () {});
 
-  describe('collection()', function () {
-    it('throws if path is not a string', function () {
-      try {
-        firebase.firestore().collection(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'collectionPath' must be a string value");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if path is empty string', function () {
-      try {
-        firebase.firestore().collection('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'collectionPath' must be a non-empty string");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if path does not point to a collection', function () {
-      try {
-        firebase.firestore().collection(`${COLLECTION}/bar`);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'collectionPath' must point to a collection");
-        return Promise.resolve();
-      }
-    });
-
-    it('returns a new CollectionReference', function () {
-      const collectionReference = firebase.firestore().collection(COLLECTION);
-      should.equal(collectionReference.constructor.name, 'FirestoreCollectionReference');
-      collectionReference.path.should.eql(COLLECTION);
-    });
-  });
+  describe('collection()', function () {});
 
   describe('doc()', function () {
-    it('throws if path is not a string', function () {
-      try {
-        firebase.firestore().doc(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'documentPath' must be a string value");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if path is empty string', function () {
-      try {
-        firebase.firestore().doc('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'documentPath' must be a non-empty string");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if path does not point to a document', function () {
-      try {
-        firebase.firestore().doc(`${COLLECTION}/bar/baz`);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'documentPath' must point to a document");
-        return Promise.resolve();
-      }
-    });
-
-    it('returns a new DocumentReference', function () {
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      should.equal(docRef.constructor.name, 'FirestoreDocumentReference');
-      docRef.path.should.eql(`${COLLECTION}/bar`);
-    });
-
     it('filters out undefined properties when setting enabled', async function () {
       await firebase.firestore().settings({ ignoreUndefinedProperties: true });
 
@@ -162,80 +79,9 @@ describe('firestore()', function () {
 
       snapData.field2.hasOwnProperty('shouldBeMissing').should.eql(false);
     });
-
-    it('throws when undefined value provided and ignored undefined is false', async function () {
-      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
-
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-
-      try {
-        await docRef.set({
-          field1: 1,
-          field2: undefined,
-        });
-
-        return Promise.reject(new Error('Expected set() to throw'));
-      } catch (e) {
-        return Promise.resolve();
-      }
-    });
-
-    it('throws when nested undefined value provided and ignored undefined is false', async function () {
-      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
-
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-
-      try {
-        await docRef.set({
-          field1: 1,
-          field2: {
-            shouldNotWork: undefined,
-          },
-        });
-
-        return Promise.reject(new Error('Expected set() to throw'));
-      } catch (e) {
-        return Promise.resolve();
-      }
-    });
   });
 
   describe('collectionGroup()', function () {
-    it('throws if id is not a string', function () {
-      try {
-        firebase.firestore().collectionGroup(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'collectionId' must be a string value");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if id is empty', function () {
-      try {
-        firebase.firestore().collectionGroup('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'collectionId' must be a non-empty string");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if id contains forward-slash', function () {
-      try {
-        firebase.firestore().collectionGroup(`${COLLECTION}/bar`);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'collectionId' must not contain '/'");
-        return Promise.resolve();
-      }
-    });
-
-    it('returns a new query instance', function () {
-      const query = firebase.firestore().collectionGroup(COLLECTION);
-      should.equal(query.constructor.name, 'FirestoreQuery');
-    });
-
     it('performs a collection group query', async function () {
       const docRef1 = firebase.firestore().doc(`${COLLECTION}/collectionGroup1`);
       const docRef2 = firebase.firestore().doc(`${COLLECTION}/collectionGroup2`);
@@ -313,118 +159,8 @@ describe('firestore()', function () {
     });
   });
 
-  describe('runTransaction()', function () {
-    it('throws if updateFunction is not a function', function () {
-      try {
-        firebase.firestore().runTransaction('foo');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'updateFunction' must be a function");
-        return Promise.resolve();
-      }
-    });
-  });
-
-  describe('settings()', function () {
-    it('throws if settings is not an object', function () {
-      try {
-        firebase.firestore().settings('foo');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings' must be an object");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if passing an incorrect setting key', function () {
-      try {
-        firebase.firestore().settings({ foo: 'bar' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings.foo' is not a valid settings field");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if cacheSizeBytes is not a number', function () {
-      try {
-        firebase.firestore().settings({ cacheSizeBytes: 'foo' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings.cacheSizeBytes' must be a number value");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if cacheSizeBytes is less than 1MB', function () {
-      try {
-        firebase.firestore().settings({ cacheSizeBytes: 123 });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings.cacheSizeBytes' the minimum cache size");
-        return Promise.resolve();
-      }
-    });
-    // NOTE: removed as it breaks emulator tests along with 'should clear any cached data' test below
-    xit('accepts an unlimited cache size', function () {
-      firebase.firestore().settings({ cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED });
-    });
-
-    it('throws if host is not a string', function () {
-      try {
-        firebase.firestore().settings({ host: 123 });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings.host' must be a string value");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if host is an empty string', function () {
-      try {
-        firebase.firestore().settings({ host: '' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings.host' must not be an empty string");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if persistence is not a boolean', function () {
-      try {
-        firebase.firestore().settings({ persistence: 'true' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings.persistence' must be a boolean value");
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if ignoreUndefinedProperties is not a boolean', function () {
-      try {
-        firebase.firestore().settings({ ignoreUndefinedProperties: 'true' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql(
-          "'settings.ignoreUndefinedProperties' must be a boolean value",
-        );
-        return Promise.resolve();
-      }
-    });
-
-    it('throws if ssl is not a boolean', function () {
-      try {
-        firebase.firestore().settings({ ssl: 'true' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql("'settings.ssl' must be a boolean value");
-        return Promise.resolve();
-      }
-    });
-  });
-
   describe('Clear cached data persistence', function () {
-    // NOTE: removed as it breaks emulator tests along with 'accepts an unlimited cache size' test above
+    // NOTE: removed as it breaks emulator tests
     xit('should clear any cached data', async function () {
       const db = firebase.firestore();
       const id = 'foobar';

--- a/packages/firestore/lib/FirestoreDocumentReference.js
+++ b/packages/firestore/lib/FirestoreDocumentReference.js
@@ -185,7 +185,11 @@ export default class FirestoreDocumentReference {
       throw new Error(`firebase.firestore().doc().set(_, *) ${e.message}.`);
     }
 
-    return this._firestore.native.documentSet(this.path, buildNativeMap(data), setOptions);
+    return this._firestore.native.documentSet(
+      this.path,
+      buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
+      setOptions,
+    );
   }
 
   update(...args) {
@@ -202,7 +206,10 @@ export default class FirestoreDocumentReference {
       throw new Error(`firebase.firestore().doc().update(*) ${e.message}`);
     }
 
-    return this._firestore.native.documentUpdate(this.path, buildNativeMap(data));
+    return this._firestore.native.documentUpdate(
+      this.path,
+      buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
+    );
   }
 }
 

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -204,7 +204,7 @@ export default class FirestoreQueryModifiers {
     const filter = {
       fieldPath,
       operator: OPERATORS[opStr],
-      value: generateNativeData(value),
+      value: generateNativeData(value, true),
     };
 
     this._filters = this._filters.concat(filter);

--- a/packages/firestore/lib/FirestoreTransaction.js
+++ b/packages/firestore/lib/FirestoreTransaction.js
@@ -85,7 +85,7 @@ export default class FirestoreTransaction {
     this._commandBuffer.push({
       type: 'SET',
       path: documentRef.path,
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
       options: setOptions,
     });
 
@@ -111,7 +111,7 @@ export default class FirestoreTransaction {
     this._commandBuffer.push({
       type: 'UPDATE',
       path: documentRef.path,
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
     });
 
     return this;

--- a/packages/firestore/lib/FirestoreWriteBatch.js
+++ b/packages/firestore/lib/FirestoreWriteBatch.js
@@ -94,7 +94,7 @@ export default class FirestoreWriteBatch {
     this._writes.push({
       path: documentRef.path,
       type: 'SET',
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
       options: setOptions,
     });
 
@@ -131,7 +131,7 @@ export default class FirestoreWriteBatch {
     this._writes.push({
       path: documentRef.path,
       type: 'UPDATE',
-      data: buildNativeMap(data),
+      data: buildNativeMap(data, this._firestore._settings.ignoreUndefinedProperties),
     });
 
     return this;

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1421,7 +1421,9 @@ export namespace FirebaseFirestoreTypes {
     ssl?: boolean;
 
     /**
-     * When this parameter is set, Cloud Firestore ignores undefined properties inside objects.
+     * Whether to skip nested properties that are set to undefined during object serialization.
+     * If set to true, these properties are skipped and not written to Firestore.
+     * If set to false or omitted, the SDK throws an exception when it encounters properties of type undefined.
      */
     ignoreUndefinedProperties?: boolean;
   }

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1419,6 +1419,11 @@ export namespace FirebaseFirestoreTypes {
      * Whether to use SSL when connecting.
      */
     ssl?: boolean;
+
+    /**
+     * When this parameter is set, Cloud Firestore ignores undefined properties inside objects.
+     */
+    ignoreUndefinedProperties?: boolean;
   }
 
   /**

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -74,6 +74,10 @@ class FirebaseFirestoreModule extends FirebaseModule {
         event,
       );
     });
+
+    this._settings = {
+      ignoreUndefinedProperties: false,
+    };
   }
 
   batch() {
@@ -185,7 +189,7 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
     const keys = Object.keys(settings);
 
-    const opts = ['cacheSizeBytes', 'host', 'persistence', 'ssl'];
+    const opts = ['cacheSizeBytes', 'host', 'persistence', 'ssl', 'ignoreUndefinedProperties'];
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
@@ -250,6 +254,18 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
     if (!isUndefined(settings.ssl) && !isBoolean(settings.ssl)) {
       throw new Error("firebase.firestore().settings(*) 'settings.ssl' must be a boolean value.");
+    }
+
+    if (!isUndefined(settings.ignoreUndefinedProperties)) {
+      if (!isBoolean(settings.ignoreUndefinedProperties)) {
+        throw new Error(
+          "firebase.firestore().settings(*) 'settings.ignoreUndefinedProperties' must be a boolean value.",
+        );
+      } else {
+        this._settings.ignoreUndefinedProperties = settings.ignoreUndefinedProperties;
+      }
+
+      delete settings.ignoreUndefinedProperties;
     }
 
     return this.native.settings(settings);

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -174,8 +174,8 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
   runTransaction(updateFunction) {
     if (!isFunction(updateFunction)) {
-      throw new Error(
-        "firebase.firestore().runTransaction(*) 'updateFunction' must be a function.",
+      return Promise.reject(
+        new Error("firebase.firestore().runTransaction(*) 'updateFunction' must be a function."),
       );
     }
 
@@ -184,7 +184,9 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
   settings(settings) {
     if (!isObject(settings)) {
-      throw new Error("firebase.firestore().settings(*) 'settings' must be an object.");
+      return Promise.reject(
+        new Error("firebase.firestore().settings(*) 'settings' must be an object."),
+      );
     }
 
     const keys = Object.keys(settings);
@@ -194,16 +196,20 @@ class FirebaseFirestoreModule extends FirebaseModule {
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       if (!opts.includes(key)) {
-        throw new Error(
-          `firebase.firestore().settings(*) 'settings.${key}' is not a valid settings field.`,
+        return Promise.reject(
+          new Error(
+            `firebase.firestore().settings(*) 'settings.${key}' is not a valid settings field.`,
+          ),
         );
       }
     }
 
     if (!isUndefined(settings.cacheSizeBytes)) {
       if (!isNumber(settings.cacheSizeBytes)) {
-        throw new Error(
-          "firebase.firestore().settings(*) 'settings.cacheSizeBytes' must be a number value.",
+        return Promise.reject(
+          new Error(
+            "firebase.firestore().settings(*) 'settings.cacheSizeBytes' must be a number value.",
+          ),
         );
       }
 
@@ -211,20 +217,26 @@ class FirebaseFirestoreModule extends FirebaseModule {
         settings.cacheSizeBytes !== FirestoreStatics.CACHE_SIZE_UNLIMITED &&
         settings.cacheSizeBytes < 1048576 // 1MB
       ) {
-        throw new Error(
-          "firebase.firestore().settings(*) 'settings.cacheSizeBytes' the minimum cache size is 1048576 bytes (1MB).",
+        return Promise.reject(
+          new Error(
+            "firebase.firestore().settings(*) 'settings.cacheSizeBytes' the minimum cache size is 1048576 bytes (1MB).",
+          ),
         );
       }
     }
 
     if (!isUndefined(settings.host)) {
       if (!isString(settings.host)) {
-        throw new Error("firebase.firestore().settings(*) 'settings.host' must be a string value.");
+        return Promise.reject(
+          new Error("firebase.firestore().settings(*) 'settings.host' must be a string value."),
+        );
       }
 
       if (settings.host === '') {
-        throw new Error(
-          "firebase.firestore().settings(*) 'settings.host' must not be an empty string.",
+        return Promise.reject(
+          new Error(
+            "firebase.firestore().settings(*) 'settings.host' must not be an empty string.",
+          ),
         );
       }
 
@@ -247,8 +259,10 @@ class FirebaseFirestoreModule extends FirebaseModule {
     }
 
     if (!isUndefined(settings.persistence) && !isBoolean(settings.persistence)) {
-      throw new Error(
-        "firebase.firestore().settings(*) 'settings.persistence' must be a boolean value.",
+      return Promise.reject(
+        new Error(
+          "firebase.firestore().settings(*) 'settings.persistence' must be a boolean value.",
+        ),
       );
     }
 
@@ -258,8 +272,10 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
     if (!isUndefined(settings.ignoreUndefinedProperties)) {
       if (!isBoolean(settings.ignoreUndefinedProperties)) {
-        throw new Error(
-          "firebase.firestore().settings(*) 'settings.ignoreUndefinedProperties' must be a boolean value.",
+        return Promise.reject(
+          new Error(
+            "firebase.firestore().settings(*) 'settings.ignoreUndefinedProperties' must be a boolean value.",
+          ),
         );
       } else {
         this._settings.ignoreUndefinedProperties = settings.ignoreUndefinedProperties;

--- a/packages/firestore/lib/utils/serialize.js
+++ b/packages/firestore/lib/utils/serialize.js
@@ -47,16 +47,24 @@ export function provideFieldValueClass(fieldValue) {
 /**
  *
  * @param data
+ * @param ignoreUndefined
  */
-export function buildNativeMap(data) {
+export function buildNativeMap(data, ignoreUndefined) {
   const nativeData = {};
   if (data) {
     const keys = Object.keys(data);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      const typeMap = generateNativeData(data[key]);
-      if (typeMap) {
-        nativeData[key] = typeMap;
+
+      if (typeof data[key] === 'undefined') {
+        if (!ignoreUndefined) {
+          throw new Error('firebase.firestore() undefined values cannot be saved');
+        }
+      } else {
+        const typeMap = generateNativeData(data[key], ignoreUndefined);
+        if (typeMap) {
+          nativeData[key] = typeMap;
+        }
       }
     }
   }
@@ -90,9 +98,10 @@ export function buildNativeArray(array) {
  * Example: [7, 'some string'];
  *
  * @param value
+ * @param ignoreUndefined
  * @returns {*}
  */
-export function generateNativeData(value) {
+export function generateNativeData(value, ignoreUndefined) {
   if (Number.isNaN(value)) {
     return getTypeMapInt('nan');
   }
@@ -165,7 +174,7 @@ export function generateNativeData(value) {
       return getTypeMapInt('fieldvalue', [value._type, value._elements]);
     }
 
-    return getTypeMapInt('object', buildNativeMap(value));
+    return getTypeMapInt('object', buildNativeMap(value, ignoreUndefined));
   }
 
   // eslint-disable-next-line no-console

--- a/packages/firestore/lib/utils/serialize.js
+++ b/packages/firestore/lib/utils/serialize.js
@@ -58,7 +58,7 @@ export function buildNativeMap(data, ignoreUndefined) {
 
       if (typeof data[key] === 'undefined') {
         if (!ignoreUndefined) {
-          throw new Error('firebase.firestore() undefined values cannot be saved');
+          throw new Error('Unsupported field value: undefined');
         }
       } else {
         const typeMap = generateNativeData(data[key], ignoreUndefined);


### PR DESCRIPTION
### Description

Add the firestore ignoreUndefinedProperties setting, per all the information on #5312 

This is a breaking change. We used to allow undefined and they would result in nulls in the database.
You will need to set ignoreUndefinedProperties to true in firestore settings to restore the old behavior if you want it

This was done because the other SDKs throw on undefined, specifically firestore-js-sdk which we attempt to mimic as much as possible including in error conditions

This supercedes the fantastic work done by @jmif on #5312 - I don't have rights to push to that repo but I wanted to re-shape how the testing was done (most of it seemed like a better fit for unit tests - something we are trying to convert to more in the repo) and it was the perfect moment, but that seems like a bit of a drag to ask of a new contributor, especially since it requires a bit of jest mocking magic

### Related issues

Related #5312
Fixes #5304 

### Release Summary

rebase merge, there are two commits, both with conventional commits messages including the breaking changes notice

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Test Plan

A great deal of unit testing and e2e testing shows it appears to be coded up correctly

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
