### PR TITLE
fix(app-distribution, ios): missing downloadURL

### DIFF
--- a/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
+++ b/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
@@ -98,7 +98,7 @@ RCT_EXPORT_METHOD(checkForUpdate
       @"buildVersion" : release.buildVersion,
       @"releaseNotes" : release.releaseNotes == nil ? [NSNull null] : release.releaseNotes,
       @"isExpired" : [NSNumber numberWithBool:release.isExpired],
-      @"downloadURL" : release.downloadURL
+      @"downloadURL" : release.downloadURL.absoluteString
     });
   }];
 }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

I found a bug that downloadURL was not being passed.

![image](https://user-images.githubusercontent.com/45357311/131526709-f5bfa911-5809-473f-b464-bc9769fa0449.png)

I have reviewed the implementation, and it seems that the `NSURL` is directly passed to `resolve`, and becomes `null` when it is serialized by RN.

`NSURL` is converted to String by accessing the `absoluteString` property, so this bug is fixed.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
