### PR TITLE
feat(ios, sdks): bump firebase-ios-sdk to 8.9.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -65,7 +65,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "8.8.0"
+      "firebase": "8.9.0"
     },
     "android": {
       "minSdk": 16,

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -56,5 +56,7 @@ target 'testing' do
       end
       aggregate_target.user_project.save
     end
+
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -354,112 +354,112 @@ PODS:
     - React-Core (= 0.67.0-rc.0)
     - React-jsi (= 0.67.0-rc.0)
     - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - Firebase/Analytics (8.8.0):
+  - Firebase/Analytics (8.9.0):
     - Firebase/Core
-  - Firebase/AppCheck (8.8.0):
+  - Firebase/AppCheck (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 8.8.0-beta)
-  - Firebase/AppDistribution (8.8.0):
+    - FirebaseAppCheck (~> 8.9.0-beta)
+  - Firebase/AppDistribution (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 8.8.0-beta)
-  - Firebase/Auth (8.8.0):
+    - FirebaseAppDistribution (~> 8.9.0-beta)
+  - Firebase/Auth (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.8.0)
-  - Firebase/Core (8.8.0):
+    - FirebaseAuth (~> 8.9.0)
+  - Firebase/Core (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.8.0)
-  - Firebase/CoreOnly (8.8.0):
-    - FirebaseCore (= 8.8.0)
-  - Firebase/Crashlytics (8.8.0):
+    - FirebaseAnalytics (~> 8.9.0)
+  - Firebase/CoreOnly (8.9.0):
+    - FirebaseCore (= 8.9.0)
+  - Firebase/Crashlytics (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.8.0)
-  - Firebase/Database (8.8.0):
+    - FirebaseCrashlytics (~> 8.9.0)
+  - Firebase/Database (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 8.8.0)
-  - Firebase/DynamicLinks (8.8.0):
+    - FirebaseDatabase (~> 8.9.0)
+  - Firebase/DynamicLinks (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 8.8.0)
-  - Firebase/Firestore (8.8.0):
+    - FirebaseDynamicLinks (~> 8.9.0)
+  - Firebase/Firestore (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 8.8.0)
-  - Firebase/Functions (8.8.0):
+    - FirebaseFirestore (~> 8.9.0)
+  - Firebase/Functions (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 8.8.0)
-  - Firebase/InAppMessaging (8.8.0):
+    - FirebaseFunctions (~> 8.9.0)
+  - Firebase/InAppMessaging (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 8.8.0-beta)
-  - Firebase/Installations (8.8.0):
+    - FirebaseInAppMessaging (~> 8.9.0-beta)
+  - Firebase/Installations (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 8.8.0)
-  - Firebase/Messaging (8.8.0):
+    - FirebaseInstallations (~> 8.9.0)
+  - Firebase/Messaging (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.8.0)
-  - Firebase/Performance (8.8.0):
+    - FirebaseMessaging (~> 8.9.0)
+  - Firebase/Performance (8.9.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 8.8.0)
-  - Firebase/RemoteConfig (8.8.0):
+    - FirebasePerformance (~> 8.9.0)
+  - Firebase/RemoteConfig (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.8.0)
-  - Firebase/Storage (8.8.0):
+    - FirebaseRemoteConfig (~> 8.9.0)
+  - Firebase/Storage (8.9.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 8.8.0)
-  - FirebaseABTesting (8.8.0):
+    - FirebaseStorage (~> 8.9.0)
+  - FirebaseABTesting (8.9.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseAnalytics (8.8.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.8.0)
-    - FirebaseCore (~> 8.0)
-    - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-    - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.8.0):
+  - FirebaseAnalytics (8.9.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.9.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAppCheck (8.8.0-beta):
+  - FirebaseAnalytics/AdIdSupport (8.9.0):
     - FirebaseCore (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleAppMeasurement (= 8.9.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+    - nanopb (~> 2.30908.0)
+  - FirebaseAppCheck (8.9.0-beta):
+    - FirebaseCore (~> 8.0)
+    - GoogleUtilities/Environment (~> 7.6)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseAppDistribution (8.8.0-beta):
+  - FirebaseAppDistribution (8.9.0-beta):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/UserDefaults (~> 7.4)
-  - FirebaseAuth (8.8.0):
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/UserDefaults (~> 7.6)
+  - FirebaseAuth (8.9.0):
     - FirebaseCore (~> 8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/Environment (~> 7.4)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/Environment (~> 7.6)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.8.0):
+  - FirebaseCore (8.9.0):
     - FirebaseCoreDiagnostics (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Logger (~> 7.4)
-  - FirebaseCoreDiagnostics (8.8.0):
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Logger (~> 7.4)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/Logger (~> 7.6)
+  - FirebaseCoreDiagnostics (8.9.0):
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/Logger (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.8.0):
+  - FirebaseCrashlytics (8.9.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.4)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.6)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseDatabase (8.8.0):
+  - FirebaseDatabase (8.9.0):
     - FirebaseCore (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (8.8.0):
+  - FirebaseDynamicLinks (8.9.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseFirestore (8.8.0):
+  - FirebaseFirestore (8.9.0):
     - abseil/algorithm (= 0.20200225.0)
     - abseil/base (= 0.20200225.0)
     - abseil/container/flat_hash_map (= 0.20200225.0)
@@ -472,68 +472,68 @@ PODS:
     - "gRPC-C++ (~> 1.28.0)"
     - leveldb-library (~> 1.22)
     - nanopb (~> 2.30908.0)
-  - FirebaseFunctions (8.8.0):
+  - FirebaseFunctions (8.9.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseInAppMessaging (8.8.0-beta):
+  - FirebaseInAppMessaging (8.9.0-beta):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
+    - GoogleUtilities/Environment (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.8.0):
+  - FirebaseInstallations (8.9.0):
     - FirebaseCore (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/UserDefaults (~> 7.4)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/UserDefaults (~> 7.6)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.8.0):
+  - FirebaseMessaging (8.9.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/Reachability (~> 7.4)
-    - GoogleUtilities/UserDefaults (~> 7.4)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/Reachability (~> 7.6)
+    - GoogleUtilities/UserDefaults (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebasePerformance (8.8.0):
+  - FirebasePerformance (8.9.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - FirebaseRemoteConfig (~> 8.0)
-    - GoogleDataTransport (~> 9.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - GoogleUtilities/ISASwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.6)
+    - GoogleUtilities/ISASwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseRemoteConfig (8.8.0):
+  - FirebaseRemoteConfig (8.9.0):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleUtilities/Environment (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
-  - FirebaseStorage (8.8.0):
+    - GoogleUtilities/Environment (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
+  - FirebaseStorage (8.9.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (8.8.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+  - GoogleAppMeasurement (8.9.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.9.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.8.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.8.0)
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+  - GoogleAppMeasurement/AdIdSupport (8.9.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.9.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.8.0):
-    - GoogleUtilities/AppDelegateSwizzler (~> 7.4)
-    - GoogleUtilities/MethodSwizzler (~> 7.4)
-    - GoogleUtilities/Network (~> 7.4)
-    - "GoogleUtilities/NSData+zlib (~> 7.4)"
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.9.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.6)
+    - GoogleUtilities/MethodSwizzler (~> 7.6)
+    - GoogleUtilities/Network (~> 7.6)
+    - "GoogleUtilities/NSData+zlib (~> 7.6)"
     - nanopb (~> 2.30908.0)
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
@@ -857,70 +857,70 @@ PODS:
     - React-logger (= 0.67.0-rc.0)
     - React-perflogger (= 0.67.0-rc.0)
   - RNFBAnalytics (12.9.3):
-    - Firebase/Analytics (= 8.8.0)
+    - Firebase/Analytics (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBApp (12.9.3):
-    - Firebase/CoreOnly (= 8.8.0)
+    - Firebase/CoreOnly (= 8.9.0)
     - React-Core
   - RNFBAppCheck (12.9.3):
-    - Firebase/AppCheck (= 8.8.0)
+    - Firebase/AppCheck (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBAppDistribution (12.9.3):
-    - Firebase/AppDistribution (= 8.8.0)
+    - Firebase/AppDistribution (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBAuth (12.9.3):
-    - Firebase/Auth (= 8.8.0)
+    - Firebase/Auth (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBCrashlytics (12.9.3):
-    - Firebase/Crashlytics (= 8.8.0)
+    - Firebase/Crashlytics (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBDatabase (12.9.3):
-    - Firebase/Database (= 8.8.0)
+    - Firebase/Database (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBDynamicLinks (12.9.3):
-    - Firebase/DynamicLinks (= 8.8.0)
+    - Firebase/DynamicLinks (= 8.9.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
   - RNFBFirestore (12.9.3):
-    - Firebase/Firestore (= 8.8.0)
+    - Firebase/Firestore (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBFunctions (12.9.3):
-    - Firebase/Functions (= 8.8.0)
+    - Firebase/Functions (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBInAppMessaging (12.9.3):
-    - Firebase/InAppMessaging (= 8.8.0)
+    - Firebase/InAppMessaging (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBInstallations (12.9.3):
-    - Firebase/Installations (= 8.8.0)
+    - Firebase/Installations (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBMessaging (12.9.3):
-    - Firebase/Messaging (= 8.8.0)
+    - Firebase/Messaging (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBML (12.9.3):
     - React-Core
     - RNFBApp
   - RNFBPerf (12.9.3):
-    - Firebase/Performance (= 8.8.0)
+    - Firebase/Performance (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBRemoteConfig (12.9.3):
-    - Firebase/RemoteConfig (= 8.8.0)
+    - Firebase/RemoteConfig (= 8.9.0)
     - React-Core
     - RNFBApp
   - RNFBStorage (12.9.3):
-    - Firebase/Storage (= 8.8.0)
+    - Firebase/Storage (= 8.9.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -1116,28 +1116,28 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 2bb3717e26358b6a664ce73175790113a85683b5
   FBReactNativeSpec: 1167e84c1dd737d7e2c8ce26d71048ff96f46ead
-  Firebase: 629510f1a9ddb235f3a7c5c8ceb23ba887f0f814
-  FirebaseABTesting: 981336dd14d84787e33466e4247f77ec2343f8d9
-  FirebaseAnalytics: 5506ea8b867d8423485a84b4cd612d279f7b0b8a
-  FirebaseAppCheck: 2c23e71c305cc93be7770fdf20bee65dec6f700b
-  FirebaseAppDistribution: fa46fb0898b0f31e0fe428b32059e2baed653d21
-  FirebaseAuth: bcf0adeff88bda5dcb3beeabe5760f1226ab7b2f
-  FirebaseCore: 98b29e3828f0a53651c363937a7f7d92a19f1ba2
-  FirebaseCoreDiagnostics: fe77f42da6329d6d83d21fd9d621a6b704413bfc
-  FirebaseCrashlytics: 3660c045c8e45cc4276110562a0ef44cf43c8157
-  FirebaseDatabase: bc4610ff3a816dcc680c1dbccf7f9f4bd94ac07d
-  FirebaseDynamicLinks: cf76a46274569da2d4491548a39ef35f3c1a992d
-  FirebaseFirestore: 29baf05d5e7e0d5003eb34e5805d92b9858b36d4
-  FirebaseFunctions: 747034115d113cf600c4995ff7e4d384697e7c49
-  FirebaseInAppMessaging: 9c4417ef987ca961a6e337f7eba57bbdb9f81885
-  FirebaseInstallations: 2563cb18a723ef9c6ef18318a49519b75dce613c
-  FirebaseMessaging: 419b5c9d84f294a753c6501d8cfb9ced1ce37304
-  FirebasePerformance: 0c01a7a496657d7cea86d40c0b1725259d164c6c
-  FirebaseRemoteConfig: f6365883d7950d784ee97bcdbbf1e442d4fa6119
-  FirebaseStorage: 54ff752ecbd27f1c354c3f5e8c55f6ad5783699b
+  Firebase: 13d8d96499e2635428d5bf0ec675df21f95d9a95
+  FirebaseABTesting: 9de50b34bf9eb4a07d4edb7af82c14152fd905aa
+  FirebaseAnalytics: 3a11ed901750e1ebcbe35e75915ff079878ea385
+  FirebaseAppCheck: eb4c5c6984804b728f71ae89711455dcf6a21054
+  FirebaseAppDistribution: c4164c8a660b8f8f1427e219d169b837a8e46575
+  FirebaseAuth: 2b78b2a32c07b3ecfa4970bdf1d3632b8304099b
+  FirebaseCore: 599ee609343eaf4941bd188f85e3aa077ffe325b
+  FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
+  FirebaseCrashlytics: 40efbd81157dae307ec95612fa1328347284d2c2
+  FirebaseDatabase: 2236b804cf0cac165b4620669bedf7ee643a2bcc
+  FirebaseDynamicLinks: 50980cbe21d2bbe8374afcdccd94dc2db20dffca
+  FirebaseFirestore: bb57bfeb3ec001d99e7e2a96dd29072b01e816f6
+  FirebaseFunctions: c78ec2f93cd453f25fb5e4c694c830f7a31ab349
+  FirebaseInAppMessaging: 2fc3754e9e63dd44daff52930f075525cc9a518c
+  FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
+  FirebaseMessaging: 82c4a48638f53f7b184f3cc9f6cd2cbe533ab316
+  FirebasePerformance: 81f183c3fc593241d000a6367e54fd0f7ed402e3
+  FirebaseRemoteConfig: a75c1bd44ebd3ed4ad3fa1ff09414a8b133be405
+  FirebaseStorage: 452c98c31ccb40b819764bf3039426c4388d9939
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
-  GoogleAppMeasurement: 5ba1164e3c844ba84272555e916d0a6d3d977e91
+  GoogleAppMeasurement: b54a857d347703d67c7a6f23713760c9bcfe9008
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
   "gRPC-C++": 13d8ccef97d5c3c441b7e3c529ef28ebee86fad2
@@ -1171,25 +1171,25 @@ SPEC CHECKSUMS:
   React-RCTVibration: e984287863f3178d0a808f51bfeb7a8b5f21a07c
   React-runtimeexecutor: 883ffdd8e0e27fc6ccb6c66f36c6664380dcc932
   ReactCommon: adf56020429e34de92b25b41efb7decaea2b9ecd
-  RNFBAnalytics: f76bfa164ac235b00505deb9fc1776634056898c
-  RNFBApp: 729c0666395b1953198dc4a1ec6deb8fbe1c302e
-  RNFBAppCheck: 36825db2d35f6b30a9fbf5a07d6d764e4e90c2c0
-  RNFBAppDistribution: 4e7df69ff3469cad8f19d06c6e3b3986cb74c77c
-  RNFBAuth: 7718be1152f5d1d0bb970a8d33094d010f1ac21c
-  RNFBCrashlytics: 2061ca863e8e2fa1aae9b12477d7dfa8e88ca0f9
-  RNFBDatabase: 1e8e42f296c43f812ac91fe078ceedbf02c77a23
-  RNFBDynamicLinks: 4cb7df93b3bea086d743ecb78127c3d11b38510d
-  RNFBFirestore: eef5fd4cfbe35316af559631db06a34b8391628a
-  RNFBFunctions: 3f35e57d169476d096c47d47970230d461e95572
-  RNFBInAppMessaging: b646527e59d56defeef204c225b009f0ee3d7f24
-  RNFBInstallations: 2f7f698141b870ba8417ef0f5710e477062f1623
-  RNFBMessaging: 8415ec196e5c1196caa26ec0742cdb48ed4d0f97
+  RNFBAnalytics: 0f6af6d3c8131b9f8b0b1058a700ada57d87b9ce
+  RNFBApp: 7fca4a99cd00f204f3cc4b247d2f89ff3688dad5
+  RNFBAppCheck: 863543cb089e71474e8a2b05c191e988feee33e6
+  RNFBAppDistribution: 7ba2fb8851fa2d70b820cd4865c3b053be5b7ae5
+  RNFBAuth: db3f6a248f1ec446daf9264459d7631a62e06c0f
+  RNFBCrashlytics: 924382cb7e9c550d0b1ba138cdd33379b99ceb5c
+  RNFBDatabase: 128b81156f884c90b6a4fd5ac7fe19b28d8a4610
+  RNFBDynamicLinks: 100b733187f46d616fee4dfcc90c1045871a2919
+  RNFBFirestore: be83b59a7e4e63620a850d19df5dbc557838859b
+  RNFBFunctions: aece64d4b32afc3825416ffb15a6bb176102ef5c
+  RNFBInAppMessaging: e74f617aa2fdc64956b7b4bbbbe0f7cf905837b0
+  RNFBInstallations: 6852561b13835759fb53d437574a6fe7f91811de
+  RNFBMessaging: 34385d692635e7c00f9634ac902ad31f09722cab
   RNFBML: 3b4331e7ac1fd492622f4c9229024d9127ec9c9e
-  RNFBPerf: 389914cda4000fe0d996a752532a591132cbf3f9
-  RNFBRemoteConfig: d88fcaa30a3a1605885c79814856abe7bbaaa929
-  RNFBStorage: 0c7bbab8436996aed5a7a9d7470a7df067a66419
+  RNFBPerf: e9994639cce21dfa522e02f70924ab04abc1629a
+  RNFBRemoteConfig: 0705aff441a5dc993f2378a3cfdfe4e773a5ae6f
+  RNFBStorage: 90ddf0b11203916835cb6cf89c9d493c919b1716
   Yoga: 080f5389e515e1d0233a75bbb9de3a4eb87d8185
 
-PODFILE CHECKSUM: 9222e25c9a047390eafc3a9e70ec01719a2a711d
+PODFILE CHECKSUM: 43fa86a6ee18afb5a0e1abf27196346cd71e6cf5
 
 COCOAPODS: 1.11.2

--- a/tests/package.json
+++ b/tests/package.json
@@ -26,7 +26,7 @@
     "@react-native-firebase/remote-config": "12.9.3",
     "@react-native-firebase/storage": "12.9.3",
     "react": "17.0.2",
-    "react-native": "0.67.0-rc.0"
+    "react-native": "0.67.0-rc.2"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^2.0.1",


### PR DESCRIPTION
- also includes a test bump to react-native 0.67.0-rc.2 but no one
sees that outside of the repo...

### Related issues

#5803

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
