### PR TITLE
test(functions, e2e): use functions emulator in e2e harness

### DIFF
--- a/.github/workflows/scripts/firebase.json
+++ b/.github/workflows/scripts/firebase.json
@@ -3,6 +3,13 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
+  "functions": {
+    "predeploy": [
+      "yarn",
+      "yarn --prefix \"$RESOURCE_DIR\" build"
+    ],
+    "source": "functions"
+  },
   "database": {
     "rules": "database.rules"
   },
@@ -18,6 +25,9 @@
     },
     "firestore": {
       "port": "8080"
+    },
+    "functions": {
+      "port": "5001"
     },
     "storage": {
       "port": "9199"

--- a/.github/workflows/scripts/functions/.gitignore
+++ b/.github/workflows/scripts/functions/.gitignore
@@ -1,0 +1,10 @@
+# Compiled JavaScript files
+lib/**/*.js
+lib/**/*.js.map
+
+# TypeScript v1 declaration files
+typings/
+
+# Node.js dependency directory
+node_modules/
+yarn.lock

--- a/.github/workflows/scripts/functions/package.json
+++ b/.github/workflows/scripts/functions/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "functions",
+  "scripts": {
+    "build": "tsc",
+    "serve": "npm run build && firebase emulators:start --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "engines": {
+    "node": "14"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "firebase-admin": "^9.8.0",
+    "firebase-functions": "^3.14.1"
+  },
+  "devDependencies": {
+    "typescript": "^3.8.0",
+    "firebase-functions-test": "^0.2.0"
+  },
+  "private": true
+}

--- a/.github/workflows/scripts/functions/src/exports.ts
+++ b/.github/workflows/scripts/functions/src/exports.ts
@@ -1,0 +1,13 @@
+/*
+ *
+ *  Testing tools for invertase/react-native-firebase use only.
+ *
+ *  Copyright (C) 2018-present Invertase Limited <oss@invertase.io>
+ *
+ *  See License file for more information.
+*/
+
+/* eslint-disable global-require */
+module.exports = {
+  SAMPLE_DATA: require('./functions/sample-data'),
+};

--- a/.github/workflows/scripts/functions/src/index.ts
+++ b/.github/workflows/scripts/functions/src/index.ts
@@ -1,0 +1,12 @@
+import * as functions from 'firebase-functions';
+
+// // Start writing Firebase Functions
+// // https://firebase.google.com/docs/functions/typescript
+//
+export const helloWorld = functions.https.onRequest((request, response) => {
+  functions.logger.info('Hello logs!', { structuredData: true });
+  response.send('Hello from Firebase!');
+});
+
+export { testFunctionCustomRegion } from './testFunctionCustomRegion';
+export { testFunctionDefaultRegion } from './testFunctionDefaultRegion';

--- a/.github/workflows/scripts/functions/src/sample-data.ts
+++ b/.github/workflows/scripts/functions/src/sample-data.ts
@@ -1,0 +1,80 @@
+/*
+ *  Testing tools for invertase/react-native-firebase use only.
+ *
+ *  Copyright (C) 2018-present Invertase Limited <oss@invertase.io>
+ *
+ *  See License file for more information.
+ */
+
+const SAMPLE_DATA: { [key: string]: any } = {
+  number: 1234,
+  string: 'acde',
+  boolean: true,
+  null: null,
+  object: {
+    number: 1234,
+    string: 'acde',
+    boolean: true,
+    null: null,
+  },
+  array: [1234, 'acde', true, null],
+  deepObject: {
+    array: [1234, 'acde', false, null],
+    object: {
+      number: 1234,
+      string: 'acde',
+      boolean: true,
+      null: null,
+      array: [1234, 'acde', true, null],
+    },
+    number: 1234,
+    string: 'acde',
+    boolean: true,
+    null: null,
+  },
+  deepArray: [
+    1234,
+    'acde',
+    true,
+    null,
+    [1234, 'acde', true, null],
+    {
+      number: 1234,
+      string: 'acde',
+      boolean: true,
+      null: null,
+      array: [1234, 'acde', true, null],
+    },
+  ],
+  deepMap: {
+    number: 123,
+    string: 'foo',
+    booleanTrue: true,
+    booleanFalse: false,
+    null: null,
+    list: ['1', 2, true, false],
+    map: {
+      number: 123,
+      string: 'foo',
+      booleanTrue: true,
+      booleanFalse: false,
+      null: null,
+    },
+  },
+  deepList: [
+    '1',
+    2,
+    true,
+    false,
+    ['1', 2, true, false],
+    {
+      number: 123,
+      string: 'foo',
+      booleanTrue: true,
+      booleanFalse: false,
+      null: null,
+    },
+  ],
+};
+
+export default SAMPLE_DATA;

