### PR TITLE
test(e2e, android): avoid database emulator on android

### DIFF
--- a/tests/app.js
+++ b/tests/app.js
@@ -35,6 +35,7 @@ import '@react-native-firebase/storage';
 import jet from 'jet/platform/react-native';
 import React from 'react';
 import { AppRegistry, Button, NativeModules, Text, View } from 'react-native';
+import { Platform } from 'react-native';
 
 jet.exposeContextProperty('NativeModules', NativeModules);
 jet.exposeContextProperty('NativeEventEmitter', NativeEventEmitter);
@@ -44,7 +45,11 @@ const firestore = firebase.firestore();
 firestore.settings({ host: 'localhost:8080', ssl: false, persistence: true });
 
 firebase.auth().useEmulator('http://localhost:9099');
-firebase.database().useEmulator('localhost', 9000);
+// Database emulator cannot handle App Check on Android yet
+// https://github.com/firebase/firebase-tools/issues/3663
+if (Platform.OS === 'ios') {
+  firebase.database().useEmulator('localhost', 9000);
+}
 firebase.storage().useEmulator('localhost', 9199);
 
 function Root() {


### PR DESCRIPTION
it is not currently compatible with App Check

### Related issues

https://github.com/firebase/firebase-tools/issues/3663

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The whole thing is made of test work (but to be specific, all CI should pass, especially e2e on android)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
