### PR TITLE
fix(app, android): put app init provider / registrar in correct manifest

### DIFF
--- a/packages/app/android/src/main/AndroidManifest.xml
+++ b/packages/app/android/src/main/AndroidManifest.xml
@@ -1,2 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.invertase.firebase" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.invertase.firebase">
+
+  <application>
+    <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+      <meta-data
+        android:name="com.google.firebase.components:io.invertase.firebase.app.ReactNativeFirebaseAppRegistrar"
+        android:value="com.google.firebase.components.ComponentRegistrar" />
+    </service>
+    <provider
+      android:name="io.invertase.firebase.app.ReactNativeFirebaseAppInitProvider"
+      android:authorities="${applicationId}.reactnativefirebaseappinitprovider"
+      android:exported="false"
+      android:initOrder="99" /> <!-- Firebase = 100, using 99 to run after Firebase initialises (highest first) -->
+  </application>
+</manifest>

--- a/packages/app/android/src/reactnative/AndroidManifest.xml
+++ b/packages/app/android/src/reactnative/AndroidManifest.xml
@@ -1,17 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.invertase.firebase">
-
-  <application>
-    <service android:name="com.google.firebase.components.ComponentDiscoveryService">
-      <meta-data
-        android:name="com.google.firebase.components:io.invertase.firebase.app.ReactNativeFirebaseAppRegistrar"
-        android:value="com.google.firebase.components.ComponentRegistrar" />
-    </service>
-    <provider
-      android:name="io.invertase.firebase.app.ReactNativeFirebaseAppInitProvider"
-      android:authorities="${applicationId}.reactnativefirebaseappinitprovider"
-      android:exported="false"
-      android:initOrder="99" /> <!-- Firebase = 100, using 99 to run after Firebase initialises (highest first) -->
-  </application>
-</manifest>
+<manifest package="io.invertase.firebase" />


### PR DESCRIPTION
### Description

local inspection of merged manifest indicated they were not being included as thought,
moving them to this manifest shows they are being included

This means that prior to this I do not believe react-native-firebase was ever registering with the native SDK

I do believe that iOS is registering successfully but I'm investigating that separately.

### Related issues

#3766

### Release Summary

Conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

1. Do the build `yarn tests:android:build`
2. Find the merged manifest `find tests/android |grep AndroidManifest.xml|grep merged|grep -v androidTest`
3. Inspect the manifest to make sure the definitions you expect are in there

Before this change they were not there! :scream: 
After this change the registrar and init provider for app are in there

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
