### PR TITLE
feat(android, emulator): add firebase.json config element to bypass localhost remap

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -28,6 +28,7 @@ jest.doMock('react-native', () => {
               options: {},
             },
           ],
+          FIREBASE_RAW_JSON: '{"asd": "Hello world"}',
           addListener: jest.fn(),
           eventsAddListener: jest.fn(),
           eventsNotifyReady: jest.fn(),

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -28,7 +28,7 @@ jest.doMock('react-native', () => {
               options: {},
             },
           ],
-          FIREBASE_RAW_JSON: '{"asd": "Hello world"}',
+          FIREBASE_RAW_JSON: '{}',
           addListener: jest.fn(),
           eventsAddListener: jest.fn(),
           eventsNotifyReady: jest.fn(),

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -105,6 +105,10 @@
         "android_background_activity_names": {
           "description": "The names (as returned by `getShortClassName()` of Activities used outside the context of react native.\nThese are ignored when determining if the app is in foreground for purposes of calling javascript background handlers",
           "type": "array"
+        },
+        "android_bypass_emulator_url_remap": {
+          "description": "On android devices, the urls of firebase emulators will be remapped from localhost to 10.0.2.2. If you don't need this behaviour set this fleg to `true`.",
+          "type": "boolean"
         }
       }
     }

--- a/packages/app/lib/internal/FirebaseModule.js
+++ b/packages/app/lib/internal/FirebaseModule.js
@@ -36,7 +36,6 @@ export default class FirebaseModule {
     if (firebaseJson) {
       return firebaseJson;
     }
-    console.log(getAppModule().FIREBASE_RAW_JSON);
     firebaseJson = JSON.parse(getAppModule().FIREBASE_RAW_JSON);
     return firebaseJson;
   }

--- a/packages/app/lib/internal/FirebaseModule.js
+++ b/packages/app/lib/internal/FirebaseModule.js
@@ -36,6 +36,7 @@ export default class FirebaseModule {
     if (firebaseJson) {
       return firebaseJson;
     }
+    console.log(getAppModule().FIREBASE_RAW_JSON);
     firebaseJson = JSON.parse(getAppModule().FIREBASE_RAW_JSON);
     return firebaseJson;
   }

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -360,19 +360,22 @@ class FirebaseAuthModule extends FirebaseModule {
     }
 
     let _url = url;
-    if (isAndroid && _url) {
+    const androidBypassEmulatorUrlRemap =
+      typeof this.firebaseJson.android_bypass_emulator_url_remap === 'boolean' &&
+      this.firebaseJson.android_bypass_emulator_url_remap;
+    if (!androidBypassEmulatorUrlRemap && isAndroid && _url) {
       if (_url.startsWith('http://localhost')) {
         _url = _url.replace('http://localhost', 'http://10.0.2.2');
         // eslint-disable-next-line no-console
         console.log(
-          'Mapping auth host "localhost" to "10.0.2.2" for android emulators. Use real IP on real devices.',
+          'Mapping auth host "localhost" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
         );
       }
       if (_url.startsWith('http://127.0.0.1')) {
         _url = _url.replace('http://127.0.0.1', 'http://10.0.2.2');
         // eslint-disable-next-line no-console
         console.log(
-          'Mapping auth host "127.0.0.1" to "10.0.2.2" for android emulators. Use real IP on real devices.',
+          'Mapping auth host "127.0.0.1" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
         );
       }
     }

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -101,12 +101,15 @@ class FirebaseFirestoreModule extends FirebaseModule {
       throw new Error('firebase.firestore().useEmulator() takes a non-empty host and port');
     }
     let _host = host;
-    if (isAndroid && _host) {
+    const androidBypassEmulatorUrlRemap =
+      typeof this.firebaseJson.android_bypass_emulator_url_remap === 'boolean' &&
+      this.firebaseJson.android_bypass_emulator_url_remap;
+    if (!androidBypassEmulatorUrlRemap && isAndroid && _host) {
       if (_host === 'localhost' || _host === '127.0.0.1') {
         _host = '10.0.2.2';
         // eslint-disable-next-line no-console
         console.log(
-          'Mapping firestore host to "10.0.2.2" for android emulators. Use real IP on real devices.',
+          'Mapping firestore host to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
         );
       }
     }

--- a/packages/functions/lib/index.js
+++ b/packages/functions/lib/index.js
@@ -93,19 +93,22 @@ class FirebaseFunctionsModule extends FirebaseModule {
 
   useFunctionsEmulator(origin) {
     let _origin = origin;
-    if (isAndroid && _origin) {
+    const androidBypassEmulatorUrlRemap =
+      typeof this.firebaseJson.android_bypass_emulator_url_remap === 'boolean' &&
+      this.firebaseJson.android_bypass_emulator_url_remap;
+    if (!androidBypassEmulatorUrlRemap && isAndroid && _origin) {
       if (_origin.startsWith('http://localhost')) {
         _origin = _origin.replace('http://localhost', 'http://10.0.2.2');
         // eslint-disable-next-line no-console
         console.log(
-          'Mapping functions host "localhost" to "10.0.2.2" for android emulators. Use real IP on real devices.',
+          'Mapping functions host "localhost" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
         );
       }
       if (_origin.startsWith('http://127.0.0.1')) {
         _origin = _origin.replace('http://127.0.0.1', 'http://10.0.2.2');
         // eslint-disable-next-line no-console
         console.log(
-          'Mapping functions host "127.0.0.1" to "10.0.2.2" for android emulators. Use real IP on real devices.',
+          'Mapping functions host "127.0.0.1" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
         );
       }
     }

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -34,6 +34,7 @@
 
     "android_task_executor_maximum_pool_size": 10,
     "android_task_executor_keep_alive_seconds": 3,
+    "android_bypass_emulator_url_remap": false,
 
     "rnfirebase_json_testing_string": "abc",
     "rnfirebase_json_testing_boolean_false": false,


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

I came accross a problem with emulators and the way they are handling `localhost` addresses, described [here](https://github.com/invertase/react-native-firebase/issues/4810).

I would love to see [this](https://reactnative.dev/docs/running-on-device) work with firebase emulators, when running and testing apps on real devices.

I started a discussion [here](https://github.com/invertase/react-native-firebase/discussions/5816)

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire: 