### PR TITLE
fix(ios, app): minimum cocoapods version is 1.10.2, not just 1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "@octokit/core": "^3.5.1",
     "@tsconfig/node12": "^1.0.9",
     "@types/jest": "^27.0.2",
-    "@types/react": "^17.0.26",
-    "@types/react-native": "^0.65.2",
+    "@types/react": "^17.0.27",
+    "@types/react-native": "^0.65.3",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
     "babel-jest": "^27.2.4",
@@ -78,7 +78,7 @@
     "typescript": "^4.4.3"
   },
   "resolutions": {
-    "@types/react": "^17.0.26"
+    "@types/react": "^17.0.27"
   },
   "workspaces": {
     "packages": [

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source              = { :git => "https://github.com/invertase/react-native-firebase.git", :tag => "v#{s.version}" }
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = "10.0"
-  s.cocoapods_version   = '>= 1.10.0'
+  s.cocoapods_version   = '>= 1.10.2'
   s.source_files        = "ios/**/*.{h,m}"
 
   # React Native dependencies

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -346,14 +346,14 @@ PODS:
     - BoringSSL-GRPC/Interface (= 0.0.7)
   - BoringSSL-GRPC/Interface (0.0.7)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.66.0-rc.4)
-  - FBReactNativeSpec (0.66.0-rc.4):
+  - FBLazyVector (0.66.0)
+  - FBReactNativeSpec (0.66.0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.0-rc.4)
-    - RCTTypeSafety (= 0.66.0-rc.4)
-    - React-Core (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
+    - RCTRequired (= 0.66.0)
+    - RCTTypeSafety (= 0.66.0)
+    - React-Core (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
   - Firebase/Analytics (8.8.0):
     - Firebase/Core
   - Firebase/AppCheck (8.8.0):
@@ -604,258 +604,258 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.66.0-rc.4)
-  - RCTTypeSafety (0.66.0-rc.4):
-    - FBLazyVector (= 0.66.0-rc.4)
+  - RCTRequired (0.66.0)
+  - RCTTypeSafety (0.66.0):
+    - FBLazyVector (= 0.66.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.0-rc.4)
-    - React-Core (= 0.66.0-rc.4)
-  - React (0.66.0-rc.4):
-    - React-Core (= 0.66.0-rc.4)
-    - React-Core/DevSupport (= 0.66.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.66.0-rc.4)
-    - React-RCTActionSheet (= 0.66.0-rc.4)
-    - React-RCTAnimation (= 0.66.0-rc.4)
-    - React-RCTBlob (= 0.66.0-rc.4)
-    - React-RCTImage (= 0.66.0-rc.4)
-    - React-RCTLinking (= 0.66.0-rc.4)
-    - React-RCTNetwork (= 0.66.0-rc.4)
-    - React-RCTSettings (= 0.66.0-rc.4)
-    - React-RCTText (= 0.66.0-rc.4)
-    - React-RCTVibration (= 0.66.0-rc.4)
-  - React-callinvoker (0.66.0-rc.4)
-  - React-Core (0.66.0-rc.4):
+    - RCTRequired (= 0.66.0)
+    - React-Core (= 0.66.0)
+  - React (0.66.0):
+    - React-Core (= 0.66.0)
+    - React-Core/DevSupport (= 0.66.0)
+    - React-Core/RCTWebSocket (= 0.66.0)
+    - React-RCTActionSheet (= 0.66.0)
+    - React-RCTAnimation (= 0.66.0)
+    - React-RCTBlob (= 0.66.0)
+    - React-RCTImage (= 0.66.0)
+    - React-RCTLinking (= 0.66.0)
+    - React-RCTNetwork (= 0.66.0)
+    - React-RCTSettings (= 0.66.0)
+    - React-RCTText (= 0.66.0)
+    - React-RCTVibration (= 0.66.0)
+  - React-callinvoker (0.66.0)
+  - React-Core (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.0-rc.4)
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-Core/Default (= 0.66.0)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.66.0-rc.4):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
-    - Yoga
-  - React-Core/Default (0.66.0-rc.4):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
-    - Yoga
-  - React-Core/DevSupport (0.66.0-rc.4):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.66.0-rc.4)
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-jsinspector (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.66.0-rc.4):
+  - React-Core/CoreModulesHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.66.0-rc.4):
+  - React-Core/Default (0.66.0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
+    - Yoga
+  - React-Core/DevSupport (0.66.0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.66.0)
+    - React-Core/RCTWebSocket (= 0.66.0)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-jsinspector (= 0.66.0)
+    - React-perflogger (= 0.66.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.66.0-rc.4):
+  - React-Core/RCTAnimationHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.66.0-rc.4):
+  - React-Core/RCTBlobHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.66.0-rc.4):
+  - React-Core/RCTImageHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.66.0-rc.4):
+  - React-Core/RCTLinkingHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.66.0-rc.4):
+  - React-Core/RCTNetworkHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.66.0-rc.4):
+  - React-Core/RCTSettingsHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.66.0-rc.4):
+  - React-Core/RCTTextHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.66.0-rc.4):
+  - React-Core/RCTVibrationHeaders (0.66.0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.0-rc.4)
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsiexecutor (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-Core/Default
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
     - Yoga
-  - React-CoreModules (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
+  - React-Core/RCTWebSocket (0.66.0):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.0-rc.4)
-    - React-Core/CoreModulesHeaders (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-RCTImage (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-cxxreact (0.66.0-rc.4):
+    - React-Core/Default (= 0.66.0)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsiexecutor (= 0.66.0)
+    - React-perflogger (= 0.66.0)
+    - Yoga
+  - React-CoreModules (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.66.0)
+    - React-Core/CoreModulesHeaders (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-RCTImage (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-cxxreact (0.66.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-jsinspector (= 0.66.0-rc.4)
-    - React-logger (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
-    - React-runtimeexecutor (= 0.66.0-rc.4)
-  - React-jsi (0.66.0-rc.4):
+    - React-callinvoker (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-jsinspector (= 0.66.0)
+    - React-logger (= 0.66.0)
+    - React-perflogger (= 0.66.0)
+    - React-runtimeexecutor (= 0.66.0)
+  - React-jsi (0.66.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.66.0-rc.4)
-  - React-jsi/Default (0.66.0-rc.4):
+    - React-jsi/Default (= 0.66.0)
+  - React-jsi/Default (0.66.0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.66.0-rc.4):
+  - React-jsiexecutor (0.66.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
-  - React-jsinspector (0.66.0-rc.4)
-  - React-logger (0.66.0-rc.4):
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-perflogger (= 0.66.0)
+  - React-jsinspector (0.66.0)
+  - React-logger (0.66.0):
     - glog
-  - React-perflogger (0.66.0-rc.4)
-  - React-RCTActionSheet (0.66.0-rc.4):
-    - React-Core/RCTActionSheetHeaders (= 0.66.0-rc.4)
-  - React-RCTAnimation (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
+  - React-perflogger (0.66.0)
+  - React-RCTActionSheet (0.66.0):
+    - React-Core/RCTActionSheetHeaders (= 0.66.0)
+  - React-RCTAnimation (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.0-rc.4)
-    - React-Core/RCTAnimationHeaders (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-RCTBlob (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
+    - RCTTypeSafety (= 0.66.0)
+    - React-Core/RCTAnimationHeaders (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-RCTBlob (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.66.0-rc.4)
-    - React-Core/RCTWebSocket (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-RCTNetwork (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-RCTImage (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
+    - React-Core/RCTBlobHeaders (= 0.66.0)
+    - React-Core/RCTWebSocket (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-RCTNetwork (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-RCTImage (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.0-rc.4)
-    - React-Core/RCTImageHeaders (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-RCTNetwork (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-RCTLinking (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
-    - React-Core/RCTLinkingHeaders (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-RCTNetwork (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
+    - RCTTypeSafety (= 0.66.0)
+    - React-Core/RCTImageHeaders (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-RCTNetwork (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-RCTLinking (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
+    - React-Core/RCTLinkingHeaders (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-RCTNetwork (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.0-rc.4)
-    - React-Core/RCTNetworkHeaders (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-RCTSettings (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
+    - RCTTypeSafety (= 0.66.0)
+    - React-Core/RCTNetworkHeaders (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-RCTSettings (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.0-rc.4)
-    - React-Core/RCTSettingsHeaders (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-RCTText (0.66.0-rc.4):
-    - React-Core/RCTTextHeaders (= 0.66.0-rc.4)
-  - React-RCTVibration (0.66.0-rc.4):
-    - FBReactNativeSpec (= 0.66.0-rc.4)
+    - RCTTypeSafety (= 0.66.0)
+    - React-Core/RCTSettingsHeaders (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-RCTText (0.66.0):
+    - React-Core/RCTTextHeaders (= 0.66.0)
+  - React-RCTVibration (0.66.0):
+    - FBReactNativeSpec (= 0.66.0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - ReactCommon/turbomodule/core (= 0.66.0-rc.4)
-  - React-runtimeexecutor (0.66.0-rc.4):
-    - React-jsi (= 0.66.0-rc.4)
-  - ReactCommon/turbomodule/core (0.66.0-rc.4):
+    - React-Core/RCTVibrationHeaders (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - ReactCommon/turbomodule/core (= 0.66.0)
+  - React-runtimeexecutor (0.66.0):
+    - React-jsi (= 0.66.0)
+  - ReactCommon/turbomodule/core (0.66.0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.0-rc.4)
-    - React-Core (= 0.66.0-rc.4)
-    - React-cxxreact (= 0.66.0-rc.4)
-    - React-jsi (= 0.66.0-rc.4)
-    - React-logger (= 0.66.0-rc.4)
-    - React-perflogger (= 0.66.0-rc.4)
+    - React-callinvoker (= 0.66.0)
+    - React-Core (= 0.66.0)
+    - React-cxxreact (= 0.66.0)
+    - React-jsi (= 0.66.0)
+    - React-logger (= 0.66.0)
+    - React-perflogger (= 0.66.0)
   - RNFBAnalytics (12.8.0):
     - Firebase/Analytics (= 8.8.0)
     - React-Core
@@ -1114,8 +1114,8 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   BoringSSL-GRPC: 8edf627ee524575e2f8d19d56f068b448eea3879
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: 44c41354a76955864b3d6227b5f338f2ca481ff4
-  FBReactNativeSpec: 97b28c619d0e565da0e2d182a703cf1a6d2d0f63
+  FBLazyVector: 6816ca39e1cc8beffd2a96783f518296789d1c48
+  FBReactNativeSpec: 3b1e86618e902743fde35b40cf9ebd100fd655b7
   Firebase: 629510f1a9ddb235f3a7c5c8ceb23ba887f0f814
   FirebaseABTesting: 981336dd14d84787e33466e4247f77ec2343f8d9
   FirebaseAnalytics: 5506ea8b867d8423485a84b4cd612d279f7b0b8a
@@ -1148,31 +1148,31 @@ SPEC CHECKSUMS:
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
-  RCTRequired: b8bd380788aa0fad4be1e26752f03162be18f829
-  RCTTypeSafety: 64acbf4f54c69b3c01b264ab868109064ef74147
-  React: 34ae3469c3c465c4823a21392f3c627130c3f02b
-  React-callinvoker: 9f65cabb5286b224ac0582eb89726a624b29848a
-  React-Core: ca5e82c26ab8627407101698fe4642f941956bdf
-  React-CoreModules: a7657bff50180a39d62a0a4cb657693d5cba8e1a
-  React-cxxreact: a2ea5dd108c2199f7e1c9a27b7c4b6fd571b00d8
-  React-jsi: ccc2853d0d9e328e2394e369d7a65c7b1491c87c
-  React-jsiexecutor: c463c31a76c32cfaa0c1354ddba8f05d5aaa6a0c
-  React-jsinspector: 9b8acfcce07be90f66969b2d9c543bd6b5e90f43
-  React-logger: c63bf8b7722923563b0f257c62a4c38c64c4b870
-  React-perflogger: 8fd84be6032fd3f065d590738d7a63e607f40212
-  React-RCTActionSheet: 0160839401fff738de248222bb8b93ca0a3e4e68
-  React-RCTAnimation: 9f45836c810fc355a4bdbdd1113cefea0fc7a453
-  React-RCTBlob: 57cbffcdb41523b11cacb2aaa4bbf5baf772f44c
-  React-RCTImage: ba9c35a4e18d0d614db98a28a0c66fc22f971534
-  React-RCTLinking: a317269591212cd454d84450fe75cc5915986381
-  React-RCTNetwork: 33fdbeeceadd59dc7fe2904dc429d44eab7f6ace
-  React-RCTSettings: 45f9d38ebfdc0357f39a8944bb89031bfc17d241
-  React-RCTText: f7f586867700d63c3eb565317f76abaca399bf54
-  React-RCTVibration: 7551dea66c9dacdc9a9b43024273984d1d6be7da
-  React-runtimeexecutor: 27256640cd38a56eca29727579b7659cbf92144c
-  ReactCommon: c6aa72c294928f0436798383d84ee4cca09e6a3d
+  RCTRequired: e4a18a90004e0ed97bba9081099104fd0f658dc9
+  RCTTypeSafety: 8a3c31d38de58e1a6a7df6e4e643644a60b00e22
+  React: 2b1d0dc3c23e01b754588a74a5b265282d9eb61e
+  React-callinvoker: 57c195e780695285fa56e61efdbc0ca0e9204484
+  React-Core: 45e4b3c57b0b5fdbb24bc6a63a964870c0405955
+  React-CoreModules: d7bb1ae3436eddd85a7eb6d5e928f8c1655d87db
+  React-cxxreact: 60c850e9997b21ee302757c36a460efc944183e7
+  React-jsi: 38d68cb1b53843703100830d530342b32f8e0878
+  React-jsiexecutor: 6a05173dc0142abc582bd4edd2d23146b8cc218a
+  React-jsinspector: be95ad424ba9f7b817aff22732eb9b1b810a000a
+  React-logger: 9a9cd87d4ea681ae929b32ef580638ff1b50fb24
+  React-perflogger: 1f554c2b684e2f484f9edcdfdaeedab039fbaca8
+  React-RCTActionSheet: 610d5a5d71ab4808734782c8bca6a12ec3563672
+  React-RCTAnimation: ec6ed97370ace32724c253f29f0586cafcab8126
+  React-RCTBlob: b3270d498ff240f49c50e1bc950b6e5fd48886ba
+  React-RCTImage: 23d5e26669b31230bea3fd99eb703af699e5d61a
+  React-RCTLinking: edaaee9dee82b79e90e7b903d8913fa72284fbba
+  React-RCTNetwork: e8825053dd1b5c2a0e1aa3cf1127750b624f90c0
+  React-RCTSettings: 40d7ae987031c5dc561d11cd3a15cc1245a11d42
+  React-RCTText: 6e104479d4f0bb593b4cf90b6fc6e5390c12ccde
+  React-RCTVibration: 53b92d54b923283638cb0186da7a5c2d2b70a49b
+  React-runtimeexecutor: 4bb657a97aa74568d9ed634c8bd478299bb8a3a6
+  ReactCommon: eb059748e842a1a86025ebbd4ac9d99e74492f88
   RNFBAnalytics: 493f19405859ebcff731ec5be496feee51ad5bb1
-  RNFBApp: c2045013e31a110a6df17f22415968da54535d1e
+  RNFBApp: 8451baf6645d782f21fff2cd5af937f6a25c404a
   RNFBAppCheck: 8fe3ae127db3b6e859fff4def766bc9cc174a25c
   RNFBAppDistribution: 95d085160290676ed6620b10749d5f7d2bff8ee2
   RNFBAuth: 876d80d193e57f79eccc4f80a2edf302e8a7a811
@@ -1188,7 +1188,7 @@ SPEC CHECKSUMS:
   RNFBPerf: 03fcef1af02abaaeb750f9fa304415fdde839ccd
   RNFBRemoteConfig: c25186cee985ce62cd8e25e73002b6a25578532e
   RNFBStorage: 2bb9df8aa098ec74739212fe35ebaea3e624a18c
-  Yoga: 993072c74154c30d07c9cae300322348f0f67e25
+  Yoga: c11abbf5809216c91fcd62f5571078b83d9b6720
 
 PODFILE CHECKSUM: c7489013e48e7b6bf3608aa0707a5507ccf9aa40
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -26,7 +26,7 @@
     "@react-native-firebase/remote-config": "12.8.0",
     "@react-native-firebase/storage": "12.8.0",
     "react": "17.0.2",
-    "react-native": "0.66.0-rc.4"
+    "react-native": "0.66.0"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^2.0.1",
@@ -34,7 +34,7 @@
     "a2a": "^0.2.0",
     "babel-plugin-istanbul": "^6.0.0",
     "detox": "^18.22.0",
-    "firebase": "^9.1.0",
+    "firebase": "^9.1.1",
     "firebase-tools": "^9.19.0",
     "jest-circus": "^27.2.4",
     "jest-environment-node": "^27.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,12 +1446,12 @@
     "@firebase/util" "1.4.0"
     tslib "^2.1.0"
 
-"@firebase/app-compat@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.1.2.tgz#ed9682325bbec6e177449f4b7403c60b088c89db"
-  integrity sha512-kF1maoqA8bZqJ4v/ojVvA7kIyyXEPkJmL48otGrC8LIgdcen7xCx3JFDe0DGeQywg+qujvdkJz/TptFN1cvAgw==
+"@firebase/app-compat@0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@firebase/app-compat/-/app-compat-0.1.3.tgz#4757c8f65d2a067d24afdfef4f736a5f53c66656"
+  integrity sha512-+/U2RgRLfLznPuluIMW3bsAehTBTVWKxA6l6jjk9noozPuP99xOulReMqf5kCrXVdW1aMHdRuKfntjbTAR8+aw==
   dependencies:
-    "@firebase/app" "0.7.1"
+    "@firebase/app" "0.7.2"
     "@firebase/component" "0.5.7"
     "@firebase/logger" "0.3.0"
     "@firebase/util" "1.4.0"
@@ -1462,26 +1462,26 @@
   resolved "https://registry.yarnpkg.com/@firebase/app-types/-/app-types-0.7.0.tgz#c9e16d1b8bed1a991840b8d2a725fb58d0b5899f"
   integrity sha512-6fbHQwDv2jp/v6bXhBw2eSRbNBpxHcd1NBF864UksSMVIqIyri9qpJB1Mn6sGZE+bnDsSQBC5j2TbMxYsJQkQg==
 
-"@firebase/app@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.7.1.tgz#b594ac4cd15bf94d2a3b97681354a52fa5cfca29"
-  integrity sha512-B4z6E1EPQc0mOjF35IPKdDRCFnT/fNQIHfM+v7F9obB7ItPhGILK3LxaQfuampSQpF6GG6TPFDbrWK6myXAq+g==
+"@firebase/app@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.7.2.tgz#0df26d6e9861d5ebe038d4e1f10b63111a28a1f7"
+  integrity sha512-xKO3KWxVqCLijJToaBGvBnXCaVGvIw+rT2Dtd9B2iyOFJieQQ+xx8/zRWgoSqbMBIZ2crQVr0KdsoyP9D2nQfg==
   dependencies:
     "@firebase/component" "0.5.7"
     "@firebase/logger" "0.3.0"
     "@firebase/util" "1.4.0"
     tslib "^2.1.0"
 
-"@firebase/auth-compat@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.1.3.tgz#0110398e665e7b709dfbb81ab9410f58e3d1a98d"
-  integrity sha512-eDDtY5If+ERJxalt+plvX6avZspuwo4/kPXssvV+csm414awhDzQBtSDPDajgbH3YB9V+O3LAFHeWcP3rrHS5w==
+"@firebase/auth-compat@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@firebase/auth-compat/-/auth-compat-0.1.4.tgz#d55084f0d37086d58a1da4748c9bbec2ede0a80a"
+  integrity sha512-Vn7Dsxa7B50ihgDAMQAVb/IxU9tcQyR1JDbWjZzf2b1212hBuuwEs1V1u01xoKunMXMSg+P8ztbG7IRxOj2FdQ==
   dependencies:
-    "@firebase/auth" "0.18.0"
+    "@firebase/auth" "0.18.1"
     "@firebase/auth-types" "0.11.0"
     "@firebase/component" "0.5.7"
     "@firebase/util" "1.4.0"
-    node-fetch "2.6.2"
+    node-fetch "2.6.5"
     selenium-webdriver "^4.0.0-beta.2"
     tslib "^2.1.0"
 
@@ -1495,15 +1495,15 @@
   resolved "https://registry.yarnpkg.com/@firebase/auth-types/-/auth-types-0.11.0.tgz#b9c73c60ca07945b3bbd7a097633e5f78fa9e886"
   integrity sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==
 
-"@firebase/auth@0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.18.0.tgz#00de488a43f84bd9b1e2f8e1d9887a499d30b93d"
-  integrity sha512-iK+VXkdDkum8SmJNgz9ZcOboRLrUN1VW7AHHkpZb76VJvoYRoCPD+A9O/v/ziI0LpwIZJwi1GFes9XjZTlfLiA==
+"@firebase/auth@0.18.1":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-0.18.1.tgz#2cba86c5ac614aea8ea1bdc55e479530c187b5ce"
+  integrity sha512-q455ls7Hjug3yGp7htLL/LABqySoXGXL/ADLJPyiSnVl22a5oQWuTKUL6N5PAXHc5LwygFfHYiHrNhpQDaGm3w==
   dependencies:
     "@firebase/component" "0.5.7"
     "@firebase/logger" "0.3.0"
     "@firebase/util" "1.4.0"
-    node-fetch "2.6.2"
+    node-fetch "2.6.5"
     selenium-webdriver "4.0.0-rc-1"
     tslib "^2.1.0"
 
@@ -3356,17 +3356,17 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
   integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
 
-"@types/react-native@^0.65.2":
-  version "0.65.2"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.65.2.tgz#2fd4b5c60a4e2a02668dc304de0d7192013f5d14"
-  integrity sha512-UjDkN6rvgZkvVl2726bCPjIupyBUt40Uv+FhtDPwGj6n7ShiHggAfv6Xl7Pzbc36L5qUIWSmBrrFBLJXZ4MEig==
+"@types/react-native@^0.65.3":
+  version "0.65.3"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.65.3.tgz#1cc6eb292ab7f4487d3c378ff0be04940fa257b4"
+  integrity sha512-23YX98rFNR43f2rvEV1cQ8VAFSj9ylXPqmzQMotC45hsK/SCNtLwJx1mgZ5jkyqs9TLjspzU0jszr58+Z9seQQ==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.26":
-  version "17.0.26"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.26.tgz#960ea4b3518cc154ed7df3b35656c508df653331"
-  integrity sha512-MXxuXrH2xOcv5cp/su4oz69dNQnSA90JjFw5HBd5wifw6Ihi94j7dRJm7qNsB30tnruXSCPc9qmlhGop4nh9Hw==
+"@types/react@*", "@types/react@^17.0.27":
+  version "17.0.27"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.27.tgz#6498ed9b3ad117e818deb5525fa1946c09f2e0e6"
+  integrity sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -6741,20 +6741,20 @@ firebase-tools@^9.19.0:
     winston-transport "^4.4.0"
     ws "^7.2.3"
 
-firebase@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/firebase/-/firebase-9.1.0.tgz#f284634ae4f4e7c789ff36494f4534cba5dffbf2"
-  integrity sha512-Pj9/FwNzT4pdSS6vpXZzm4mFscI73N+AH70gaWZPnZrQBvyMAPTuKXXscjrFePPlqs94b4Emq+2mSwLGcwod/A==
+firebase@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/firebase/-/firebase-9.1.1.tgz#a2980cf397cdbf9933430576c0413ec5c30e2f62"
+  integrity sha512-106PqKLwWo4vINQUwEbk2aU/nAFhRbCBE2IdnQmf7UDaW4wqJGZcgRvy3jSyuZr/dkqnT7ymKX0GGrDSzNLU6g==
   dependencies:
     "@firebase/analytics" "0.7.1"
     "@firebase/analytics-compat" "0.1.2"
-    "@firebase/app" "0.7.1"
+    "@firebase/app" "0.7.2"
     "@firebase/app-check" "0.4.1"
     "@firebase/app-check-compat" "0.1.2"
-    "@firebase/app-compat" "0.1.2"
+    "@firebase/app-compat" "0.1.3"
     "@firebase/app-types" "0.7.0"
-    "@firebase/auth" "0.18.0"
-    "@firebase/auth-compat" "0.1.3"
+    "@firebase/auth" "0.18.1"
+    "@firebase/auth-compat" "0.1.4"
     "@firebase/database" "0.12.1"
     "@firebase/database-compat" "0.1.1"
     "@firebase/firestore" "3.1.0"
@@ -10562,6 +10562,13 @@ node-fetch@2.6.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.2.tgz#986996818b73785e47b1965cc34eb093a1d464d0"
   integrity sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==
 
+node-fetch@2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz#42735537d7f080a7e5f78b6c549b7146be1742fd"
+  integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -11938,10 +11945,10 @@ react-native-port-patcher@^1.0.4:
   dependencies:
     command-line-args "^3.0.5"
 
-react-native@0.66.0-rc.4:
-  version "0.66.0-rc.4"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.66.0-rc.4.tgz#04742298e073cfe79b58a19d931ac98caa0f9ff7"
-  integrity sha512-hPmmEA20mHISzMCMsrHH37Z65unBl3F1T/wn9bUvAbezROG8N5LcD9plx+DqHMlkakoqkXEIQVhxkyf67QdFdA==
+react-native@0.66.0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.66.0.tgz#99bdd83a9a612a71b94242767989d666d445b007"
+  integrity sha512-m26TKwzsfHVdZ1hDG+7mZ4M4ftxFFZrhtiT0OXuwfBzmNtB3xhsJtYszPeizw33c9YNp8rvehKT3c4ldDCW6kA==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^6.0.0"
@@ -13747,6 +13754,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
@@ -14311,6 +14323,11 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -14356,6 +14373,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.4.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
This matches underlying firebase-ios-sdk v8.8.0 requirement

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
