### PR TITLE
fix(firestore, android): fix firestore android dependency error

### DIFF
--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -88,6 +88,7 @@ dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   implementation "com.google.firebase:firebase-firestore"
+  implementation "com.google.protobuf:protobuf-javalite:3.14.0"
 }
 
 ReactNative.shared.applyPackageVersion()


### PR DESCRIPTION
### Description
There is a dependency error when installing @react-native-firebase/firestore
<img width="1680" alt="스크린샷 2021-12-01 오후 1 58 08" src="https://user-images.githubusercontent.com/45306565/144174774-7d883cbd-1bf6-4357-9637-e4cbd1cea559.png">

By adding `"com.google.protobuf:protobuf-javalite:3.14.0"` to dependencies, it fixes the dependency error

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
