### PR TITLE
docs: setBackgroundMessageHandler invocation tip in FAQ

### DIFF
--- a/docs/faqs-and-tips.md
+++ b/docs/faqs-and-tips.md
@@ -68,6 +68,7 @@ Sometimes, after step 3, you have to click inside a "Text color" field, but this
 When the app is closed/quit, this can happen even when you are getting notifications and even when you are able to invoke the app in a headless state.
 
 To fix this:
+
 1. You first need to send the payload with "content-available: 1" in the `apns` section of the message payload so the app gets invoked in a headless state.
 2. On the `index.js` page, if the app is invoked in headless mode, instead of returning null, return a simple component that does nothing and renders nothing. Otherwise, return the actual `App` component.
 


### PR DESCRIPTION
Fix for invoking setBackgroundMessageHandler in quit state on iOS devices. Added a new question in the FAQ section.

### Description

New question in the FAQ section that addresses a fix for invoking setbackgroundMessageHandler when the app is in quit state on iOS.

### Release Summary

setbackgroundMessageHandler invocation on iOS when app is in quit state

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
