### PR TITLE
fix(auth, phone): call verifyPhoneNumber callbacks correctly

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -958,11 +958,11 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       final String requestKey,
       final int timeout,
       final boolean forceResend) {
+    Log.d(TAG, "verifyPhoneNumber:" + phoneNumber);
+
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
     final FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
     final Activity activity = getCurrentActivity();
-
-    Log.d(TAG, "verifyPhoneNumber:" + phoneNumber);
 
     // reset force resending token if phone number changes
     if (!phoneNumber.equals(mLastPhoneNumber)) {

--- a/packages/auth/e2e/phone.e2e.js
+++ b/packages/auth/e2e/phone.e2e.js
@@ -23,7 +23,7 @@ describe('auth() => Phone', function () {
 
   describe('signInWithPhoneNumber', function () {
     it('signs in with a valid code', async function () {
-      const testPhone = await getRandomPhoneNumber();
+      const testPhone = getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       confirmResult.verificationId.should.be.a.String();
       should.ok(confirmResult.verificationId.length, 'verificationId string should not be empty');
@@ -37,7 +37,7 @@ describe('auth() => Phone', function () {
     });
 
     it('errors on invalid code', async function () {
-      const testPhone = await getRandomPhoneNumber();
+      const testPhone = getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       confirmResult.verificationId.should.be.a.String();
       should.ok(confirmResult.verificationId.length, 'verificationId string should not be empty');
@@ -56,7 +56,7 @@ describe('auth() => Phone', function () {
 
   describe('verifyPhoneNumber', function () {
     it('successfully verifies', async function () {
-      const testPhone = await getRandomPhoneNumber();
+      const testPhone = getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       const lastSmsCode = await getLastSmsCode(testPhone);
       await confirmResult.confirm(lastSmsCode);
@@ -64,7 +64,7 @@ describe('auth() => Phone', function () {
     });
 
     it('uses the autoVerifyTimeout when a non boolean autoVerifyTimeoutOrForceResend is provided', async function () {
-      const testPhone = await getRandomPhoneNumber();
+      const testPhone = getRandomPhoneNumber();
       const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
       const lastSmsCode = await getLastSmsCode(testPhone);
       await confirmResult.confirm(lastSmsCode);
@@ -72,7 +72,7 @@ describe('auth() => Phone', function () {
     });
 
     it('throws an error with an invalid on event', async function () {
-      const testPhone = await getRandomPhoneNumber();
+      const testPhone = getRandomPhoneNumber();
       try {
         await firebase
           .auth()
@@ -89,7 +89,7 @@ describe('auth() => Phone', function () {
     });
 
     it('throws an error with an invalid observer event', async function () {
-      const testPhone = await getRandomPhoneNumber();
+      const testPhone = getRandomPhoneNumber();
       try {
         await firebase
           .auth()
@@ -106,7 +106,7 @@ describe('auth() => Phone', function () {
     });
 
     it('successfully runs verification complete handler', async function () {
-      const testPhone = await getRandomPhoneNumber();
+      const testPhone = getRandomPhoneNumber();
       await firebase
         .auth()
         .verifyPhoneNumber(testPhone)

--- a/packages/auth/e2e/phone.e2e.js
+++ b/packages/auth/e2e/phone.e2e.js
@@ -107,33 +107,72 @@ describe('auth() => Phone', function () {
 
     it('successfully runs verification complete handler', async function () {
       const testPhone = getRandomPhoneNumber();
-      await firebase
-        .auth()
-        .verifyPhoneNumber(testPhone)
-        .then($ => $);
-
-      return Promise.resolve();
+      const thenCb = sinon.spy();
+      await firebase.auth().verifyPhoneNumber(testPhone).then(thenCb);
+      thenCb.should.be.calledOnce();
+      const successAuthSnapshot = thenCb.args[0][0];
+      if (device.getPlatform() === 'ios') {
+        successAuthSnapshot.state.should.equal('sent');
+      } else {
+        successAuthSnapshot.state.should.equal('timeout');
+      }
     });
 
-    it('successfully runs and adds emitters', async function () {
-      const testPhone = await getRandomPhoneNumber();
-      const obervserCb = () => {};
-      const errorCb = () => {};
-      const successCb = () => {
-        return Promise.resolve();
-      };
+    it('successfully runs and calls success callback', async function () {
+      const testPhone = getRandomPhoneNumber();
+      const successCb = sinon.spy();
+      const observerCb = sinon.spy();
+      const errorCb = sinon.spy();
 
       await firebase
         .auth()
         .verifyPhoneNumber(testPhone)
-        .on('state_changed', obervserCb, errorCb, successCb, () => {});
+        .on('state_changed', observerCb, errorCb, successCb);
+
+      await Utils.spyToBeCalledOnceAsync(successCb);
+      errorCb.should.be.callCount(0);
+      successCb.should.be.calledOnce();
+      let observerAuthSnapshot = observerCb.args[0][0];
+      const successAuthSnapshot = successCb.args[0][0];
+      successAuthSnapshot.verificationId.should.be.a.String();
+      if (device.getPlatform() === 'ios') {
+        observerCb.should.be.calledOnce();
+        successAuthSnapshot.state.should.equal('sent');
+      } else {
+        // android waits for SMS auto retrieval which does not work on an emulator
+        // it gets a sent and a timeout message on observer, just the timeout on success
+        observerCb.should.be.calledTwice();
+        observerAuthSnapshot = observerCb.args[1][0];
+        successAuthSnapshot.state.should.equal('timeout');
+      }
+      JSON.stringify(successAuthSnapshot).should.equal(JSON.stringify(observerAuthSnapshot));
+    });
+
+    // TODO determine why this is not stable on the emulator, is it also not stable on real device?
+    xit('successfully runs and calls error callback', async function () {
+      const successCb = sinon.spy();
+      const observerCb = sinon.spy();
+      const errorCb = sinon.spy();
+
+      await firebase
+        .auth()
+        .verifyPhoneNumber('notaphonenumber')
+        .on('state_changed', observerCb, errorCb, successCb);
+
+      await Utils.spyToBeCalledOnceAsync(errorCb);
+      errorCb.should.be.calledOnce();
+      observerCb.should.be.calledOnce();
+      // const observerEvent = observerCb.args[0][0];
+      successCb.should.be.callCount(0);
+      // const errorEvent = errorCb.args[0][0];
+      // errorEvent.error.should.containEql('auth/invalid-phone-number');
+      // JSON.stringify(errorEvent).should.equal(JSON.stringify(observerEvent));
     });
 
     it('catches an error and emits an error event', async function () {
-      return firebase
-        .auth()
-        .verifyPhoneNumber('test')
-        .catch(() => Promise.resolve());
+      const catchCb = sinon.spy();
+      await firebase.auth().verifyPhoneNumber('badphonenumber').catch(catchCb);
+      catchCb.should.be.calledOnce();
     });
   });
 });

--- a/packages/auth/lib/PhoneAuthListener.js
+++ b/packages/auth/lib/PhoneAuthListener.js
@@ -206,16 +206,16 @@ export default class PhoneAuthListener {
     this._addUserObserver(observer);
 
     if (isFunction(errorCb)) {
-      const subscription = this._auth.emitter.addListener(this._publicEvents.error, () => {
-        errorCb;
+      const subscription = this._auth.emitter.addListener(this._publicEvents.error, event => {
         subscription.remove();
+        errorCb(event);
       });
     }
 
     if (isFunction(successCb)) {
-      const subscription = this._auth.emitter.addListener(this._publicEvents.success, () => {
-        successCb;
+      const subscription = this._auth.emitter.addListener(this._publicEvents.success, event => {
         subscription.remove();
+        successCb(event);
       });
     }
 


### PR DESCRIPTION
### Description

@Avishayy noticed in #5917 that our e2e phone auth tests were false-positive and the implementation was in fact broken during the once/on event changeover for one of the recent RN version updates

This fixes the e2e testing and repairs the code

### Related issues

Fixes #5917

### Release Summary

All conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Lots of e2e testing on this one. I'm still not satisfied with the error case but I have seen it work and it follows the same code pattern as the success callback which is definitely working. Needs wider testing

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
