### PR TITLE
fix(app, android): minSdk should be 19 to match firebase-android-sdk

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -68,7 +68,7 @@
       "firebase": "8.10.0"
     },
     "android": {
-      "minSdk": 21,
+      "minSdk": 19,
       "targetSdk": 31,
       "compileSdk": 31,
       "buildTools": "30.0.3",


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

As @mikehardy requested in [this comment](https://github.com/invertase/react-native-firebase/issues/5379#issuecomment-1003750956) I have tested react-native-firebase on projects with minSdk 19 and it works fine for me.

### Release Summary

Downgraded default minSdk from 21 to 19 to support more android devices.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

It worth mentioning that I'm currently using the cloud messaging package in my project. if anyone is willing to test this PR on the other packages, feel free to clean its project and then apply the same simple change on this PR, and test their packages' functionality, and report the result on this Thread.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
