### PR TITLE
docs(messaging): Document the 8 second delay introduced by the earlier mitigation to Issue 4144

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -111,6 +111,11 @@ The device state and message contents determines which handler will be called:
   as low priority and will ignore it (i.e. no event will be sent). You can however increase the priority by setting the `priority` to `high` (Android) and
   `content-available` to `true` (iOS) properties on the payload.
 
+- On iOS in cases where the message is data-only and the device is in the background or quit, the message will be delayed 8 seconds
+  from the time it arrives on the device until the background message handler registered with setBackgroundMessageHandler is invoked
+  to allow for the applications javascript to be loaded and ready to run [Issue 4144]
+  (https://github.com/invertase/react-native-firebase/pull/4144).
+
 To learn more about how to send these options in your message payload, view the Firebase documentation for your [FCM API implementation](https://firebase.google.com/docs/cloud-messaging/concept-options).
 
 ### Notifications


### PR DESCRIPTION
### Description

This change documents the 8 second delay in the delivery of background notifications so developers are aware of the minimum time it will take for a notification do make it to the application in a background state and not have to wonder why it's taking so long.
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

4144

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X ] No



### Test Plan

Documentation change

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
