### PR TITLE
fix(auth, android): remove browser dependency, upstream includes now

### DIFF
--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -81,21 +81,10 @@ repositories {
   mavenCentral()
 }
 
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
-}
-
-def BROWSER_VERSION = safeExtGet('androidxBrowserVersion', '[1.0.0, 2.0.0)')
-
 dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-auth"
-
-  // This is needed for the reCAPTCHA flow but is incorrectly missing as a transitive dependency upstream
-  // https://github.com/invertase/react-native-firebase/issues/4744
-  // https://github.com/firebase/firebase-android-sdk/issues/2164
-  implementation "androidx.browser:browser:${BROWSER_VERSION}"
 }
 
 ReactNative.shared.applyPackageVersion()


### PR DESCRIPTION
Previous versions of firebase-android-sdk did not express their dependency
on androidx.browser library but used it for reCAPTHCA flow, leading to crashes.
We had to temporarily add a dependency here/downstream to work around.

Upstream has the dependency now, verified via `./gradlew :app:dependencies`

Fixes #4744


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
