### PR TITLE
docs(messaging): a little typo fix

### DIFF
--- a/docs/messaging/server-integration.md
+++ b/docs/messaging/server-integration.md
@@ -169,7 +169,7 @@ Firebase Cloud Messaging tokens are associated with the instance of the installe
 
 This means that by default, if your app has users and you allow them to log out and log in on the same app on the same device, the same FCM token will be used for both users. Usually this is not what you want, so you must take care to cycle the FCM token at the same time you handle user logout/login.
 
-How and when you invalidate a token and generate a new one will be specific to your project, but a common pattern is to delete the FCM token during logout and update your back end to remove ti, then to fetch the FCM token during login and update your back end systems to associate the new token with the logged in user.
+How and when you invalidate a token and generate a new one will be specific to your project, but a common pattern is to delete the FCM token during logout and update your back end to remove it, then to fetch the FCM token during login and update your back end systems to associate the new token with the logged in user.
 
 <https://rnfirebase.io/reference/messaging#deleteToken>
 <https://rnfirebase.io/reference/messaging#getToken>


### PR DESCRIPTION
### Description

A little typo fix in the Server Integration page of the messaging docs.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [] No

🔥