### PR TITLE
fix(storage, ios): do not enumerate on dictionary being mutated

### DIFF
--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -61,13 +61,13 @@ RCT_EXPORT_MODULE();
 }
 
 - (void)dealloc {
-  for (NSString *key in PENDING_TASKS) {
+  for (NSString *key in [PENDING_TASKS allKeys]) {
     [PENDING_TASKS removeObjectForKey:key];
   }
 }
 
 - (void)invalidate {
-  for (NSString *key in PENDING_TASKS) {
+  for (NSString *key in [PENDING_TASKS allKeys]) {
     [PENDING_TASKS removeObjectForKey:key];
   }
 }


### PR DESCRIPTION
### Description

Noticed crashes originating from RNFBStorage regarding `Collection <__NSDictionaryM: XXXXXXX> was mutated while being enumerated.`.  This appears to be addressed in some of the other packages already.

### Related issues

https://github.com/invertase/react-native-firebase/issues/3736


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- This is a breaking change;
  - [ ] Yes
  - [x] No
