### PR TITLE
feat(auth): add support for multi-factor auth with SMS code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
       version: '16.1.0',
     },
   },
+  env: { node: true },
   rules: {
     'jest/no-identical-title': 0,
     'eslint-comments/no-unlimited-disable': 0,
@@ -27,7 +28,7 @@ module.exports = {
     'class-methods-use-this': 0,
     'no-console': 1,
     'no-plusplus': 0,
-    'no-undef': 0,
+    'no-undef': 2,
     'no-shadow': 0,
     'no-catch-shadow': 0,
     'no-underscore-dangle': 'off',

--- a/packages/app/lib/internal/NativeFirebaseError.js
+++ b/packages/app/lib/internal/NativeFirebaseError.js
@@ -58,6 +58,10 @@ export default class NativeFirebaseError extends Error {
       enumerable: false,
       value: userInfo.nativeErrorMessage || null,
     });
+    Object.defineProperty(this, 'resolver', {
+      enumerable: false,
+      value: userInfo.resolver || null,
+    });
 
     this.stack = NativeFirebaseError.getStackWithMessage(
       `NativeFirebaseError: ${this.message}`,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-firebase/app",
-  "version": "12.0.0",
+  "version": "12.0.2",
   "author": "Invertase <oss@invertase.io> (http://invertase.io)",
   "description": "A well tested, feature rich Firebase implementation for React Native, supporting iOS & Android. Individual module support for Admob, Analytics, Auth, Crash Reporting, Cloud Firestore, Database, Dynamic Links, Functions, Messaging (FCM), Remote Config, Storage and more.",
   "main": "lib/index.js",

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
@@ -82,13 +82,13 @@ NSString * const AuthErrorCode_toJSErrorCode[] = {
   [FIRAuthErrorCodeInternalError] = @"internal-error",
   [FIRAuthErrorCodeMalformedJWT] = @"malformed-jwt",
     
-    [FIRAuthErrorCodeSecondFactorRequired] = @"auth/multi-factor-auth-required",
-    [FIRAuthErrorCodeMissingMultiFactorSession] = @"auth/missing-multi-factor-session",
-    [FIRAuthErrorCodeMissingMultiFactorInfo] = @"auth/missing-multi-factor-info",
-    [FIRAuthErrorCodeInvalidMultiFactorSession] = @"auth/invalid-multi-factor-session",
-    [FIRAuthErrorCodeMultiFactorInfoNotFound] = @"auth/multi-factor-info-not-found",
-    [FIRAuthErrorCodeSecondFactorAlreadyEnrolled] = @"auth/second-factor-already-in-use",
-    [FIRAuthErrorCodeMaximumSecondFactorCountExceeded] = @"auth/maximum-second-factor-count-exceeded",
-    [FIRAuthErrorCodeUnsupportedFirstFactor] = @"auth/unsupported-first-factor",
+    [FIRAuthErrorCodeSecondFactorRequired] = @"multi-factor-auth-required",
+    [FIRAuthErrorCodeMissingMultiFactorSession] = @"missing-multi-factor-session",
+    [FIRAuthErrorCodeMissingMultiFactorInfo] = @"missing-multi-factor-info",
+    [FIRAuthErrorCodeInvalidMultiFactorSession] = @"invalid-multi-factor-session",
+    [FIRAuthErrorCodeMultiFactorInfoNotFound] = @"multi-factor-info-not-found",
+    [FIRAuthErrorCodeSecondFactorAlreadyEnrolled] = @"second-factor-already-in-use",
+    [FIRAuthErrorCodeMaximumSecondFactorCountExceeded] = @"maximum-second-factor-count-exceeded",
+    [FIRAuthErrorCodeUnsupportedFirstFactor] = @"unsupported-first-factor",
 
 };

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
@@ -80,5 +80,15 @@ NSString * const AuthErrorCode_toJSErrorCode[] = {
   [FIRAuthErrorCodeNullUser] = @"null-user",
   [FIRAuthErrorCodeKeychainError] = @"keychain-error",
   [FIRAuthErrorCodeInternalError] = @"internal-error",
-  [FIRAuthErrorCodeMalformedJWT] = @"malformed-jwt"
+  [FIRAuthErrorCodeMalformedJWT] = @"malformed-jwt",
+    
+    [FIRAuthErrorCodeSecondFactorRequired] = @"auth/multi-factor-auth-required",
+    [FIRAuthErrorCodeMissingMultiFactorSession] = @"auth/missing-multi-factor-session",
+    [FIRAuthErrorCodeMissingMultiFactorInfo] = @"auth/missing-multi-factor-info",
+    [FIRAuthErrorCodeInvalidMultiFactorSession] = @"auth/invalid-multi-factor-session",
+    [FIRAuthErrorCodeMultiFactorInfoNotFound] = @"auth/multi-factor-info-not-found",
+    [FIRAuthErrorCodeSecondFactorAlreadyEnrolled] = @"auth/second-factor-already-in-use",
+    [FIRAuthErrorCodeMaximumSecondFactorCountExceeded] = @"auth/maximum-second-factor-count-exceeded",
+    [FIRAuthErrorCodeUnsupportedFirstFactor] = @"auth/unsupported-first-factor",
+
 };

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -942,7 +942,7 @@ RCT_EXPORT_METHOD(useEmulator:
       [[FIRAuth authWithApp:firebaseApp] useEmulatorWithHost: host port:port];
 }
 
-RCT_EXPORT_METHOD(enrollToMFAWithPhone:
+RCT_EXPORT_METHOD(multiFactorEnrollWithPhone:
   (FIRApp *) firebaseApp
     :(NSString *) phoneNumber
     :(RCTPromiseResolveBlock) resolve
@@ -988,7 +988,7 @@ RCT_EXPORT_METHOD(enrollToMFAWithPhone:
 }
 
 
-RCT_EXPORT_METHOD(enrollToMFAWithPhoneConfirm:
+RCT_EXPORT_METHOD(multiFactorEnrollConfirm:
                   (FIRApp *) firebaseApp
                   :(NSString *) kPhoneSecondFactorVerificationCode
                   :(RCTPromiseResolveBlock) resolve
@@ -1024,7 +1024,7 @@ RCT_EXPORT_METHOD(enrollToMFAWithPhoneConfirm:
     }
 }
      
-RCT_EXPORT_METHOD(signinWithMultiFactorInfo:
+RCT_EXPORT_METHOD(signInWithMultiFactorInfo:
                   (FIRApp *) firebaseApp
                   :(NSString *) multiFactorHintUID
                   :(RCTPromiseResolveBlock) resolve
@@ -1063,7 +1063,7 @@ RCT_EXPORT_METHOD(signinWithMultiFactorInfo:
     
 }
 
-RCT_EXPORT_METHOD(signinWithMultiFactorInfoConfirm:
+RCT_EXPORT_METHOD(signInWithMultiFactorInfoConfirm:
                   (FIRApp *) firebaseApp
                   :(NSString *) kPhoneSecondFactorVerificationCode
                   :(RCTPromiseResolveBlock) resolve

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1016,7 +1016,7 @@ RCT_EXPORT_METHOD(multiFactorEnrollConfirm:
             if (error) {
                 [self promiseRejectAuthException:reject error:error];
             } else {
-                [self reloadAndReturnUser:user resolver:resolve rejecter:reject];
+                [self promiseWithUser:resolve rejecter:reject user:user];
             }
         }];
     } else {
@@ -1107,7 +1107,7 @@ RCT_EXPORT_METHOD(multiFactorUnenroll:
             if (error != nil) {
                 [self promiseRejectAuthException:reject error:error];
             } else {
-                [self reloadAndReturnUser:user resolver:resolve rejecter:reject];
+                [self promiseWithUser:resolve rejecter:reject user:user];
             }
         }];
     } else {

--- a/packages/auth/lib/ConfirmationResultMFAEnroll.js
+++ b/packages/auth/lib/ConfirmationResultMFAEnroll.js
@@ -16,14 +16,15 @@
  */
 
 export default class ConfirmationResultMFAEnroll {
-  constructor(auth, verificationId) {
+  constructor(auth, verificationId, displayName) {
     this._auth = auth;
     this._verificationId = verificationId;
+    this._displayName = displayName;
   }
 
   confirm(verificationCode) {
     return this._auth.native
-      .multiFactorEnrollConfirm(verificationCode)
+      .multiFactorEnrollConfirm(verificationCode, this._displayName)
       .then(user => this._auth._setUser(user));
   }
 

--- a/packages/auth/lib/ConfirmationResultMFAEnroll.js
+++ b/packages/auth/lib/ConfirmationResultMFAEnroll.js
@@ -24,7 +24,7 @@ export default class ConfirmationResultMFAEnroll {
   confirm(verificationCode) {
     return this._auth.native
       .multiFactorEnrollConfirm(verificationCode)
-      .then(userCredential => this._auth._setUserCredential(userCredential));
+      .then(user => this._auth._setUser(user));
   }
 
   get verificationId() {

--- a/packages/auth/lib/ConfirmationResultMFAEnroll.js
+++ b/packages/auth/lib/ConfirmationResultMFAEnroll.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export default class ConfirmationResultMFAEnroll {
+  constructor(auth, verificationId) {
+    this._auth = auth;
+    this._verificationId = verificationId;
+  }
+
+  confirm(verificationCode) {
+    return this._auth.native
+      .multiFactorEnrollConfirm(verificationCode)
+      .then(userCredential => this._auth._setUserCredential(userCredential));
+  }
+
+  get verificationId() {
+    return this._verificationId;
+  }
+}

--- a/packages/auth/lib/ConfirmationResultMFASignIn.js
+++ b/packages/auth/lib/ConfirmationResultMFASignIn.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export default class ConfirmationResultMFASignIn {
+  constructor(auth, verificationId) {
+    this._auth = auth;
+    this._verificationId = verificationId;
+  }
+
+  confirm(verificationCode) {
+    return this._auth.native
+      .signInWithMultiFactorInfoConfirm(verificationCode)
+      .then(userCredential => this._auth._setUserCredential(userCredential));
+  }
+
+  get verificationId() {
+    return this._verificationId;
+  }
+}

--- a/packages/auth/lib/User.js
+++ b/packages/auth/lib/User.js
@@ -16,6 +16,7 @@
  */
 
 import { isObject, isString, isUndefined, isBoolean } from '@react-native-firebase/app/lib/common';
+import ConfirmationResultMFAEnroll from './ConfirmationResultMFAEnroll';
 
 export default class User {
   constructor(auth, user) {
@@ -294,6 +295,12 @@ export default class User {
     return this._auth.native.verifyBeforeUpdateEmail(newEmail, actionCodeSettings).then(user => {
       this._auth._setUser(user);
     });
+  }
+
+  multiFactorEnrollWithPhone(phoneNumber) {
+    return this._auth.native
+      .multiFactorEnrollWithPhone(phoneNumber)
+      .then(result => new ConfirmationResultMFAEnroll(this._auth, result.verificationId));
   }
 
   /**

--- a/packages/auth/lib/User.js
+++ b/packages/auth/lib/User.js
@@ -84,7 +84,7 @@ export default class User {
           );
       },
       unenroll: hint => {
-        return this._auth.native.multiFactorUnenroll(hint.uid).then(user => {
+        return this._auth.native.multiFactorUnenroll(hint.UID).then(user => {
           this._auth._setUser(user);
         });
       },

--- a/packages/auth/lib/User.js
+++ b/packages/auth/lib/User.js
@@ -73,6 +73,22 @@ export default class User {
     return this._user.uid;
   }
 
+  get multiFactor() {
+    return {
+      enroll(phoneNumber) {
+        return this._auth.native
+          .multiFactorEnrollWithPhone(phoneNumber)
+          .then(result => new ConfirmationResultMFAEnroll(this._auth, result.verificationId));
+      },
+      unenroll(hint) {
+        return this._auth.native.multiFactorUnenroll(hint.uid).then(user => {
+          this._auth._setUser(user);
+        });
+      },
+      enrolledFactors: this._user.enrolledFactors,
+    };
+  }
+
   delete() {
     return this._auth.native.delete().then(() => {
       this._auth._setUser();
@@ -295,12 +311,6 @@ export default class User {
     return this._auth.native.verifyBeforeUpdateEmail(newEmail, actionCodeSettings).then(user => {
       this._auth._setUser(user);
     });
-  }
-
-  multiFactorEnrollWithPhone(phoneNumber) {
-    return this._auth.native
-      .multiFactorEnrollWithPhone(phoneNumber)
-      .then(result => new ConfirmationResultMFAEnroll(this._auth, result.verificationId));
   }
 
   /**

--- a/packages/auth/lib/User.js
+++ b/packages/auth/lib/User.js
@@ -75,17 +75,20 @@ export default class User {
 
   get multiFactor() {
     return {
-      enroll(phoneNumber) {
+      enroll: (phoneNumber, displayName = '') => {
         return this._auth.native
           .multiFactorEnrollWithPhone(phoneNumber)
-          .then(result => new ConfirmationResultMFAEnroll(this._auth, result.verificationId));
+          .then(
+            result =>
+              new ConfirmationResultMFAEnroll(this._auth, result.verificationId, displayName),
+          );
       },
-      unenroll(hint) {
+      unenroll: hint => {
         return this._auth.native.multiFactorUnenroll(hint.uid).then(user => {
           this._auth._setUser(user);
         });
       },
-      enrolledFactors: this._user.enrolledFactors,
+      enrolledFactors: this._user.multiFactorEnrolledFactors,
     };
   }
 

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -40,6 +40,7 @@ import AppleAuthProvider from './providers/AppleAuthProvider';
 import Settings from './Settings';
 import User from './User';
 import version from './version';
+import ConfirmationResultMFASignIn from './ConfirmationResultMFASignIn';
 
 const statics = {
   AppleAuthProvider,
@@ -272,6 +273,12 @@ class FirebaseAuthModule extends FirebaseModule {
     return this.native
       .signInWithCredential(credential.providerId, credential.token, credential.secret)
       .then(userCredential => this._setUserCredential(userCredential));
+  }
+
+  signInWithMultiFactorInfo(hint) {
+    return this.native
+      .signInWithMultiFactorInfo(hint.UID)
+      .then(result => new ConfirmationResultMFASignIn(this, result.verificationId));
   }
 
   sendPasswordResetEmail(email, actionCodeSettings = null) {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-firebase/auth",
-  "version": "12.0.2",
+  "version": "12.0.3",
   "author": "Invertase <oss@invertase.io> (http://invertase.io)",
   "description": "React Native Firebase - The authentication module provides an easy-to-use API to integrate an authentication workflow into new and existing applications. React Native Firebase provides access to all Firebase authentication methods and identity providers.",
   "main": "lib/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-firebase/auth",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "author": "Invertase <oss@invertase.io> (http://invertase.io)",
   "description": "React Native Firebase - The authentication module provides an easy-to-use API to integrate an authentication workflow into new and existing applications. React Native Firebase provides access to all Firebase authentication methods and identity providers.",
   "main": "lib/index.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-firebase/auth",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "author": "Invertase <oss@invertase.io> (http://invertase.io)",
   "description": "React Native Firebase - The authentication module provides an easy-to-use API to integrate an authentication workflow into new and existing applications. React Native Firebase provides access to all Firebase authentication methods and identity providers.",
   "main": "lib/index.js",


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Hi guys! Thanks for this wonderful library. I needed to use MFA on my project so I decided to go ahead and add the implementation. I only needed it for IOS so it is IOS only for now. 
I can confirm that it works in my project, providing most of the functionality that Firebase provides (including unenrolling and user second factor status reporting).

This is my first experience working with native modules so obviously this implementation is not perfect and I have many doubts on different decisions I had to make. Hence it is only a draft of PR.

Here goes my list of questions if you don't mind:

- **(/auth/ios/RNFBAuth/RNFBAuthModule.m) Why do you store verificationId in users defaults and not just send it back from JS? Should I store some similar things in defaults?**
- **(/auth/ios/RNFBAuth/RNFBAuthModule.m) Am I doing the right thing with the way I store multiple pointers to MFAResolver in the global dictionary mfaResolvers? Perhaps just use global var? See _signInWithMultiFactorInfo_. Should I store opaque session the same way to achieve complete accordance with firebase-js-sdk?** 
- (/auth/ios/RNFBAuth/RNFBAuthModule.m) There is some kind of a bug when I read mfa factors in FIRUser enrolled factors: each of them suppose to have some value in factorID by which I should know to cast into phone auth factor and fetch the phone number. This doesn’t work and factorID is nil. It works however when factors are coming from MFA resolver (during sign in)
- (/auth/ios/RNFBAuth/RNFBAuthModule.m) Multifactor-not-found error gets stuck somewhere after successful unenroll attempt and then it throws on the next enroll attempt unless the app is restarted. I didn’t really work with this, perhaps it is just another Firebase SDK bug, but most likely it is my implementation. Perhaps you know something that could explain this behaviour? 
- ~~(/auth/package.json) How should I deal with package versioning? Not touch it? Update all? I decided to bump up the versions of the packages that I updated, but since I had to update the App package (it has the main FirebaseError structure in it) all other packages started complaining about them being outdated.~~
- (/auth/lib/User.js) I feel like multiFactor property inside the user that I put as a getter function looks foreign in your code, perhaps you could advise on how to do it better?
- Should the SMS handling part be designed with another kind of PhoneAuthListeners similar to different ConfirmationResults that I added (/auth/lib/ConfirmationResultMFAEnroll.js)? Currently I’m using a promise-based approach, but I suppose it wouldn’t work on Android?
- ~~Typescript typings are not done yet. That's not a problem to do for me later.~~
- ~~Tests are not written yet. Perhaps you could advise what kind of testing would be crucial here? I mean should I concentrate on e2e with simulator or just some simple unit tests first?~~
- ~~Can I modify .eslint?~~

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #4166

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
 🔥