### PR TITLE
fix(messaging): Refactor code to avoid bugs

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -176,9 +176,6 @@
           notificationIOS[@"subtitleLocArgs"] = apsAlertDict[@"subtitle-loc-args"];
         }
       }
-
-      notification[@"ios"] = notificationIOS;
-      message[@"notification"] = notification;
     }
 
     // message.notification.ios.sound
@@ -208,10 +205,13 @@
         // message.notification.ios.sound
         notificationIOS[@"sound"] = notificationIOSSound;
       }
-
-      notification[@"ios"] = notificationIOS;
-      message[@"notification"] = notification;
     }
+  }
+  if ([notificationIOS count] > 0) {
+    notification[@"ios"] = notificationIOS;
+  }
+  if ([notification count] > 0) {
+    message[@"notification"] = notification;
   }
 
   return message;


### PR DESCRIPTION

### Description

When NotificationIOS only contains badge, it's not serialized... So I fixed it

### Release Summary

Fixed an issue with iOS notification serializing, fixing some missing keys in some edge cases

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
