### PR TITLE
test(e2e): fix up auth + perf test platform exclusions, increase dynamic-links e2e testing

### DIFF
--- a/packages/auth/e2e/rnReload.e2e.js
+++ b/packages/auth/e2e/rnReload.e2e.js
@@ -24,9 +24,13 @@ describe('auth()', function () {
     }
   });
 
-  // TODO(salakar): Detox on iOS crashing app on reloads
-  android.describe('firebase.auth().currentUser', () => {
+  describe('firebase.auth().currentUser', function () {
     it('exists after reload', async function () {
+      // Detox on iOS crashing app on reloads, documented
+      // https://github.com/wix/detox/blob/master/docs/APIRef.DeviceObjectAPI.md#devicereloadreactnative
+      if (device.getPlatform() === 'ios') {
+        this.skip();
+      }
       let currentUser;
       // before reload
       await firebase.auth().signInAnonymously();

--- a/packages/dynamic-links/e2e/dynamicLinks.e2e.js
+++ b/packages/dynamic-links/e2e/dynamicLinks.e2e.js
@@ -15,16 +15,45 @@
  *
  */
 
+// This host is set up in Xcode/iOS applinks: + Android intent-filter + Firebase console Android test app SHA256
+const DYNAMIC_LINK_DOMAIN = 'https://reactnativefirebase.page.link';
+const LINK_TARGET_DOMAIN = 'https://reactnativefirebase.page.link'; // was https://invertase.io
+const TEST_LINK1_TARGET = `${LINK_TARGET_DOMAIN}/developers`;
+const TEST_LINK1 = `${DYNAMIC_LINK_DOMAIN}/?link=${TEST_LINK1_TARGET}&apn=com.invertase.testing`;
+const TEST_LINK2_TARGET = `${LINK_TARGET_DOMAIN}/contact`;
+const TEST_LINK2 = `${DYNAMIC_LINK_DOMAIN}/?link=${TEST_LINK2_TARGET}&apn=com.invertase.testing`;
+const TEST_LINK3_TARGET = `${LINK_TARGET_DOMAIN}/blog`;
+const TEST_LINK3 = `${DYNAMIC_LINK_DOMAIN}/?link=${TEST_LINK3_TARGET}&apn=com.invertase.testing`;
+
 const baseParams = {
-  link: 'https://invertase.io',
-  domainUriPrefix: 'https://reactnativefirebase.page.link',
+  link: TEST_LINK2_TARGET,
+  domainUriPrefix: DYNAMIC_LINK_DOMAIN,
 };
 
-const TEST_LINK =
-  'https://reactnativefirebase.page.link/?link=https://rnfirebase.io&apn=com.invertase.testing';
-const TEST_LINK2 =
-  'https://reactnativefirebase.page.link/?link=https://invertase.io/hire-us&apn=com.invertase.testing';
-const TEST_LINK3 = 'https://invertase.io';
+const getShortLink = async function (url, type) {
+  return await firebase.dynamicLinks().buildShortLink(
+    {
+      link: url,
+      domainUriPrefix: DYNAMIC_LINK_DOMAIN,
+      analytics: {
+        source: 'github',
+        medium: 'web',
+        campaign: 'prs-welcome',
+        content: 'fluff',
+        term: 'long',
+      },
+      ios: {
+        bundleId: 'io.invertase.testing',
+        minimumVersion: '123',
+      },
+      android: {
+        packageName: 'com.invertase.testing',
+        minimumVersion: '123', // the version code in tests/android/app/build.gradle must be higher!
+      },
+    },
+    type,
+  );
+};
 
 module.exports.baseParams = baseParams;
 
@@ -67,25 +96,17 @@ describe('dynamicLinks()', function () {
 
   describe('resolveLink()', function () {
     it('resolves a long link', async function () {
+      // TODO: flaky on android if link is used for open tests as well?
+      // https://github.com/firebase/firebase-android-sdk/issues/2909
       const link = await firebase.dynamicLinks().resolveLink(TEST_LINK2);
       link.should.be.an.Object();
-      link.url.should.equal('https://invertase.io/hire-us');
+      link.url.should.equal(TEST_LINK2_TARGET);
       should.equal(link.minimumAppVersion, null);
     });
 
     it('resolves a short link', async function () {
-      const shortLink = await firebase.dynamicLinks().buildShortLink(
-        {
-          ...baseParams,
-          ios: {
-            bundleId: 'io.invertase.testing',
-            minimumVersion: '123',
-          },
-          android: {
-            packageName: 'com.invertase.testing',
-            minimumVersion: '123',
-          },
-        },
+      const shortLink = await getShortLink(
+        TEST_LINK2_TARGET,
         firebase.dynamicLinks.ShortLinkType.UNGUESSABLE,
       );
       shortLink.should.be.String();
@@ -94,11 +115,16 @@ describe('dynamicLinks()', function () {
 
       const link = await firebase.dynamicLinks().resolveLink(shortLink);
       link.should.be.an.Object();
-      link.url.should.equal(baseParams.link);
+      link.url.should.equal(TEST_LINK2_TARGET);
       // TODO: harmonize the API so that minimumAppVersion is either a number or a string
       // it would be a breaking change in the API though
       // On Android it's a number and iOS a String, so parseInt is used to have a single test
       parseInt(link.minimumAppVersion, 10).should.equal(123);
+
+      // "utm_content" and "utm_term" will not come back when resolved, even if you build with them
+      link.utmParameters.utm_source.should.equal('github');
+      link.utmParameters.utm_medium.should.equal('web');
+      link.utmParameters.utm_campaign.should.equal('prs-welcome');
     });
 
     it('throws on links that do not exist', async function () {
@@ -114,7 +140,7 @@ describe('dynamicLinks()', function () {
 
     it('throws on static links', async function () {
       try {
-        await firebase.dynamicLinks().resolveLink(TEST_LINK3);
+        await firebase.dynamicLinks().resolveLink(TEST_LINK2_TARGET);
         return Promise.reject(new Error('Did not throw Error.'));
       } catch (e) {
         e.message.should.containEql('Dynamic link not found');
@@ -145,35 +171,65 @@ describe('dynamicLinks()', function () {
     // });
   });
 
-  ios.describe('getInitialLink()', () => {
+  describe('getInitialLink()', function () {
     it('should return the dynamic link instance that launched the app', async function () {
-      await device.openURL({
-        url: TEST_LINK,
-      });
+      const shortLink = await getShortLink(
+        TEST_LINK3_TARGET,
+        firebase.dynamicLinks.ShortLinkType.SHORT,
+      );
+      if (device.getPlatform() === 'android') {
+        await device.launchApp({ newInstance: true, url: shortLink });
+      } else {
+        // #2660 - iOS getInitialLink fails, while Linking.getInitialLink() will return the link for resolution !?
+        // #2631 - on iOS getInitialLink will return same link: open app w/link (correct), background, open again (old link)
+        await device.openURL({ url: TEST_LINK3 });
+        // TODO: ios is not able to open short links on simulator?
+        // await device.openURL({ url: shortLink });
+      }
+      const link = await firebase.dynamicLinks().getInitialLink();
 
-      const dynamicLink = await firebase.dynamicLinks().getInitialLink();
-
-      dynamicLink.should.be.an.Object();
-      dynamicLink.url.should.equal('https://rnfirebase.io');
-      dynamicLink.utmParameters.should.eql({});
+      link.should.be.an.Object();
+      link.url.should.equal(TEST_LINK3_TARGET);
+      // "utm_content" and "utm_term" will not come back when resolved, even if you build with them
+      // and they only come back when resolved from a short link, which is android only in testing
+      if (device.getPlatform() === 'android') {
+        link.utmParameters.utm_source.should.equal('github');
+        link.utmParameters.utm_medium.should.equal('web');
+        link.utmParameters.utm_campaign.should.equal('prs-welcome');
+      } else {
+        link.utmParameters.should.eql({});
+      }
     });
   });
 
-  ios.describe('onLink()', () => {
+  describe('onLink()', function () {
     it('should emit dynamic links', async function () {
+      const shortLink = await getShortLink(
+        TEST_LINK1_TARGET,
+        firebase.dynamicLinks.ShortLinkType.DEFAULT,
+      );
       const spy = sinon.spy();
-
       firebase.dynamicLinks().onLink(spy);
 
-      await device.openURL({
-        url: TEST_LINK2,
-      });
-
+      if (device.getPlatform() === 'android') {
+        await device.launchApp({ url: shortLink });
+      } else {
+        await device.openURL({ url: TEST_LINK1 });
+      }
       await Utils.spyToBeCalledOnceAsync(spy);
 
-      spy.getCall(0).args[0].should.be.an.Object();
-      spy.getCall(0).args[0].url.should.equal('https://invertase.io/hire-us');
-      spy.getCall(0).args[0].utmParameters.should.eql({});
+      const link = spy.getCall(0).args[0];
+      link.should.be.an.Object();
+      link.url.should.equal(TEST_LINK1_TARGET);
+      // "utm_content" and "utm_term" will not come back when resolved, even if you build with them
+      // and they only come back when resolved from a short link, which is android only in testing
+      if (device.getPlatform() === 'android') {
+        link.utmParameters.utm_source.should.equal('github');
+        link.utmParameters.utm_medium.should.equal('web');
+        link.utmParameters.utm_campaign.should.equal('prs-welcome');
+      } else {
+        link.utmParameters.should.eql({});
+      }
     });
   });
 });

--- a/packages/perf/e2e/HttpMetric.e2e.js
+++ b/packages/perf/e2e/HttpMetric.e2e.js
@@ -17,7 +17,7 @@
 
 const aCoolUrl = 'https://invertase.io';
 
-android.describe('perf()', () => {
+describe('perf()', function () {
   describe('HttpMetric', function () {
     describe('start()', function () {
       it('correctly starts with internal flag ', async function () {
@@ -77,8 +77,8 @@ android.describe('perf()', () => {
       });
     });
 
-    // describe('removeAttribute()', async () => {
-    //   it('errors if not a string', async () => {
+    // describe('removeAttribute()', function () {
+    //   it('errors if not a string', async function () {
     //     const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
     //     try {
     //       httpMetric.putAttribute('inver', 'tase');
@@ -89,8 +89,8 @@ android.describe('perf()', () => {
     //       return Promise.resolve();
     //     }
     //   });
-    //
-    //   it('removes an attribute', async () => {
+
+    //   it('removes an attribute', async function () {
     //     const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');
     //     httpMetric.putAttribute('inver', 'tase');
     //     const value = httpMetric.getAttribute('inver');

--- a/packages/perf/e2e/Trace.e2e.js
+++ b/packages/perf/e2e/Trace.e2e.js
@@ -15,7 +15,7 @@
  *
  */
 
-android.describe('perf()', () => {
+describe('perf()', function () {
   describe('Trace', function () {
     describe('start()', function () {
       it('correctly starts with internal flag ', async function () {
@@ -60,8 +60,8 @@ android.describe('perf()', () => {
       });
     });
 
-    // describe('removeAttribute()', async () => {
-    //   it('errors if not a string', async () => {
+    // describe('removeAttribute()', function () {
+    //   it('errors if not a string', async function () {
     //     const trace = firebase.perf().newTrace('invertase');
     //     try {
     //       trace.putAttribute('inver', 'tase');
@@ -72,8 +72,8 @@ android.describe('perf()', () => {
     //       return Promise.resolve();
     //     }
     //   });
-    //
-    //   it('removes an attribute', async () => {
+
+    //   it('removes an attribute', async function () {
     //     const trace = firebase.perf().newTrace('invertase');
     //     trace.putAttribute('inver', 'tase');
     //     const value = trace.getAttribute('inver');

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
     applicationId 'com.invertase.testing'
     minSdkVersion rootProject.ext.minSdkVersion
     targetSdkVersion rootProject.ext.targetSdkVersion
-    versionCode 1
+    versionCode 200
     versionName '1.0'
 
     // detox
@@ -77,6 +77,7 @@ android {
     debug {
       debuggable true
       testCoverageEnabled true
+      signingConfig signingConfigs.release // sign with shared SHA256; configured in firebase dynamic-links
     }
     release {
       minifyEnabled true

--- a/tests/android/app/src/main/AndroidManifest.xml
+++ b/tests/android/app/src/main/AndroidManifest.xml
@@ -28,13 +28,13 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
       <!-- Dynamic DynamicLinks Test -->
-      <intent-filter>
+      <intent-filter android:autoVerify="true">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
         <data
-          android:host="invertase.io"
+          android:host="reactnativefirebase.page.link"
           android:scheme="https" />
       </intent-filter>
     </activity>

--- a/tests/ios/testing/Info.plist
+++ b/tests/ios/testing/Info.plist
@@ -33,19 +33,21 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.invertase.testing</string>
+      <string>Firebase Deep Links</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>invertase</string>
+				<string>reactnativefirebase.page.link</string>
 			</array>
 		</dict>
 		<dict/>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>200</string>
 	<key>FirebaseDynamicLinksCustomDomains</key>
 	<array>
-		<string>https://invertase.io/hire-us</string>
+		<string>https://invertase.io/developers</string>
+		<string>https://invertase.io/contact</string>
+		<string>https://invertase.io/blog</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
### Description

Trying very very hard to test some dynamic-link issues, and I was able to increase testing here a lot but not really pinpoint the iOS getInitialLink problems

I believe it will have to run on device to really be a good test, which requires all sorts of setup for Xcode signing etc, and doesn't work with Detox in an automated way.

I may have to handle it like the crash buttons and just setup a couple buttons in the test app so that when installed on a real device testing is still possible

### Related issues

Unfortunately - neither of these fixed here - just trying to probe them, not successfully:
#2660 - iOS getInitialLink fails, while Linking.getInitialLink() will return the link for resolution !?
#2631 - on iOS getInitialLink will return same link: open app w/link (correct), background, open again (old link)


### Release Summary

Conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The whole thing is tests - however, it's possible that the android e2e test will fail first time, depending on how the deep-link is handled (maybe it opens a chooser? maybe it's possible to auto-associate the chooser to the app, or maybe the test will need to be modified)


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
