### PR TITLE
feat(firestore): stricter DocumentData type

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -90,7 +90,7 @@ export namespace FirebaseFirestoreTypes {
    * A `DocumentData` object represents the data in a document.
    */
   export interface DocumentData {
-    [key: string]: any;
+    [key: string]: DocumentFieldType;
   }
 
   /**


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Beginning with react-native-firebase 12, setting `undefined` in a firestore object throws instead of setting it to `null`. However, typescript does not warn you if you do something like:

```ts
await ref.set({
  test: undefined,
});
```

This PR aims to fix that.

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

feat(firestore): stricter DocumentData type

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes (but only typescript types)
  - [ ] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

Set an object value to `undefined` and ensure that typescript shows an error:

![image](https://user-images.githubusercontent.com/1394504/144311258-e7338179-0f60-40d3-9dfe-85380ed95d59.png)
