### PR TITLE
fix(app-check): getToken returns `{token: string}` not `string` matching firebase-js-sdk

### DIFF
--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
@@ -82,10 +82,8 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
             getExecutor(),
             (task) -> {
               if (task.isSuccessful()) {
-                String token = task.getResult().getToken();
-
                 WritableMap tokenResultMap = Arguments.createMap();
-                tokenResultMap.putString("token", tokne);
+                tokenResultMap.putString("token", task.getResult().getToken());
                 promise.resolve(tokenResultMap);
               } else {
                 Log.e(

--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
@@ -82,7 +82,11 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
             getExecutor(),
             (task) -> {
               if (task.isSuccessful()) {
-                promise.resolve(task.getResult().getToken());
+                String token = task.getResult().getToken();
+
+                WritableMap tokenResultMap = Arguments.createMap();
+                tokenResultMap.putString("token", tokne);
+                promise.resolve(tokenResultMap);
               } else {
                 Log.e(
                     TAG,

--- a/packages/app-check/e2e/appcheck.e2e.js
+++ b/packages/app-check/e2e/appcheck.e2e.js
@@ -43,7 +43,7 @@ describe('appCheck()', function () {
   describe('getToken())', function () {
     it('token fetch attempt should work', async function () {
       // Our tests configure a debug provider with shared secret so we should get a valid token
-      const token = await firebase.appCheck().getToken();
+      const { token } = await firebase.appCheck().getToken();
       token.should.not.equal('');
       const decodedToken = jwt.decode(token);
       decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
@@ -53,7 +53,7 @@ describe('appCheck()', function () {
 
       // Force refresh should get a different token?
       // TODO sometimes fails on android https://github.com/firebase/firebase-android-sdk/issues/2954
-      const token2 = await firebase.appCheck().getToken(true);
+      const { token: token2 } = await firebase.appCheck().getToken(true);
       token2.should.not.equal('');
       const decodedToken2 = jwt.decode(token2);
       decodedToken2.aud[1].should.equal('projects/react-native-firebase-testing');

--- a/packages/app-check/e2e/appcheck.e2e.js
+++ b/packages/app-check/e2e/appcheck.e2e.js
@@ -44,7 +44,6 @@ describe('appCheck()', function () {
     it('token fetch attempt should work', async function () {
       // Our tests configure a debug provider with shared secret so we should get a valid token
       const token = await firebase.appCheck().getToken();
-      token.should.be.a.String();
       token.should.not.equal('');
       const decodedToken = jwt.decode(token);
       decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
@@ -55,7 +54,6 @@ describe('appCheck()', function () {
       // Force refresh should get a different token?
       // TODO sometimes fails on android https://github.com/firebase/firebase-android-sdk/issues/2954
       const token2 = await firebase.appCheck().getToken(true);
-      token.should.be.a.String();
       token2.should.not.equal('');
       const decodedToken2 = jwt.decode(token2);
       decodedToken2.aud[1].should.equal('projects/react-native-firebase-testing');

--- a/packages/app-check/e2e/appcheck.e2e.js
+++ b/packages/app-check/e2e/appcheck.e2e.js
@@ -44,6 +44,7 @@ describe('appCheck()', function () {
     it('token fetch attempt should work', async function () {
       // Our tests configure a debug provider with shared secret so we should get a valid token
       const token = await firebase.appCheck().getToken();
+      token.should.be.a.String();
       token.should.not.equal('');
       const decodedToken = jwt.decode(token);
       decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
@@ -54,6 +55,7 @@ describe('appCheck()', function () {
       // Force refresh should get a different token?
       // TODO sometimes fails on android https://github.com/firebase/firebase-android-sdk/issues/2954
       const token2 = await firebase.appCheck().getToken(true);
+      token.should.be.a.String();
       token2.should.not.equal('');
       const decodedToken2 = jwt.decode(token2);
       decodedToken2.aud[1].should.equal('projects/react-native-firebase-testing');

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
@@ -97,8 +97,10 @@ RCT_EXPORT_METHOD(getToken
                                                            }];
                          return;
                        }
-
-                       resolve(token.token);
+                       
+                       NSMutableDictionary *tokenResultDictionary = [NSMutableDictionary new];
+                       tokenResultDictionary[@"token"] = token.token;
+                       resolve(tokenResultDictionary);
                      }];
 }
 

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
@@ -97,7 +97,7 @@ RCT_EXPORT_METHOD(getToken
                                                            }];
                          return;
                        }
-                       
+
                        NSMutableDictionary *tokenResultDictionary = [NSMutableDictionary new];
                        tokenResultDictionary[@"token"] = token.token;
                        resolve(tokenResultDictionary);

--- a/packages/app-check/lib/index.d.ts
+++ b/packages/app-check/lib/index.d.ts
@@ -65,18 +65,9 @@ export namespace FirebaseAppCheckTypes {
     /**
      * Returns an AppCheck token.
      */
-    getToken(): Promise<AppCheckToken>;
+    getToken(): Promise<string>;
   }
 
-  /**
-   * Result returned by `getToken()`.
-   */
-  interface AppCheckTokenResult {
-    /**
-     * The token string in JWT format.
-     */
-    readonly token: string;
-  }
   /**
    * The token returned from an `AppCheckProvider`.
    */
@@ -157,7 +148,7 @@ export namespace FirebaseAppCheckTypes {
      * If false, the cached token is used if it exists and has not expired yet.
      * In most cases, false should be used. True should only be used if the server explicitly returns an error, indicating a revoked token.
      */
-    getToken(forceRefresh?: boolean): Promise<AppCheckTokenResult>;
+    getToken(forceRefresh?: boolean): Promise<string>;
 
     /**
      * Registers a listener to changes in the token state. There can be more
@@ -168,7 +159,7 @@ export namespace FirebaseAppCheckTypes {
      * @returns A function that unsubscribes this listener.
      */
     // TODO there is a great deal of Observer / PartialObserver typing to carry-in
-    // onTokenChanged(observer: PartialObserver<AppCheckTokenResult>): () => void;
+    // onTokenChanged(observer: PartialObserver<string>): () => void;
 
     /**
      * TODO implement token listener for android.
@@ -184,7 +175,7 @@ export namespace FirebaseAppCheckTypes {
      * @returns A function that unsubscribes this listener.
      */
     // onTokenChanged(
-    //   onNext: (tokenResult: AppCheckTokenResult) => void,
+    //   onNext: (tokenResult: string) => void,
     //   onError?: (error: Error) => void,
     //   onCompletion?: () => void,
     // ): () => void;

--- a/packages/app-check/lib/index.d.ts
+++ b/packages/app-check/lib/index.d.ts
@@ -65,9 +65,18 @@ export namespace FirebaseAppCheckTypes {
     /**
      * Returns an AppCheck token.
      */
-    getToken(): Promise<string>;
+    getToken(): Promise<AppCheckToken>;
   }
 
+  /**
+   * Result returned by `getToken()`.
+   */
+  interface AppCheckTokenResult {
+    /**
+     * The token string in JWT format.
+     */
+    readonly token: string;
+  }
   /**
    * The token returned from an `AppCheckProvider`.
    */
@@ -148,7 +157,7 @@ export namespace FirebaseAppCheckTypes {
      * If false, the cached token is used if it exists and has not expired yet.
      * In most cases, false should be used. True should only be used if the server explicitly returns an error, indicating a revoked token.
      */
-    getToken(forceRefresh?: boolean): Promise<string>;
+    getToken(forceRefresh?: boolean): Promise<AppCheckTokenResult>;
 
     /**
      * Registers a listener to changes in the token state. There can be more
@@ -159,7 +168,7 @@ export namespace FirebaseAppCheckTypes {
      * @returns A function that unsubscribes this listener.
      */
     // TODO there is a great deal of Observer / PartialObserver typing to carry-in
-    // onTokenChanged(observer: PartialObserver<string>): () => void;
+    // onTokenChanged(observer: PartialObserver<AppCheckTokenResult>): () => void;
 
     /**
      * TODO implement token listener for android.
@@ -175,7 +184,7 @@ export namespace FirebaseAppCheckTypes {
      * @returns A function that unsubscribes this listener.
      */
     // onTokenChanged(
-    //   onNext: (tokenResult: string) => void,
+    //   onNext: (tokenResult: AppCheckTokenResult) => void,
     //   onError?: (error: Error) => void,
     //   onCompletion?: () => void,
     // ): () => void;


### PR DESCRIPTION
### Description

The return type of the `getToken` method is not of type `{ token: string }`, but rather of type `string`.

On the Android side, the task result here is the `AppCheckTokenResult` class.

https://github.com/invertase/react-native-firebase/blob/master/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java#L85

The `AppCheckTokenResult` class itself has a `getToken` method, which returns a `String`. 

https://github.com/firebase/firebase-android-sdk/blob/6da8617afe903126afac46ef71b1d857dcfe7ef9/appcheck/firebase-appcheck/src/main/java/com/google/firebase/appcheck/internal/DefaultAppCheckTokenResult.java#L55

Since the string is what is resolved in the Promise, the return type of the javascript method bound to this native code should also be a string.

On the iOS side, the promise is also passed the `token.token`, which should be a string, instead of the `token`.

https://github.com/invertase/react-native-firebase/blob/master/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m#L101

In our own app, we found that at runtime the `getToken` call was returning a string, so we had to use typescript assertions to prevent compiler errors due to the incorrect type.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No
  - [x] Somewhat? (it may break existing typescript builds, but they would have been typed incorrectly anyways)

### Test Plan

I added a few tests to assert that `getToken` returns a string. It should have already be returning this type, as in the tests it is passed into `jwt.decode`, which accepts a string.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
