### PR TITLE
style(spelling): add setBackgroundMessageHandler to dictionary

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -128,6 +128,7 @@ SDK.
 SDKs
 SDKs.
 serverless
+setBackgroundMessageHandler
 SHA1
 SHA-256
 SIGABRT


### PR DESCRIPTION

I merged a PR with a properly-used bit of jargon that was not in the spellcheck dictionary, fixing