### PR TITLE
docs(database, offline): setPersistence* methods are sync not async

### DIFF
--- a/docs/database/offline-support.md
+++ b/docs/database/offline-support.md
@@ -19,9 +19,7 @@ as early on in your application code as possible:
 import { AppRegistry } from 'react-native';
 import database from '@react-native-firebase/database';
 
-database()
-  .setPersistenceEnabled(true)
-  .then(() => console.log('Realtime Database persistence enabled'));
+database().setPersistenceEnabled(true);
 
 AppRegistry.registerComponent('app', () => App);
 ```
@@ -93,5 +91,5 @@ little or too much data, call the `setPersistenceCacheSizeBytes` method to updat
 ```js
 import database from '@react-native-firebase/database';
 
-await database().setPersistenceCacheSizeBytes(2000000); // 2MB
+database().setPersistenceCacheSizeBytes(2000000); // 2MB
 ```

--- a/docs/database/offline-support.md
+++ b/docs/database/offline-support.md
@@ -21,6 +21,7 @@ import database from '@react-native-firebase/database';
 
 database().setPersistenceEnabled(true);
 
+
 AppRegistry.registerComponent('app', () => App);
 ```
 

--- a/docs/database/offline-support.md
+++ b/docs/database/offline-support.md
@@ -21,7 +21,6 @@ import database from '@react-native-firebase/database';
 
 database().setPersistenceEnabled(true);
 
-
 AppRegistry.registerComponent('app', () => App);
 ```
 

--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -1217,7 +1217,7 @@ export namespace FirebaseDatabaseTypes {
      *
      * @param enabled Whether persistence is enabled for the Database service.
      */
-    setPersistenceEnabled(enabled: boolean): Promise<void>;
+    setPersistenceEnabled(enabled: boolean): void;
 
     /**
      * Sets the native logging level for the database module. By default,
@@ -1237,7 +1237,7 @@ export namespace FirebaseDatabaseTypes {
      *
      * @param enabled Whether debug logging is enabled.
      */
-    setLoggingEnabled(enabled: boolean): Promise<void>;
+    setLoggingEnabled(enabled: boolean): void;
 
     /**
      * By default Firebase Database will use up to 10MB of disk space to cache data. If the cache grows beyond this size,
@@ -1262,7 +1262,7 @@ export namespace FirebaseDatabaseTypes {
      *
      * @param bytes The new size of the cache in bytes.
      */
-    setPersistenceCacheSizeBytes(bytes: number): Promise<void>;
+    setPersistenceCacheSizeBytes(bytes: number): void;
 
     /**
      * Modify this Database instance to communicate with the Firebase Database emulator.


### PR DESCRIPTION
### Description

`setPeristenceEnabled` and `setPersistenceCacheSizeBytes` are sync calls, which do not return a promise.

Currently the examples expect a promise. This fixes them to expect a sync call.

### Related issues

[<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->]

https://github.com/invertase/react-native-firebase/issues/5886

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
