### PR TITLE
feat(messaging, ios): add provideAppNotificationSettings iOS permission / handler

### DIFF
--- a/docs/messaging/ios-permissions.md
+++ b/docs/messaging/ios-permissions.md
@@ -141,7 +141,7 @@ import messaging from '@react-native-firebase/messaging'
 ...
 
 messaging().setOpenSettingsForNotificationsHandler(async () => {
-    // Set persistent value
+    // Set persistent value, using the MMKV package just as an example of how you might do it
     MMKV.setBool(openSettingsForNotifications, true)
 })
 

--- a/docs/messaging/ios-permissions.md
+++ b/docs/messaging/ios-permissions.md
@@ -54,14 +54,15 @@ await messaging().requestPermission({
 
 The full list of permission settings can be seen in the table below along with their default values:
 
-| Permission     | Default | Description                                                                                                                   |
-| -------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `alert`        | `true`  | Sets whether notifications can be displayed to the user on the device.                                                        |
-| `announcement` | `false` | If enabled, Siri will read the notification content out when devices are connected to AirPods.                                |
-| `badge`        | `true`  | Sets whether a notification dot will appear next to the app icon on the device when there are unread notifications.           |
-| `carPlay`      | `true`  | Sets whether notifications will appear when the device is connected to [CarPlay](https://www.apple.com/ios/carplay/).         |
-| `provisional`  | `false` | Sets whether provisional permissions are granted. See [Provisional permission](#provisional-permission) for more information. |
-| `sound`        | `true`  | Sets whether a sound will be played when a notification is displayed on the device.                                           |
+| Permission                        | Default | Description                                                                                                                   |
+| --------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `alert`                           | `true`  | Sets whether notifications can be displayed to the user on the device.                                                        |
+| `announcement`                    | `false` | If enabled, Siri will read the notification content out when devices are connected to AirPods.                                |
+| `badge`                           | `true`  | Sets whether a notification dot will appear next to the app icon on the device when there are unread notifications.           |
+| `carPlay`                         | `true`  | Sets whether notifications will appear when the device is connected to [CarPlay](https://www.apple.com/ios/carplay/).         |
+| `provisional`                     | `false` | Sets whether provisional permissions are granted. See [Provisional permission](#provisional-permission) for more information. |
+| `sound`                           | `true`  | Sets whether a sound will be played when a notification is displayed on the device.                                           |
+| `providesAppNotificationSettings` | `false` | Indicates the system to display a button for in-app notification settings.                                                    |
 
 The settings provided will be stored by the device and will be visible in the iOS Settings UI for your application.
 
@@ -119,3 +120,66 @@ await messaging().requestPermission({
 ```
 
 Users can then choose a permission option via the notification itself, and select whether they can continue to display quietly, display prominently or not at all.
+
+
+### Handle button for in-app notifications settings
+
+Devices on iOS 12+ can provide a button in iOS Notifications Settings *(at OS level: `Settings -> [App name] -> Notifications`)* to redirect users to in-app notifications settings. 
+
+
+1. Request `providesAppNotificationSettings` permissions:
+```typescript
+await messaging().requestPermission({ providesAppNotificationSettings: true })
+```
+
+2. Handle interaction when app is in background state (*eg: with MMKV or Recoil*):
+```typescript
+// index.js
+import { AppRegistry } from 'react-native'
+import messaging from '@react-native-firebase/messaging'
+
+...
+
+messaging().setOpenSettingsForNotificationsHandler(async () => {
+    MMKV.setBool(openSettingsForNotifications, true)
+})
+
+...
+
+AppRegistry.registerComponent(appName, () => App)
+```
+
+```typescript
+// App.tsx
+
+const App = () => {
+  const [openSettingsForNotifications] = useMMKVStorage('openSettingsForNotifications', MMKV, false)
+
+  useEffect(() => {
+    if (openSettingsForNotifications) {
+      navigate('NotificationsSettingsScreen')
+    }
+  }, [openSettingsForNotifications])
+
+  ...
+}
+```
+
+3. Handle interaction when app is in quit state:
+```typescript
+// App.tsx
+
+const App = () => {
+  useEffect(() => {
+        messaging()
+            .getDidOpenSettingsForNotification()
+            .then(async didOpenSettingsForNotification => {
+                if (didOpenSettingsForNotification) {
+                    navigate('NotificationsSettingsScreen')
+                }
+            })
+  }, [])
+
+    ...
+}
+```

--- a/docs/messaging/ios-permissions.md
+++ b/docs/messaging/ios-permissions.md
@@ -121,18 +121,18 @@ await messaging().requestPermission({
 
 Users can then choose a permission option via the notification itself, and select whether they can continue to display quietly, display prominently or not at all.
 
-
 ### Handle button for in-app notifications settings
 
-Devices on iOS 12+ can provide a button in iOS Notifications Settings *(at OS level: `Settings -> [App name] -> Notifications`)* to redirect users to in-app notifications settings. 
-
+Devices on iOS 12+ can provide a button in iOS Notifications Settings _(at OS level: `Settings -> [App name] -> Notifications`)_ to redirect users to in-app notifications settings.
 
 1. Request `providesAppNotificationSettings` permissions:
+
 ```typescript
-await messaging().requestPermission({ providesAppNotificationSettings: true })
+await messaging().requestPermission({ providesAppNotificationSettings: true });
 ```
 
-2. Handle interaction when app is in background state (*eg: with MMKV or Recoil*):
+2. Handle interaction when app is in background state (_eg: with MMKV or Recoil_):
+
 ```typescript
 // index.js
 import { AppRegistry } from 'react-native'
@@ -166,6 +166,7 @@ const App = () => {
 ```
 
 3. Handle interaction when app is in quit state:
+
 ```typescript
 // App.tsx
 

--- a/docs/messaging/ios-permissions.md
+++ b/docs/messaging/ios-permissions.md
@@ -131,7 +131,7 @@ Devices on iOS 12+ can provide a button in iOS Notifications Settings _(at OS le
 await messaging().requestPermission({ providesAppNotificationSettings: true });
 ```
 
-1. Handle interaction when app is in background state:
+2. Handle interaction when app is in background state:
 
 ```typescript
 // index.js

--- a/docs/messaging/ios-permissions.md
+++ b/docs/messaging/ios-permissions.md
@@ -131,7 +131,7 @@ Devices on iOS 12+ can provide a button in iOS Notifications Settings _(at OS le
 await messaging().requestPermission({ providesAppNotificationSettings: true });
 ```
 
-2. Handle interaction when app is in background state (_eg: with MMKV or Recoil_):
+1. Handle interaction when app is in background state:
 
 ```typescript
 // index.js
@@ -141,6 +141,7 @@ import messaging from '@react-native-firebase/messaging'
 ...
 
 messaging().setOpenSettingsForNotificationsHandler(async () => {
+    // Set persistent value
     MMKV.setBool(openSettingsForNotifications, true)
 })
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RNFBMessagingUNUserNotificationCenter : NSObject <UNUserNotificationCenterDelegate>
 
 @property NSDictionary *initialNotification;
+@property BOOL didOpenSettingsForNotification;
 @property(nonatomic, nullable, weak) id<UNUserNotificationCenterDelegate> originalDelegate;
 
 + (_Nonnull instancetype)sharedInstance;
@@ -29,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)observe;
 
 - (nullable NSDictionary *)getInitialNotification;
+
+- (NSNumber *)getDidOpenSettingsForNotification;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -33,6 +33,7 @@ struct {
   dispatch_once(&once, ^{
     sharedInstance = [[RNFBMessagingUNUserNotificationCenter alloc] init];
     sharedInstance.initialNotification = nil;
+    sharedInstance.didOpenSettingsForNotification = NO;
   });
   return sharedInstance;
 }
@@ -66,6 +67,15 @@ struct {
   }
 
   return nil;
+}
+
+- (NSNumber *)getDidOpenSettingsForNotification {
+  if (_didOpenSettingsForNotification != NO) {
+    _didOpenSettingsForNotification = NO;
+    return @YES;
+  }
+
+  return @NO;
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
@@ -126,6 +136,8 @@ struct {
     NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
     [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_settings_for_notification_opened"
                                                body:notificationDict];
+
+    _didOpenSettingsForNotification = YES;
   }
 }
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -119,7 +119,13 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     openSettingsForNotification:(nullable UNNotification *)notification {
   if (_originalDelegate != nil && originalDelegateRespondsTo.openSettingsForNotification) {
-    [_originalDelegate userNotificationCenter:center openSettingsForNotification:notification];
+    if (@available(iOS 12.0, *)) {
+      [_originalDelegate userNotificationCenter:center openSettingsForNotification:notification];
+    }
+  } else {
+    NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
+    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_settings_for_notification_opened"
+                                               body:notificationDict];
   }
 }
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -81,7 +81,8 @@ RCT_EXPORT_METHOD(getInitialNotification
 RCT_EXPORT_METHOD(getDidOpenSettingsForNotification
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  resolve([[RNFBMessagingUNUserNotificationCenter sharedInstance] getDidOpenSettingsForNotification]);
+  resolve(
+      [[RNFBMessagingUNUserNotificationCenter sharedInstance] getDidOpenSettingsForNotification]);
 }
 
 RCT_EXPORT_METHOD(setAutoInitEnabled

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -78,6 +78,12 @@ RCT_EXPORT_METHOD(getInitialNotification
   resolve([[RNFBMessagingUNUserNotificationCenter sharedInstance] getInitialNotification]);
 }
 
+RCT_EXPORT_METHOD(getDidOpenSettingsForNotification
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  resolve([[RNFBMessagingUNUserNotificationCenter sharedInstance] getDidOpenSettingsForNotification]);
+}
+
 RCT_EXPORT_METHOD(setAutoInitEnabled
                   : (BOOL)enabled
                   : (RCTPromiseResolveBlock)resolve

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -217,6 +217,10 @@ RCT_EXPORT_METHOD(requestPermission
       options |= UNAuthorizationOptionCarPlay;
     }
 
+    if ([permissions[@"providesAppNotificationSettings"] isEqual:@(YES)]) {
+      options |= UNAuthorizationOptionProvidesAppNotificationSettings;
+    }
+
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     [center requestAuthorizationWithOptions:options
                           completionHandler:^(BOOL granted, NSError *_Nullable error) {

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -435,6 +435,15 @@ export namespace FirebaseMessagingTypes {
      * Defaults to true.
      */
     sound?: boolean;
+
+    /**
+     * Request permission to display a button for in-app notification settings.
+     *
+     * Default to false
+     *
+     * @platform ios iOS >= 12
+     */
+    providesAppNotificationSettings?: boolean;
   }
 
   /**

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -568,6 +568,15 @@ export namespace FirebaseMessagingTypes {
     getInitialNotification(): Promise<RemoteMessage | null>;
 
     /**
+     * When the app is opened from iOS notifications settings from a quit state,
+     * this method will return `true` or `false` if the app was opened via another method.
+     *
+     * See `setOpenSettingsForNotificationsHandler` to subscribe to when the notificiation is opened when the app
+     * is in background state.
+     */
+    getDidOpenSettingsForNotification(): Promise<boolean>;
+
+    /**
      * Returns an FCM token for this device. Optionally you can specify a custom authorized entity
      * or scope to tailor tokens to your own use-case.
      *

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -573,6 +573,8 @@ export namespace FirebaseMessagingTypes {
      *
      * See `setOpenSettingsForNotificationsHandler` to subscribe to when the notificiation is opened when the app
      * is in background state.
+     *
+     * @ios iOS >= 12
      */
     getDidOpenSettingsForNotification(): Promise<boolean>;
 

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -896,6 +896,17 @@ export namespace FirebaseMessagingTypes {
     setBackgroundMessageHandler(handler: (message: RemoteMessage) => Promise<any>): void;
 
     /**
+     * Set a handler function which is called when the `${App Name} notifications settings`
+     * link in iOS settings is clicked.
+     *
+     * This method must be called **outside** of your application lifecycle, e.g. alongside your
+     * `AppRegistry.registerComponent()` method call at the the entry point of your application code.
+     *
+     * @ios iOS >= 12
+     */
+    setOpenSettingsForNotificationsHandler(handler: (message: RemoteMessage) => any): void;
+
+    /**
      * Send a new `RemoteMessage` to the FCM server.
      *
      * The promise resolves when the message has been added to the internal queue. Use `onMessageSent()`

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -58,6 +58,7 @@ const namespace = 'messaging';
 const nativeModuleName = 'RNFBMessagingModule';
 
 let backgroundMessageHandler;
+let openSettingsForNotificationHandler;
 
 class FirebaseMessagingModule extends FirebaseModule {
   constructor(...args) {
@@ -91,6 +92,19 @@ class FirebaseMessagingModule extends FirebaseModule {
         }
 
         return backgroundMessageHandler(remoteMessage);
+      });
+
+      this.emitter.addListener('messaging_settings_for_notification_opened', remoteMessage => {
+        if (!openSettingsForNotificationHandler) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            'No handler for notification settings link has been set. Set a handler via the "setOpenSettingsForNotificationsHandler" method',
+          );
+
+          return Promise.resolve();
+        }
+
+        return openSettingsForNotificationHandler(remoteMessage);
       });
     }
   }
@@ -312,6 +326,22 @@ class FirebaseMessagingModule extends FirebaseModule {
     }
   }
 
+  setOpenSettingsForNotificationsHandler(handler) {
+    if (!isIOS) {
+      throw new Error(
+        'firebase.messaging().setOpenSettingsForNotificationsHandler() is only supported on iOS devices.',
+      );
+    }
+
+    if (!isFunction(handler)) {
+      throw new Error(
+        "firebase.messaging().setOpenSettingsForNotificationsHandler(*) 'handler' expected a function.",
+      );
+    }
+
+    openSettingsForNotificationHandler = handler;
+  }
+
   sendMessage(remoteMessage) {
     if (isIOS) {
       throw new Error(`firebase.messaging().sendMessage() is only supported on Android devices.`);
@@ -390,7 +420,9 @@ export default createModuleNamespace({
     'messaging_message_received',
     'messaging_message_send_error',
     'messaging_notification_opened',
-    ...(isIOS ? ['messaging_message_received_background'] : []),
+    ...(isIOS
+      ? ['messaging_message_received_background', 'messaging_settings_for_notification_opened']
+      : []),
   ],
   hasMultiAppSupport: false,
   hasCustomUrlOrRegionSupport: false,

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -144,6 +144,12 @@ class FirebaseMessagingModule extends FirebaseModule {
     });
   }
 
+  getDidOpenSettingsForNotification() {
+    return this.native.getDidOpenSettingsForNotification().then(value => {
+      return value;
+    });
+  }
+
   getIsHeadless() {
     return this.native.getIsHeadless();
   }

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -145,6 +145,7 @@ class FirebaseMessagingModule extends FirebaseModule {
   }
 
   getDidOpenSettingsForNotification() {
+    if (!isIOS) return Promise.resolve(false);
     return this.native.getDidOpenSettingsForNotification().then(value => value);
   }
 

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -190,6 +190,7 @@ class FirebaseMessagingModule extends FirebaseModule {
       provisional: false,
       sound: true,
       criticalAlert: false,
+      providesAppNotificationSettings: false,
     };
 
     if (!permissions) {

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -145,9 +145,7 @@ class FirebaseMessagingModule extends FirebaseModule {
   }
 
   getDidOpenSettingsForNotification() {
-    return this.native.getDidOpenSettingsForNotification().then(value => {
-      return value;
-    });
+    return this.native.getDidOpenSettingsForNotification().then(value => value);
   }
 
   getIsHeadless() {

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -332,9 +332,7 @@ class FirebaseMessagingModule extends FirebaseModule {
 
   setOpenSettingsForNotificationsHandler(handler) {
     if (!isIOS) {
-      throw new Error(
-        'firebase.messaging().setOpenSettingsForNotificationsHandler() is only supported on iOS devices.',
-      );
+      return;
     }
 
     if (!isFunction(handler)) {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

`providesAppNotificationSettings` is useful to display a button/link in iOS settings to redirect user to in-app notification settings. However the option is not available in `@react-native-firebase/messaging`

[Apple developer documentation | UNNotificationSettings | providesAppNotificationSettings](https://developer.apple.com/documentation/usernotifications/unnotificationsettings/2990404-providesappnotificationsettings?language=objc)

<img src="https://user-images.githubusercontent.com/37045374/147665603-a895ed9e-7353-4064-8d8a-18cd543015eb.png" width="200"/>

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥 