### PR TITLE
test(e2e, emulator): correctly handle exit in non-ci environments

### DIFF
--- a/.github/workflows/scripts/start-firebase-emulator.sh
+++ b/.github/workflows/scripts/start-firebase-emulator.sh
@@ -17,6 +17,7 @@ while [ $RETRIES -le $MAX_RETRIES ]; do
   if [ "$1" == "--no-daemon" ]; then
     echo "Starting Firebase Emulator Suite in foreground."
     $EMU_START_COMMAND
+    exit 0
   else
     echo "Starting Firebase Emulator Suite in background."
     $EMU_START_COMMAND &


### PR DESCRIPTION
### Description

Last script edit was perfect for CI but did not get the *non*-CI case correct, so it would re-spawn after exit

Now in non-CI environments it will correctly exit when the emulator is done

### Related issues

Original commit was in PR #5335 

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
