### PR TITLE
fix(messaging): ensure token is refreshed when calling `deleteToken` on iOS

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -125,7 +125,7 @@ RCT_EXPORT_METHOD(deleteToken:
   (RCTPromiseResolveBlock) resolve
     :(RCTPromiseRejectBlock) reject
 ) {
-  [[FIRMessaging messaging] deleteTokenWithCompletion:^(NSError *_Nullable error) {
+  [[FIRInstallations installations] deleteWithCompletion:^(NSError * _Nullable error) {
     if (error) {
       [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
     } else {


### PR DESCRIPTION
### Description

This will always refresh the fcm token, but it's unclear to me if this is the correct approach or not based on the documentation and changelog

I've opened up a ticket on https://github.com/firebase/firebase-ios-sdk/issues/8491 for guidance from the iOS team.

I don't believe there are any side-effects of always deleting the installations id, but it would be good to get confirmation as this approach always will delete it when refreshing the fcm token.

### Related issues
Fixes https://github.com/invertase/react-native-firebase/issues/5570 
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
