### PR TITLE
feat(sdks, android)!: firebase-android-sdk v29 / minSdkVersion API19 / target+compile API31

### DIFF
--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -40,7 +40,7 @@ buildscript {
   // ..
   dependencies {
     // ..
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.0'
   }
   // ..
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -183,16 +183,16 @@ project.ext {
     versions: [
       // Overriding Build/Android SDK Versions
       android : [
-        minSdk    : 16,
-        targetSdk : 30,
-        compileSdk: 30,
-        buildTools: "30.0.2"
+        minSdk    : 19,
+        targetSdk : 31,
+        compileSdk: 31,
+        buildTools: "30.0.3"
       ],
 
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "28.3.1"
+        bom           : "29.0.0"
       ],
     ],
   ])
@@ -207,7 +207,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '8.5.0'
+$FirebaseSDKVersion = '8.9.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -69,9 +69,9 @@
     },
     "android": {
       "minSdk": 16,
-      "targetSdk": 30,
-      "compileSdk": 30,
-      "buildTools": "30.0.2",
+      "targetSdk": 31,
+      "compileSdk": 31,
+      "buildTools": "30.0.3",
       "firebase": "28.4.2",
       "firebaseCrashlyticsGradle": "2.7.1",
       "firebasePerfGradle": "1.4.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,12 +68,12 @@
       "firebase": "8.9.0"
     },
     "android": {
-      "minSdk": 16,
+      "minSdk": 21,
       "targetSdk": 31,
       "compileSdk": 31,
       "buildTools": "30.0.3",
-      "firebase": "28.4.2",
-      "firebaseCrashlyticsGradle": "2.7.1",
+      "firebase": "29.0.0",
+      "firebaseCrashlyticsGradle": "2.8.0",
       "firebasePerfGradle": "1.4.0",
       "gmsGoogleServicesGradle": "4.3.10",
       "playServicesAuth": "19.2.0"

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.0'
         classpath(\\"com.android.tools.build:gradle:4.1.0\\")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -35,7 +35,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:7.0.3'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.4.0'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.7.1'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.0'
     classpath 'com.google.firebase:firebase-appdistribution-gradle:2.2.0'
   }
 }

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -346,14 +346,14 @@ PODS:
     - BoringSSL-GRPC/Interface (= 0.0.7)
   - BoringSSL-GRPC/Interface (0.0.7)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.67.0-rc.0)
