### PR TITLE
docs: Updated Expo installation steps

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -64,6 +64,7 @@ HTTP
 HTTPS
 IDFA
 installable
+IntelliSense
 Interstitials
 interstitials
 Invertase

--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -5,7 +5,7 @@ description: Additional Android steps for Crashlytics integration
 
 > If you're migrating from Fabric, make sure you remove the `fabric.properties` file from your Android project. If you do not do this you will not receive crash reports on the Firebase console.
 
-> If you're using Expo, add the `@react-native-firebase/crashlytics` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Expo](/#expo) section.
+> If you're using Expo, make sure to add the `@react-native-firebase/crashlytics` config plugin to your `app.json` or `app.config.js`. It handles the below installation steps for you. For instructions on how to do that, view the [Expo](/#expo) installation section.
 
 # Adding Firebase Crashlytics Gradle Tools
 

--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -5,7 +5,7 @@ description: Additional Android steps for Crashlytics integration
 
 > If you're migrating from Fabric, make sure you remove the `fabric.properties` file from your Android project. If you do not do this you will not receive crash reports on the Firebase console.
 
-> If you're using Expo, add the `@react-native-firebase/crashlytics` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Getting Started](/#expo) documentation.
+> If you're using Expo, add the `@react-native-firebase/crashlytics` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Expo](/#expo) section.
 
 # Adding Firebase Crashlytics Gradle Tools
 

--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -5,6 +5,8 @@ description: Additional Android steps for Crashlytics integration
 
 > If you're migrating from Fabric, make sure you remove the `fabric.properties` file from your Android project. If you do not do this you will not receive crash reports on the Firebase console.
 
+> If you're using Expo, add the `@react-native-firebase/crashlytics` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Getting Started](/#expo) documentation.
+
 # Adding Firebase Crashlytics Gradle Tools
 
 These steps are required, if you do not add these your app will most likely crash at startup with the following Error:

--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -26,6 +26,8 @@ Once installed, you must complete the following additional setup steps for Andro
 
 - [Android Additional Setup](/crashlytics/android-setup).
 
+If you're using Expo, you should add the [config plugin](https://docs.expo.io/guides/config-plugins/) instead to your app config. It handles the installation steps for you. For more details, view the [Getting Started](/#expo) documentation.
+
 If you're using an older version of React Native without autolinking support, or wish to integrate into an existing project,
 you can follow the manual installation steps for [iOS](/crashlytics/usage/installation/ios) and [Android](/crashlytics/usage/installation/android).
 

--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -26,7 +26,7 @@ Once installed, you must complete the following additional setup steps for Andro
 
 - [Android Additional Setup](/crashlytics/android-setup).
 
-If you're using Expo, you should add the [config plugin](https://docs.expo.io/guides/config-plugins/) instead to your app config. It handles the installation steps for you. For more details, view the [Getting Started](/#expo) documentation.
+If you're using Expo, add the `@react-native-firebase/crashlytics` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Expo](/#expo) section.
 
 If you're using an older version of React Native without autolinking support, or wish to integrate into an existing project,
 you can follow the manual installation steps for [iOS](/crashlytics/usage/installation/ios) and [Android](/crashlytics/usage/installation/android).

--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -26,7 +26,7 @@ Once installed, you must complete the following additional setup steps for Andro
 
 - [Android Additional Setup](/crashlytics/android-setup).
 
-If you're using Expo, add the `@react-native-firebase/crashlytics` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Expo](/#expo) section.
+> If you're using Expo, make sure to add the `@react-native-firebase/crashlytics` config plugin to your `app.json` or `app.config.js`. It handles the Android installation steps for you. For instructions on how to do that, view the [Expo](/#expo) installation section.
 
 If you're using an older version of React Native without autolinking support, or wish to integrate into an existing project,
 you can follow the manual installation steps for [iOS](/crashlytics/usage/installation/ios) and [Android](/crashlytics/usage/installation/android).

--- a/docs/index.md
+++ b/docs/index.md
@@ -257,17 +257,19 @@ $RNFirebaseAsStaticFramework = true
 
 ### Expo
 
