### PR TITLE
docs(crashlytics, android): show configuration for native libs

### DIFF
--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -70,10 +70,11 @@ android {
         release {
             /* Add the firebaseCrashlytics extension (by default,
             * it's disabled to improve build speeds) and set
-            * nativeSymbolUploadEnabled to true. */
+            * nativeSymbolUploadEnabled to true along with a pointer to native libs. */
 
             firebaseCrashlytics {
                 nativeSymbolUploadEnabled true
+                unstrippedNativeLibsDir 'build/intermediates/merged_native_libs/release/out/lib'
             }
             // ...
         }

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -83,6 +83,10 @@ android {
       proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
       proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
       signingConfig signingConfigs.release
+      firebaseCrashlytics {
+        nativeSymbolUploadEnabled true
+          unstrippedNativeLibsDir 'build/intermediates/merged_native_libs/release/out/lib'
+      }
     }
   }
 


### PR DESCRIPTION
### Description

Historically it has been difficult to configure crashlytics to upload symbols for native libraries but there's a style now confirmed from the community to work

### Related issues

Fixes #4253 

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

`cd tests/android && ./gradlew assembleRelease` and it worked

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
