### PR TITLE
fix(app, expo): Update AppDelegate config plugin for Expo SDK 44

### DIFF
--- a/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m (SDK 43+) 1`] = `
-"// This AppDelegate template is used in Expo SDK 43 and newer
+exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m (SDK 43) 1`] = `
+"// This AppDelegate template is used in Expo SDK 43
 // It is (nearly) identical to the pure template used when
 // creating a bare React Native app (without Expo)
 
@@ -89,6 +89,147 @@ static void InitializeFlipper(UIApplication *application) {
                    continueUserActivity:userActivity
                      restorationHandler:restorationHandler];
 }
+
+@end
+"
+`;
+
+exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with Expo ReactDelegate support (SDK 44+) 1`] = `
+"// This AppDelegate prebuild template is used in Expo SDK 44+
+// It has the RCTBridge to be created by Expo ReactDelegate
+
+#import \\"AppDelegate.h\\"
+@import Firebase;
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-ecd111c37e49fdd1ed6354203cd6b1e2a38cccda
+[FIRApp configure];
+// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@\\"main\\" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@\\"index\\" fallbackResource:nil];
+ #else
+  return [[NSBundle mainBundle] URLForResource:@\\"main\\" withExtension:@\\"jsbundle\\"];
+ #endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+@end
+"
+`;
+
+exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with fallback regex (if the original one fails) 1`] = `
+"// This AppDelegate template is modified to have RCTBridge
+// created in some non-standard way or not created at all.
+// This should trigger the fallback regex in iOS AppDelegate Expo plugin.
+
+// some parts omitted to be short
+
+#import \\"AppDelegate.h\\"
+@import Firebase;
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions-fallback - expo prebuild (DO NOT MODIFY) sync-ecd111c37e49fdd1ed6354203cd6b1e2a38cccda
+[FIRApp configure];
+// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions-fallback
+
+// The generated code should appear above ^^^
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  // the line below is malfolmed not to be matched by the Expo plugin regex
+  // RCTBridge* briddge = [RCTBridge new];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:briddge moduleName:@\\"main\\" initialProperties:nil];
+  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@\\"RCTRootViewBackgroundColor\\"];
+  if (rootViewBackgroundColor != nil) {
+    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
 
 @end
 "

--- a/packages/app/plugin/__tests__/fixtures/AppDelegate_fallback.m
+++ b/packages/app/plugin/__tests__/fixtures/AppDelegate_fallback.m
@@ -1,0 +1,46 @@
+// This AppDelegate template is modified to have RCTBridge
+// created in some non-standard way or not created at all.
+// This should trigger the fallback regex in iOS AppDelegate Expo plugin.
+
+// some parts omitted to be short
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+
+// The generated code should appear above ^^^
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  // the line below is malfolmed not to be matched by the Expo plugin regex
+  // RCTBridge* briddge = [RCTBridge new];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:briddge moduleName:@"main" initialProperties:nil];
+  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+  if (rootViewBackgroundColor != nil) {
+    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+@end

--- a/packages/app/plugin/__tests__/fixtures/AppDelegate_sdk44.m
+++ b/packages/app/plugin/__tests__/fixtures/AppDelegate_sdk44.m
@@ -1,6 +1,5 @@
-// This AppDelegate template is used in Expo SDK 43
-// It is (nearly) identical to the pure template used when
-// creating a bare React Native app (without Expo)
+// This AppDelegate prebuild template is used in Expo SDK 44+
+// It has the RCTBridge to be created by Expo ReactDelegate
 
 #import "AppDelegate.h"
 
@@ -37,17 +36,11 @@ static void InitializeFlipper(UIApplication *application) {
   InitializeFlipper(application);
 #endif
   
-  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
-  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
-  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
-  if (rootViewBackgroundColor != nil) {
-    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
-  } else {
-    rootView.backgroundColor = [UIColor whiteColor];
-  }
-
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [UIViewController new];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];

--- a/packages/app/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/app/plugin/__tests__/iosPlugin.test.ts
@@ -12,9 +12,28 @@ describe('Config Plugin iOS Tests', function () {
     expect(result).toMatchSnapshot();
   });
 
-  it('tests changes made to AppDelegate.m (SDK 43+)', async function () {
+  it('tests changes made to AppDelegate.m (SDK 43)', async function () {
     const appDelegate = await fs.readFile(
       path.join(__dirname, './fixtures/AppDelegate_bare_sdk43.m'),
+      {
+        encoding: 'utf8',
+      },
+    );
+    const result = modifyObjcAppDelegate(appDelegate);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('tests changes made to AppDelegate.m with Expo ReactDelegate support (SDK 44+)', async function () {
+    const appDelegate = await fs.readFile(path.join(__dirname, './fixtures/AppDelegate_sdk44.m'), {
+      encoding: 'utf8',
+    });
+    const result = modifyObjcAppDelegate(appDelegate);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('tests changes made to AppDelegate.m with fallback regex (if the original one fails)', async function () {
+    const appDelegate = await fs.readFile(
+      path.join(__dirname, './fixtures/AppDelegate_fallback.m'),
       {
         encoding: 'utf8',
       },

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -1,11 +1,16 @@
-import { ConfigPlugin, IOSConfig, withDangerousMod } from '@expo/config-plugins';
+import { ConfigPlugin, IOSConfig, WarningAggregator, withDangerousMod } from '@expo/config-plugins';
 import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
 import fs from 'fs';
 
 const methodInvocationBlock = `[FIRApp configure];`;
-// https://regex101.com/r/Imm3E8/1
+// https://regex101.com/r/mPgaq6/1
 const methodInvocationLineMatcher =
-  /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[\[RCTBridge alloc\])/g;
+  /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))/g;
+
+// https://regex101.com/r/nHrTa9/1/
+// if the above regex fails, we can use this one as a fallback:
+const fallbackInvocationLineMatcher =
+  /-\s*\(BOOL\)\s*application:\s*\(UIApplication\s*\*\s*\)\s*\w+\s+didFinishLaunchingWithOptions:/g;
 
 export function modifyObjcAppDelegate(contents: string): string {
   // Add import
@@ -22,15 +27,44 @@ export function modifyObjcAppDelegate(contents: string): string {
     return contents;
   }
 
+  if (
+    !methodInvocationLineMatcher.test(contents) &&
+    !fallbackInvocationLineMatcher.test(contents)
+  ) {
+    WarningAggregator.addWarningIOS(
+      '@react-native-firebase/app',
+      'The AppDelegate.m may be malfolmed. Skiping adding Firebase to it.',
+    );
+    return contents;
+  }
+
   // Add invocation
-  return mergeContents({
-    tag: '@react-native-firebase/app-didFinishLaunchingWithOptions',
-    src: contents,
-    newSrc: methodInvocationBlock,
-    anchor: methodInvocationLineMatcher,
-    offset: 0, // new line will be inserted right before matched anchor
-    comment: '//',
-  }).contents;
+  try {
+    return mergeContents({
+      tag: '@react-native-firebase/app-didFinishLaunchingWithOptions',
+      src: contents,
+      newSrc: methodInvocationBlock,
+      anchor: methodInvocationLineMatcher,
+      offset: 0, // new line will be inserted right above matched anchor
+      comment: '//',
+    }).contents;
+  } catch (e: any) {
+    // tests if the opening `{` is in the new line
+    const multilineMatcher = new RegExp(fallbackInvocationLineMatcher.source + '.+\\n*{');
+    const isHeaderMultiline = multilineMatcher.test(contents);
+
+    // we fallback to another regex if the first one fails
+    return mergeContents({
+      tag: '@react-native-firebase/app-didFinishLaunchingWithOptions-fallback',
+      src: contents,
+      newSrc: methodInvocationBlock,
+      anchor: fallbackInvocationLineMatcher,
+      // new line will be inserted right below matched anchor
+      // or two lines, if the `{` is in the new line
+      offset: isHeaderMultiline ? 2 : 1,
+      comment: '//',
+    }).contents;
+  }
 }
 
 export const withFirebaseAppDelegate: ConfigPlugin = config => {
@@ -39,6 +73,7 @@ export const withFirebaseAppDelegate: ConfigPlugin = config => {
     async config => {
       const fileInfo = IOSConfig.Paths.getAppDelegate(config.modRequest.projectRoot);
       let contents = await fs.promises.readFile(fileInfo.path, 'utf-8');
+      WarningAggregator.addWarningIOS('dupa', `${config.sdkVersion}`);
       if (fileInfo.language === 'objc') {
         contents = modifyObjcAppDelegate(contents);
       } else {

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 const methodInvocationBlock = `[FIRApp configure];`;
 // https://regex101.com/r/mPgaq6/1
 const methodInvocationLineMatcher =
-  /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))/g;
+  /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))/g;
 
 // https://regex101.com/r/nHrTa9/1/
 // if the above regex fails, we can use this one as a fallback:
@@ -73,7 +73,6 @@ export const withFirebaseAppDelegate: ConfigPlugin = config => {
     async config => {
       const fileInfo = IOSConfig.Paths.getAppDelegate(config.modRequest.projectRoot);
       let contents = await fs.promises.readFile(fileInfo.path, 'utf-8');
-      WarningAggregator.addWarningIOS('dupa', `${config.sdkVersion}`);
       if (fileInfo.language === 'objc') {
         contents = modifyObjcAppDelegate(contents);
       } else {

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -33,7 +33,7 @@ export function modifyObjcAppDelegate(contents: string): string {
   ) {
     WarningAggregator.addWarningIOS(
       '@react-native-firebase/app',
-      'The AppDelegate.m may be malfolmed. Skiping adding Firebase to it.',
+      'Unable to determine correct Firebase insertion point in AppDelegate.m. Skipping Firebase addition.',
     );
     return contents;
   }


### PR DESCRIPTION
### Description

See https://github.com/invertase/react-native-firebase/issues/5936#issuecomment-994412911

The AppDelegate template for Expo has changed again.
- Updated the existing regex
- _Proposed_ a fallback regex, if the line matched by the previous regex ever changes again (hope not!). It matches for `- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:`, but surprisingly is less stable than the previous one. Why? It can be multiline (e.g. the method opening bracket `{` can be in the same or new line). And `mergeContents()` from `@expo/config-plugins` doesn't support multiline matchers. 😒 So I left this solution as a second chance.

## Are we forced to rely on RegExp forever?

> I am leaving it here for further discussion / reference.

Hopefully not. Interestingly, the line that broke SDK 44, actually was part of a change (series of changes), that would allow libraries to define their own _"App Delegate Extensions" (I'm still not sure about the official name)_, which can contain custom code to be executed in `AppDelegate` methods.

In this case, such `extension` could look like this (it's Swift, but afaik there's a possibility to do it in Obj-C too):
```swift
import ExpoModulesCore
import Firebase

public class RNFBExpoAppDelegate: ExpoAppDelegateSubscriber {
  public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
    FirebaseApp.configure()
    return true
  }
}
```
Then, this class name should be provided in one expo-specific configuration file (`expo-module.config.json`) shipped with the library, and expo-modules-autolinking will do the rest.

More info in this PR: https://github.com/expo/expo/pull/14867

This will let us get rid of that regex changes. Why didn't I implement it yet and stay with regex? A couple of reasons:
- It's undocumented yet
- It's introduced in SDK 44, the API might be unstable.
- It most likely requires RNFB to add `ExpoModulesCore` as an iOS pod dependency - I don't want to mess with it here yet. 
- That dependency is a Swift module, but I don't know much about objc-swift interop between libraries

If the above are not blockers, then I can try to implement this.

### Related issues

Fixes #5936


### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- Regex tested in Regex101 (links in code)
- Tested on an SDK 44 app,
- Updated jest tests and snapshots
