### PR TITLE
fix(app-distribution, android): implement react methods so module loads

### DIFF
--- a/packages/app-check/android/settings.gradle
+++ b/packages/app-check/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = '@react-native-firebase_appCheck'
+rootProject.name = '@react-native-firebase_app-check'

--- a/packages/app-distribution/android/settings.gradle
+++ b/packages/app-distribution/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = '@react-native-firebase_appdistribution'
+rootProject.name = '@react-native-firebase_app-distribution'

--- a/packages/app-distribution/android/src/main/java/io/invertase/firebase/appdistribution/ReactNativeFirebaseAppDistributionModule.java
+++ b/packages/app-distribution/android/src/main/java/io/invertase/firebase/appdistribution/ReactNativeFirebaseAppDistributionModule.java
@@ -26,4 +26,28 @@ public class ReactNativeFirebaseAppDistributionModule extends ReactNativeFirebas
   ReactNativeFirebaseAppDistributionModule(ReactApplicationContext reactContext) {
     super(reactContext, TAG);
   }
+
+  @ReactMethod
+  public void isTesterSignedIn(Promise promise) {
+    rejectPromiseWithCodeAndMessage(
+        promise, "platform-unsupported", "Android is not supported for App Distribution");
+  }
+
+  @ReactMethod
+  public void signInTester(Promise promise) {
+    rejectPromiseWithCodeAndMessage(
+        promise, "platform-unsupported", "Android is not supported for App Distribution");
+  }
+
+  @ReactMethod
+  public void checkForUpdate(Promise promise) {
+    rejectPromiseWithCodeAndMessage(
+        promise, "platform-unsupported", "Android is not supported for App Distribution");
+  }
+
+  @ReactMethod
+  public void signOutTester(Promise promise) {
+    rejectPromiseWithCodeAndMessage(
+        promise, "platform-unsupported", "Android is not supported for App Distribution");
+  }
 }

