### PR TITLE
fix(remote-config, getAll): init with empty config

### DIFF
--- a/packages/remote-config/__tests__/remote-config.test.ts
+++ b/packages/remote-config/__tests__/remote-config.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { firebase } from '../lib';
+
+describe('remoteConfig()', function () {
+  describe('namespace', function () {
+    it('accessible from firebase.app()', function () {
+      const app = firebase.app();
+      expect(app.remoteConfig()).toBeDefined();
+      expect(app.remoteConfig().app).toEqual(app);
+    });
+
+    it('supports multiple apps', async function () {
+      expect(firebase.remoteConfig().app.name).toEqual('[DEFAULT]');
+      expect(firebase.app('secondaryFromNative').remoteConfig().app.name).toEqual(
+        'secondaryFromNative',
+      );
+    });
+  });
+
+  describe('statics', function () {
+    it('LastFetchStatus', function () {
+      expect(firebase.remoteConfig.LastFetchStatus).toBeDefined();
+      expect(firebase.remoteConfig.LastFetchStatus.FAILURE).toEqual('failure');
+      expect(firebase.remoteConfig.LastFetchStatus.SUCCESS).toEqual('success');
+      expect(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET).toEqual('no_fetch_yet');
+      expect(firebase.remoteConfig.LastFetchStatus.THROTTLED).toEqual('throttled');
+    });
+
+    it('ValueSource', function () {
+      expect(firebase.remoteConfig.ValueSource).toBeDefined();
+      expect(firebase.remoteConfig.ValueSource.REMOTE).toEqual('remote');
+      expect(firebase.remoteConfig.ValueSource.STATIC).toEqual('static');
+      expect(firebase.remoteConfig.ValueSource.DEFAULT).toEqual('default');
+    });
+  });
+
+  describe('fetch()', function () {
+    it('it throws if expiration is not a number', function () {
+      expect(() => {
+        // @ts-ignore - incorrect argument on purpose to check validation
+        firebase.remoteConfig().fetch('foo');
+      }).toThrow('must be a number value');
+    });
+  });
+
+  describe('setConfigSettings()', function () {
+    it('it throws if arg is not an object', async function () {
+      expect(() => {
+        // @ts-ignore - incorrect argument on purpose to check validation
+        firebase.remoteConfig().setConfigSettings('not an object');
+      }).toThrow('must set an object');
+    });
+
+    it('throws if minimumFetchIntervalMillis is not a number', async function () {
+      expect(() => {
+        // @ts-ignore - incorrect argument on purpose to check validation
+        firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 'potato' });
+      }).toThrow('must be a number type in milliseconds.');
+    });
+
+    it('throws if fetchTimeMillis is not a number', function () {
+      expect(() => {
+        // @ts-ignore - incorrect argument on purpose to check validation
+        firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 'potato' });
+      }).toThrow('must be a number type in milliseconds.');
+    });
+  });
+
+  // TODO set up a mock for getAll from issue 5854 and probe if result is empty
+  // describe('getAll() with remote', function () {
+  //   it('should return an object of all available values', function () {
+  //     const config = firebase.remoteConfig().getAll();
+  //     config.number.asNumber().should.equal(1337);
+  //     config.number.getSource().should.equal('remote');
+  //     // firebase console stores as a string
+  //     config.float.asNumber().should.equal(123.456);
+  //     config.float.getSource().should.equal('remote');
+  //     config.prefix_1.asNumber().should.equal(1);
+  //     config.prefix_1.getSource().should.equal('remote');
+  //   });
+  // });
+
+  describe('setDefaults()', function () {
+    it('it throws if defaults object not provided', function () {
+      expect(() => {
+        // @ts-ignore - incorrect argument on purpose to check validation
+        firebase.remoteConfig().setDefaults('not an object');
+      }).toThrow('must be an object.');
+    });
+  });
+
+  describe('setDefaultsFromResource()', function () {
+    it('throws if resourceName is not a string', function () {
+      expect(() => {
+        // @ts-ignore - incorrect argument on purpose to check validation
+        firebase.remoteConfig().setDefaultsFromResource(1337);
+      }).toThrow('must be a string value');
+    });
+  });
+});

--- a/packages/remote-config/__tests__/remote-config.test.ts
+++ b/packages/remote-config/__tests__/remote-config.test.ts
@@ -81,20 +81,6 @@ describe('remoteConfig()', function () {
     });
   });
 
