### PR TITLE
fix(firestore, types): allow FieldValues, Date and Timestamp in doc set and update

### DIFF
--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -1,4 +1,4 @@
-import firestore, { firebase } from '../lib';
+import firestore, { firebase, FirebaseFirestoreTypes } from '../lib';
 
 const COLLECTION = 'firestore';
 
@@ -304,6 +304,28 @@ describe('Storage', function () {
         field2: {
           shouldNotWork: undefined,
         },
+      });
+    });
+
+    it('does not throw when Date is provided instead of Timestamp', async function () {
+      type BarType = {
+        myDate: FirebaseFirestoreTypes.Timestamp;
+      };
+
+      const docRef = firebase.firestore().doc<BarType>(`${COLLECTION}/bar`);
+      await docRef.set({
+        myDate: new Date(),
+      });
+    });
+
+    it('does not throw when serverTimestamp is provided instead of Timestamp', async function () {
+      type BarType = {
+        myDate: FirebaseFirestoreTypes.Timestamp;
+      };
+
+      const docRef = firebase.firestore().doc<BarType>(`${COLLECTION}/bar`);
+      await docRef.set({
+        myDate: firestore.FieldValue.serverTimestamp(),
       });
     });
   });

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -429,7 +429,7 @@ export namespace FirebaseFirestoreTypes {
      * @param data A map of the fields and values for the document.
      * @param options An object to configure the set behavior.
      */
-    set(data: T, options?: SetOptions): Promise<void>;
+    set(data: SetValue<T>, options?: SetOptions): Promise<void>;
 
     /**
      * Updates fields in the document referred to by this `DocumentReference`. The update will fail
@@ -448,7 +448,7 @@ export namespace FirebaseFirestoreTypes {
      *
      * @param data An object containing the fields and values with which to update the document. Fields can contain dots to reference nested fields within the document.
      */
-    update(data: Partial<{ [K in keyof T]: T[K] | FieldValue }>): Promise<void>;
+    update(data: Partial<SetValue<T>>): Promise<void>;
 
     /**
      * Updates fields in the document referred to by this DocumentReference. The update will fail if
@@ -2080,6 +2080,17 @@ export namespace FirebaseFirestoreTypes {
      */
     useEmulator(host: string, port: number): void;
   }
+
+  /**
+   * Utility type to allow FieldValue and to allow Date in place of Timestamp objects.
+   */
+  export type SetValue<T> = T extends Timestamp
+    ? Timestamp | Date // allow Date in place of Timestamp
+    : T extends object
+    ? {
+        [P in keyof T]: SetValue<T[P]> | FieldValue; // allow FieldValue in place of values
+      }
+    : T;
 }
 
 declare const defaultExport: ReactNativeFirebase.FirebaseModuleWithStaticsAndApp<


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This is a fix for Typescript types to remove the following two errors:

```ts
type BarType = {
  myDate: FirebaseFirestoreTypes.Timestamp;
};

const docRef = firebase.firestore().doc<BarType>(`${COLLECTION}/bar`);
await docRef.set({
  myDate: new Date(), // TS2739 Type 'Date' is missing the following properties from type 'Timestamp', [...]
});
await docRef.set({
  myDate: firestore.FieldValue.serverTimestamp(),// TS2739 Type 'FieldValue' is missing the following properties from type 'Timestamp', [...]
});
```

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
fix(firestore): Adjust types to allow setting FieldValues and allow Date in place of Timestamp 

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Run tests.