### PR TITLE
docs(messaging): Correct documentation delay in iOS background notification delivery

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -111,10 +111,9 @@ The device state and message contents determines which handler will be called:
   as low priority and will ignore it (i.e. no event will be sent). You can however increase the priority by setting the `priority` to `high` (Android) and
   `content-available` to `true` (iOS) properties on the payload.
 
-- On iOS in cases where the message is data-only and the device is in the background or quit, the message will be delayed 8 seconds
-  from the time it arrives on the device until the background message handler registered with setBackgroundMessageHandler is invoked
-  to allow for the applications javascript to be loaded and ready to run [Issue 4144]
-  (https://github.com/invertase/react-native-firebase/pull/4144).
+- On iOS in cases where the message is data-only and the device is in the background or quit, the message will be delayed
+  until the background message handler is registered with setBackgroundMessageHandler signalling the applications javascript
+  is loaded and ready to run.
 
 To learn more about how to send these options in your message payload, view the Firebase documentation for your [FCM API implementation](https://firebase.google.com/docs/cloud-messaging/concept-options).
 

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -112,7 +112,7 @@ The device state and message contents determines which handler will be called:
   `content-available` to `true` (iOS) properties on the payload.
 
 - On iOS in cases where the message is data-only and the device is in the background or quit, the message will be delayed
-  until the background message handler is registered with setBackgroundMessageHandler signalling the applications javascript
+  until the background message handler is registered via setBackgroundMessageHandler, signaling the application's javascript
   is loaded and ready to run.
 
 To learn more about how to send these options in your message payload, view the Firebase documentation for your [FCM API implementation](https://firebase.google.com/docs/cloud-messaging/concept-options).


### PR DESCRIPTION
### Description

Document the behavior of background notifications on iOS when the app is returning from the Quit state.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No


