### PR TITLE
fix: add database get method

### DIFF
--- a/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQuery.java
+++ b/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQuery.java
@@ -53,6 +53,14 @@ public class ReactNativeFirebaseDatabaseQuery {
       }
     }
   }
+  
+  /**
+   * Gets the server values for this query. Updates the cache and raises events if successful. If
+   * not connected, falls back to a locally-cached value.
+   */
+  public void get() {
+    query.get();
+  }
 
   /**
    * Attaches a single single value event listener to the query

--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -691,6 +691,12 @@ export namespace FirebaseDatabaseTypes {
       failureCallbackContext?: ((a: Error) => void) | Record<string, any> | null,
     ): Promise<DataSnapshot>;
 
+    
+    /**
+     * Get the server-value for this query, or return a cached value if not connected.
+     */
+    get(): Promise<DataSnapshot>;
+  
     /**
      * Generates a new `Query` object ordered by the specified child key.
      *


### PR DESCRIPTION
### Description

If persistence is enabled SingleEvent Snapshot will read from the local database. Very non-intuitive and making migration of an online to offline somehow complicated.

A good solution to this problem will be to use the new method "get" in the SDK. This method gets the server values for the query. Updates the cache and raises events if successful. If not connected, falls back to a locally-cached value.

This is the required behavior in most cases.

### Related issues

Fixes #724012604

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  Yes
- My change supports the following platforms;
  `Android`
- This is a breaking change;
   No