--- a/.github/workflows/scripts/functions/src/testFunctionCustomRegion.ts
+++ b/.github/workflows/scripts/functions/src/testFunctionCustomRegion.ts
@@ -1,0 +1,14 @@
+/*
+ *
+ *  Testing tools for invertase/react-native-firebase use only.
+ *
+ *  Copyright (C) 2018-present Invertase Limited <oss@invertase.io>
+ *
+ *  See License file for more information.
+ */
+
+import * as functions from 'firebase-functions';
+
+export const testFunctionCustomRegion = functions
+  .region('europe-west1')
+  .https.onCall(() => 'europe-west1');

--- a/.github/workflows/scripts/functions/src/testFunctionDefaultRegion.ts
+++ b/.github/workflows/scripts/functions/src/testFunctionDefaultRegion.ts
@@ -1,0 +1,70 @@
+/*
+ *
+ *  Testing tools for invertase/react-native-firebase use only.
+ *
+ *  Copyright (C) 2018-present Invertase Limited <oss@invertase.io>
+ *
+ *  See License file for more information.
+ */
+
+import * as assert from 'assert';
+import { FirebaseError } from 'firebase-admin';
+import * as functions from 'firebase-functions';
+import SAMPLE_DATA from './sample-data';
+
+export const testFunctionDefaultRegion = functions.https.onCall(data => {
+  console.log(Date.now(), data);
+
+  if (typeof data === 'undefined') {
+    return 'undefined';
+  }
+
+  if (typeof data === 'string') {
+    return 'string';
+  }
+
+  if (typeof data === 'number') {
+    return 'number';
+  }
+
+  if (typeof data === 'boolean') {
+    return 'boolean';
+  }
+
+  if (data === null) {
+    return 'null';
+  }
+
+  if (Array.isArray(data)) {
+    return 'array';
+  }
+
+  const { type, asError, inputData } = data;
+  if (!Object.hasOwnProperty.call(SAMPLE_DATA, type)) {
+    throw new functions.https.HttpsError('invalid-argument', 'Invalid test requested.');
+  }
+
+  const outputData = SAMPLE_DATA[type];
+
+  try {
+    assert.deepEqual(outputData, inputData);
+  } catch (e) {
+    console.error(e);
+    throw new functions.https.HttpsError(
+      'invalid-argument',
+      'Input and Output types did not match.',
+      (e as FirebaseError).message,
+    );
+  }
+
+  // all good
+  if (asError) {
+    throw new functions.https.HttpsError(
+      'cancelled',
+      'Response data was requested to be sent as part of an Error payload, so here we are!',
+      outputData,
+    );
+  }
+
+  return outputData;
+});

--- a/.github/workflows/scripts/functions/tsconfig.json
+++ b/.github/workflows/scripts/functions/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "outDir": "lib",
+    "sourceMap": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2017"
+  },
+  "compileOnSave": true,
+  "include": [
+    "src"
+  ]
+}

--- a/.github/workflows/scripts/start-firebase-emulator.sh
+++ b/.github/workflows/scripts/start-firebase-emulator.sh
@@ -4,11 +4,14 @@ if ! [ -x "$(command -v firebase)" ]; then
   exit 1
 fi
 
-EMU_START_COMMAND="firebase emulators:start --only auth,database,firestore,storage --project react-native-firebase-testing"
+EMU_START_COMMAND="firebase emulators:start --only auth,database,firestore,functions,storage --project react-native-firebase-testing"
 #EMU_START_COMMAND="sleep 120"
 MAX_RETRIES=3
 MAX_CHECKATTEMPTS=60
 CHECKATTEMPTS_WAIT=1
+
+# Make sure functions are ready to go
+pushd "$(dirname "$0")/functions" && yarn && yarn build && popd
 
 
 RETRIES=1

--- a/packages/functions/e2e/functions.e2e.js
+++ b/packages/functions/e2e/functions.e2e.js
@@ -15,7 +15,7 @@
  *
  */
 
-const { SAMPLE_DATA } = require('@react-native-firebase/private-tests-firebase-functions');
+const SAMPLE_DATA = require('../../../.github/workflows/scripts/functions/lib/sample-data').default;
 
 describe('functions()', function () {
   describe('namespace', function () {

--- a/tests/app.js
+++ b/tests/app.js
@@ -51,6 +51,7 @@ if (Platform.OS === 'ios') {
 firebase.auth().useEmulator('http://localhost:9099');
 firebase.firestore().useEmulator('localhost', 8080);
 firebase.storage().useEmulator('localhost', 9199);
+firebase.functions().useFunctionsEmulator('http://localhost:5001');
 
 function Root() {
   return (

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -856,70 +856,70 @@ PODS:
     - React-jsi (= 0.67.0-rc.5)
     - React-logger (= 0.67.0-rc.5)
     - React-perflogger (= 0.67.0-rc.5)
-  - RNFBAnalytics (13.1.1):
+  - RNFBAnalytics (14.0.1):
     - Firebase/Analytics (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (13.1.1):
+  - RNFBApp (14.0.1):
     - Firebase/CoreOnly (= 8.10.0)
     - React-Core
-  - RNFBAppCheck (13.1.1):
+  - RNFBAppCheck (14.0.1):
     - Firebase/AppCheck (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (13.1.1):
+  - RNFBAppDistribution (14.0.1):
     - Firebase/AppDistribution (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (13.1.1):
+  - RNFBAuth (14.0.1):
     - Firebase/Auth (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (13.1.1):
+  - RNFBCrashlytics (14.0.1):
     - Firebase/Crashlytics (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (13.1.1):
+  - RNFBDatabase (14.0.1):
     - Firebase/Database (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (13.1.1):
+  - RNFBDynamicLinks (14.0.1):
     - Firebase/DynamicLinks (= 8.10.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (13.1.1):
+  - RNFBFirestore (14.0.1):
     - Firebase/Firestore (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (13.1.1):
+  - RNFBFunctions (14.0.1):
     - Firebase/Functions (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (13.1.1):
+  - RNFBInAppMessaging (14.0.1):
     - Firebase/InAppMessaging (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (13.1.1):
+  - RNFBInstallations (14.0.1):
     - Firebase/Installations (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (13.1.1):
+  - RNFBMessaging (14.0.1):
     - Firebase/Messaging (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBML (13.1.1):
+  - RNFBML (14.0.1):
     - React-Core
     - RNFBApp
-  - RNFBPerf (13.1.1):
+  - RNFBPerf (14.0.1):
     - Firebase/Performance (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (13.1.1):
+  - RNFBRemoteConfig (14.0.1):
     - Firebase/RemoteConfig (= 8.10.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (13.1.1):
+  - RNFBStorage (14.0.1):
     - Firebase/Storage (= 8.10.0)
     - React-Core
     - RNFBApp
@@ -1171,23 +1171,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: 907bce319076cf626512e5d21d49a20a4f44f94b
   React-runtimeexecutor: f6ca394eae7a8d7880b244c749cc2040400d07dd
   ReactCommon: 4314d74f159d795b67b7d79a3943737b4e2f39eb
-  RNFBAnalytics: 9337a84539ea8497409a8c1db1c301dc1b2b3858
-  RNFBApp: 6e20f07b316346d96737191f377777f61f51a8d2
-  RNFBAppCheck: 15a77362b86217fb43b7b15858c6f04dce895064
-  RNFBAppDistribution: 83d15f74d35cce2520d357a9d5564b67ee6e2cb2
-  RNFBAuth: e2ba12680f849537c643e049df5f0d0d4f1b0ee1
-  RNFBCrashlytics: 649e0fa724d807362cb4265069fea98b2960c46b
-  RNFBDatabase: ac2ea4a368e9875ea2eb01dbefd4094840aeefdf
-  RNFBDynamicLinks: 140a76744739274fc589c3de88fe2161e2214a34
-  RNFBFirestore: 1629b5e89bdab92493fdc0e88753a9089ef13940
-  RNFBFunctions: 111db6c1e773c5ae940f9f543026a886d566792f
-  RNFBInAppMessaging: 91e1b840a0c829dcc9bbcd4344c3c8560be8c7ac
-  RNFBInstallations: 276ecca53f916cf684e47eb72088e180ec85c1d9
-  RNFBMessaging: eb8d1b08795c8718706007ed0743732d00e1acc4
-  RNFBML: dd7ac898526f798ff60a63a63fd020f1979d7c92
-  RNFBPerf: 6b2468912af04481db2c3b4e13a1a121425b29f0
-  RNFBRemoteConfig: 95812cc586fbe7a20dadd7eb4cd0a0f1b8e34ce2
-  RNFBStorage: bffb285f037e0cb3937bdc2c72992dd7a6a83982
+  RNFBAnalytics: 7559ac75a8d289ca8272b63c980fc68c8d633da9
+  RNFBApp: b6eef98aff9bfb2f7c135efee640215f72d718ab
+  RNFBAppCheck: e2606e7efe310b33eaee4bd75ae3b11234dafd5d
+  RNFBAppDistribution: 806a067a6d87572b59f44824868cf52093c810f4
+  RNFBAuth: d6f91ae9dc4330014b90a87ea97910b5dc5adaaf
+  RNFBCrashlytics: 27fe03701209b7dde02f986e0d67404d1f84a1e6
+  RNFBDatabase: cf714ef2e3b45673db63626d7178de92b8d48c55
+  RNFBDynamicLinks: a567809399423b9e70d9485e8d3b11f0017bb5b7
+  RNFBFirestore: be3c95593d8f493ad4f02f63684c3329bb6d7638
+  RNFBFunctions: cb7708ebee2df8f079659703d7c61f9b70b08043
+  RNFBInAppMessaging: 0b76514c2d3307a858f61d1f61ed60db031f8423
+  RNFBInstallations: 477c02340ea201b86821cd23b6bc1411a7165277
+  RNFBMessaging: c5eca0063e7de2c84039838fd5dda5f19f7dc469
+  RNFBML: 9a3be11b5b1dffa6858f07ad4231b2fce916a037
+  RNFBPerf: af21a5263dd74d21c8c194edc66560ff72d033f6
+  RNFBRemoteConfig: 4b707ed0633016a5fb5578b33caf298b7941fbe0
+  RNFBStorage: bdb7d18f75b5499a7beebab8e0d1574ab1d0d3b9
   Yoga: 4e413bcfc159bb24650466ba3567b533c66e3e1a
 
 PODFILE CHECKSUM: a4854589561b42da6b3b0726136a46ac6aef3ebd


### PR DESCRIPTION
### Description

We were relying on some unpublished function code running in the cloud to verify functions behavior, and not verifying the emulator

Now the functions code is visible in our test harness's emulator directory, and we're using the emulator

### Related issues

#5462 was having a problem with custom regions, now we exercise that and it seems fine

### Release Summary

conventional commits per usual

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

It is literally made of testing

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
