### PR TITLE
build(e2e): centralize build commands to use all yarn run scripts

### DIFF
--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -95,7 +95,7 @@ jobs:
           timeout_minutes: 15
           retry_wait_seconds: 60
           max_attempts: 3
-          command: cd tests/android && ./gradlew assembleDebug assembleAndroidTest lintDebug -DtestBuildType=debug -Dorg.gradle.daemon=false
+          command: yarn tests:android:build
 
       - name: Metro Bundler Cache
         uses: actions/cache@v2

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -127,9 +127,8 @@ jobs:
           ccache -s
           export SKIP_BUNDLING=1
           export RCT_NO_LAUNCH_PACKAGER=1
-          cd tests
           set -o pipefail
-          ./node_modules/.bin/detox build --configuration ios.sim.debug
+          yarn tests:ios:build
           ccache -s
         shell: bash
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -72,7 +72,7 @@
       },
       "android.emu.debug": {
         "binaryPath": "android/app/build/outputs/apk/debug/app-debug.apk",
-        "build": "cd android && ./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug && cd ..",
+        "build": "cd android && ./gradlew assembleDebug assembleAndroidTest lintDebug -DtestBuildType=debug && cd ..",
         "type": "android.emulator",
         "device": {
           "avdName": "TestingAVD"


### PR DESCRIPTION
### Description

Just noticed that the detox / e2e build commands were still sometimes doing custom commands instead of using the yarn run scripts. This makes it hard to change/improve things as there are multiple command styles in use

With this change the e2e scripts are now all using yarn run scripts for everything I think


### Test Plan

If CI passes, it's good

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
