### PR TITLE
docs(auth, facebook): update fbsdk link to fbsdk-next repo

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -81,7 +81,7 @@ with the new authentication state of the user.
 
 ## Facebook
 
-Facebook provide an [official React Native library](https://www.npmjs.com/package/react-native-fbsdk-next) which wraps around
+There is a [community-supported React Native library](https://github.com/thebergamo/react-native-fbsdk-next) which wraps around
 the native Facebook SDKs to enable Facebook sign-in.
 
 Before getting started, ensure you have installed the library, [configured your Android & iOS applications](https://developers.facebook.com/docs/android/getting-started/) and

--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -81,7 +81,7 @@ with the new authentication state of the user.
 
 ## Facebook
 
-Facebook provide an [official React Native library](https://github.com/facebook/react-native-fbsdk) which wraps around
+Facebook provide an [official React Native library](https://www.npmjs.com/package/react-native-fbsdk-next) which wraps around
 the native Facebook SDKs to enable Facebook sign-in.
 
 Before getting started, ensure you have installed the library, [configured your Android & iOS applications](https://developers.facebook.com/docs/android/getting-started/) and


### PR DESCRIPTION
### Description

Facebook is recommending this new (-next) library and on your page the old one is linked:
New library: https://www.npmjs.com/package/react-native-fbsdk-next

See here the official Facebook note 'https://github.com/facebookarchive/react-native-fbsdk'
