### PR TITLE
style(lint): ignore typescript compilation artifacts, fix lint in storage e2e test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ docs
 packages/template/project/**
 app.playground.js
 type-test.ts
+packages/**/modular/dist/**

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,20 +42,6 @@ jobs:
           command: yarn --no-audit --prefer-offline
       - name: Lint
         run: yarn lint
-      - name: Save Code Linting Report JSON
-        run: yarn lint:report
-        continue-on-error: true
-      - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@1.1.2
-        continue-on-error: true
-        with:
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          report-json: 'eslint-report.json'
-      - name: Upload ESLint report
-        uses: actions/upload-artifact@v2
-        with:
-          name: eslint-report.json
-          path: eslint-report.json
 
   typescript:
     name: TypeScript Build Validation

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "prepare": "yarn run lerna:link && lerna run prepare --parallel",
     "build:all:clean": "lerna run build:clean",
     "build:all:build": "lerna run build",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "lint:markdown": "prettier --check \"docs/**/*.md\"",
     "lint:report": "eslint --output-file=eslint-report.json --format=json . --ext .js,.jsx,.ts,.tsx",
     "lint:spellcheck": "spellchecker --quiet --files=\"docs/**/*.md\" --dictionaries=\"./.spellcheck.dict.txt\" --reports=\"spelling.json\" --plugins spell indefinite-article repeated-words syntax-mentions syntax-urls frontmatter",

--- a/packages/storage/e2e/StorageTask.e2e.js
+++ b/packages/storage/e2e/StorageTask.e2e.js
@@ -15,7 +15,7 @@
  *
  */
 
-const { PATH, seed, WRITE_ONLY_NAME } = require('./helpers');
+const { PATH, WRITE_ONLY_NAME } = require('./helpers');
 
 function snapshotProperties(snapshot) {
   snapshot.should.have.property('state');


### PR DESCRIPTION
### Description

Two small lint fixes, this allows lint test to pass - without these it failed

### Related issues

none logged

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
