### PR TITLE
fix(auth, android): linkWithCredential will not attempt to upgrade from anon user (matches iOS)

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1214,30 +1214,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
                   } else {
                     Exception exception = task.getException();
                     Log.e(TAG, "link:onComplete:failure", exception);
-                    if (exception instanceof FirebaseAuthUserCollisionException) {
-                      FirebaseAuthUserCollisionException authUserCollisionException =
-                          (FirebaseAuthUserCollisionException) exception;
-                      AuthCredential updatedCredential =
-                          authUserCollisionException.getUpdatedCredential();
-                      try {
-                        firebaseAuth
-                            .signInWithCredential(updatedCredential)
-                            .addOnCompleteListener(
-                                getExecutor(),
-                                result -> {
-                                  if (result.isSuccessful()) {
-                                    promiseWithAuthResult(result.getResult(), promise);
-                                  } else {
-                                    promiseRejectAuthException(promise, exception);
-                                  }
-                                });
-                      } catch (Exception e) {
-                        // we the attempt to log in after the collision failed, reject back to JS
-                        promiseRejectAuthException(promise, exception);
-                      }
-                    } else {
-                      promiseRejectAuthException(promise, exception);
-                    }
+                    promiseRejectAuthException(promise, exception);
                   }
                 });
       } else {


### PR DESCRIPTION
### Description
When doing "linkWithCredential" in Android and the users exists, it makes relogin with this new user instead of launch exception:
Error: [auth/credential-already-in-use] This credential is already associated with a different user account.

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes --> Only for Android
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
