### PR TITLE
test: fix docs lint, update tests Podfile.lock, switch to ccache

### DIFF
--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -37,16 +37,40 @@ jobs:
         with:
           fetch-depth: 50
 
+      # Set up tool versions
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Install firebase CLI
+
+      - name: Configure JDK 1.11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11' # ubuntu-latest is about to default to 11, force it everywhere
+
+      # Set path variables needed for caches
+      - name: Set workflow variables
+        id: workflow-variables
+        run: |
+          echo "::set-output name=metro-cache::$HOME/.metro"
+          echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
+          echo "::set-output name=tempdir::$TMPDIR"
+
+      - uses: actions/cache@v2
+        name: Yarn Cache
+        id: yarn-cache
+        with:
+          path: ${{ steps.workflow-variables.outputs.yarn-cache-dir }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          restore-keys: ${{ runner.os }}-yarn-v1
+
+      - name: Yarn Install
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: npm i -g firebase-tools
+          command: DETOX_DISABLE_POSTINSTALL=1 yarn --no-audit --prefer-offline
 
       - name: Cache Firestore Emulator
         uses: actions/cache@v2
@@ -58,44 +82,12 @@ jobs:
       - name: Start Firestore Emulator
         run: yarn tests:emulator:start-ci
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v2
-        name: Yarn Cache
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
-          restore-keys: ${{ runner.os }}-yarn-v1
-
       - uses: actions/cache@v2
         name: Gradle Cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-v1-${{ hashFiles('**/*.gradle*') }}
           restore-keys: ${{ runner.os }}-gradle-v1
-
-      - name: Yarn Install
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: DETOX_DISABLE_POSTINSTALL=1 yarn --no-audit --prefer-offline
-
-      - name: Configure JDK 1.11
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '11' # ubuntu-latest is about to default to 11, force it everywhere
-
-      - name: Verify JDK11
-        # Default JDK varies depending on different runner flavors, make sure we are on 11
-        # Run a check that exits with error unless it is 11 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '11.0'
-        shell: bash
 
       - name: Build Android App
         uses: nick-invision/retry@v2
@@ -105,10 +97,17 @@ jobs:
           max_attempts: 3
           command: cd tests/android && ./gradlew assembleDebug assembleAndroidTest lintDebug -DtestBuildType=debug -Dorg.gradle.daemon=false
 
+      - name: Metro Bundler Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.workflow-variables.outputs.metro-cache }}
+          key: ${{ runner.os }}-metro-v1-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-metro-v1
+
       - name: Pre-fetch Javascript bundle
         # Prebuild the bundle so that's fast when the app starts.
         run: |
-          nohup yarn tests:packager:jet &
+          nohup yarn tests:packager:jet-ci &
           printf 'Waiting for packager to come online'
           until curl --output /dev/null --silent --head --fail http://localhost:8081/status; do
             printf '.'

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -32,16 +32,7 @@ jobs:
         with:
           all_but_latest: true
 
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 50
-
-      - uses: mikehardy/buildcache-action@v1
-        name: Buildcache
-        with:
-          cache_key: ${{ runner.os }}-v1
-          upload_buildcache_log: true
-
+      # Set up tool versions
       - uses: actions/setup-node@v2
         with:
           node-version: 14
@@ -50,54 +41,39 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      - name: Get Xcode version
-        id: xcode-version
-        run: echo "::set-output name=xcode-version::$(xcodebuild -version|tail -1|cut -f3 -d' ')"
-
-      - name: Install firebase CLI
-        uses: nick-invision/retry@v2
+      - uses: actions/checkout@v2
         with:
-          timeout_minutes: 10
-          retry_wait_seconds: 60
-          max_attempts: 3
-          command: npm i -g firebase-tools
+          fetch-depth: 50
 
-      - name: Cache Firestore Emulator
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/firebase/emulators
-          key: firebase-emulators-v1-${{ github.run_id }}
-          restore-keys: firebase-emulators-v1
-
-      - name: Start Firestore Emulator
-        run: yarn tests:emulator:start-ci
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+      # Set path variables needed for caches
+      - name: Set workflow variables
+        id: workflow-variables
+        run: |
+          echo "::set-output name=metro-cache::$HOME/.metro"
+          echo "::set-output name=xcode-version::$(xcodebuild -version|tail -1|cut -f3 -d' ')"
+          echo "::set-output name=yarn-cache-dir::$(yarn cache dir)"
 
       - uses: actions/cache@v2
         name: Yarn Cache
         id: yarn-cache
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          path: ${{ steps.workflow-variables.outputs.yarn-cache-dir }}
           key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
           restore-keys: ${{ runner.os }}-yarn-v1