-Integration with Expo is possible in bare workflow and [custom managed workflow](https://docs.expo.io/workflow/customizing/) via [config plugins](https://docs.expo.io/guides/config-plugins/).
+Integration with Expo is possible in both bare workflow and [custom managed workflow](https://docs.expo.io/workflow/customizing/) via [config plugins](https://docs.expo.io/guides/config-plugins/).
 
 React Native Firebase cannot be used in the "Expo Go" app, because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
 
 #### Installation
 
+_If you're using [Bare Workflow](https://docs.expo.io/introduction/managed-vs-bare/#bare-workflow), please follow the above installation steps instead._
+
 After installing the `@react-native-firebase/app` NPM package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`.
 
 Also, you have to provide paths to the `google-services.json` and `GoogleService-Info.plist` files by specifying the [`expo.android.googleServicesFile`](https://docs.expo.io/versions/latest/config/app/#googleservicesfile-1) and [`expo.ios.googleServicesFile`](https://docs.expo.io/versions/latest/config/app/#googleservicesfile) fields respectively.
 
-The `app.json` should contain the following:
+The `app.json` for integration that included the optional crashlytics and performance as well as the mandatory app plugin would look like this, customize based on which optional modules you use:
 
 ```json
 {
@@ -278,13 +280,19 @@ The `app.json` should contain the following:
     "ios": {
       "googleServicesFile": "./GoogleService-Info.plist"
     },
-    "plugins": ["@react-native-firebase/app"]
+    "plugins": [
+      "@react-native-firebase/app"
+      "@react-native-firebase/perf"
+      "@react-native-firebase/crashlytics"
+    ]
   }
 }
 ```
 
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
-Analogous steps are required for other React Native Firebase packages, which require custom native installation steps. Packages without native steps required will work out of the box.
+Config plugins are only required for React Native Firebase modules, which require custom native installation steps - e.g. modifying the Xcode project, `Podfile`, `build.gradle`, `AndroidManifest.xml` etc. Packages without native steps required will work out of the box.
 
-> Not all React Native Firebase packages have Expo config plugins provided yet. Currently supported packages are `app`, `perf` and `crashlytics`.
+> Not all React Native Firebase packages have Expo config plugins provided yet. You may see if a module is supported by checking if it contains the `app.plugin.js` file in its package directory.
+>
+> If you're using the [Expo Tools](https://marketplace.visualstudio.com/items?itemName=byCedric.vscode-expo) VSCode extension, the IntelliSense will display a list of available plugins, when editing the `plugins` section of `app.json`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -257,4 +257,24 @@ $RNFirebaseAsStaticFramework = true
 
 ### Expo
 
-Expo does not support integration with native modules via its ["Managed workflow"](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/#managed-workflow). Integration is only possible when used with the ["Bare workflow"](https://docs.expo.io/versions/latest/introduction/managed-vs-bare/#bare-workflow).
+> React Native Firebase cannot be used in the "Expo Go" app because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
+
+Integration with Expo is possible in bare workflow and [custom managed workflow](https://docs.expo.io/workflow/customizing/) via [config plugins](https://docs.expo.io/guides/config-plugins/).
+
+#### Installation
+
+After installing the `@react-native-firebase/app` NPM package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    "plugins": ["@react-native-firebase/app"]
+  }
+}
+```
+
+Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
+
+Analogous steps are required for other React Native Firebase modules, which require custom native installation steps. Modules without native steps required will work out of the box.
+
+> Not all React Native Firebase modules have Expo config plugins provided yet. Currently supported modules are `app`, `perf` and `crashlytics`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -257,9 +257,9 @@ $RNFirebaseAsStaticFramework = true
 
 ### Expo
 
-> React Native Firebase cannot be used in the "Expo Go" app because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
-
 Integration with Expo is possible in bare workflow and [custom managed workflow](https://docs.expo.io/workflow/customizing/) via [config plugins](https://docs.expo.io/guides/config-plugins/).
+
+React Native Firebase cannot be used in the "Expo Go" app, because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
 
 #### Installation
 
@@ -275,6 +275,6 @@ After installing the `@react-native-firebase/app` NPM package, add the [config p
 
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
-Analogous steps are required for other React Native Firebase modules, which require custom native installation steps. Modules without native steps required will work out of the box.
+Analogous steps are required for other React Native Firebase packages, which require custom native installation steps. Packages without native steps required will work out of the box.
 
-> Not all React Native Firebase modules have Expo config plugins provided yet. Currently supported modules are `app`, `perf` and `crashlytics`.
+> Not all React Native Firebase packages have Expo config plugins provided yet. Currently supported packages are `app`, `perf` and `crashlytics`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -263,11 +263,21 @@ React Native Firebase cannot be used in the "Expo Go" app, because [it requires 
 
 #### Installation
 
-After installing the `@react-native-firebase/app` NPM package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`:
+After installing the `@react-native-firebase/app` NPM package, add the [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`.
+
+Also, you have to provide paths to the `google-services.json` and `GoogleService-Info.plist` files by specifying the [`expo.android.googleServicesFile`](https://docs.expo.io/versions/latest/config/app/#googleservicesfile-1) and [`expo.ios.googleServicesFile`](https://docs.expo.io/versions/latest/config/app/#googleservicesfile) fields respectively.
+
+The `app.json` should contain the following:
 
 ```json
 {
   "expo": {
+    "android": {
+      "googleServicesFile": "./google-services.json"
+    },
+    "ios": {
+      "googleServicesFile": "./GoogleService-Info.plist"
+    },
     "plugins": ["@react-native-firebase/app"]
   }
 }

--- a/docs/perf/usage/index.md
+++ b/docs/perf/usage/index.md
@@ -27,6 +27,8 @@ you can follow the manual installation steps for [iOS](/perf/usage/installation/
 
 ## Add the Performance Monitoring Plugin
 
+> If you're using Expo, add the `@react-native-firebase/perf` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Getting Started](/#expo) documentation.
+
 On Android, you need to install the Google Performance Monitoring Plugin which enables automatic
 HTTPS network request monitoring.
 

--- a/docs/perf/usage/index.md
+++ b/docs/perf/usage/index.md
@@ -27,7 +27,7 @@ you can follow the manual installation steps for [iOS](/perf/usage/installation/
 
 ## Add the Performance Monitoring Plugin
 
-> If you're using Expo, add the `@react-native-firebase/perf` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Expo](/#expo) section.
+> If you're using Expo, make sure to add the `@react-native-firebase/perf` config plugin to your `app.json` or `app.config.js`. It handles the below installation steps for you. For instructions on how to do that, view the [Expo](/#expo) installation section.
 
 On Android, you need to install the Google Performance Monitoring Plugin which enables automatic
 HTTPS network request monitoring.

--- a/docs/perf/usage/index.md
+++ b/docs/perf/usage/index.md
@@ -27,7 +27,7 @@ you can follow the manual installation steps for [iOS](/perf/usage/installation/
 
 ## Add the Performance Monitoring Plugin
 
-> If you're using Expo, add the `@react-native-firebase/perf` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Getting Started](/#expo) documentation.
+> If you're using Expo, add the `@react-native-firebase/perf` [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. It handles the installation steps for you. For more details, view the [Expo](/#expo) section.
 
 On Android, you need to install the Google Performance Monitoring Plugin which enables automatic
 HTTPS network request monitoring.


### PR DESCRIPTION
### Description

Follow-up of #5480, answer to the https://github.com/invertase/react-native-firebase/pull/5480#issuecomment-885475091

Updated documentation about Expo installation steps. I'm not sure how it should look like to be maximum simple and user-friendly. This is how it currently looks like (click to enlarge):

<img alt="Docs Expo Screen" src="https://user-images.githubusercontent.com/278340/127292762-ae40ac9b-799a-42a5-ae11-f7a9102583f1.png" width="400">


#### Updated sections:
- [Homepage: **Expo** section](https://rnfirebase.io/#expo)
- [Performance Monitoring - Android installation](https://rnfirebase.io/perf/usage#add-the-performance-monitoring-plugin)
- [Crashlytics: Usage - installation section](https://rnfirebase.io/crashlytics/usage#installation)
- [Crashlytics: Android installation page](https://rnfirebase.io/crashlytics/android-setup) - in case someone missed the note in "Usage" page

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


### Test Plan

- `yarn lint:spellcheck`, `yarn lint:markdown`.
- Ran website locally (`yarn develop`).

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
