### PR TITLE
fix(ios, messaging): serialize google.c.sender.id to message.from

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -63,7 +63,7 @@
     }
 
     // message.from
-    if ([key isEqualToString:@"from"]) {
+    if ([key isEqualToString:@"from"] || [key isEqualToString:@"google.c.sender.id"]) {
       message[@"from"] = userInfo[key];
       continue;
     }


### PR DESCRIPTION
This from key was provided in react-native-firebase v5 and somewhere
along the way it was lost, the iOS SDK now passes this key through the
internal google.c.sender.id key in userInfo, use it as well.

### Description

This relates to the missing `from` key on #5987

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

fix missing message.from key in iOS messaging

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Before the change, an iOS data-only message (with data being `{'test': '123'}` on v6 would look like:
```
{
  "messageId": "1641319541474655",
  "data": {
    "test": "123"
  },
  "contentAvailable": true
}
```

after this fix, it looks like:
```
{
  "messageId": "1641319541474655",
  "data": {
    "test": "123"
  },
  "contentAvailable": true,
  "from": "179667159224"
}
```
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