-
-      - uses: actions/cache@v2
-        name: Cache Pods
-        id: pods-cache
-        with:
-          path: tests/ios/Pods
-          key: ${{ runner.os }}-pods-v2-${{ hashFiles('**/Podfile.lock') }}
-          restore-keys: ${{ runner.os }}-pods-v2
 
       - uses: actions/cache@v2
         name: Detox Framework Cache
         id: detox-cache
         with:
           path: ~/Library/Detox/ios
-          key: ${{ runner.os }}-detox-framework-cache-${{ steps.xcode-version.outputs.xcode-version }}
+          key: ${{ runner.os }}-detox-framework-cache-${{ steps.workflow-variables.outputs.xcode-version }}
+
+      # Detox is compiled during yarn install, using Xcode, set up cache first
+      - uses: hendrikmuhs/ccache-action@v1
+        name: Xcode Compile Cache
+        with:
+          key: ${{ runner.os }}-v2 # makes a unique key w/related restore key internally
+          max-size: 400M
 
       - name: Yarn Install
         uses: nick-invision/retry@v2
@@ -110,39 +86,71 @@ jobs:
       - name: Update Ruby build tools
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 10
+          timeout_minutes: 2
           retry_wait_seconds: 60
           max_attempts: 3
           command: gem update cocoapods xcodeproj
 
+      - uses: actions/cache@v2
+        name: Cache Pods
+        id: pods-cache
+        with:
+          path: tests/ios/Pods
+          key: ${{ runner.os }}-pods-v2-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: ${{ runner.os }}-pods-v2
+
       - name: Pod Install
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 10
+          timeout_minutes: 2
           retry_wait_seconds: 60
           max_attempts: 3
           command: yarn tests:ios:pod:install
 
+      - name: Cache Firestore Emulator
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/firebase/emulators
+          key: firebase-emulators-v1-${{ github.run_id }}
+          restore-keys: firebase-emulators-v1
+
+      - name: Start Firestore Emulator
+        run: yarn tests:emulator:start-ci
+
       - name: Build iOS App
         run: |
+          export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"
+          export CCACHE_SLOPPINESS=clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
+          export CCACHE_FILECLONE=true
+          export CCACHE_DEPEND=true
+          export CCACHE_INODECACHE=true
+          ccache -s
           export SKIP_BUNDLING=1
           export RCT_NO_LAUNCH_PACKAGER=1
           cd tests
           set -o pipefail
           ./node_modules/.bin/detox build --configuration ios.sim.debug
+          ccache -s
         shell: bash
 
       - name: Install applesimutils
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 10
+          timeout_minutes: 5
           retry_wait_seconds: 60
           max_attempts: 3
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew && HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils && applesimutils --list
 
+      - name: Metro Bundler Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.workflow-variables.outputs.metro-cache }}
+          key: ${{ runner.os }}-metro-v1-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-metro-v1
+
       - name: Pre-fetch Javascript bundle
         run: |
-          nohup yarn tests:packager:jet &
+          nohup yarn tests:packager:jet-ci &
           printf 'Waiting for packager to come online'
           until curl --output /dev/null --silent --head --fail http://localhost:8081/status; do
             printf '.'
@@ -159,17 +167,10 @@ jobs:
         run: nohup sh -c "sleep 30 && xcrun simctl spawn booted log stream --level debug --style compact > simulator.log 2>&1 &"
 
       - name: Detox Test
-        timeout-minutes: 40
+        timeout-minutes: 10
         run: |
           cd tests
           ./node_modules/.bin/nyc ./node_modules/.bin/detox test --debug-synchronization 200 --configuration ios.sim.debug
-
-      - name: Upload Buildcache Log
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: buildcache_log
-          path: ./.buildcache/buildcache.log
 
       - name: Compress Simulator Log
         if: always()

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "tests:jest-coverage": "jest --coverage",
     "tests:packager:chrome": "cd tests && node_modules/.bin/react-native start --reset-cache",
     "tests:packager:jet": "cd tests && cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --no-interactive",
