### PR TITLE
docs(app-distribution): remove incorrect reference to app-check

### DIFF
--- a/docs/app-distribution/usage/index.md
+++ b/docs/app-distribution/usage/index.md
@@ -15,7 +15,7 @@ module, view the [Getting Started](/) documentation.
 # Install & setup the app module
 yarn add @react-native-firebase/app
 
-# Install the app-check module
+# Install the app-distribution module
 yarn add @react-native-firebase/app-distribution
 
 # If you're developing your app using iOS, run this command


### PR DESCRIPTION
### Description

The App Distribution usage documentation mentions `app-check` which, I assume, is a copy-paste error.

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

N/A

:fire: