### PR TITLE
docs(firestore): update emulator usage example with new 

### DIFF
--- a/docs/firestore/emulator.md
+++ b/docs/firestore/emulator.md
@@ -31,11 +31,13 @@ You need to configure the following property as soon as possible in the startup 
 import '@react-native-firebase/app';
 import firestore from '@react-native-firebase/firestore';
 
-const db = firestore();
-
-// set the host property to connect to the emulator
+// set the host and the port property to connect to the emulator
 // set these before any read/write operations occur to ensure it doesn't affect your Cloud Firestore data!
-db.settings({ host: 'localhost:8080', ssl: false });
+if (__DEV__) {
+  firestore().useEmulator('localhost', 8080);
+}
+
+const db = firestore();
 ```
 
 # Clear locally stored emulator data


### PR DESCRIPTION
### Description
I got warn 'host in settings to connect with firestore emulator is deprecated. Use useEmulator instead.' So I propose to update with part.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
