### PR TITLE
fix(ios, messaging): add ios version guard for `UNAuthorizationOptionProvidesAppNotificationSettings` usage

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -225,7 +225,7 @@ RCT_EXPORT_METHOD(requestPermission
     }
 
     if ([permissions[@"providesAppNotificationSettings"] isEqual:@(YES)]) {
-      if (@available(iOS 12.0, *)) {
+      if (@available(iOS 12, macOS 10.14, macCatalyst 13, tvOS 12, watchOS 5, *)) {
         options |= UNAuthorizationOptionProvidesAppNotificationSettings;
       }
     }


### PR DESCRIPTION
### Description

There are some warnings while using UNAuthorizationOptionProvidesAppNotificationSettings without version check.

### Related issues

No related issues.

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
