### PR TITLE
fix(app): Fix Node 12 `fs/promises` error in `AppDelegate` Expo plugin

### DIFF
--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -1,5 +1,5 @@
 import { ConfigPlugin, IOSConfig, withDangerousMod } from '@expo/config-plugins';
-import fs from 'fs/promises';
+import fs from 'fs';
 
 const methodInvocationBlock = `[FIRApp configure];`;
 
@@ -31,7 +31,7 @@ export const withFirebaseAppDelegate: ConfigPlugin = config => {
     'ios',
     async config => {
       const fileInfo = IOSConfig.Paths.getAppDelegate(config.modRequest.projectRoot);
-      let contents = await fs.readFile(fileInfo.path, 'utf-8');
+      let contents = await fs.promises.readFile(fileInfo.path, 'utf-8');
       if (fileInfo.language === 'objc') {
         contents = modifyObjcAppDelegate(contents);
       } else {
@@ -40,7 +40,7 @@ export const withFirebaseAppDelegate: ConfigPlugin = config => {
           `Cannot add Firebase code to AppDelegate of language "${fileInfo.language}"`,
         );
       }
-      await fs.writeFile(fileInfo.path, contents);
+      await fs.promises.writeFile(fileInfo.path, contents);
 
       return config;
     },


### PR DESCRIPTION
### Description

https://github.com/invertase/react-native-firebase/issues/5584#issuecomment-898088052
I feel bad at myself not double-checking this earlier. 🤦 

### Related issues

#5584

### Test Plan

This time checked that it is the only occurrence of `fs/promises` in **published v12.5.0**:
```
mkdir rnfb_fs_promises && cd rnfb_fs_promises
yarn init
yarn add @react-native-firebase/app @react-native-firebase/perf @react-native-firebase/crashlytics
grep -r fs/promises node_modules
```
The grep output:
```
~/dev/temp/rnfb_fs_promises » grep -r fs/promises node_modules
node_modules/@react-native-firebase/app/CHANGELOG.md:- **app, expo:** Use `fs/promises` in Node 12 compatible way ([#5585](https://github.com/invertase/react-native-firebase/issues/5585)) ([64f569a](https://github.com/invertase/react-native-firebase/commit/64f569acd2cea284baa305451df9533f138539e7))
node_modules/@react-native-firebase/app/plugin/build/ios/appDelegate.js:const promises_1 = __importDefault(require("fs/promises"));
```

---

The `react-native-firebase` repository still have some occurences in `__tests__` but they're not used in prod nor published:
```
~/dev/react-native-firebase(master) » grep -r fs/promises . 
./CHANGELOG.md:* **app, expo:** Use `fs/promises` in Node 12 compatible way ([#5585](https://github.com/invertase/react-native-firebase/issues/5585)) ([64f569a](https://github.com/invertase/react-native-firebase/commit/64f569acd2cea284baa305451df9533f138539e7))
./packages/crashlytics/plugin/__tests__/androidPlugin.test.ts:import fs from 'fs/promises';
./packages/app/CHANGELOG.md:- **app, expo:** Use `fs/promises` in Node 12 compatible way ([#5585](https://github.com/invertase/react-native-firebase/issues/5585)) ([64f569a](https://github.com/invertase/react-native-firebase/commit/64f569acd2cea284baa305451df9533f138539e7))
./packages/app/plugin/__tests__/iosPlugin.test.ts:import fs from 'fs/promises';
./packages/app/plugin/__tests__/androidPlugin.test.ts:import fs from 'fs/promises';
./packages/app/plugin/src/ios/appDelegate.ts:import fs from 'fs/promises';
./packages/perf/plugin/__tests__/androidPlugin.test.ts:import fs from 'fs/promises';
```