### PR TITLE
docs(app, ios): remove nil check prior to configure

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -112,9 +112,7 @@ Within your existing `didFinishLaunchingWithOptions` method, add the following t
 ```
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   // Add me --- \/
-  if ([FIRApp defaultApp] == nil) {
-    [FIRApp configure];
-  }
+  [FIRApp configure];
   // Add me --- /\
   // ...
 }


### PR DESCRIPTION
It appears that checking `[FIRApp defaultApp] == nil` will log an error message,
and I'm not sure how it could ever be called twice (which would throw an exception instead)?

Conforms with [upstream documentation](https://firebase.google.com/docs/ios/setup#objective-c)

Fixes #5739
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
