### PR TITLE
fix(database, types): setPersistence* promise -> void

### DIFF
--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -1218,7 +1218,6 @@ export namespace FirebaseDatabaseTypes {
      * @param enabled Whether persistence is enabled for the Database service.
      */
     setPersistenceEnabled(enabled: boolean): void;
-    
 
     /**
      * Sets the native logging level for the database module. By default,

--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -1218,6 +1218,7 @@ export namespace FirebaseDatabaseTypes {
      * @param enabled Whether persistence is enabled for the Database service.
      */
     setPersistenceEnabled(enabled: boolean): void;
+    
 
     /**
      * Sets the native logging level for the database module. By default,

--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -1217,7 +1217,7 @@ export namespace FirebaseDatabaseTypes {
      *
      * @param enabled Whether persistence is enabled for the Database service.
      */
-    setPersistenceEnabled(enabled: boolean): Promise<void>;
+    setPersistenceEnabled(enabled: boolean): void;
 
     /**
      * Sets the native logging level for the database module. By default,
@@ -1262,7 +1262,7 @@ export namespace FirebaseDatabaseTypes {
      *
      * @param bytes The new size of the cache in bytes.
      */
-    setPersistenceCacheSizeBytes(bytes: number): Promise<void>;
+    setPersistenceCacheSizeBytes(bytes: number): void;
 
     /**
      * Modify this Database instance to communicate with the Firebase Database emulator.


### PR DESCRIPTION
### Description

`setPeristenceEnabled` and `setPersistenceCacheSizeBytes` are sync calls, which do not return a promise.

Currently the types say it returns a promise. This fixes them to return void.

### Related issues

Fixes #5886

### Release Summary

Fix setPeristence* types

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
