### PR TITLE
fix(analytics): allow more than 25 event parameters

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -28,6 +28,7 @@ jest.doMock('react-native', () => {
           addListener: jest.fn(),
           eventsAddListener: jest.fn(),
           eventsNotifyReady: jest.fn(),
+          removeListeners: jest.fn(),
         },
         RNFBAuthModule: {
           APP_LANGUAGE: {

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -9,6 +9,9 @@ jest.doMock('react-native', () => {
       },
       NativeModules: {
         ...ReactNative.NativeModules,
+        RNFBAnalyticsModule: {
+          logEvent: jest.fn(),
+        },
         RNFBAppModule: {
           NATIVE_FIREBASE_APPS: [
             {

--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -130,14 +130,6 @@ describe('Analytics', function () {
       );
     });
 
-    it('errors if more than 25 params provided', function () {
-      expect(() =>
-        firebase.analytics().logEvent('invertase', Object.assign({}, new Array(26).fill(1))),
-      ).toThrowError(
-        "firebase.analytics().logEvent(_, *) 'params' maximum number of parameters exceeded (25).",
-      );
-    });
-
     describe('logScreenView()', function () {
       it('errors if param is not an object', function () {
         // @ts-ignore test

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -32,22 +32,6 @@ describe('analytics()', function () {
     });
   });
 
-  describe('setAnalyticsCollectionEnabled()', function () {
-    it('true', async function () {
-      await firebase.analytics().setAnalyticsCollectionEnabled(true);
-    });
-
-    it('false', async function () {
-      await firebase.analytics().setAnalyticsCollectionEnabled(false);
-    });
-  });
-
-  describe('resetAnalyticsData()', function () {
-    it('calls native fn without error', async function () {
-      await firebase.analytics().resetAnalyticsData();
-    });
-  });
-
   describe('setSessionTimeoutDuration()', function () {
     it('default duration', async function () {
       await firebase.analytics().setSessionTimeoutDuration();
@@ -430,6 +414,25 @@ describe('analytics()', function () {
 
     it('set default parameters', async function () {
       await firebase.analytics().setDefaultEventParameters({ number: 1, stringn: '123' });
+    });
+  });
+
+  // Test this one near end so all the previous hits are visible in DebugView is that is enabled
+  describe('resetAnalyticsData()', function () {
+    it('calls native fn without error', async function () {
+      await firebase.analytics().resetAnalyticsData();
+    });
+  });
+
+  // Test this last so it does not stop delivery to DebugView
+  describe('setAnalyticsCollectionEnabled()', function () {
+    it('false', async function () {
+      await firebase.analytics().setAnalyticsCollectionEnabled(false);
+    });
+
+    // Enable as the last action, so the rest of the hits are visible in DebugView if enabled
+    it('true', async function () {
+      await firebase.analytics().setAnalyticsCollectionEnabled(true);
     });
   });
 });

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -642,7 +642,12 @@ export namespace FirebaseAnalyticsTypes {
    */
   export class Module extends FirebaseModule {
     /**
-     * Log a custom event with optional params.
+     * Log a custom event with optional params. Note that there are various limits that applied
+     * to event parameters (total parameter count, etc), but analytics applies the limits during
+     * cloud processing, the errors will not be seen as Promise rejections when you call logEvent.
+     * While integrating this API in your app you are strongly encouraged to enable
+     * [DebugView](https://firebase.google.com/docs/analytics/debugview) -
+     * any errors in your events will show up in the firebase web console with links to relevant documentation
      *
      * #### Example
      *

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -94,13 +94,6 @@ class FirebaseAnalyticsModule extends FirebaseModule {
       );
     }
 
-    // maximum number of allowed params check
-    if (params && Object.keys(params).length > 25) {
-      throw new Error(
-        "firebase.analytics().logEvent(_, *) 'params' maximum number of parameters exceeded (25).",
-      );
-    }
-
     return this.native.logEvent(name, params);
   }
 


### PR DESCRIPTION
### Description

There are cases where the actual limit is more than the default 25, for instance with upgrade analytics plans, 100 may be the actual limit.

### Related issues

See https://github.com/invertase/react-native-firebase/discussions/5676

### Release Summary

Conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The limit was only enforced in the javascript code, native would take whatever javascript validated.
So I added a jest test for the positive and negative cases of setting and using the limit.


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