-  // TODO set up a mock for getAll from issue 5854 and probe if result is empty
-  // describe('getAll() with remote', function () {
-  //   it('should return an object of all available values', function () {
-  //     const config = firebase.remoteConfig().getAll();
-  //     config.number.asNumber().should.equal(1337);
-  //     config.number.getSource().should.equal('remote');
-  //     // firebase console stores as a string
-  //     config.float.asNumber().should.equal(123.456);
-  //     config.float.getSource().should.equal('remote');
-  //     config.prefix_1.asNumber().should.equal(1);
-  //     config.prefix_1.getSource().should.equal('remote');
-  //   });
-  // });
-
   describe('setDefaults()', function () {
     it('it throws if defaults object not provided', function () {
       expect(() => {
@@ -110,6 +96,14 @@ describe('remoteConfig()', function () {
         // @ts-ignore - incorrect argument on purpose to check validation
         firebase.remoteConfig().setDefaultsFromResource(1337);
       }).toThrow('must be a string value');
+    });
+  });
+
+  describe('getAll() should not crash', function () {
+    it('should return an empty object pre-fetch, pre-defaults', function () {
+      const config = firebase.remoteConfig().getAll();
+      expect(config).toBeDefined();
+      expect(config).toEqual({});
     });
   });
 });

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -16,44 +16,6 @@
  */
 
 describe('remoteConfig()', function () {
-  describe('namespace', function () {
-    it('accessible from firebase.app()', function () {
-      const app = firebase.app();
-      should.exist(app.remoteConfig);
-      app.remoteConfig().app.should.equal(app);
-    });
-
-    it('supports multiple apps', async function () {
-      firebase.firestore().app.name.should.equal('[DEFAULT]');
-
-      firebase
-        .firestore(firebase.app('secondaryFromNative'))
-        .app.name.should.equal('secondaryFromNative');
-
-      firebase
-        .app('secondaryFromNative')
-        .remoteConfig()
-        .app.name.should.equal('secondaryFromNative');
-    });
-  });
-
-  describe('statics', function () {
-    it('LastFetchStatus', function () {
-      firebase.remoteConfig.LastFetchStatus.should.be.an.Object();
-      firebase.remoteConfig.LastFetchStatus.FAILURE.should.equal('failure');
-      firebase.remoteConfig.LastFetchStatus.SUCCESS.should.equal('success');
-      firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET.should.equal('no_fetch_yet');
-      firebase.remoteConfig.LastFetchStatus.THROTTLED.should.equal('throttled');
-    });
-
-    it('ValueSource', function () {
-      firebase.remoteConfig.ValueSource.should.be.an.Object();
-      firebase.remoteConfig.ValueSource.REMOTE.should.equal('remote');
-      firebase.remoteConfig.ValueSource.STATIC.should.equal('static');
-      firebase.remoteConfig.ValueSource.DEFAULT.should.equal('default');
-    });
-  });
-
   describe('fetch()', function () {
     it('with expiration provided', async function () {
       const date = Date.now() - 30000;
@@ -72,15 +34,6 @@ describe('remoteConfig()', function () {
     });
     it('without expiration provided', function () {
       return firebase.remoteConfig().fetch();
-    });
-    it('it throws if expiration is not a number', function () {
-      try {
-        firebase.remoteConfig().fetch('foo');
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must be a number value');
-        return Promise.resolve();
-      }
     });
   });
 
@@ -114,49 +67,16 @@ describe('remoteConfig()', function () {
   });
 
   describe('setConfigSettings()', function () {
-    it('it throws if arg is not an object', async function () {
-      try {
-        firebase.remoteConfig().setConfigSettings('not an object');
-
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must set an object');
-        return Promise.resolve();
-      }
-    });
-
     it('minimumFetchIntervalMillis sets correctly', async function () {
       await firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 3000 });
 
       firebase.remoteConfig().settings.minimumFetchIntervalMillis.should.be.equal(3000);
     });
 
-    it('throws if minimumFetchIntervalMillis is not a number', async function () {
-      try {
-        firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 'potato' });
-
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must be a number type in milliseconds.');
-        return Promise.resolve();
-      }
-    });
-
     it('fetchTimeMillis sets correctly', async function () {
       await firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 3000 });
 
       firebase.remoteConfig().settings.fetchTimeMillis.should.be.equal(3000);
-    });
-
-    it('throws if fetchTimeMillis is not a number', function () {
-      try {
-        firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 'potato' });
-
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must be a number type in milliseconds.');
-        return Promise.resolve();
-      }
     });
   });
 
@@ -200,16 +120,6 @@ describe('remoteConfig()', function () {
       values.some_key.getSource().should.equal('default');
       values.some_key_1.getSource().should.equal('default');
       values.some_key_2.getSource().should.equal('default');
-    });
-
-    it('it throws if defaults object not provided', function () {
-      try {
-        firebase.remoteConfig().setDefaults('not an object');
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must be an object.');
-        return Promise.resolve();
-      }
     });
   });
 
@@ -375,16 +285,6 @@ describe('remoteConfig()', function () {
       // TODO dasherize error namespace
       error.code.should.equal('remoteConfig/resource_not_found');
       error.message.should.containEql('was not found');
-    });
-
-    it('throws if resourceName is not a string', function () {
-      try {
-        firebase.remoteConfig().setDefaultsFromResource(1337);
-        return Promise.reject(new Error('Did not throw'));
-      } catch (error) {
-        error.message.should.containEql('must be a string value');
-        return Promise.resolve();
-      }
     });
   });
 

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -58,6 +58,7 @@ class FirebaseConfigModule extends FirebaseModule {
       minimumFetchIntervalMillis: 43200000,
     };
     this._lastFetchTime = -1;
+    this._values = {};
   }
 
   getValue(key) {
@@ -89,9 +90,7 @@ class FirebaseConfigModule extends FirebaseModule {
 
   getAll() {
     const values = {};
-
     Object.keys(this._values).forEach(key => (values[key] = this.getValue(key)));
-
     return values;
   }
 


### PR DESCRIPTION
### Description

previously if you incorrectly called getAll before setting defaults or fetching any
remote config, we would crash.

Now we initialize values as an empty object, so we have a graceful failure

confirmed via code inspection that this matches expecations from firebase-js-sdk
https://github.com/firebase/firebase-js-sdk/blob/acc58102d4429ce0593ec22192e76018e9d16ed7/packages/remote-config/test/remote_config.test.ts#L333-L335

### Related issues

Fixes #5854

### Release Summary

rebase merge the conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I refactored the remote config tests to put the non-native ones in a jest config and verified those worked
I added a new jest test that probed this, and failed as expected
I repaired this in a way that seems compatible with firebase-js-sdk and the test passed

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
