### PR TITLE
feat(analytics): Updated reserved event name list

### DIFF
--- a/docs/analytics/usage/index.md
+++ b/docs/analytics/usage/index.md
@@ -109,16 +109,19 @@ The Analytics package works out of the box, however a number of events are autom
 These event names are called as 'Reserved Events'. Attempting to send any custom event using the `logEvent` method
 with any of the following event names will throw an error.
 
-| Reserved Events Names  |                           |                     |
-| ---------------------- | ------------------------- | ------------------- |
-| `app_clear_data`       | `app_uninstall`           | `app_update`        |
-| `error`                | `first_open`              | `first_visit`       |
-| `first_open_time`      | `first_visit_time`        | `in_app_purchase`   |
-| `notification_dismiss` | `notification_foreground` | `notification_open` |
-| `notification_receive` | `os_update`               | `session_start`     |
-| `screen_view`          | `user_engagement`         | `ad_impression`     |
-| `ad_click`             | `ad_query`                | `ad_exposure`       |
-| `adunit_exposure`      | `ad_activeiew`            |
+| Reserved Events Names            |                                |                                 |
+| -------------------------------- | ------------------------------ | ------------------------------- |
+| `ad_activeview`                  | `ad_click`                     | `ad_exposure`                   |
+| `ad_impression`                  | `ad_query`                     | `ad_reward`                     |
+| `adunit_exposure`                | `app_background`               | `app_clear_data`                |
+| `app_remove`                     | `app_store_refund`             | `app_store_subscription_cancel` |
+| `app_store_subscription_convert` | `app_store_subscription_renew` | `app_update`                    |
+| `app_upgrade`                    | `dynamic_link_app_open`        | `dynamic_link_app_update`       |
+| `dynamic_link_first_open`        | `error`                        | `first_open`                    |
+| `first_visit`                    | `in_app_purchase`              | `notification_dismiss`          |
+| `notification_foreground`        | `notification_open`            | `notification_receive`          |
+| `os_update`                      | `session_start`                | `session_start_with_rollout`    |
+| `user_engagement`                |
 
 ## App instance id
 

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -37,7 +37,13 @@ import version from './version';
 import * as structs from './structs';
 
 const ReservedEventNames = [
+  'ad_activeview',
+  'ad_click',
+  'ad_exposure',
+  'ad_impression',
+  'ad_query',
   'ad_reward',
+  'adunit_exposure',
   'app_background',
   'app_clear_data',
   // 'app_exception',
@@ -53,6 +59,7 @@ const ReservedEventNames = [
   'dynamic_link_first_open',
   'error',
   'first_open',
+  'first_visit',
   'in_app_purchase',
   'notification_dismiss',
   'notification_foreground',


### PR DESCRIPTION
### Description

This PR updates the docs and code with the current reserved event name list from https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event

I didn't understand the reserved analytics event name `ad_activeiew` in the docs and when I checked it against the list I found that it was spelt wrong, it's meant to be `ad_activeview`. While checking that I also realised that the reserved event name list has changed and more items are now included.

I'm not 100% sure if I should have marked this as a breaking change or not. I haven't changed the `logEvent` function's parameters itself but the function will now `throw Error` in some situations where a previous version of the library wouldn't (although, I assume if someone had previously logged with one of the reserved event names that weren't in the list Firebase would have just discarded the event anyway).

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No

### Test Plan

The existing test for reserved event names on `logEvent` only tests one name (`session_start` - https://github.com/invertase/react-native-firebase/blob/master/packages/analytics/__tests__/analytics.test.ts#L121) so I've not updated the tests in this PR currently. Let me know if you want the test changed for an `it.each` which goes across the whole list.

The JS tests failed for Firestore but were failing before I made edits so I don't believe I've affected them.

The Android e2e tests pass. The iOS e2e tests were failing compilation locally for me due to nvm and I'm afraid I don't currently have time to dig into resolving that while keeping my other dev stuff that uses nvm working. Nothing I've done should be platform-specific so I hope the Android ones passing locally is sufficient.

I'm not sure if the spellcheck dictionary needs an update for this PR. I couldn't `yarn lint:spellcheck` because I don't have the `spellchecker` binary and I don't know what app I need to install for that (couldn't find it listed anywhere in the contributing docs). Happy to update the PR (and raise a new PR for updating the contributing docs) if I know what spellchecking app I need.

Reserved event name `app_exception` was commented out from the list before I did my updates so I've kept it commented out in the new list. Likewise, it wasn't mentioned in the docs so I've not added it. This looks to be because of this piece of code in the crashlytics module: https://github.com/invertase/react-native-firebase/blob/master/packages/crashlytics/lib/handlers.js#L100. Would you like a more specific solution to be implemented here so it can still throw an error for normal consumers? I was debating having it allow `app_exception` if the params are `fatal` and `timestamp` (which is how the crashlytics module calls it) but `throw Error` otherwise?

:fire: