### PR TITLE
fix(app, expo): Missing `fs/promises` import in Node 12

### DIFF
--- a/packages/app/plugin/src/android/copyGoogleServices.ts
+++ b/packages/app/plugin/src/android/copyGoogleServices.ts
@@ -2,7 +2,7 @@ import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
 
 import { DEFAULT_TARGET_PATH } from './constants';
 import path from 'path';
-import fs from 'fs/promises';
+import fs from 'fs';
 
 /**
  * Copy `google-services.json`
@@ -24,7 +24,7 @@ export const withCopyAndroidGoogleServices: ConfigPlugin = config => {
       const destPath = path.resolve(config.modRequest.platformProjectRoot, DEFAULT_TARGET_PATH);
 
       try {
-        await fs.copyFile(srcPath, destPath);
+        await fs.promises.copyFile(srcPath, destPath);
       } catch (e) {
         throw new Error(
           `Cannot copy google-services.json, because the file ${srcPath} doesn't exist. Please provide a valid path in \`app.json\`.`,


### PR DESCRIPTION
Looks like `fs.promises` was introduced even in Node 10: https://nodejs.org/dist/latest-v10.x/docs/api/fs.html#fs_fspromises_copyfile_src_dest_flags

### Description

Node 12 doesn't have `fs/promises` import. But [according to the docs](https://nodejs.org/dist/latest-v12.x/docs/api/fs.html#fs_fspromises_copyfile_src_dest_flags), the `fs.promises` was introduced in Node 10.

I prefer the asynchronous approach because of better error handling.

### Related issues

Resolves #5584

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

CI tests

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
