### PR TITLE
feat(app): bump SDKs: firebase-android-sdk 28.1.0 / firebase-ios-sdk 8.1.1

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -7,6 +7,7 @@ analytics
 APIs
 APIs.
 APNs
+AirPods
 async
 ATT
 ATT-compatible
@@ -26,6 +27,7 @@ Barcode
 barcode
 barcodes
 BUGFIX
+CarPlay
 Changelog
 CLI
 CocoaPods
@@ -128,6 +130,7 @@ serverless
 SHA1
 SHA-256
 SIGABRT
+Siri
 SMS
 src
 stacktrace
@@ -135,6 +138,7 @@ SVG
 TestLab
 TFUA
 thenable
+ThreadPoolExecutor
 timezones
 triaging
 TypeDoc

--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -38,7 +38,7 @@ buildscript {
   // ..
   dependencies {
     // ..
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.6.1'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.0'
   }
   // ..
 }

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -1,8 +1,8 @@
 ---
 title: Release notes
 description: View the latest release notes for React Native Firebase
-next: /typescript
-previous: /migrating-to-v6
+next: /migrating-to-v6
+previous: /typescript
 ---
 
 Starting from version `10.0.0`, React Native Firebase packages share a single common version, with aggregated release notes available:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,14 +62,14 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "8.0.0"
+      "firebase": "8.1.1"
     },
     "android": {
       "minSdk": 16,
       "targetSdk": 30,
       "compileSdk": 30,
       "buildTools": "30.0.2",
-      "firebase": "28.0.1",
+      "firebase": "28.1.0",
       "playServicesAuth": "19.0.0"
     }
   }

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -35,7 +35,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:4.2.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.4.0'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.6.1'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.0'
   }
 }
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -9,68 +9,50 @@ PODS:
     - React-Core (= 0.64.1)
     - React-jsi (= 0.64.1)
     - ReactCommon/turbomodule/core (= 0.64.1)
-  - Firebase/Analytics (8.0.0):
+  - Firebase/Analytics (8.1.1):
     - Firebase/Core
