### PR TITLE
docs(writing-deploying-functions): Given curl command doesn't work

### DIFF
--- a/docs/functions/writing-deploying-functions.md
+++ b/docs/functions/writing-deploying-functions.md
@@ -129,7 +129,7 @@ functions: listProducts: http://localhost:5000/rnfirebase-demo/us-central1/listP
 In your terminal (or browser), access the endpoint provided. Our list of generated products is ready for use.
 
 ```
-curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d '{"data":{}}' http://localhost:5000/rnfirebase-demo/us-central1/listProducts 
+curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d '{"data":{}}' http://localhost:5000/rnfirebase-demo/us-central1/listProducts
 ```
 
 ### Security

--- a/docs/functions/writing-deploying-functions.md
+++ b/docs/functions/writing-deploying-functions.md
@@ -129,7 +129,7 @@ functions: listProducts: http://localhost:5000/rnfirebase-demo/us-central1/listP
 In your terminal (or browser), access the endpoint provided. Our list of generated products is ready for use.
 
 ```
-curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X GET  http://localhost:5000/rnfirebase-demo/us-central1/listProducts
+curl -i -H "Accept: application/json" -H "Content-Type: application/json" -X POST -d '{"data":{}}' http://localhost:5000/rnfirebase-demo/us-central1/listProducts 
 ```
 
 ### Security


### PR DESCRIPTION
The current curl command in writing-deploying-functions.md doesn't work. Firebase Callable functions expect a POST method and the body must contain a field called data.
(See: https://firebase.google.com/docs/functions/callable-reference)
