### PR TITLE
feat(firestore): serverTimestampBehavior

### DIFF
--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -112,6 +112,18 @@ describe('Storage', function () {
         return expect(e.message).toContain("ignoreUndefinedProperties' must be a boolean value.");
       }
     });
+
+    it("throws if serverTimestampBehavior is not one of 'estimate', 'previous', 'none'", async function () {
+      try {
+        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+        await firestore().settings({ serverTimestampBehavior: 'bogus' });
+        return Promise.reject(new Error('Should throw'));
+      } catch (e) {
+        return expect(e.message).toContain(
+          "serverTimestampBehavior' must be one of 'estimate', 'previous', 'none'",
+        );
+      }
+    });
   });
 
   describe('runTransaction()', function () {

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
@@ -75,6 +75,12 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
           UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + appName, (boolean) settings.get("ssl"));
       }
 
+      // settings.serverTimestampBehavior
+      if (settings.containsKey("serverTimestampBehavior")) {
+        UniversalFirebasePreferences.getSharedInstance().setStringValue(
+          UniversalFirebaseFirestoreStatics.FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR + "_" + appName, (String) settings.get("serverTimestampBehavior"));
+      }
+
       return null;
     });
   }

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreStatics.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreStatics.java
@@ -22,4 +22,5 @@ public class UniversalFirebaseFirestoreStatics {
   public static String FIRESTORE_HOST = "firebase_firestore_host";
   public static String FIRESTORE_PERSISTENCE = "firebase_firestore_persistence";
   public static String FIRESTORE_SSL = "firebase_firestore_ssl";
+  public static String FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR = "firebase_firestore_server_timestamp_behavior";
 }

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -66,6 +66,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
 
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
     ReactNativeFirebaseFirestoreQuery firestoreQuery = new ReactNativeFirebaseFirestoreQuery(
+      appName,
       getQueryForFirestore(firebaseFirestore, path, type),
       filters,
       orders,
@@ -128,6 +129,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   ) {
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
     ReactNativeFirebaseFirestoreQuery query = new ReactNativeFirebaseFirestoreQuery(
+      appName,
       getQueryForFirestore(firebaseFirestore, path, type),
       filters,
       orders,
@@ -160,7 +162,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   }
 
   private void sendOnSnapshotEvent(String appName, int listenerId, QuerySnapshot querySnapshot, MetadataChanges metadataChanges) {
-    Tasks.call(getTransactionalExecutor(Integer.toString(listenerId)), () -> snapshotToWritableMap("onSnapshot", querySnapshot, metadataChanges)).addOnCompleteListener(task -> {
+    Tasks.call(getTransactionalExecutor(Integer.toString(listenerId)), () -> snapshotToWritableMap(appName, "onSnapshot", querySnapshot, metadataChanges)).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         WritableMap body = Arguments.createMap();
         body.putMap("snapshot", task.getResult());

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCommon.java
@@ -19,7 +19,10 @@ package io.invertase.firebase.firestore;
 
 
 import com.facebook.react.bridge.Promise;
+import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestoreException;
+
+import io.invertase.firebase.common.UniversalFirebasePreferences;
 
 import static io.invertase.firebase.common.ReactNativeFirebaseModule.rejectPromiseWithCodeAndMessage;
 import static io.invertase.firebase.common.ReactNativeFirebaseModule.rejectPromiseWithExceptionMap;
@@ -38,5 +41,21 @@ class ReactNativeFirebaseFirestoreCommon {
     } else {
       rejectPromiseWithExceptionMap(promise, exception);
     }
+  }
+
+  static DocumentSnapshot.ServerTimestampBehavior getServerTimestampBehavior(String appName) {
+    UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
+    String key = UniversalFirebaseFirestoreStatics.FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR + "_" + appName;
+    String behavior = preferences.getStringValue(key, "none");
+
+    if ("estimate".equals(behavior)) {
+      return DocumentSnapshot.ServerTimestampBehavior.ESTIMATE;
+    }
+
+    if ("previous".equals(behavior)) {
+      return DocumentSnapshot.ServerTimestampBehavior.PREVIOUS;
+    }
+
+    return DocumentSnapshot.ServerTimestampBehavior.NONE;
   }
 }

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -131,7 +131,7 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
     Tasks.call(getExecutor(), () -> {
       DocumentSnapshot documentSnapshot = Tasks.await(documentReference.get(source));
-      return snapshotToWritableMap(documentSnapshot);
+      return snapshotToWritableMap(appName, documentSnapshot);
     }).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         promise.resolve(task.getResult());
@@ -261,7 +261,7 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   private void sendOnSnapshotEvent(String appName, int listenerId, DocumentSnapshot documentSnapshot) {
-    Tasks.call(getExecutor(), () -> snapshotToWritableMap(documentSnapshot)).addOnCompleteListener(task -> {
+    Tasks.call(getExecutor(), () -> snapshotToWritableMap(appName, documentSnapshot)).addOnCompleteListener(task -> {
       if (task.isSuccessful()) {
         WritableMap body = Arguments.createMap();
         body.putMap("snapshot", task.getResult());

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
@@ -37,14 +37,17 @@ import static io.invertase.firebase.common.RCTConvertFirebase.toArrayList;
 import static io.invertase.firebase.firestore.ReactNativeFirebaseFirestoreSerialize.*;
 
 public class ReactNativeFirebaseFirestoreQuery {
+  String appName;
   Query query;
 
   ReactNativeFirebaseFirestoreQuery(
+    String appName,
     Query query,
     ReadableArray filters,
     ReadableArray orders,
     ReadableMap options
   ) {
+    this.appName = appName;
     this.query = query;
     applyFilters(filters);
     applyOrders(orders);
@@ -54,7 +57,7 @@ public class ReactNativeFirebaseFirestoreQuery {
   public Task<WritableMap> get(Executor executor, Source source) {
     return Tasks.call(executor, () -> {
       QuerySnapshot querySnapshot = Tasks.await(query.get(source));
-      return snapshotToWritableMap("get", querySnapshot, null);
+      return snapshotToWritableMap(this.appName, "get", querySnapshot, null);
     });
   }
 

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
@@ -72,7 +72,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
     Tasks
-      .call(getTransactionalExecutor(), () -> snapshotToWritableMap(transactionHandler.getDocument(documentReference)))
+      .call(getTransactionalExecutor(), () -> snapshotToWritableMap(appName, transactionHandler.getDocument(documentReference)))
       .addOnCompleteListener(task -> {
         if (task.isSuccessful()) {
           promise.resolve(task.getResult());

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -148,7 +148,8 @@ RCT_EXPORT_METHOD(collectionGet:
     if (error) {
       return [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
     } else {
-      NSDictionary *serialized = [RNFBFirestoreSerialize querySnapshotToDictionary:@"get" snapshot:snapshot includeMetadataChanges:false];
+      NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
+      NSDictionary *serialized = [RNFBFirestoreSerialize querySnapshotToDictionary:@"get" snapshot:snapshot includeMetadataChanges:false appName:appName];
       resolve(serialized);
     }
   }];
@@ -158,7 +159,8 @@ RCT_EXPORT_METHOD(collectionGet:
                listenerId:(nonnull NSNumber *)listenerId
                  snapshot:(FIRQuerySnapshot *)snapshot
    includeMetadataChanges:(BOOL)includeMetadataChanges {
-  NSDictionary *serialized = [RNFBFirestoreSerialize querySnapshotToDictionary:@"onSnapshot" snapshot:snapshot includeMetadataChanges:includeMetadataChanges];
+  NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firApp.name];
+  NSDictionary *serialized = [RNFBFirestoreSerialize querySnapshotToDictionary:@"onSnapshot" snapshot:snapshot includeMetadataChanges:includeMetadataChanges appName:appName];
   [[RNFBRCTEventEmitter shared] sendEventWithName:RNFB_FIRESTORE_COLLECTION_SYNC body:@{
       @"appName": [RNFBSharedUtils getAppJavaScriptName:firApp.name],
       @"listenerId": listenerId,

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
@@ -41,4 +41,5 @@ extern NSString *const FIRESTORE_CACHE_SIZE;
 extern NSString *const FIRESTORE_HOST;
 extern NSString *const FIRESTORE_PERSISTENCE;
 extern NSString *const FIRESTORE_SSL;
-extern NSMutableDictionary * instanceCache;
+extern NSString *const FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR;
+extern NSMutableDictionary *instanceCache;

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
@@ -23,6 +23,7 @@ NSString *const FIRESTORE_CACHE_SIZE = @"firebase_firestore_cache_size";
 NSString *const FIRESTORE_HOST = @"firebase_firestore_host";
 NSString *const FIRESTORE_PERSISTENCE = @"firebase_firestore_persistence";
 NSString *const FIRESTORE_SSL = @"firebase_firestore_ssl";
+NSString *const FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR = @"firebase_firestore_server_timestamp_behavior";
 
 NSMutableDictionary * instanceCache;
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -136,7 +136,8 @@ RCT_EXPORT_METHOD(documentGet:
     if (error) {
       return [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
     } else {
-      NSDictionary *serialized = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot];
+      NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
+      NSDictionary *serialized = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot appName:appName];
       resolve(serialized);
     }
   }];
@@ -259,7 +260,8 @@ RCT_EXPORT_METHOD(documentBatch:
 - (void)sendSnapshotEvent:(FIRApp *)firApp
                listenerId:(nonnull NSNumber *)listenerId
                  snapshot:(FIRDocumentSnapshot *)snapshot {
-  NSDictionary *serialized = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot];
+  NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firApp.name];
+  NSDictionary *serialized = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot appName:appName];
   [[RNFBRCTEventEmitter shared] sendEventWithName:RNFB_FIRESTORE_DOCUMENT_SYNC body:@{
       @"appName": [RNFBSharedUtils getAppJavaScriptName:firApp.name],
       @"listenerId": listenerId,

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -100,6 +100,11 @@ RCT_EXPORT_METHOD(settings:
     [[RNFBPreferences shared] setBooleanValue:sslKey boolValue:[settings[@"ssl"] boolValue]];
   }
 
+  if (settings[@"serverTimestampBehavior"]) {
+    NSString *key = [NSString stringWithFormat:@"%@_%@", FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR, appName];
+    [[RNFBPreferences shared] setStringValue:key stringValue:settings[@"serverTimestampBehavior"]];
+  }
+
   resolve([NSNull null]);
 }
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
@@ -21,11 +21,11 @@
 
 @interface RNFBFirestoreSerialize : NSObject
 
-+ (NSDictionary *)querySnapshotToDictionary:(NSString *)source snapshot:(FIRQuerySnapshot *)snapshot includeMetadataChanges:(BOOL)includeMetadataChanges;
++ (NSDictionary *)querySnapshotToDictionary:(NSString *)source snapshot:(FIRQuerySnapshot *)snapshot includeMetadataChanges:(BOOL)includeMetadataChanges appName:(NSString *)appName;
 
-+ (NSDictionary *)documentChangeToDictionary:(FIRDocumentChange *)documentChange isMetadataChange:(BOOL)isMetadataChange;
++ (NSDictionary *)documentChangeToDictionary:(FIRDocumentChange *)documentChange isMetadataChange:(BOOL)isMetadataChange appName:(NSString *)appName;
 
-+ (NSDictionary *)documentSnapshotToDictionary:(FIRDocumentSnapshot *)snapshot;
++ (NSDictionary *)documentSnapshotToDictionary:(FIRDocumentSnapshot *)snapshot appName:(NSString *)appName;
 
 + (NSDictionary *)serializeDictionary:(NSDictionary *)dictionary;
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -84,7 +84,8 @@ RCT_EXPORT_METHOD(transactionGetDocument:
     if (error != nil) {
       [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
     } else {
-      NSDictionary *snapshotDict = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot];
+      NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
+      NSDictionary *snapshotDict = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot appName:appName];
       NSString *snapshotPath = snapshotDict[@"path"];
 
       if (snapshotPath == nil) {

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1426,6 +1426,19 @@ export namespace FirebaseFirestoreTypes {
      * If set to false or omitted, the SDK throws an exception when it encounters properties of type undefined.
      */
     ignoreUndefinedProperties?: boolean;
+
+    /**
+     * If set, controls the return value for server timestamps that have not yet been set to their final value.
+     *
+     * By specifying 'estimate', pending server timestamps return an estimate based on the local clock.
+     * This estimate will differ from the final value and cause these values to change once the server result becomes available.
+     *
+     * By specifying 'previous', pending timestamps will be ignored and return their previous value instead.
+     *
+     * If omitted or set to 'none', null will be returned by default until the server value becomes available.
+     *
+     */
+    serverTimestampBehavior?: 'estimate' | 'previous' | 'none';
   }
 
   /**

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -191,7 +191,14 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
     const keys = Object.keys(settings);
 
-    const opts = ['cacheSizeBytes', 'host', 'persistence', 'ssl', 'ignoreUndefinedProperties'];
+    const opts = [
+      'cacheSizeBytes',
+      'host',
+      'persistence',
+      'ssl',
+      'ignoreUndefinedProperties',
+      'serverTimestampBehavior',
+    ];
 
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
@@ -268,6 +275,17 @@ class FirebaseFirestoreModule extends FirebaseModule {
 
     if (!isUndefined(settings.ssl) && !isBoolean(settings.ssl)) {
       throw new Error("firebase.firestore().settings(*) 'settings.ssl' must be a boolean value.");
+    }
+
+    if (
+      !isUndefined(settings.serverTimestampBehavior) &&
+      !['estimate', 'previous', 'none'].includes(settings.serverTimestampBehavior)
+    ) {
+      return Promise.reject(
+        new Error(
+          "firebase.firestore().settings(*) 'settings.serverTimestampBehavior' must be one of 'estimate', 'previous', 'none'.",
+        ),
+      );
     }
 
     if (!isUndefined(settings.ignoreUndefinedProperties)) {


### PR DESCRIPTION
### Description

This is 100% from @JanErikFoss - just carried his commits into this PR after clobbering #5514

Implements serverTimestampBehavior as a firestore setting.
It's currently impossible to implement SnapshotOptions as they work in the javascript sdk, this is the next best option in my opinion.

### Related issues

#5514

### Release Summary

Squash-merge - PR title is conventional

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