-  - Firebase/Auth (8.0.0):
+  - Firebase/Auth (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.0.0)
-  - Firebase/Core (8.0.0):
+    - FirebaseAuth (~> 8.1.0)
+  - Firebase/Core (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.0.0)
-  - Firebase/CoreOnly (8.0.0):
-    - FirebaseCore (= 8.0.0)
-  - Firebase/Crashlytics (8.0.0):
+    - FirebaseAnalytics (~> 8.1.0)
+  - Firebase/CoreOnly (8.1.1):
+    - FirebaseCore (= 8.1.0)
+  - Firebase/Crashlytics (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.0.0)
-  - Firebase/Database (8.0.0):
+    - FirebaseCrashlytics (~> 8.1.0)
+  - Firebase/Database (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 8.0.0)
-  - Firebase/DynamicLinks (8.0.0):
+    - FirebaseDatabase (~> 8.1.0)
+  - Firebase/DynamicLinks (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 8.0.0)
-  - Firebase/Firestore (8.0.0):
+    - FirebaseDynamicLinks (~> 8.1.0)
+  - Firebase/Firestore (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 8.0.0)
-  - Firebase/Functions (8.0.0):
+    - FirebaseFirestore (~> 8.1.0)
+  - Firebase/Functions (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 8.0.0)
-  - Firebase/InAppMessaging (8.0.0):
+    - FirebaseFunctions (~> 8.1.0)
+  - Firebase/InAppMessaging (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 8.0.0-beta)
-  - Firebase/Messaging (8.0.0):
+    - FirebaseInAppMessaging (~> 8.1.0-beta)
+  - Firebase/Messaging (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.0.0)
-  - Firebase/Performance (8.0.0):
+    - FirebaseMessaging (~> 8.1.0)
+  - Firebase/Performance (8.1.1):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 8.0.0)
-  - Firebase/RemoteConfig (8.0.0):
+    - FirebasePerformance (~> 8.1.0)
+  - Firebase/RemoteConfig (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.0.0)
-  - Firebase/Storage (8.0.0):
+    - FirebaseRemoteConfig (~> 8.1.0)
+  - Firebase/Storage (8.1.1):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 8.0.0)
-  - FirebaseABTesting (8.0.0):
+    - FirebaseStorage (~> 8.1.0)
+  - FirebaseABTesting (8.1.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseAnalytics (8.0.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.0.0)
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.0.0):
-    - FirebaseAnalytics/Base (= 8.0.0)
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.0.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/Base (8.0.0):
+  - FirebaseAnalytics (8.1.1):
+    - FirebaseAnalytics/AdIdSupport (= 8.1.1)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
@@ -78,60 +60,78 @@ PODS:
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAuth (8.0.0):
+  - FirebaseAnalytics/AdIdSupport (8.1.1):
+    - FirebaseAnalytics/Base (= 8.1.1)
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleAppMeasurement (= 8.1.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
+    - GoogleUtilities/MethodSwizzler (~> 7.4)
+    - GoogleUtilities/Network (~> 7.4)
+    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAnalytics/Base (8.1.1):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
+    - GoogleUtilities/MethodSwizzler (~> 7.4)
+    - GoogleUtilities/Network (~> 7.4)
+    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAuth (8.1.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/Environment (~> 7.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.0.0):
+  - FirebaseCore (8.1.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
-  - FirebaseCoreDiagnostics (8.0.0):
+  - FirebaseCoreDiagnostics (8.1.0):
     - GoogleDataTransport (~> 9.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.0.0):
+  - FirebaseCrashlytics (8.1.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.0)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (~> 1.2)
-  - FirebaseDatabase (8.0.0):
+  - FirebaseDatabase (8.1.0):
     - FirebaseCore (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (8.0.0):
+  - FirebaseDynamicLinks (8.1.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseFirestore (8.0.0):
-    - FirebaseFirestore/AutodetectLeveldb (= 8.0.0)
-  - FirebaseFirestore/AutodetectLeveldb (8.0.0):
+  - FirebaseFirestore (8.1.0):
+    - FirebaseFirestore/AutodetectLeveldb (= 8.1.0)
+  - FirebaseFirestore/AutodetectLeveldb (8.1.0):
     - FirebaseFirestore/Base
-  - FirebaseFirestore/Base (8.0.0)
-  - FirebaseFirestore/WithoutLeveldb (8.0.0):
+  - FirebaseFirestore/Base (8.1.0)
+  - FirebaseFirestore/WithoutLeveldb (8.1.0):
     - FirebaseFirestore/Base
-  - FirebaseFunctions (8.0.0):
+  - FirebaseFunctions (8.1.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseInAppMessaging (8.0.0-beta):
+  - FirebaseInAppMessaging (8.1.0-beta):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.0.0):
+  - FirebaseInstallations (8.1.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/UserDefaults (~> 7.4)
     - PromisesObjC (~> 1.2)
-  - FirebaseMessaging (8.0.0):
+  - FirebaseMessaging (8.1.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Reachability (~> 7.4)
     - GoogleUtilities/UserDefaults (~> 7.4)
-  - FirebasePerformance (8.0.0):
+  - FirebasePerformance (8.1.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - FirebaseRemoteConfig (~> 8.0)
@@ -140,30 +140,30 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - Protobuf (~> 3.15)
-  - FirebaseRemoteConfig (8.0.0):
+  - FirebaseRemoteConfig (8.1.0):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
-  - FirebaseStorage (8.0.0):
+  - FirebaseStorage (8.1.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
   - glog (0.3.5)
-  - GoogleAppMeasurement (8.0.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.0.0)
+  - GoogleAppMeasurement (8.1.1):
+    - GoogleAppMeasurement/AdIdSupport (= 8.1.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.0.0):
+  - GoogleAppMeasurement/AdIdSupport (8.1.1):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - GoogleDataTransport (9.0.0):
+  - GoogleDataTransport (9.0.1):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (~> 1.2)
@@ -455,59 +455,59 @@ PODS:
     - React-cxxreact (= 0.64.1)
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
-  - RNFBAnalytics (11.5.0):
-    - Firebase/Analytics (= 8.0.0)
+  - RNFBAnalytics (12.0.0):
+    - Firebase/Analytics (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBApp (11.5.0):
-    - Firebase/CoreOnly (= 8.0.0)
+  - RNFBApp (12.0.0):
+    - Firebase/CoreOnly (= 8.1.1)
     - React-Core
-  - RNFBAuth (11.5.0):
-    - Firebase/Auth (= 8.0.0)
-    - React-Core
-    - RNFBApp
-  - RNFBCrashlytics (11.5.0):
-    - Firebase/Crashlytics (= 8.0.0)
+  - RNFBAuth (12.0.0):
+    - Firebase/Auth (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (11.5.0):
-    - Firebase/Database (= 8.0.0)
+  - RNFBCrashlytics (12.0.0):
+    - Firebase/Crashlytics (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (11.5.0):
-    - Firebase/DynamicLinks (= 8.0.0)
+  - RNFBDatabase (12.0.0):
+    - Firebase/Database (= 8.1.1)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (12.0.0):
+    - Firebase/DynamicLinks (= 8.1.1)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (11.5.0):
-    - Firebase/Firestore (= 8.0.0)
+  - RNFBFirestore (12.0.0):
+    - Firebase/Firestore (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (11.5.0):
-    - Firebase/Functions (= 8.0.0)
+  - RNFBFunctions (12.0.0):
+    - Firebase/Functions (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (11.5.0):
-    - Firebase/InAppMessaging (= 8.0.0)
+  - RNFBInAppMessaging (12.0.0):
+    - Firebase/InAppMessaging (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (11.5.0):
-    - Firebase/Messaging (= 8.0.0)
+  - RNFBMessaging (12.0.0):
+    - Firebase/Messaging (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBML (11.5.0):
+  - RNFBML (12.0.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (11.5.0):
-    - Firebase/Performance (= 8.0.0)
+  - RNFBPerf (12.0.0):
+    - Firebase/Performance (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (11.5.0):
-    - Firebase/RemoteConfig (= 8.0.0)
+  - RNFBRemoteConfig (12.0.0):
+    - Firebase/RemoteConfig (= 8.1.1)
     - React-Core
     - RNFBApp
-  - RNFBStorage (11.5.0):
-    - Firebase/Storage (= 8.0.0)
+  - RNFBStorage (12.0.0):
+    - Firebase/Storage (= 8.1.1)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -516,7 +516,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - FirebaseFirestore/WithoutLeveldb (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `8.0.0`)
+  - FirebaseFirestore/WithoutLeveldb (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `8.1.1`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Jet (from `../node_modules/jet/ios`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -597,7 +597,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 8.0.0
+    :tag: 8.1.1
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Jet:
@@ -682,33 +682,33 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 8.0.0
+    :tag: 8.1.1
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
   FBReactNativeSpec: 61ae6bc80c7c2b86b5491427cc0eab2af9b84135
-  Firebase: 73c3e3b216ec1ecbc54d2ffdd4670c65c749edb1
-  FirebaseABTesting: daebc95ec8829607d07dfe5e92dc3285aca29bc4
-  FirebaseAnalytics: dcb92c7c9ef4fa7ffac276e8f87bd4fc8c97f1b8
-  FirebaseAuth: b8cd992fca5b53dc6eec09e873a3f375f000c5a1
-  FirebaseCore: 3f09591d51292843e2a46f18358d60bf4e996255
-  FirebaseCoreDiagnostics: a31d987ba0fe16d59886a5dbadc2f1de871f88c8
-  FirebaseCrashlytics: 69cddb6bfa7656c5346e603bc85b029392252ee6
-  FirebaseDatabase: 363961e25451425be8b14bb8801a592515ec58f2
-  FirebaseDynamicLinks: 42858c22626d9c519b28e0421b2ea6bcc5a241ff
-  FirebaseFirestore: 25c5a5b1437dda2ae612d0601b965b19cfccd3a7
-  FirebaseFunctions: 57fedef9b8808b83be40e176bcb28aa2aa78cf92
-  FirebaseInAppMessaging: c5cdb9753a4c592a6d6f8ae3941cb0c0c304aca9
-  FirebaseInstallations: c4aab1005d6547b00a7529777fe52f5d4d45165b
-  FirebaseMessaging: 1a33b4af3c8042ed6ddacb6c031894af2064bfab
-  FirebasePerformance: d89e4529f8ab0837cfe3697506262fb2759ca69e
-  FirebaseRemoteConfig: 055f6b5ba1751547596ded5032c4d5c6054ca501
-  FirebaseStorage: 61bcd27880fa17362f68be67d3683d04bfd7b1c7
+  Firebase: 4bb49ae87756034cef870fa3c4006235eb46f475
+  FirebaseABTesting: 5b22abfa9a55d5b9cd3d1e500a3ca29f6b1264cb
+  FirebaseAnalytics: d6dd061b26a04744cb988c66e29697181152b2a3
+  FirebaseAuth: e069ff5736fe9d5dcf61f36244bb1b1ce1897d17
+  FirebaseCore: 389c4ce9a7cce4a7e25eb22326b4bee0050557b2
+  FirebaseCoreDiagnostics: 3e249cee3de5c5f9cfd6cc2a19997231286fec11
+  FirebaseCrashlytics: 1b55b3a718f9e20d59d96db46a4652d95a8ba1d2
+  FirebaseDatabase: cc219dac8f37fe80f5838ed5ffd84ce3daa443ad
+  FirebaseDynamicLinks: 12c4a8cc556a7624340dac01826559340a9c3129
+  FirebaseFirestore: c34d4532446ff6f0893b9733a6cb035d06461d34
+  FirebaseFunctions: 2cdcb06c0edbceac807eaf52014b8676c8a66d13
+  FirebaseInAppMessaging: 9b75ed74a912aef488184e4b36fa1fc0296e07fa
+  FirebaseInstallations: 7f31798a8198c354eadcb87176d2090b62edc187
+  FirebaseMessaging: c8871b0907dcf4e76de81241eb6a62be6d657d2f
+  FirebasePerformance: f4c53dfbac3dc51cbbb2afb951ebc7d4490f4bc0
+  FirebaseRemoteConfig: eef8513f6d368ba5c6ed6d1cb267b4d949cf65bf
+  FirebaseStorage: 5b5958efaf84fb991568ad36f157f60c76bdcd80
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  GoogleAppMeasurement: c6bbc9753d046b5456dd4f940057fbad2c28419e
-  GoogleDataTransport: 11e3a5f2c190327df1a4a5d7e7ae3d4d5b9c9e4c
+  GoogleAppMeasurement: 31c7d7655818784b7dd34bdf6884f75b465d5f6c
+  GoogleDataTransport: 04c3e9a480bbcaa2ec3f5d27f1cdeb6a92f20c8d
   GoogleUtilities: f8a43108b38a68eebe8b3540e1f4f2d28843ce20
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52
   Jet: 84fd0e2e9d49457fc04bc79b5d8857737a01c507
@@ -739,20 +739,20 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
-  RNFBAnalytics: 63b358420c0b17d2a8d932aa868fa279b2e70bd7
-  RNFBApp: c9c0354a5300e7a01db0092a8cdb510271cb9984
-  RNFBAuth: 106b52a2c04be7ea1b0cb88ab31ad414c2507181
-  RNFBCrashlytics: 7eefa7ea2999900fbeded703bcbb8fc5344496b0
-  RNFBDatabase: f239154777ab0e1248604e1bbfe90419abfc8fe8
-  RNFBDynamicLinks: 1087749ca62cd7820c1fa49369f185e570622eba
-  RNFBFirestore: 33aea87a41c83edb7d451eb542f20ba9da1d100e
-  RNFBFunctions: aeb3f0deb0ea5b56eacbf6a3d246224bf96ec206
-  RNFBInAppMessaging: cb0d2d3e60d95fbbbb7f2e063cc7e1a8e3dfa7e0
-  RNFBMessaging: 1f113dea1ac339fdad0aa885e11a728d2ac13c4a
-  RNFBML: 7367665372f94f24be3063cee9d57a794b225048
-  RNFBPerf: 60d28d6d7b96615fd03b2d0190c10216ec80e1b9
-  RNFBRemoteConfig: 8f5298c47caadfa5c0ba20cd3ff3ae0d54ccf6eb
-  RNFBStorage: 02768f467521c4db60dede17cf31852e9522d9d2
+  RNFBAnalytics: 6a4b3866e4ebd373a8027150b6ade95beff0d135
+  RNFBApp: 9c25c0489c4aa12942f5400c71ff88d543eb121b
+  RNFBAuth: 92e2efa4410bb6295824b0f8317e62129d8fbfca
+  RNFBCrashlytics: cfe97e53d2d8a6a5fbefec0467cea785e66395b2
+  RNFBDatabase: acae231cca6d6cba57796573a9e01b5972faa486
+  RNFBDynamicLinks: c9d189dc908ad5178b6289cbe803f323d657bd1e
+  RNFBFirestore: 9dd9a189b341ab87ec1f5ca3aeccaaf2a58c0b19
+  RNFBFunctions: da6880040e656b804ef0bddac98d748111ce3ea7
+  RNFBInAppMessaging: 029a6a9b0ea790d41acb7b3ec5859ec05ffd191b
+  RNFBMessaging: 9960922f5a64192bd540be23bb1a7384b8ec0d33
+  RNFBML: e61a47c621eb294f95f016b3bfcec8d47a1f2b2b
+  RNFBPerf: b793eb358310cd9bbf41511229af0ff8f9610ed3
+  RNFBRemoteConfig: 634169913eb4a9bc0fdb84a46059aef638ff0c63
+  RNFBStorage: 55cd84ccf8f00545ce3ad60d8a3f533cbb28fcaf
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
 
 PODFILE CHECKSUM: cd2f69084949aea10ca551be89eb96c34004b9ee


### PR DESCRIPTION
### Description

- fix up a spelling dictionary lint thing
- bump SDK versions, especially for firebase-ios-sdk 8.1.1 to avoid app store rejections

### Related issues

https://github.com/firebase/firebase-ios-sdk/issues/8222

### Release Summary

conventional commits, should result in v12.1.0 here

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Passed e2e testing on local device, should pass CI as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
