### PR TITLE
fix(messaging, ios): revert "fix(messaging, ios): only call onMessage handler if message is data-only or undelivered"

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -210,15 +210,10 @@
         [sharedInstance.conditionBackgroundMessageHandlerSet unlock];
       }
     } else {
-      // TODO: send an event to track notification has been delivered
-      // Only sends to react for data-only messages
       DLog(@"didReceiveRemoteNotification while app was in foreground");
-      if (userInfo[@"aps"][@"alert"] == nil) {
-        DLog(@"didReceiveRemoteNotification send event for data-only message while app was in foreground");
-        [[RNFBRCTEventEmitter shared]
-            sendEventWithName:@"messaging_message_received"
-                        body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
-      }
+      [[RNFBRCTEventEmitter shared]
+          sendEventWithName:@"messaging_message_received"
+                       body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
       completionHandler(UIBackgroundFetchResultNoData);
     }
   }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -210,15 +210,14 @@
         [sharedInstance.conditionBackgroundMessageHandlerSet unlock];
       }
     } else {
-      // TODO: send an event to track notification has been delivered (possible needs a new event
-      // handler for `didReceiveRemoteNotification`) Only sends for data-only messages
+      // TODO: send an event to track notification has been delivered
+      // Only sends to react for data-only messages
       DLog(@"didReceiveRemoteNotification while app was in foreground");
       if (userInfo[@"aps"][@"alert"] == nil) {
-        DLog(@"didReceiveRemoteNotification send event for data-only message while app was in "
-             @"foreground");
+        DLog(@"didReceiveRemoteNotification send event for data-only message while app was in foreground");
         [[RNFBRCTEventEmitter shared]
             sendEventWithName:@"messaging_message_received"
-                         body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
+                        body:[RNFBMessagingSerializer remoteMessageUserInfoToDict:userInfo]];
       }
       completionHandler(UIBackgroundFetchResultNoData);
     }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -76,10 +76,11 @@ struct {
     NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
 
     // Always send an event to know there is an incoming message in the foreground
-    // Client app will have to display the notification as `UNNotificationPresentationOptionNone` is
-    // always sent to completion handler (see below)
+    // Client app will have to display the notification as `UNNotificationPresentationOptionNone` is always sent
+    // to completion handler (see below)
     [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
-                                               body:notificationDict];
+                                                 body:notificationDict];
+
 
     // TODO in a later version allow customizing completion options in JS code
     completionHandler(UNNotificationPresentationOptionNone);

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -75,14 +75,14 @@ struct {
   if (notification.request.content.userInfo[@"gcm.message_id"]) {
     NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
 
-    // Always send an event to know there is an incoming message in the foreground
-    // Client app will have to display the notification as `UNNotificationPresentationOptionNone` is always sent
-    // to completion handler (see below)
-    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
+    // Don't send an event if contentAvailable is true - application:didReceiveRemoteNotification
+    // will send the event for us, we don't want to duplicate them
+    if (!notificationDict[@"contentAvailable"]) {
+      [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
                                                  body:notificationDict];
+    }
 
-
-    // TODO in a later version allow customizing completion options in JS code
+    // TODO in a later version allow customising completion options in JS code
     completionHandler(UNNotificationPresentationOptionNone);
   }
 


### PR DESCRIPTION
Reverts invertase/react-native-firebase#5604

From additional testing, fixes the duplication issue but causes another issue where apple throttle `willPresentNotification` with the presence of `mutableContent` in the payload

I will be pursuing other solutions as the duplicate notification bug causes a big issue in apps