### PR TITLE
feat(sdk): bump firebase-ios-sdk to 8.8.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -65,7 +65,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "8.7.0"
+      "firebase": "8.8.0"
     },
     "android": {
       "minSdk": 16,

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -9,59 +9,59 @@ PODS:
     - React-Core (= 0.66.0-rc.1)
     - React-jsi (= 0.66.0-rc.1)
     - ReactCommon/turbomodule/core (= 0.66.0-rc.1)
-  - Firebase/Analytics (8.7.0):
+  - Firebase/Analytics (8.8.0):
     - Firebase/Core
-  - Firebase/AppCheck (8.7.0):
+  - Firebase/AppCheck (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 8.7.0-beta)
-  - Firebase/AppDistribution (8.7.0):
+    - FirebaseAppCheck (~> 8.8.0-beta)
+  - Firebase/AppDistribution (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 8.7.0-beta)
-  - Firebase/Auth (8.7.0):
+    - FirebaseAppDistribution (~> 8.8.0-beta)
+  - Firebase/Auth (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.7.0)
-  - Firebase/Core (8.7.0):
+    - FirebaseAuth (~> 8.8.0)
+  - Firebase/Core (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.7.0)
-  - Firebase/CoreOnly (8.7.0):
-    - FirebaseCore (= 8.7.0)
-  - Firebase/Crashlytics (8.7.0):
+    - FirebaseAnalytics (~> 8.8.0)
+  - Firebase/CoreOnly (8.8.0):
+    - FirebaseCore (= 8.8.0)
+  - Firebase/Crashlytics (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.7.0)
-  - Firebase/Database (8.7.0):
+    - FirebaseCrashlytics (~> 8.8.0)
+  - Firebase/Database (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 8.7.0)
-  - Firebase/DynamicLinks (8.7.0):
+    - FirebaseDatabase (~> 8.8.0)
+  - Firebase/DynamicLinks (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 8.7.0)
-  - Firebase/Firestore (8.7.0):
+    - FirebaseDynamicLinks (~> 8.8.0)
+  - Firebase/Firestore (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 8.7.0)
-  - Firebase/Functions (8.7.0):
+    - FirebaseFirestore (~> 8.8.0)
+  - Firebase/Functions (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 8.7.0)
-  - Firebase/InAppMessaging (8.7.0):
+    - FirebaseFunctions (~> 8.8.0)
+  - Firebase/InAppMessaging (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 8.7.0-beta)
-  - Firebase/Installations (8.7.0):
+    - FirebaseInAppMessaging (~> 8.8.0-beta)
+  - Firebase/Installations (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 8.7.0)
-  - Firebase/Messaging (8.7.0):
+    - FirebaseInstallations (~> 8.8.0)
+  - Firebase/Messaging (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.7.0)
-  - Firebase/Performance (8.7.0):
+    - FirebaseMessaging (~> 8.8.0)
+  - Firebase/Performance (8.8.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 8.7.0)
-  - Firebase/RemoteConfig (8.7.0):
+    - FirebasePerformance (~> 8.8.0)
+  - Firebase/RemoteConfig (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.7.0)
-  - Firebase/Storage (8.7.0):
+    - FirebaseRemoteConfig (~> 8.8.0)
+  - Firebase/Storage (8.8.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 8.7.0)
-  - FirebaseABTesting (8.7.0):
+    - FirebaseStorage (~> 8.8.0)
+  - FirebaseABTesting (8.8.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseAnalytics (8.7.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.7.0)
+  - FirebaseAnalytics (8.8.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
@@ -69,73 +69,73 @@ PODS:
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.7.0):
+  - FirebaseAnalytics/AdIdSupport (8.8.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.7.0)
+    - GoogleAppMeasurement (= 8.8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAppCheck (8.7.0-beta):
+  - FirebaseAppCheck (8.8.0-beta):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseAppDistribution (8.7.0-beta):
+  - FirebaseAppDistribution (8.8.0-beta):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/UserDefaults (~> 7.4)
-  - FirebaseAuth (8.7.0):
+  - FirebaseAuth (8.8.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/Environment (~> 7.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.7.0):
+  - FirebaseCore (8.8.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
-  - FirebaseCoreDiagnostics (8.7.0):
+  - FirebaseCoreDiagnostics (8.8.0):
     - GoogleDataTransport (~> 9.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/Logger (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.7.0):
+  - FirebaseCrashlytics (8.8.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.0)
     - GoogleUtilities/Environment (~> 7.4)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseDatabase (8.7.0):
+  - FirebaseDatabase (8.8.0):
     - FirebaseCore (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (8.7.0):
+  - FirebaseDynamicLinks (8.8.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseFirestore (8.7.0):
-    - FirebaseFirestore/AutodetectLeveldb (= 8.7.0)
-  - FirebaseFirestore/AutodetectLeveldb (8.7.0):
+  - FirebaseFirestore (8.8.0):
+    - FirebaseFirestore/AutodetectLeveldb (= 8.8.0)
+  - FirebaseFirestore/AutodetectLeveldb (8.8.0):
     - FirebaseFirestore/Base
-  - FirebaseFirestore/Base (8.7.0)
-  - FirebaseFirestore/WithoutLeveldb (8.7.0):
+  - FirebaseFirestore/Base (8.8.0)
+  - FirebaseFirestore/WithoutLeveldb (8.8.0):
     - FirebaseFirestore/Base
-  - FirebaseFunctions (8.7.0):
+  - FirebaseFunctions (8.8.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseInAppMessaging (8.7.0-beta):
+  - FirebaseInAppMessaging (8.8.0-beta):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.7.0):
+  - FirebaseInstallations (8.8.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - GoogleUtilities/UserDefaults (~> 7.4)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.7.0):
+  - FirebaseMessaging (8.8.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.0)
@@ -144,7 +144,7 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.4)
     - GoogleUtilities/UserDefaults (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebasePerformance (8.7.0):
+  - FirebasePerformance (8.8.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - FirebaseRemoteConfig (~> 8.0)
@@ -153,25 +153,32 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - nanopb (~> 2.30908.0)
-  - FirebaseRemoteConfig (8.7.0):
+  - FirebaseRemoteConfig (8.8.0):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
-  - FirebaseStorage (8.7.0):
+  - FirebaseStorage (8.8.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (8.7.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.7.0)
+  - GoogleAppMeasurement (8.8.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
     - "GoogleUtilities/NSData+zlib (~> 7.4)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.7.0):
+  - GoogleAppMeasurement/AdIdSupport (8.8.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.8.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
+    - GoogleUtilities/MethodSwizzler (~> 7.4)
+    - GoogleUtilities/Network (~> 7.4)
+    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+    - nanopb (~> 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.8.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
     - GoogleUtilities/MethodSwizzler (~> 7.4)
     - GoogleUtilities/Network (~> 7.4)
@@ -474,71 +481,71 @@ PODS:
     - React-jsi (= 0.66.0-rc.1)
     - React-logger (= 0.66.0-rc.1)
     - React-perflogger (= 0.66.0-rc.1)
-  - RNFBAnalytics (12.7.5):
-    - Firebase/Analytics (= 8.7.0)
+  - RNFBAnalytics (12.8.0):
+    - Firebase/Analytics (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (12.7.5):
-    - Firebase/CoreOnly (= 8.7.0)
+  - RNFBApp (12.8.0):
+    - Firebase/CoreOnly (= 8.8.0)
     - React-Core
-  - RNFBAppCheck (12.7.5):
-    - Firebase/AppCheck (= 8.7.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (12.7.5):
-    - Firebase/AppDistribution (= 8.7.0)
+  - RNFBAppCheck (12.8.0):
+    - Firebase/AppCheck (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (12.7.5):
-    - Firebase/Auth (= 8.7.0)
+  - RNFBAppDistribution (12.8.0):
+    - Firebase/AppDistribution (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (12.7.5):
-    - Firebase/Crashlytics (= 8.7.0)
+  - RNFBAuth (12.8.0):
+    - Firebase/Auth (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (12.7.5):
-    - Firebase/Database (= 8.7.0)
+  - RNFBCrashlytics (12.8.0):
+    - Firebase/Crashlytics (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (12.7.5):
-    - Firebase/DynamicLinks (= 8.7.0)
+  - RNFBDatabase (12.8.0):
+    - Firebase/Database (= 8.8.0)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (12.8.0):
+    - Firebase/DynamicLinks (= 8.8.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (12.7.5):
-    - Firebase/Firestore (= 8.7.0)
+  - RNFBFirestore (12.8.0):
+    - Firebase/Firestore (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (12.7.5):
-    - Firebase/Functions (= 8.7.0)
+  - RNFBFunctions (12.8.0):
+    - Firebase/Functions (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (12.7.5):
-    - Firebase/InAppMessaging (= 8.7.0)
+  - RNFBInAppMessaging (12.8.0):
+    - Firebase/InAppMessaging (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (12.7.5):
-    - Firebase/Installations (= 8.7.0)
+  - RNFBInstallations (12.8.0):
+    - Firebase/Installations (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (12.7.5):
-    - Firebase/Messaging (= 8.7.0)
+  - RNFBMessaging (12.8.0):
+    - Firebase/Messaging (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBML (12.7.5):
+  - RNFBML (12.8.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (12.7.5):
-    - Firebase/Performance (= 8.7.0)
+  - RNFBPerf (12.8.0):
+    - Firebase/Performance (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (12.7.5):
-    - Firebase/RemoteConfig (= 8.7.0)
+  - RNFBRemoteConfig (12.8.0):
+    - Firebase/RemoteConfig (= 8.8.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (12.7.5):
-    - Firebase/Storage (= 8.7.0)
+  - RNFBStorage (12.8.0):
+    - Firebase/Storage (= 8.8.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -548,7 +555,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - FirebaseFirestore/WithoutLeveldb (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `8.7.0`)
+  - FirebaseFirestore/WithoutLeveldb (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `8.8.0`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Jet (from `../node_modules/jet/ios`)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -636,7 +643,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/React/FBReactNativeSpec"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 8.7.0
+    :tag: 8.8.0
   glog:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   Jet:
@@ -729,35 +736,35 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 8.7.0
+    :tag: 8.8.0
 
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 4d9a15242af90ad4c538574f884aa197ab2cdc1d
   FBReactNativeSpec: 80a16687a08ac2498b89ad40d80537fc924970eb
-  Firebase: bc9325d5ee2041524bac78a5213d0e530c651309
-  FirebaseABTesting: 5a72ea0e88422f9e223614cb4016cafffb2af8d1
-  FirebaseAnalytics: 52768800c2add1d84b751420cb4caaf8195f2c41
-  FirebaseAppCheck: 1165576c9ad15d10d96637d9b2f678ed35dd9985
-  FirebaseAppDistribution: e1c746f591c659e18494352b2773688822d72dd3
-  FirebaseAuth: 2e7d029977648c67a5d51a263d4cbab76d34cf12
-  FirebaseCore: f4804c1d3f4bbbefc88904d15653038f2c99ddf7
-  FirebaseCoreDiagnostics: b63732f581a1c6a453ec7241f9ab60b3a5bd3450
-  FirebaseCrashlytics: 6fac03d1eef054833b71c929c93ab95c12989728
-  FirebaseDatabase: afc82291f9ed94ff949cec1b9505e8c3b944bc0f
-  FirebaseDynamicLinks: e3fd315f43196811df8eac95803f10ff47c3b026
-  FirebaseFirestore: aba4f6db8c545b0c77fbfbc3fb6a252e43f0f22b
-  FirebaseFunctions: 9b78e79a3de4ee00ca1af7fd8c5fd7ed76fbf702
-  FirebaseInAppMessaging: d1cff11faa69d294bef9c0773b91a6c84f771ac5
-  FirebaseInstallations: ede6fb72bb6337914e5888b399271259d0c4910c
-  FirebaseMessaging: 93227dd71d7888e200baef65043f81acb2b6596e
-  FirebasePerformance: a1a23adbc53917d7654c349d355371d5239cc340
-  FirebaseRemoteConfig: 34300dd83055c06e2768d0932dd8fb2c1575745f
-  FirebaseStorage: 2e6e58fe31fb0061fdce3f156d0ebc964e9de6ba
+  Firebase: 629510f1a9ddb235f3a7c5c8ceb23ba887f0f814
+  FirebaseABTesting: 981336dd14d84787e33466e4247f77ec2343f8d9
+  FirebaseAnalytics: 5506ea8b867d8423485a84b4cd612d279f7b0b8a
+  FirebaseAppCheck: 2c23e71c305cc93be7770fdf20bee65dec6f700b
+  FirebaseAppDistribution: fa46fb0898b0f31e0fe428b32059e2baed653d21
+  FirebaseAuth: bcf0adeff88bda5dcb3beeabe5760f1226ab7b2f
+  FirebaseCore: 98b29e3828f0a53651c363937a7f7d92a19f1ba2
+  FirebaseCoreDiagnostics: fe77f42da6329d6d83d21fd9d621a6b704413bfc
+  FirebaseCrashlytics: 3660c045c8e45cc4276110562a0ef44cf43c8157
+  FirebaseDatabase: bc4610ff3a816dcc680c1dbccf7f9f4bd94ac07d
+  FirebaseDynamicLinks: cf76a46274569da2d4491548a39ef35f3c1a992d
+  FirebaseFirestore: 3f868e4d9166cec8613b18f8fd890a7d688cf40a
+  FirebaseFunctions: 747034115d113cf600c4995ff7e4d384697e7c49
+  FirebaseInAppMessaging: 9c4417ef987ca961a6e337f7eba57bbdb9f81885
+  FirebaseInstallations: 2563cb18a723ef9c6ef18318a49519b75dce613c
+  FirebaseMessaging: 419b5c9d84f294a753c6501d8cfb9ced1ce37304
+  FirebasePerformance: 0c01a7a496657d7cea86d40c0b1725259d164c6c
+  FirebaseRemoteConfig: f6365883d7950d784ee97bcdbbf1e442d4fa6119
+  FirebaseStorage: 54ff752ecbd27f1c354c3f5e8c55f6ad5783699b
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
-  GoogleAppMeasurement: 2be61ce546ad074dbe4dd545f222ac6033bb1d9e
+  GoogleAppMeasurement: 5ba1164e3c844ba84272555e916d0a6d3d977e91
   GoogleDataTransport: 85fd18ff3019bb85d3f2c551d04c481dedf71fc9
   GoogleUtilities: 8de2a97a17e15b6b98e38e8770e2d129a57c0040
   GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
@@ -789,25 +796,25 @@ SPEC CHECKSUMS:
   React-RCTVibration: e22c6ab90161c66794f596ca315b879daf8dda8f
   React-runtimeexecutor: d453001bf6f2db17f2921fa2a96042b4fd778be4
   ReactCommon: 834ee32fc9de8bd76ea230ddce827f6c7be11992
-  RNFBAnalytics: ee597416e42d72c22afaf4b01508fe247929cb6d
-  RNFBApp: 09f7853e63826dba596338769579db7ed877d3d2
-  RNFBAppCheck: d8d318fc78c9286ae982c2461678085b9c74c9a1
-  RNFBAppDistribution: 5f9cc35092d6b101643875f02a01bcf8421ff3ee
-  RNFBAuth: 12d27650adcd5b5adc4dc68348fdb65483aad1d7
-  RNFBCrashlytics: b8efb4096208bf516b7eebd28096da56fbf9683e
-  RNFBDatabase: 22a4e79ffeffab7f85c39e3d0db333cb39942cba
-  RNFBDynamicLinks: ff4416cb698f4e08c42954dfac1f2b2e97a2baf1
-  RNFBFirestore: 0d9af23b81a58bfaa8cd2e0eae6c52a2b26dff3e
-  RNFBFunctions: 4b0fa9afc877f85402a130d2c9d2bf756c5c7508
-  RNFBInAppMessaging: daf2587caaa35a1493646addcaf694843f3f586e
-  RNFBInstallations: 9dfccdc98dc3823ea4b622fb3095bd4de6a8a723
-  RNFBMessaging: 21414cb822b4288082320728b02cd949b9fd4acb
-  RNFBML: ffbefb5e55416f68cdc4ee3604af2255f555d0c9
-  RNFBPerf: e3e9f6de58c6e001b893a6ab895f50d3136101b6
-  RNFBRemoteConfig: 3d7db60f20e1caf6f75d38f74ff84c4b6e5d00ad
-  RNFBStorage: c9c7f8b4e46a06717430b6c9176d4d4137b961e5
+  RNFBAnalytics: 493f19405859ebcff731ec5be496feee51ad5bb1
+  RNFBApp: c2045013e31a110a6df17f22415968da54535d1e
+  RNFBAppCheck: 8fe3ae127db3b6e859fff4def766bc9cc174a25c
+  RNFBAppDistribution: 95d085160290676ed6620b10749d5f7d2bff8ee2
+  RNFBAuth: 876d80d193e57f79eccc4f80a2edf302e8a7a811
+  RNFBCrashlytics: 55698c61c1650b05b9bd493270f5d58f5967b4b1
+  RNFBDatabase: 2053935b44984e779422a6b02d8cdeecf86294c9
+  RNFBDynamicLinks: b54f8e297802b8a8e468291a1783048a55f083df
+  RNFBFirestore: 077e15f625a86014871b741a835b1d3c2c52fc70
+  RNFBFunctions: ce25007fc5fc9047a3dc8a47f6ec763bc4638288
+  RNFBInAppMessaging: 9d27973373805ee19d5fb245de11c836a0de7912
+  RNFBInstallations: a8a6d639112252dec243575ec75a3fd7afbb94e8
+  RNFBMessaging: fe7d26d8c3ec3f2c467d30b2a24ba377c143f643
+  RNFBML: 2335ad97fda34437a20c8573a6f348577cdc82f6
+  RNFBPerf: 03fcef1af02abaaeb750f9fa304415fdde839ccd
+  RNFBRemoteConfig: c25186cee985ce62cd8e25e73002b6a25578532e
+  RNFBStorage: 2bb9df8aa098ec74739212fe35ebaea3e624a18c
   Yoga: 0b151c4ff6b3c093a118e99334061a88bdd315a3
 
 PODFILE CHECKSUM: 3a511a510d693f7a163c31647baf58a698d6f5f3
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.11.2


### PR DESCRIPTION
### Description

Standard firebase-ios-sdk bump, this one appears to diminish some flakiness seen in my Detox upgrade attempt #5734 which is just about ready to go

### Test Plan

This passes local e2e tests for me, CI will check it as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