-  - FBReactNativeSpec (0.67.0-rc.0):
+  - FBLazyVector (0.67.0-rc.2)
+  - FBReactNativeSpec (0.67.0-rc.2):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.67.0-rc.0)
-    - RCTTypeSafety (= 0.67.0-rc.0)
-    - React-Core (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
+    - RCTRequired (= 0.67.0-rc.2)
+    - RCTTypeSafety (= 0.67.0-rc.2)
+    - React-Core (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
   - Firebase/Analytics (8.9.0):
     - Firebase/Core
   - Firebase/AppCheck (8.9.0):
@@ -604,258 +604,258 @@ PODS:
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
-  - RCTRequired (0.67.0-rc.0)
-  - RCTTypeSafety (0.67.0-rc.0):
-    - FBLazyVector (= 0.67.0-rc.0)
+  - RCTRequired (0.67.0-rc.2)
+  - RCTTypeSafety (0.67.0-rc.2):
+    - FBLazyVector (= 0.67.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.67.0-rc.0)
-    - React-Core (= 0.67.0-rc.0)
-  - React (0.67.0-rc.0):
-    - React-Core (= 0.67.0-rc.0)
-    - React-Core/DevSupport (= 0.67.0-rc.0)
-    - React-Core/RCTWebSocket (= 0.67.0-rc.0)
-    - React-RCTActionSheet (= 0.67.0-rc.0)
-    - React-RCTAnimation (= 0.67.0-rc.0)
-    - React-RCTBlob (= 0.67.0-rc.0)
-    - React-RCTImage (= 0.67.0-rc.0)
-    - React-RCTLinking (= 0.67.0-rc.0)
-    - React-RCTNetwork (= 0.67.0-rc.0)
-    - React-RCTSettings (= 0.67.0-rc.0)
-    - React-RCTText (= 0.67.0-rc.0)
-    - React-RCTVibration (= 0.67.0-rc.0)
-  - React-callinvoker (0.67.0-rc.0)
-  - React-Core (0.67.0-rc.0):
+    - RCTRequired (= 0.67.0-rc.2)
+    - React-Core (= 0.67.0-rc.2)
+  - React (0.67.0-rc.2):
+    - React-Core (= 0.67.0-rc.2)
+    - React-Core/DevSupport (= 0.67.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.67.0-rc.2)
+    - React-RCTActionSheet (= 0.67.0-rc.2)
+    - React-RCTAnimation (= 0.67.0-rc.2)
+    - React-RCTBlob (= 0.67.0-rc.2)
+    - React-RCTImage (= 0.67.0-rc.2)
+    - React-RCTLinking (= 0.67.0-rc.2)
+    - React-RCTNetwork (= 0.67.0-rc.2)
+    - React-RCTSettings (= 0.67.0-rc.2)
+    - React-RCTText (= 0.67.0-rc.2)
+    - React-RCTVibration (= 0.67.0-rc.2)
+  - React-callinvoker (0.67.0-rc.2)
+  - React-Core (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.67.0-rc.0)
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-Core/Default (= 0.67.0-rc.2)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.67.0-rc.0):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
-    - Yoga
-  - React-Core/Default (0.67.0-rc.0):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
-    - Yoga
-  - React-Core/DevSupport (0.67.0-rc.0):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.67.0-rc.0)
-    - React-Core/RCTWebSocket (= 0.67.0-rc.0)
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-jsinspector (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.67.0-rc.0):
+  - React-Core/CoreModulesHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.67.0-rc.0):
+  - React-Core/Default (0.67.0-rc.2):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
+    - Yoga
+  - React-Core/DevSupport (0.67.0-rc.2):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.67.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.67.0-rc.2)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-jsinspector (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.67.0-rc.0):
+  - React-Core/RCTAnimationHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTImageHeaders (0.67.0-rc.0):
+  - React-Core/RCTBlobHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.67.0-rc.0):
+  - React-Core/RCTImageHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.67.0-rc.0):
+  - React-Core/RCTLinkingHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.67.0-rc.0):
+  - React-Core/RCTNetworkHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTTextHeaders (0.67.0-rc.0):
+  - React-Core/RCTSettingsHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.67.0-rc.0):
+  - React-Core/RCTTextHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-Core/RCTWebSocket (0.67.0-rc.0):
+  - React-Core/RCTVibrationHeaders (0.67.0-rc.2):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.67.0-rc.0)
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsiexecutor (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-Core/Default
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
     - Yoga
-  - React-CoreModules (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
+  - React-Core/RCTWebSocket (0.67.0-rc.2):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.67.0-rc.0)
-    - React-Core/CoreModulesHeaders (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-RCTImage (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-cxxreact (0.67.0-rc.0):
+    - React-Core/Default (= 0.67.0-rc.2)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsiexecutor (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
+    - Yoga
+  - React-CoreModules (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.67.0-rc.2)
+    - React-Core/CoreModulesHeaders (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-RCTImage (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-cxxreact (0.67.0-rc.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-jsinspector (= 0.67.0-rc.0)
-    - React-logger (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
-    - React-runtimeexecutor (= 0.67.0-rc.0)
-  - React-jsi (0.67.0-rc.0):
+    - React-callinvoker (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-jsinspector (= 0.67.0-rc.2)
+    - React-logger (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
+    - React-runtimeexecutor (= 0.67.0-rc.2)
+  - React-jsi (0.67.0-rc.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.67.0-rc.0)
-  - React-jsi/Default (0.67.0-rc.0):
+    - React-jsi/Default (= 0.67.0-rc.2)
+  - React-jsi/Default (0.67.0-rc.2):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.67.0-rc.0):
+  - React-jsiexecutor (0.67.0-rc.2):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
-  - React-jsinspector (0.67.0-rc.0)
-  - React-logger (0.67.0-rc.0):
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
+  - React-jsinspector (0.67.0-rc.2)
+  - React-logger (0.67.0-rc.2):
     - glog
-  - React-perflogger (0.67.0-rc.0)
-  - React-RCTActionSheet (0.67.0-rc.0):
-    - React-Core/RCTActionSheetHeaders (= 0.67.0-rc.0)
-  - React-RCTAnimation (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
+  - React-perflogger (0.67.0-rc.2)
+  - React-RCTActionSheet (0.67.0-rc.2):
+    - React-Core/RCTActionSheetHeaders (= 0.67.0-rc.2)
+  - React-RCTAnimation (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.67.0-rc.0)
-    - React-Core/RCTAnimationHeaders (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-RCTBlob (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
+    - RCTTypeSafety (= 0.67.0-rc.2)
+    - React-Core/RCTAnimationHeaders (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-RCTBlob (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.67.0-rc.0)
-    - React-Core/RCTWebSocket (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-RCTNetwork (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-RCTImage (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
+    - React-Core/RCTBlobHeaders (= 0.67.0-rc.2)
+    - React-Core/RCTWebSocket (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-RCTNetwork (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-RCTImage (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.67.0-rc.0)
-    - React-Core/RCTImageHeaders (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-RCTNetwork (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-RCTLinking (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
-    - React-Core/RCTLinkingHeaders (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-RCTNetwork (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
+    - RCTTypeSafety (= 0.67.0-rc.2)
+    - React-Core/RCTImageHeaders (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-RCTNetwork (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-RCTLinking (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
+    - React-Core/RCTLinkingHeaders (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-RCTNetwork (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.67.0-rc.0)
-    - React-Core/RCTNetworkHeaders (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-RCTSettings (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
+    - RCTTypeSafety (= 0.67.0-rc.2)
+    - React-Core/RCTNetworkHeaders (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-RCTSettings (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.67.0-rc.0)
-    - React-Core/RCTSettingsHeaders (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-RCTText (0.67.0-rc.0):
-    - React-Core/RCTTextHeaders (= 0.67.0-rc.0)
-  - React-RCTVibration (0.67.0-rc.0):
-    - FBReactNativeSpec (= 0.67.0-rc.0)
+    - RCTTypeSafety (= 0.67.0-rc.2)
+    - React-Core/RCTSettingsHeaders (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-RCTText (0.67.0-rc.2):
+    - React-Core/RCTTextHeaders (= 0.67.0-rc.2)
+  - React-RCTVibration (0.67.0-rc.2):
+    - FBReactNativeSpec (= 0.67.0-rc.2)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - ReactCommon/turbomodule/core (= 0.67.0-rc.0)
-  - React-runtimeexecutor (0.67.0-rc.0):
-    - React-jsi (= 0.67.0-rc.0)
-  - ReactCommon/turbomodule/core (0.67.0-rc.0):
+    - React-Core/RCTVibrationHeaders (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - ReactCommon/turbomodule/core (= 0.67.0-rc.2)
+  - React-runtimeexecutor (0.67.0-rc.2):
+    - React-jsi (= 0.67.0-rc.2)
+  - ReactCommon/turbomodule/core (0.67.0-rc.2):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.67.0-rc.0)
-    - React-Core (= 0.67.0-rc.0)
-    - React-cxxreact (= 0.67.0-rc.0)
-    - React-jsi (= 0.67.0-rc.0)
-    - React-logger (= 0.67.0-rc.0)
-    - React-perflogger (= 0.67.0-rc.0)
+    - React-callinvoker (= 0.67.0-rc.2)
+    - React-Core (= 0.67.0-rc.2)
+    - React-cxxreact (= 0.67.0-rc.2)
+    - React-jsi (= 0.67.0-rc.2)
+    - React-logger (= 0.67.0-rc.2)
+    - React-perflogger (= 0.67.0-rc.2)
   - RNFBAnalytics (12.9.3):
     - Firebase/Analytics (= 8.9.0)
     - React-Core
@@ -1114,8 +1114,8 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   BoringSSL-GRPC: 8edf627ee524575e2f8d19d56f068b448eea3879
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: 2bb3717e26358b6a664ce73175790113a85683b5
-  FBReactNativeSpec: 1167e84c1dd737d7e2c8ce26d71048ff96f46ead
+  FBLazyVector: 00400d797554bc25cdc6609668e2f2bd115e212d
+  FBReactNativeSpec: eaee9b411b9a56c6516ff42015f7588ae28640b5
   Firebase: 13d8d96499e2635428d5bf0ec675df21f95d9a95
   FirebaseABTesting: 9de50b34bf9eb4a07d4edb7af82c14152fd905aa
   FirebaseAnalytics: 3a11ed901750e1ebcbe35e75915ff079878ea385
@@ -1148,29 +1148,29 @@ SPEC CHECKSUMS:
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
   RCT-Folly: 803a9cfd78114b2ec0f140cfa6fa2a6bafb2d685
-  RCTRequired: 3ffe2ff93963278286a3b3551bdde5e710177776
-  RCTTypeSafety: 7e1e71d3f8cb22a0d7a5f1e34282db7d12e00eac
-  React: c83530b1898d8b86618fd5108463cdbf2925e5d8
-  React-callinvoker: 39544ac4ed8efcf85d404035aa0f4c3b28a821b1
-  React-Core: ff6feab0c912f698dde5cf3a5dd5a3199cf6d80c
-  React-CoreModules: 181eb1373bba2b746bb570367abd345958dafcbb
-  React-cxxreact: 7288f64dc6a4749494b70f90d31c3d19c1cdb6bb
-  React-jsi: 2f3d86517825f3f81ce158dd9172b5cd2d5b9f8a
-  React-jsiexecutor: e6c3e6f9dc6c1471819be276470ddbe70ac35e98
-  React-jsinspector: fc08e6f4bca09ce911e5affe271e4cd28961427a
-  React-logger: bd9c8af0dd8edac814f09bdd0e65299fb712a440
-  React-perflogger: 1da82e770fe9a65d506b3df496a4d50ed8ba51a3
-  React-RCTActionSheet: 01af046ebaf379acd029dca708d03f5c7124c324
-  React-RCTAnimation: 97ff68ccf61840d9c9b52e37ddcb0e59bc7f3ede
-  React-RCTBlob: 92c1d2adc5dd570ead0737b809087112838f9ced
-  React-RCTImage: 92cf961778187446ae5d1e8da7465291927ef4ac
-  React-RCTLinking: e148535150adbdfb4137104616d4fc7cec04039f
-  React-RCTNetwork: 9c22c7b1f10f6c8a8cea76a74c892c32e57c8009
-  React-RCTSettings: 5b30860739af1dda64486cd724f7066c0643e032
-  React-RCTText: 933dfc4a9dd8f8215bda36d1a979f349f8c69a74
-  React-RCTVibration: e984287863f3178d0a808f51bfeb7a8b5f21a07c
-  React-runtimeexecutor: 883ffdd8e0e27fc6ccb6c66f36c6664380dcc932
-  ReactCommon: adf56020429e34de92b25b41efb7decaea2b9ecd
+  RCTRequired: e94bac8c0770aa02dd4959b86e32c6fe0e077e2d
+  RCTTypeSafety: 400db7e174b0cb36ba4b85aaef60789df434043e
+  React: 921833f22439a2cf6dbc760a56ee1bfc54aeed03
+  React-callinvoker: b6e025c5059e0be1d4c205c2f4a07e209128ae9b
+  React-Core: 2367b92596a12f1e41ecdd7a0ce08918a340c343
+  React-CoreModules: b33031ab9c0d4a2c918e21ad2326c6599f53f917
+  React-cxxreact: 766be1c740095d26e168e94b309f506cc9a56ffe
+  React-jsi: ec418a707f9121146e6aa6307c4490b03e7087e6
+  React-jsiexecutor: efa82fa815a206f07fc94ec9bc65a6489d76998e
+  React-jsinspector: e7c2f187c5da30d52e23830c6b2ded9d3b97b004
+  React-logger: 627b3877b57b993d2dc32696e1ceea8c8192796d
+  React-perflogger: 3f27bd186397202b7d2085b18da5ad0a0978c746
+  React-RCTActionSheet: 349bc4d2a22ae46da02a1eb3095fb3f05f0e0c87
+  React-RCTAnimation: 18029521ca3cd27b8c1ecd110eb440c5d6c5dfa6
+  React-RCTBlob: 1ac3dcaec035948e8f10145927bfe3b6a7e730dc
+  React-RCTImage: 8f62c3b485849386cfcdadd8dfbcb2828af9b374
+  React-RCTLinking: 98e121b788ea1a61beaae76306ca175c3ed97dc9
+  React-RCTNetwork: 29a1f35db74800371cdc82129b51ad645a5526c4
+  React-RCTSettings: 92a0959b472022b45b4f76303bc22c5d80938d2c
+  React-RCTText: 826dacc617087590880fe854390fa5f40bd2df2e
+  React-RCTVibration: f4457007b33185bbe9c2cd7cdf00bc05ec16e0eb
+  React-runtimeexecutor: 1ff872a9cb0fff8329334829b109cb6b380c7907
+  ReactCommon: fda8de1535cec34971adef653f9afd954142eb7c
   RNFBAnalytics: 0f6af6d3c8131b9f8b0b1058a700ada57d87b9ce
   RNFBApp: 7fca4a99cd00f204f3cc4b247d2f89ff3688dad5
   RNFBAppCheck: 863543cb089e71474e8a2b05c191e988feee33e6
@@ -1188,7 +1188,7 @@ SPEC CHECKSUMS:
   RNFBPerf: e9994639cce21dfa522e02f70924ab04abc1629a
   RNFBRemoteConfig: 0705aff441a5dc993f2378a3cfdfe4e773a5ae6f
   RNFBStorage: 90ddf0b11203916835cb6cf89c9d493c919b1716
-  Yoga: 080f5389e515e1d0233a75bbb9de3a4eb87d8185
+  Yoga: 63f25ad38b6f7597fa5dfee27088b29a01e83447
 
 PODFILE CHECKSUM: 43fa86a6ee18afb5a0e1abf27196346cd71e6cf5
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11605,10 +11605,10 @@ react-native-port-patcher@^1.0.4:
   dependencies:
     command-line-args "^3.0.5"
 
-react-native@0.67.0-rc.0:
-  version "0.67.0-rc.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.67.0-rc.0.tgz#abcfeeb12c5d2a390bf731078342624e276d36fc"
-  integrity sha512-TG+jH3yD3oTxjFCL+etP4MQvkPBVUr9mCNkoccdkn6JLprXOIqNsG7XEvci+Bd3/7e37iJGoKUBMxfjI/ir9tw==
+react-native@0.67.0-rc.2:
+  version "0.67.0-rc.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.67.0-rc.2.tgz#a0fd84881d56237b9c1b08b585f25d0b271a0713"
+  integrity sha512-JwVrFd1UvSMQtSO3x2hEr2ToIa/0uJOzJECbDpy6+c3xLh7LCKEq+E9lCPXRc1Cmz9kKZ3RQCsynRmZyCDAu5Q==
   dependencies:
     "@jest/create-cache-key-function" "^27.0.1"
     "@react-native-community/cli" "^6.0.0"


### PR DESCRIPTION
### Description

- increase our compatibility up to target/compile SDK 31 - this has no impact on library consumers
- increase firebase-android-sdk to v29, this is a breaking change and requires consumers to update their apps to minSdkVersion 19 (as required in underlying react-native 0.64+)

### Release Summary

Conventional commits on each one, carefully set up so the breaking change version and notes should go out automatically with useful details

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Test Plan

Each commit tested locally, should work in CI as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
