### PR TITLE
fix(analytics, ios): Convert NSNull values to nil

### DIFF
--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -66,7 +66,7 @@ RCT_EXPORT_METHOD(setUserId
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
   @try {
-    [FIRAnalytics setUserID:id];
+    [FIRAnalytics setUserID:[self convertNSNullToNil:id]];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
   }
@@ -79,7 +79,7 @@ RCT_EXPORT_METHOD(setUserProperty
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
   @try {
-    [FIRAnalytics setUserPropertyString:value forName:name];
+    [FIRAnalytics setUserPropertyString:[self convertNSNullToNil:value] forName:name];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
   }
@@ -92,7 +92,7 @@ RCT_EXPORT_METHOD(setUserProperties
                   : (RCTPromiseRejectBlock)reject) {
   @try {
     [properties enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
-      [FIRAnalytics setUserPropertyString:value forName:key];
+      [FIRAnalytics setUserPropertyString:[self convertNSNullToNil:value] forName:key];
     }];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
@@ -160,6 +160,12 @@ RCT_EXPORT_METHOD(setDefaultEventParameters
     newParams[kFIRParameterExtendSession] = @YES;
   }
   return [newParams copy];
+}
+
+/// Converts null values received over the bridge from NSNull to nil
+/// @param value Nullable string value
+- (NSString *)convertNSNullToNil:(NSString *)value {
+  return [value isEqual:[NSNull null]] ? nil : value;
 }
 
 @end


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
I would like to reset the analytics user ID when a user logs out of my app. According to the [setUserId documentation](https://rnfirebase.io/reference/analytics#setUserId), calling `analytics().setUserId(null);` should remove a previously assigned ID from analytics. This works on Android, however on iOS I encounter the following log from the native iOS Firebase SDK:

```
[Firebase/Analytics] User property must be NSString. Value: (nil)
```

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #4931 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
fix issue resetting user-property values on ios

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Currently, the following log is printed when calling `analytics().setUserId(null);`

```
[Firebase/Analytics] User property must be NSString. Value: (nil)
```
With this change, the following log is printed:
```
[Firebase/Analytics] User property removed. Name: user_id (_id)
```

The issue was caused by null values passed across the bridge being converted to [NSNull](https://developer.apple.com/documentation/foundation/nsnull?language=objc) in Objective-C. However, according to the [FirebaseAnalytics Framework Reference (Objective-C)](https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#+setuserid:), the parameter provided to [setUserID:](https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#parameters_2) or [setUserPropertyString:forName:](https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics#parameters_1) must be `nil` in order to remove the previously set value.

Note: Whilst working on this ticket I also learnt that [Objective-C has 4 values to symbolise nothing](https://nshipster.com/nil/), who knew?! 🤔 

--- 

🔥

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
