### PR TITLE
fix(messaging, ios): only call onMessage handler if message is data-only or undelivered

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -210,14 +210,15 @@
         [sharedInstance.conditionBackgroundMessageHandlerSet unlock];
       }
     } else {
-      // TODO: send an event to track notification has been delivered
-      // Only sends to react for data-only messages
+      // TODO: send an event to track notification has been delivered (possible needs a new event
+      // handler for `didReceiveRemoteNotification`) Only sends for data-only messages
       DLog(@"didReceiveRemoteNotification while app was in foreground");
       if (userInfo[@"aps"][@"alert"] == nil) {
-        DLog(@"didReceiveRemoteNotification send event for data-only message while app was in foreground");
+        DLog(@"didReceiveRemoteNotification send event for data-only message while app was in "
+             @"foreground");
         [[RNFBRCTEventEmitter shared]
             sendEventWithName:@"messaging_message_received"
-                        body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
+                         body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
       }
       completionHandler(UIBackgroundFetchResultNoData);
     }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -210,10 +210,15 @@
         [sharedInstance.conditionBackgroundMessageHandlerSet unlock];
       }
     } else {
+      // TODO: send an event to track notification has been delivered
+      // Only sends to react for data-only messages
       DLog(@"didReceiveRemoteNotification while app was in foreground");
-      [[RNFBRCTEventEmitter shared]
-          sendEventWithName:@"messaging_message_received"
-                       body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
+      if (userInfo[@"aps"][@"alert"] == nil) {
+        DLog(@"didReceiveRemoteNotification send event for data-only message while app was in foreground");
+        [[RNFBRCTEventEmitter shared]
+            sendEventWithName:@"messaging_message_received"
+                        body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
+      }
       completionHandler(UIBackgroundFetchResultNoData);
     }
   }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -75,14 +75,14 @@ struct {
   if (notification.request.content.userInfo[@"gcm.message_id"]) {
     NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
 
-    // Don't send an event if contentAvailable is true - application:didReceiveRemoteNotification
-    // will send the event for us, we don't want to duplicate them
-    if (!notificationDict[@"contentAvailable"]) {
-      [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
+    // Always send an event to know there is an incoming message in the foreground
+    // Client app will have to display the notification as `UNNotificationPresentationOptionNone` is always sent
+    // to completion handler (see below)
+    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
                                                  body:notificationDict];
-    }
 
-    // TODO in a later version allow customising completion options in JS code
+
+    // TODO in a later version allow customizing completion options in JS code
     completionHandler(UNNotificationPresentationOptionNone);
   }
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -76,11 +76,10 @@ struct {
     NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
 
     // Always send an event to know there is an incoming message in the foreground
-    // Client app will have to display the notification as `UNNotificationPresentationOptionNone` is always sent
-    // to completion handler (see below)
+    // Client app will have to display the notification as `UNNotificationPresentationOptionNone` is
+    // always sent to completion handler (see below)
     [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
-                                                 body:notificationDict];
-
+                                               body:notificationDict];
 
     // TODO in a later version allow customizing completion options in JS code
     completionHandler(UNNotificationPresentationOptionNone);


### PR DESCRIPTION
### Description

This prevents `onMessage` from firing on a notification tap when `contentAvailable` is set and the app is in a quit-state,
Currently, the library causes the notification to display twice - once when the app is quit, and again when the notification is tapped to open the app

It's in both apple and firebase docs, that `didReceiveRemoteNotification` can be triggered when  :

[Firebase](https://firebase.google.com/docs/cloud-messaging/ios/receive#handle_silent_push_notifications) :
```
  // If you are receiving a notification message while your app is in the background,
  // this callback will not be fired till the user taps on the notification launching the application.

```

[Apple](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623013-application?language=objc):

`If the user opens your app from the system-displayed alert, the system may call this method again when your app is about to enter the foreground so that you can update your user interface and display information pertaining to the notification.
`

`onMessage` will still fire for data-only messages as `willPresentNotification` is not triggered for those.

This is the log from tapping on a notification when the app is quit:
```
 LOG  Running "notifeedemo" with {"rootTag":1,"initialProps":{}}
 LOG  initialNotification ->  undefined
 LOG  {"fcmToken": "xxxx"}
 LOG  onNotificationOpenedApp -> message {"contentAvailable": true, "data": {"hllo": "1"}, "messageId": "xxx", "notification": {"ios": {}, "title": "1A notification titleeeeeere"}}
 LOG  setBackgroundMessageHandler: message:  {"contentAvailable": true, "data": {"hllo": "1"}, "messageId": "xxxx", "notification": {"ios": {}, "title": "1A notification titleeeeeere"}}
```
As you can see the `setBackgroundMessageHandler` event still comes through, it's slower than the `onNotificationOpenedApp`, but at least we're not getting `onMessage` coming through. 


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
