### PR TITLE
fix(database): call cancellation callback when using ref.on

### DIFF
--- a/packages/database/e2e/query/on.e2e.js
+++ b/packages/database/e2e/query/on.e2e.js
@@ -108,7 +108,7 @@ describe('database().ref().on()', function () {
   });
 
   // the cancelCallback is never called for ref.on but ref.once works?
-  xit('should cancel when something goes wrong', async function () {
+  it('should cancel when something goes wrong', async function () {
     const successCallback = sinon.spy();
     const cancelCallback = sinon.spy();
     const ref = firebase.database().ref('nope');

--- a/packages/database/lib/DatabaseSyncTree.js
+++ b/packages/database/lib/DatabaseSyncTree.js
@@ -263,12 +263,7 @@ class DatabaseSyncTree {
 
     if (once) {
       const subscription = SharedEventEmitter.addListener(eventRegistrationKey, event => {
-        const wrappedListener = this._onOnceRemoveRegistration(
-          eventRegistrationKey,
-          listener,
-          event,
-        );
-        wrappedListener(event);
+        this._onOnceRemoveRegistration(eventRegistrationKey, listener)(event);
         subscription.remove();
       });
     } else {

--- a/packages/database/lib/DatabaseSyncTree.js
+++ b/packages/database/lib/DatabaseSyncTree.js
@@ -263,7 +263,11 @@ class DatabaseSyncTree {
 
     if (once) {
       const subscription = SharedEventEmitter.addListener(eventRegistrationKey, event => {
-        const wrappedListener = this._onOnceRemoveRegistration(eventRegistrationKey, listener, event);
+        const wrappedListener = this._onOnceRemoveRegistration(
+          eventRegistrationKey,
+          listener,
+          event,
+        );
         wrappedListener(event);
         subscription.remove();
       });

--- a/packages/database/lib/DatabaseSyncTree.js
+++ b/packages/database/lib/DatabaseSyncTree.js
@@ -263,7 +263,8 @@ class DatabaseSyncTree {
 
     if (once) {
       const subscription = SharedEventEmitter.addListener(eventRegistrationKey, event => {
-        this._onOnceRemoveRegistration(eventRegistrationKey, listener, event);
+        const wrappedListener = this._onOnceRemoveRegistration(eventRegistrationKey, listener, event);
+        wrappedListener(event);
         subscription.remove();
       });
     } else {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
The cancellation/error callback is not being triggered using the following api

```
ref.on('value', (val) => ... , (err) => { ... })
```

Digging through the code, I noticed the listener is being wrapped but not called. I noticed there is a test for this...but not sure how that is passing.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

Fixes #5370 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
