### PR TITLE
fix(analytics): extend_session parameter

### DIFF
--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -175,6 +175,10 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
         ((Bundle) item).putInt(FirebaseAnalytics.Param.QUANTITY, (int) number);
       }
     }
+    if (bundle.containsKey(FirebaseAnalytics.Param.EXTEND_SESSION)) {
+      double number = bundle.getDouble(FirebaseAnalytics.Param.EXTEND_SESSION);
+      bundle.putLong(FirebaseAnalytics.Param.EXTEND_SESSION, (long) number);
+    }
     return bundle;
   }
 }

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -155,6 +155,10 @@ RCT_EXPORT_METHOD(setDefaultEventParameters
         }];
     newParams[kFIRParameterItems] = [newItems copy];
   }
+  NSNumber *extendSession = [newParams valueForKey:kFIRParameterExtendSession];
+  if ([extendSession isEqualToNumber:@1]) {
+    newParams[kFIRParameterExtendSession] = @YES;
+  }
   return [newParams copy];
 }
 


### PR DESCRIPTION
### Description

This PR modifies the event parameters so that the `extend_session` parameter is cast to the correct value.

```js
analytics().logEvent('event', { extend_session: 1 })
```

### Motivation

From [Firebase documentation](https://support.google.com/firebase/answer/9191807) (under the heading "Adjust app session timeout"):
> An app session begins to time out when an app is moved to the background, but you have the option to extend that session by including an extend_session parameter (with a value of 1) with events you send while the app is in the background. This is useful if your app is frequently used in the background, (e.g. as with navigation and music apps.)

We found in development that the `extend_session` parameter wasn't being respected through react-native-firebase because they were set to the incorrect values. [Android docs](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Param#public-static-final-string-extend_session) specify a long value of 1. [iOS docs](https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Constants#/c:FIRParameterNames.h@kFIRParameterExtendSession) specify a value of `@YES`. 

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

We've used this same code in production, applied via patch-package.

On Android, LogCat shows a helpful message once the value is correctly set:
```
V/FA: EXTEND_SESSION param attached: initiate a new session or extend the current active session
```

iOS doesn't show the same confirmation message, but I can confirm through our own app analytics session data that it works.

:fire:
