### PR TITLE
feat(app, config): implement setLogLevel API

### DIFF
--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion('firebase', 'bom')}")
   // These are beta, so they are not in the BoM yet. We have to specify the versions explicitly.
   implementation 'com.google.firebase:firebase-appcheck-safetynet:16.0.0-beta02'
-  debugImplementation 'com.google.firebase:firebase-appcheck-debug:16.0.0-beta02'
+  implementation 'com.google.firebase:firebase-appcheck-debug:16.0.0-beta02'
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/app/e2e/app.e2e.js
+++ b/packages/app/e2e/app.e2e.js
@@ -52,6 +52,20 @@ describe('firebase', function () {
     should.equal(firebase.app().automaticDataCollectionEnabled, false);
   });
 
+  it('should allow setting of log level', function () {
+    firebase.setLogLevel('error');
+    firebase.setLogLevel('verbose');
+  });
+
+  it('should error if logLevel is invalid', function () {
+    try {
+      firebase.setLogLevel('silent');
+      throw new Error('did not throw on invalid loglevel');
+    } catch (e) {
+      e.message.should.containEql('LogLevel must be one of');
+    }
+  });
+
   it('it should initialize dynamic apps', async function () {
     const appCount = firebase.apps.length;
     const name = `testscoreapp${FirebaseHelpers.id}`;

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -33,6 +33,10 @@
           "description": "Whether automatic data collection is enabled for all products, unless overridden by product-specific data collection settings.\n Setting this to false is useful for opt-in-first data flows, for example when dealing with GDPR compliance. \nThis may be overridden dynamically in Javascript via automaticDataCollectionEnabled FirebaseAppConfig property.",
           "type": "boolean"
         },
+        "app_log_level": {
+          "description": "Set the log level across all modules. Only applies to iOS currently. Can be 'error', 'warn', 'info', 'debug'.\n Logs messages at the configured level or lower.\n Note that if an app is running from AppStore, it will never log above info even if level is set to a higher (more verbose) setting",
+          "type": "string"
+        },
         "app_check_token_auto_refresh": {
           "description": "If this flag is disabled then Firebase App Check will not periodically auto-refresh the app check token.\n This is useful for opt-in-first data flows, for example when dealing with GDPR compliance. \nIf unset it will default to the SDK-wide data collection default enabled setting. This may be overridden dynamically in Javascript.",
           "type": "boolean"

--- a/packages/app/ios/RNFBApp/RNFBAppModule.h
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.h
@@ -21,4 +21,6 @@
 
 @interface RNFBAppModule : NSObject <RCTBridgeModule>
 
+- (void)setLogLevel:(NSString *)logLevel;
+
 @end

--- a/packages/app/ios/RNFBApp/RNFBAppModule.m
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.m
@@ -58,6 +58,10 @@ RCT_EXPORT_MODULE();
       [FIRApp registerLibrary:@"react-native-firebase" withVersion:[RNFBVersionString copy]];
     });
 #endif
+    if ([[RNFBJSON shared] contains:@"app_log_level"]) {
+      NSString *logLevel = [[RNFBJSON shared] getStringValue:@"app_log_level" defaultValue:@"info"];
+      [self setLogLevel:logLevel];
+    }
   }
 
   return self;
@@ -189,6 +193,21 @@ RCT_EXPORT_METHOD(initializeApp
 
     resolve([RNFBSharedUtils firAppToDictionary:firApp]);
   });
