### PR TITLE
fix(messaging, ios): ensure getInitialNotification returns null vs undefined per types

### DIFF
--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -142,7 +142,7 @@ describe('messaging()', function () {
 
   describe('getInitialNotification', function () {
     it('returns null when no initial notification', async function () {
-      should.equal(await firebase.messaging().getInitialNotification(), null);
+      should.strictEqual(await firebase.messaging().getInitialNotification(), null);
     });
   });
 

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -122,7 +122,12 @@ class FirebaseMessagingModule extends FirebaseModule {
   }
 
   getInitialNotification() {
-    return this.native.getInitialNotification();
+    return this.native.getInitialNotification().then(value => {
+      if (value) {
+        return value;
+      }
+      return null;
+    });
   }
 
   getIsHeadless() {


### PR DESCRIPTION
### Description

On iOS, `getInitialNotification` in `RNFBMessaging+UNUserNotificationCenter.m` can be `nil` so `getInitialNotification` can be `undefined`. However TS definition says it is `Promise<RemoteMessage | null>`.
I first was thinking of correcting this type definition, however as it will be a breaking change, fixed the proxy layer instead.

### Related issues

None.

### Release Summary

None.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__` 
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Automated tests should cover already.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
