### PR TITLE
fix(dynamic-links, android): check for null currentIntent in getInitialLink to avoid crash

### DIFF
--- a/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
+++ b/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
@@ -167,7 +167,7 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
       promise.resolve(null);
       return;
     }
-    
+
     // Verify if the app was resumed from the Overview (history) screen.
     launchedFromHistory =
         (currentIntent != null)

--- a/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
+++ b/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
@@ -163,6 +163,11 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
     }
 
     Intent currentIntent = currentActivity.getIntent();
+    if (currentIntent == null) {
+      promise.resolve(null);
+      return;
+    }
+    
     // Verify if the app was resumed from the Overview (history) screen.
     launchedFromHistory =
         (currentIntent != null)


### PR DESCRIPTION
### Description

If a null intent is passed to `FirebseDynamicLinks.getInstance().getDynamicLink(currentIntent)`, it crashes with the following error: 
`Attempt to invoke virtual method 'java.lang.String android.content.Intent.getDataString()' on a null object reference.`

To avoid that, I added a check for null currentIntent. Of it's null, resolve the promise and return early (same as the check above it for null currentActivity).

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android` (resolves a crash that was only happening on Android)
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No
:fire: