### PR TITLE
fix(app, android): firebase-android-sdk 29.0.3 to fix underlying NPE in 29.0.2

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -4,6 +4,7 @@ Ad
 AdMob
 Analytics
 analytics
+ANR
 APIs
 APIs.
 AppAttest

--- a/docs/crashlytics/crash-reports.md
+++ b/docs/crashlytics/crash-reports.md
@@ -50,11 +50,10 @@ issue, preventing this from happening.
 # Android ANR Collection Support
 
 The Firebase Team enabled the ability to collect
-Application Not Responding (ANR) issues that occur when the  UI thread of an Android app is blocked for too long,
+Application Not Responding (ANR) issues that occur when the UI thread of an Android app is blocked for too long,
 for more information on ANR see the
 [android developer documentation](https://developer.android.com/topic/performance/vitals/anr).
 
 The support for ANR collection is added in the Android Crashlytics version
 [18.2.4](https://firebase.google.com/support/release-notes/android#crashlytics_v18-2-4)
-so that your react native application can collect ANR, make sure you are using at least version 13.0.1 of this library
-
+so that your react native application can collect ANR, make sure you are using at least version 13.0.1 of this librar

--- a/docs/crashlytics/crash-reports.md
+++ b/docs/crashlytics/crash-reports.md
@@ -56,4 +56,4 @@ for more information on ANR see the
 
 The support for ANR collection is added in the Android Crashlytics version
 [18.2.4](https://firebase.google.com/support/release-notes/android#crashlytics_v18-2-4)
-so that your react native application can collect ANR, make sure you are using at least version 13.0.1 of this librar
+so that your react native application can collect ANR, make sure you are using at least version 13.0.1 of this library

--- a/docs/crashlytics/crash-reports.md
+++ b/docs/crashlytics/crash-reports.md
@@ -46,3 +46,15 @@ you to filter it out in the overview by selecting 'Open' under 'Issue state', wh
 This is visible in the first example, where we're displaying only 3 relevant non-fatal events out of the 12 that occurred.
 When the same issue re-occurs, it will automatically open again. By clicking the arrow next to the button we can mute the
 issue, preventing this from happening.
+
+# Android ANR Collection Support
+
+The Firebase Team enabled the ability to collect
+Application Not Responding (ANR) issues that occur when the  UI thread of an Android app is blocked for too long,
+for more information on ANR see the
+[android developer documentation](https://developer.android.com/topic/performance/vitals/anr).
+
+The support for ANR collection is added in the Android Crashlytics version
+[18.2.4](https://firebase.google.com/support/release-notes/android#crashlytics_v18-2-4)
+so that your react native application can collect ANR, make sure you are using at least version 13.0.1 of this library
+

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -72,7 +72,7 @@
       "targetSdk": 31,
       "compileSdk": 31,
       "buildTools": "30.0.3",
-      "firebase": "29.0.2",
+      "firebase": "29.0.3",
       "firebaseCrashlyticsGradle": "2.8.1",
       "firebasePerfGradle": "1.4.0",
       "gmsGoogleServicesGradle": "4.3.10",


### PR DESCRIPTION
### Description

I'm updating the latest version of this library in our app so we can collect ANR issues using the latest version of Firebase Crashlytics, so when reading the Firebase Android BoM documentation I saw that they sent a patch yesterday to avoid a crash (NullPointerException) with the previous version of the firebase analytics library:
https://issuetracker.google.com/issues/210908929

So I think it will be wonderful to have the most stable version. 👍🏽 

![image](https://user-images.githubusercontent.com/10731555/146615737-f6a6f783-c54a-4add-a9f7-b9c3004a4e18.png)



### Release Summary

- firebase-android-sdk 29.0.3
- Add ANR collection support documentation

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

No breaking changes, only internal changes in the android firebase analytics library

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter


🔥 
