### PR TITLE
test(e2e, android): forward-port test app to targetSdkVersion 31

### DIFF
--- a/tests/android/app/src/debug/AndroidManifest.xml
+++ b/tests/android/app/src/debug/AndroidManifest.xml
@@ -8,6 +8,9 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+        <activity
+            android:name="com.facebook.react.devsupport.DevSettingsActivity"
+            android:exported="true"
+        />
     </application>
 </manifest>

--- a/tests/android/app/src/main/AndroidManifest.xml
+++ b/tests/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
       android:name=".MainActivity"
       android:label="@string/app_name"
       android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
+      android:exported="true"
       android:launchMode="singleTask"
       android:windowSoftInputMode="adjustResize">
       <intent-filter>

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
   ext.buildToolsVersion = '31.0.0'
   ext.minSdkVersion = 21
-  ext.compileSdkVersion = 30
-  ext.targetSdkVersion = 30
+  ext.compileSdkVersion = 31
+  ext.targetSdkVersion = 31
   ext.ndkVersion = '21.4.7075529'
 
   ext.kotlinVersion = '1.5.31' // https://kotlinlang.org/releases.html

--- a/tests/patches/detox+18.23.1.patch
+++ b/tests/patches/detox+18.23.1.patch
@@ -1,3 +1,24 @@
+diff --git a/node_modules/detox/android/detox/build.gradle b/node_modules/detox/android/detox/build.gradle
+index 8bef864..3689459 100644
+--- a/node_modules/detox/android/detox/build.gradle
++++ b/node_modules/detox/android/detox/build.gradle
+@@ -86,12 +86,12 @@ dependencies {
+     // Versions are in-sync with the 'androidx-test-1.2.0' release/tag of the android-test github repo,
+     // used by the Detox generator. See https://github.com/android/android-test/releases/tag/androidx-test-1.2.0
+     // Important: Should remain so when generator tag is replaced!
+-    api('androidx.test.espresso:espresso-core:3.3.0') { // Needed all across Detox but also makes Espresso seamlessly provided to Detox users with hybrid apps/E2E-tests.
++    api('androidx.test.espresso:espresso-core:3.4.0') { // Needed all across Detox but also makes Espresso seamlessly provided to Detox users with hybrid apps/E2E-tests.
+         exclude group: 'com.google.code.findbugs', module: 'jsr305'
+     }
+-    api 'androidx.test.espresso:espresso-web:3.3.0' // Web-View testing
+-    api 'androidx.test:rules:1.2.0' // Needed because of ActivityTestRule. Needed by users *and* internally used by Detox.
+-    api 'androidx.test.ext:junit:1.1.1' // Needed so as to seamlessly provide AndroidJUnit4 to Detox users. Depends on junit core.
++    api 'androidx.test.espresso:espresso-web:3.4.0' // Web-View testing
++    api 'androidx.test:rules:1.4.0' // Needed because of ActivityTestRule. Needed by users *and* internally used by Detox.
++    api 'androidx.test.ext:junit:1.1.3' // Needed so as to seamlessly provide AndroidJUnit4 to Detox users. Depends on junit core.
+ 
+     // Version is the latest; Cannot sync with the Github repo (e.g. android/android-test) because the androidx
+     // packaging version of associated classes is simply not there...
 diff --git a/node_modules/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java b/node_modules/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java
 index 2407926..65d17d8 100644
 --- a/node_modules/detox/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/UIModuleIdlingResource.java


### PR DESCRIPTION
It was proposed in #5834 that the modules did not work with Android 12

I showed in https://github.com/mikehardy/rnfbdemo/commit/218f551c831c3df4d0034b9783459e833ec880e5#diff-3e27ae623577d0c559bd8ab973a0c34af8cc65ef9beb9868a9cdb029854f8078 that it could work

...but forward-porting our own internal test app to api31 is the best way to show it works

It was seemless except for Detox relying on non-Android12 compatible transitives

Required a patch to Detox, tracked here:
https://github.com/wix/Detox/pull/3055


### Test Plan

It works locally, if it passes CI it's good

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