--- a/packages/app-distribution/e2e/app-distribution.e2e.js
+++ b/packages/app-distribution/e2e/app-distribution.e2e.js
@@ -16,6 +16,12 @@
  */
 
 describe('appDistribution()', function () {
+  describe('native module is loaded', function () {
+    it('checks native module load status', function () {
+      firebase.appDistribution().native;
+    });
+  });
+
   describe('isTesterSignedIn()', function () {
     it('checks if a tester is signed in', async function () {
       if (device.getPlatform() === 'ios') {

--- a/packages/in-app-messaging/android/settings.gradle
+++ b/packages/in-app-messaging/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = '@react-native-firebase_inAppMessaging'
+rootProject.name = '@react-native-firebase_in-app-messaging'

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -845,70 +845,70 @@ PODS:
     - React-cxxreact (= 0.65.1)
     - React-jsi (= 0.65.1)
     - React-perflogger (= 0.65.1)
-  - RNFBAnalytics (12.7.0):
+  - RNFBAnalytics (12.7.1):
     - Firebase/Analytics (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (12.7.0):
+  - RNFBApp (12.7.1):
     - Firebase/CoreOnly (= 8.6.0)
     - React-Core
-  - RNFBAppCheck (12.7.0):
+  - RNFBAppCheck (12.7.1):
     - Firebase/AppCheck (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (12.7.0):
+  - RNFBAppDistribution (12.7.1):
     - Firebase/AppDistribution (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (12.7.0):
+  - RNFBAuth (12.7.1):
     - Firebase/Auth (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (12.7.0):
+  - RNFBCrashlytics (12.7.1):
     - Firebase/Crashlytics (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (12.7.0):
+  - RNFBDatabase (12.7.1):
     - Firebase/Database (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (12.7.0):
+  - RNFBDynamicLinks (12.7.1):
     - Firebase/DynamicLinks (= 8.6.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (12.7.0):
+  - RNFBFirestore (12.7.1):
     - Firebase/Firestore (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (12.7.0):
+  - RNFBFunctions (12.7.1):
     - Firebase/Functions (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (12.7.0):
+  - RNFBInAppMessaging (12.7.1):
     - Firebase/InAppMessaging (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (12.7.0):
+  - RNFBInstallations (12.7.1):
     - Firebase/Installations (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (12.7.0):
+  - RNFBMessaging (12.7.1):
     - Firebase/Messaging (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBML (12.7.0):
+  - RNFBML (12.7.1):
     - React-Core
     - RNFBApp
-  - RNFBPerf (12.7.0):
+  - RNFBPerf (12.7.1):
     - Firebase/Performance (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (12.7.0):
+  - RNFBRemoteConfig (12.7.1):
     - Firebase/RemoteConfig (= 8.6.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (12.7.0):
+  - RNFBStorage (12.7.1):
     - Firebase/Storage (= 8.6.0)
     - React-Core
     - RNFBApp
@@ -1154,23 +1154,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: 92d41c2442e5328cc4d342cd7f78e5876b68bae5
   React-runtimeexecutor: 85187f19dd9c47a7c102f9994f9d14e4dc2110de
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
-  RNFBAnalytics: 66b04c5a140c38233988b8e00256f9a785e17873
-  RNFBApp: 89e2c070a5433a312e00e18d9d31f42fc2634f78
-  RNFBAppCheck: f940d9eff0c55ce77467f12940259209d2d174a3
-  RNFBAppDistribution: 00d7dbb6b8e9c398fd00bea113580a2900a6a746
-  RNFBAuth: d94728591b9f9a7cf1da0fedbd66a85ffba06cce
-  RNFBCrashlytics: 975aceb73460baabd8c399e47610204d2f3d6a64
-  RNFBDatabase: 6e03e1f77aa7ead14a75d0699e149534be3ddef4
-  RNFBDynamicLinks: b5472d7e5ac6b9971226ba5b0c5d78e42f035e39
-  RNFBFirestore: 1c8404a41b757195bdf3298eca559f060a2b133f
-  RNFBFunctions: 69b8fa54268d3a1d07735f727ac0ca301c2e05e0
-  RNFBInAppMessaging: 5f4b45c567b398009a866e8dc3946fb4099a548e
-  RNFBInstallations: 13cd2eb40595b915befa4e8bf9684fd533e30840
-  RNFBMessaging: 68663046575dd13f7b4aa0e278fbe2e552613e8d
-  RNFBML: 2eaf6180094e87f98e029279670d28455a37ac6a
-  RNFBPerf: fc4d5968348b1bb157ebaf044a218fbd58c2318f
-  RNFBRemoteConfig: 5d4d2e2d939bc6131bc7bd80633e883f51a25bac
-  RNFBStorage: 9f646b864b60bb57f60723ae6196156ab1e508e0
+  RNFBAnalytics: c2468814a480168ca67517ddb42a48a6c25514ec
+  RNFBApp: a4ce8d24c5c6864fa543a34b030a014bd015e628
+  RNFBAppCheck: e55ffc2c55e53a4aa50a893622a8dfdca61e40bb
+  RNFBAppDistribution: 19e4036c0785776718f3eacf1233e05ec1a09bb8
+  RNFBAuth: 3c110a974ffa2fead60274b541aef701a96c5b07
+  RNFBCrashlytics: 3c9bd32e59be40edbab7693f480d4973cca5553b
+  RNFBDatabase: 56009cb76c23eaa70b512e36dab9ee4938221cfc
+  RNFBDynamicLinks: 590d9d1266f0a316e79bf30483e35011f27c6916
+  RNFBFirestore: 0c2790637580751afab9a2aefb772a9c5e3f3ce5
+  RNFBFunctions: 462d16902318c655950ae2ac9bfd03ee6666c4c8
+  RNFBInAppMessaging: 9344eb451c8c69b859aa8b3e862966f7e987a6a6
+  RNFBInstallations: 35d4901b32bd985ce1de616827a6113031a1c636
+  RNFBMessaging: 510bef8284ab30807e3815dde6d91a02c282abe0
+  RNFBML: d06149166c655e4fd8b2f1e53b57894edf9312ed
+  RNFBPerf: 207a0d0898736dd69774bed4c5a85e6dc5623148
+  RNFBRemoteConfig: 653012922d6b55c4245591cc5c2bea037fa98be3
+  RNFBStorage: dfa03d5b478358e11ad90deaeda8250927c14c67
   Yoga: aa0cb45287ebe1004c02a13f279c55a95f1572f4
 
 PODFILE CHECKSUM: b64131ad767c3bc406d855320c4b5edad229a8d1


### PR DESCRIPTION
### Description

I noticed while test-integrating the new modules that app-distribution didn't even load on android, which is unexpected

It is not supported on android yet, but the module should at least load


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

rnfbdemo is my test-integration test bed, it failed without this, and I was able to probe it in e2e

If CI passes, we're good

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