+}
+
+RCT_EXPORT_METHOD(setLogLevel : (NSString *)logLevel) {
+  int level = FIRLoggerLevelError;
+  if ([logLevel isEqualToString:@"verbose"]) {
+    level = FIRLoggerLevelDebug;
+  } else if ([logLevel isEqualToString:@"debug"]) {
+    level = FIRLoggerLevelDebug;
+  } else if ([logLevel isEqualToString:@"info"]) {
+    level = FIRLoggerLevelInfo;
+  } else if ([logLevel isEqualToString:@"warn"]) {
+    level = FIRLoggerLevelWarning;
+  }
+  DLog(@"RNFBSetLogLevel: setting level to %d from %@.", level, logLevel);
+  [[FIRConfiguration sharedInstance] setLoggerLevel:level];
 }
 
 RCT_EXPORT_METHOD(setAutomaticDataCollectionEnabled : (FIRApp *)firApp enabled : (BOOL)enabled) {

--- a/packages/app/lib/index.d.ts
+++ b/packages/app/lib/index.d.ts
@@ -58,6 +58,8 @@ export namespace ReactNativeFirebase {
     readonly nativeErrorMessage: string;
   }
 
+  export type LogLevelString = 'debug' | 'verbose' | 'info' | 'warn' | 'error' | 'silent';
+
   export interface FirebaseAppOptions {
     /**
      * The Google App ID that is used to uniquely identify an instance of an app.
@@ -184,6 +186,19 @@ export namespace ReactNativeFirebase {
      * @param name The optional name of the app to return ('[DEFAULT]' if omitted)
      */
     app(name?: string): FirebaseApp;
+
+    /**
+     * Set the log level across all modules. Only applies to iOS currently, has no effect on Android.
+     * Should be one of 'error', 'warn', 'info', or 'debug'.
+     * Logs messages at the configured level or lower (less verbose / more important).
+     * Note that if an app is running from AppStore, it will never log above info even if
+     * level is set to a higher (more verbose) setting.
+     * Note that iOS is missing firebase-js-sdk log levels 'verbose' and 'silent'.
+     * 'verbose' if used will map to 'debug', 'silent' has no valid mapping and will return an error if used.
+     *
+     * @ios
+     */
+    setLogLevel(logLevel: LogLevelString): void;
 
     /**
      * A (read-only) array of all the initialized Apps.

--- a/packages/app/lib/internal/registry/app.js
+++ b/packages/app/lib/internal/registry/app.js
@@ -15,7 +15,13 @@
  *
  */
 
-import { isNull, isObject, isString, isUndefined } from '@react-native-firebase/app/lib/common';
+import {
+  isIOS,
+  isNull,
+  isObject,
+  isString,
+  isUndefined,
+} from '@react-native-firebase/app/lib/common';
 import FirebaseApp from '../../FirebaseApp';
 import { DEFAULT_APP_NAME } from '../constants';
 import { getAppModule } from './nativeModule';
@@ -188,6 +194,16 @@ export function initializeApp(options = {}, configOrName) {
       // Now allow calling code to handle the initialization issue
       throw e;
     });
+}
+
+export function setLogLevel(logLevel) {
+  if (!['error', 'warn', 'info', 'debug', 'verbose'].includes(logLevel)) {
+    throw new Error('LogLevel must be one of "error", "warn", "info", "debug", "verbose"');
+  }
+
+  if (isIOS) {
+    getAppModule().setLogLevel(logLevel);
+  }
 }
 
 /**

--- a/packages/app/lib/internal/registry/namespace.js
+++ b/packages/app/lib/internal/registry/namespace.js
@@ -20,7 +20,14 @@ import FirebaseApp from '../../FirebaseApp';
 import SDK_VERSION from '../../version';
 import { DEFAULT_APP_NAME, KNOWN_NAMESPACES } from '../constants';
 import FirebaseModule from '../FirebaseModule';
-import { getApp, getApps, initializeApp, setOnAppCreate, setOnAppDestroy } from './app';
+import {
+  getApp,
+  getApps,
+  initializeApp,
+  setLogLevel,
+  setOnAppCreate,
+  setOnAppDestroy,
+} from './app';
 
 // firebase.X
 let FIREBASE_ROOT = null;
@@ -231,6 +238,7 @@ export function createFirebaseRoot() {
       return getApps();
     },
     SDK_VERSION,
+    setLogLevel,
   };
 
   for (let i = 0; i < KNOWN_NAMESPACES.length; i++) {

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -3,6 +3,7 @@
     "android_background_activity_names": "NotActuallyAnActivity",
 
     "app_data_collection_default_enabled": false,
+    "app_log_level": "debug",
 
     "app_check_token_auto_refresh": false,
 


### PR DESCRIPTION
### Description

Now you may set the firebase log level from firebase.json or via JS
This is very interesting in some cases, like when you need the AppCheck debug token
on iOS, to test AppCheck SafetyNet during development

### Related issues

#5346 - mentioned release build error https://github.com/invertase/react-native-firebase/discussions/5346#discussioncomment-1193672
#5581

### Release Summary

conventional commits - rebase merge...

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
