### PR TITLE
fix(crashlytics): Expo SDK 44 compatibility

### DIFF
--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -18,11 +18,11 @@
 #include <Foundation/Foundation.h>
 #include <sys/sysctl.h>
 
+#import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
 #import <Firebase/Firebase.h>
-#import "RCTConvert.h"
 #import "RNFBApp/RNFBSharedUtils.h"
 #import "RNFBCrashlyticsInitProvider.h"
 #import "RNFBCrashlyticsModule.h"


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Using `crashlytics` in a Expo SDK 44 (latest version) project fails. This is because expo patches the react podspec for swift compatibility reasons (https://github.com/expo/expo/pull/15299) and that causes old style imports to not work.

I fixed the issue by changing the import style. 

More information: https://github.com/expo/expo/issues/15622#issuecomment-997141629

```
› Compiling @react-native-firebase/crashlytics Pods/RNFBCrashlytics » RNFBCrashlyticsModule.m

❌  (/Users/yonom/Documents/GitHub/app/node_modules/@react-native-firebase/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m:40:10)

  38 |   NSMutableDictionary *constants = [NSMutableDictionary new];
  39 |   constants[@"isCrashlyticsCollectionEnabled"] =
> 40 |       @([RCTConvert BOOL:@([RNFBCrashlyticsInitProvider isCrashlyticsCollectionEnabled])]);
     |          ^ declaration of 'RCTConvert' must be imported from module 'React.RCTConvert' before it is required
  41 |   constants[@"isErrorGenerationOnJSCrashEnabled"] =
  42 |       @([RCTConvert BOOL:@([RNFBCrashlyticsInitProvider isErrorGenerationOnJSCrashEnabled])]);
  43 |   constants[@"isCrashlyticsJavascriptExceptionHandlerChainingEnabled"] =
```

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
fix(crashlytics): Expo SDK 44 compatibility

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

Tested by adding crashlytics to a brand new expo sdk 44 project and compiling the app using `expo run:ios`

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
