### PR TITLE
fix: correct path to 'Info.plist' in ios build script input

### DIFF
--- a/packages/app/react-native.config.js
+++ b/packages/app/react-native.config.js
@@ -10,7 +10,7 @@ module.exports = {
             name: '[RNFB] Core Configuration',
             path: './ios_config.sh',
             execution_position: 'after_compile',
-            input_files: ['$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)'],
+            input_files: ['$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)'],
           },
         ],
       },


### PR DESCRIPTION
### Description

The issue was discussed a little [here](https://github.com/invertase/react-native-firebase/discussions/5513). I've been using a patch with this change for a while already and haven't seen this issue so far.

The path used in the script is `_TARGET_PLIST="${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}"`, but the path specified as "input files" was `$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`. This caused that sometimes values from `firebase.json` were not taken into account on iOS, because build step "Processing Info.plist" could be executed after "[RNFB] Core Configuration" and it could overwrite the `Info.plist` file.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
