### PR TITLE
fix(expo): Do not publish plugin tests and sources to NPM

### DIFF
--- a/packages/app/.npmignore
+++ b/packages/app/.npmignore
@@ -28,6 +28,11 @@ android/.idea/scopes/scope_settings.xml
 android/.idea/vcs.xml
 android/*.iml
 
+# Expo config plugin
+plugin/src/
+plugin/__tests__/
+plugin/tsconfig.json
+
 # Xcode
 *.pbxuser
 *.mode1v3

--- a/packages/crashlytics/.npmignore
+++ b/packages/crashlytics/.npmignore
@@ -28,6 +28,11 @@ android/.idea/scopes/scope_settings.xml
 android/.idea/vcs.xml
 android/*.iml
 
+# Expo config plugin
+plugin/src/
+plugin/__tests__/
+plugin/tsconfig.json
+
 # Xcode
 *.pbxuser
 *.mode1v3

--- a/packages/perf/.npmignore
+++ b/packages/perf/.npmignore
@@ -28,6 +28,11 @@ android/.idea/scopes/scope_settings.xml
 android/.idea/vcs.xml
 android/*.iml
 
+# Expo config plugin
+plugin/src/
+plugin/__tests__/
+plugin/tsconfig.json
+
 # Xcode
 *.pbxuser
 *.mode1v3


### PR DESCRIPTION
### Description

I noticed that the whole `plugin` directory is published to NPM. The only subdirectory really needed is `plugin/build`, others (src, tests) can be npm-ignored to make the package smaller.

The `plugin/build` dir is generated from `plugin/src` during `npm prepare` step. Its content is required by the `app.plugin.js` file.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

🤷 
<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