+    "tests:packager:jet-ci": "cd tests && cross-env TMPDIR=$HOME/.metro REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --no-interactive",
     "tests:packager:jet-reset-cache": "cd tests && cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --reset-cache --no-interactive",
     "tests:emulator:start": "cd ./.github/workflows/scripts && ./start-firebase-emulator.sh --no-daemon",
     "tests:emulator:start-ci": "cd ./.github/workflows/scripts && ./start-firebase-emulator.sh",

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -455,58 +455,58 @@ PODS:
     - React-cxxreact (= 0.64.1)
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
-  - RNFBAnalytics (12.0.0):
+  - RNFBAnalytics (12.1.0):
     - Firebase/Analytics (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBApp (12.0.0):
+  - RNFBApp (12.1.0):
     - Firebase/CoreOnly (= 8.1.1)
     - React-Core
-  - RNFBAuth (12.0.0):
+  - RNFBAuth (12.1.0):
     - Firebase/Auth (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (12.0.0):
+  - RNFBCrashlytics (12.1.0):
     - Firebase/Crashlytics (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (12.0.0):
+  - RNFBDatabase (12.1.0):
     - Firebase/Database (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (12.0.0):
+  - RNFBDynamicLinks (12.1.0):
     - Firebase/DynamicLinks (= 8.1.1)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (12.0.0):
+  - RNFBFirestore (12.1.0):
     - Firebase/Firestore (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (12.0.0):
+  - RNFBFunctions (12.1.0):
     - Firebase/Functions (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (12.0.0):
+  - RNFBInAppMessaging (12.1.0):
     - Firebase/InAppMessaging (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (12.0.0):
+  - RNFBMessaging (12.1.0):
     - Firebase/Messaging (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBML (12.0.0):
+  - RNFBML (12.1.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (12.0.0):
+  - RNFBPerf (12.1.0):
     - Firebase/Performance (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (12.0.0):
+  - RNFBRemoteConfig (12.1.0):
     - Firebase/RemoteConfig (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBStorage (12.0.0):
+  - RNFBStorage (12.1.0):
     - Firebase/Storage (= 8.1.1)
     - React-Core
     - RNFBApp
@@ -739,20 +739,20 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
-  RNFBAnalytics: 6a4b3866e4ebd373a8027150b6ade95beff0d135
-  RNFBApp: 9c25c0489c4aa12942f5400c71ff88d543eb121b
-  RNFBAuth: 92e2efa4410bb6295824b0f8317e62129d8fbfca
-  RNFBCrashlytics: cfe97e53d2d8a6a5fbefec0467cea785e66395b2
-  RNFBDatabase: acae231cca6d6cba57796573a9e01b5972faa486
-  RNFBDynamicLinks: c9d189dc908ad5178b6289cbe803f323d657bd1e
-  RNFBFirestore: 9dd9a189b341ab87ec1f5ca3aeccaaf2a58c0b19
-  RNFBFunctions: da6880040e656b804ef0bddac98d748111ce3ea7
-  RNFBInAppMessaging: 029a6a9b0ea790d41acb7b3ec5859ec05ffd191b
-  RNFBMessaging: 9960922f5a64192bd540be23bb1a7384b8ec0d33
-  RNFBML: e61a47c621eb294f95f016b3bfcec8d47a1f2b2b
-  RNFBPerf: b793eb358310cd9bbf41511229af0ff8f9610ed3
-  RNFBRemoteConfig: 634169913eb4a9bc0fdb84a46059aef638ff0c63
-  RNFBStorage: 55cd84ccf8f00545ce3ad60d8a3f533cbb28fcaf
+  RNFBAnalytics: 1d620e112afef80e381a2cb5a88c086809536aab
+  RNFBApp: 406bc9586c70ccf20504b4d3b54ac4341c98993f
+  RNFBAuth: 638d012551135969cfd12d122def3ee40c05974d
+  RNFBCrashlytics: 963a2757f6a52e37ae50adab5832162a7d81f98f
+  RNFBDatabase: ce7a7805f8f53b70752ce96f5639cd08e536fe17
+  RNFBDynamicLinks: eb76e8f5ab0ea943899dd4bbb849f48a30e03e6d
+  RNFBFirestore: b96f258a3f5d6a901ff96cd64306e3a2d221ad08
+  RNFBFunctions: a172927d5bb663db720910b77279f1e469e378da
+  RNFBInAppMessaging: 5c097a51cea6dcc7413a2b414793fa6c7ae6a5e1
+  RNFBMessaging: 154dc7815e2b6c55941793630ffb3a55f03d77e6
+  RNFBML: 41c38d1d3200fb6686d9289e78b859dd2c9572ad
+  RNFBPerf: 243e8bd24e72333b39ab56642cb3948b5436981a
+  RNFBRemoteConfig: c8546356d2879524e712022629a8ce981a7da099
+  RNFBStorage: c326632c37e247af7a0986ad3d9c12d682e90962
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
 
 PODFILE CHECKSUM: cd2f69084949aea10ca551be89eb96c34004b9ee


### PR DESCRIPTION
### Description

CI Speedups

- ccache 4.3 *should* fix the problem with Xcode always seeming to "use multiple source files" causing cache miss
- podfile.lock was out of date
- metro bundler cache could be better and firebase-tools didn't need a separate install

This batch shaves about 10 minutes off iOS E2E and 5-6 minutes off Android E2E best case, no harm worst case

### Release Summary

No release needed, commits follow angular conventional commit guidelines


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

It's made of tests.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
