### PR TITLE
docs(firebase.json): improved grammar

### DIFF
--- a/docs/app/json-config.md
+++ b/docs/app/json-config.md
@@ -5,7 +5,7 @@ next: /app/utils
 previous: /app/usage
 ---
 
-You can configure the modules creating a file named `firebase.json` at the root of your project directory.
+You can configure your installed modules by creating a file named `firebase.json` at the root of your project directory.
 An example configuration file is available for inspection in our internal test app: [`<repo>/tests/firebase.json`](https://github.com/invertase/react-native-firebase/blob/main/tests/firebase.json)
 
 ## JSON Schema


### PR DESCRIPTION
### Description
This PR changes the language around the configuring of modules to be ``you can configure *your installed* modules *by* creating....`` instead of just ``you can configure modules creating...`` with the aim to fix awkward wording and make what it's trying to say clearer.

### Release Summary
Tweaked grammar on firebase config page

### Checklist
- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change is to docs and thus is not platform specific
- My change is to docs and thus does not include tests
- My changes is to docs and thus only requires one typescript type: ``change: awesome`` (cheesy, I know)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan
``Not Applicable (As far as I can tell - plus, I promise my grammar tweaks won't break anything! (maybe))``

:fire: