### PR TITLE
feat: Include actionIdentifier on the notification data sent to RN when on iOS (closes #4883)

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -98,6 +98,7 @@ struct {
     // if there is an actionIdentifier on this notification, also add that in.
     [mergedDict setObject:response.actionIdentifier forKey:@"actionIdentifier"];
 
+    // send payload to JS space
     [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened" body:mergedDict];
     _initialNotification = notificationDict;
   }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -88,7 +88,17 @@ struct {
   NSDictionary *remoteNotification = response.notification.request.content.userInfo;
   if (remoteNotification[@"gcm.message_id"]) {
     NSDictionary *notificationDict = [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
-    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened" body:notificationDict];
+
+    // create a merged dictionary that will hold the serialized userInfo data, as well as any actionIdentifier
+    NSMutableDictionary * mergedDict = [NSMutableDictionary dictionary];
+
+    // copy the values of notificationDict into mergedDict
+    [mergedDict addEntriesFromDictionary:notificationDict];
+
+    // if there is an actionIdentifier on this notification, also add that in.
+    [mergedDict setObject:response.actionIdentifier forKey:@"actionIdentifier"];
+
+    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened" body:mergedDict];
     _initialNotification = notificationDict;
   }
 


### PR DESCRIPTION
## Description

Hi there, as discussed in #4883 , for situations where the developer has decided to add Quick Actions directly onto a remote notification there is no way to determine if a notification was tapped/swiped or an action button was pressed in React Native Firebase.

Motivations for doing this range from code simplicity to inconsistent handling of background pushes due to iOS performance management using the silent remote / rich local pattern.

The information is readily available on the native side and can be passed to RN by adding a single property to the NSDictionary.

This would not be a breaking change.

When a quick action is pressed, it triggers the `FirebaseMessaging().onNotificationOpenedApp` handler.

An example of how this could be handled by a user:

```
// open handler
notification => {
    switch(notification.actionIdentifier) {
        case 'YES':
        case 'NO':
            // a quick action was pressed
        default:
            // unrecognised action, or the notification was opened in the normal way - fall back to normal behaviour
    }
}
```
### Related issues

#4883 - originally proposed by @TNicholson11 and @mikehardy 

### Release Summary

If you choose to register quick actions for specific notification categories on iOS, you will now be able to detect when these are pressed with the `.actionIdentifier` key in your `FirebaseMessaging().onNotificationOpenedApp` handler.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

![IMG_4131](https://user-images.githubusercontent.com/2470659/124279350-4dd29100-db3f-11eb-85a1-5daf265169fb.PNG)
![IMG_4128](https://user-images.githubusercontent.com/2470659/124279379-5925bc80-db3f-11eb-8e6f-df33e7537631.PNG)
![IMG_4129](https://user-images.githubusercontent.com/2470659/124279384-5c20ad00-db3f-11eb-8b34-82dc6a4b39b1.PNG)
![IMG_4130](https://user-images.githubusercontent.com/2470659/124279386-5dea7080-db3f-11eb-89b0-840cc7da1c04.PNG)

![IMG_4132](https://user-images.githubusercontent.com/2470659/124279408-62168e00-db3f-11eb-857d-26064a30a6ac.PNG)
![IMG_4133](https://user-images.githubusercontent.com/2470659/124279415-6478e800-db3f-11eb-9443-4434034f3672.PNG)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
