### PR TITLE
feat(app-check): android debug token argument for app-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tests:packager:jet-reset-cache": "cd tests && cross-env REACT_DEBUGGER=\"echo nope\" node_modules/.bin/react-native start --reset-cache --no-interactive",
     "tests:emulator:start": "cd ./.github/workflows/scripts && ./start-firebase-emulator.sh --no-daemon",
     "tests:emulator:start-ci": "cd ./.github/workflows/scripts && ./start-firebase-emulator.sh",
-    "tests:android:build": "cd tests && yarn detox build --configuration android.emu.debug",
+    "tests:android:build": "cd tests && FIREBASE_APP_CHECK_DEBUG_TOKEN=\"698956B2-187B-49C6-9E25-C3F3530EEBAF\" yarn detox build --configuration android.emu.debug",
     "tests:android:build-release": "cd tests && yarn detox build --configuration android.emu.release",
     "tests:android:test": "cd tests && yarn detox test --configuration android.emu.debug",
     "tests:android:test:debug": "cd tests && yarn detox test --configuration android.emu.debug --inspect",

--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -66,6 +66,9 @@ project.ext {
 android {
   defaultConfig {
     multiDexEnabled true
+    // Here we add a build config field to allow devs to provide a
+    // FIREBASE_APP_CHECK_DEBUG_TOKEN to be used in debug mode.
+    buildConfigField "String", "FIREBASE_APP_CHECK_DEBUG_TOKEN", "\"${System.env.FIREBASE_APP_CHECK_DEBUG_TOKEN}\""
   }
   lintOptions {
     disable 'GradleCompatible'

--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
@@ -23,10 +23,12 @@ import android.util.Log;
 import com.facebook.react.bridge.*;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.appcheck.AppCheckProviderFactory;
 import com.google.firebase.appcheck.FirebaseAppCheck;
 import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory;
 import com.google.firebase.appcheck.safetynet.SafetyNetAppCheckProviderFactory;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
+import java.lang.reflect.*;
 
 public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule {
   private static final String TAG = "AppCheck";
@@ -51,7 +53,26 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
       }
 
       if (isDebuggable) {
-        firebaseAppCheck.installAppCheckProviderFactory(DebugAppCheckProviderFactory.getInstance());
+
+        if (BuildConfig.FIREBASE_APP_CHECK_DEBUG_TOKEN != "null") {
+          // Get DebugAppCheckProviderFactory class
+          Class<DebugAppCheckProviderFactory> debugACFactoryClass =
+              DebugAppCheckProviderFactory.class;
+
+          // Get the (undocumented) constructor accepting a debug token as string
+          Class<?>[] argType = {String.class};
+          Constructor c = debugACFactoryClass.getDeclaredConstructor(argType);
+
+          // Create a object containing the constructor arguments
+          // and initialize a new instance.
+          Object[] cArgs = {BuildConfig.FIREBASE_APP_CHECK_DEBUG_TOKEN};
+          firebaseAppCheck.installAppCheckProviderFactory(
+              (AppCheckProviderFactory) c.newInstance(cArgs));
+        } else {
+          firebaseAppCheck.installAppCheckProviderFactory(
+              DebugAppCheckProviderFactory.getInstance());
+        }
+
       } else {
         firebaseAppCheck.installAppCheckProviderFactory(
             SafetyNetAppCheckProviderFactory.getInstance());

--- a/packages/app-check/e2e/appcheck.e2e.js
+++ b/packages/app-check/e2e/appcheck.e2e.js
@@ -42,6 +42,7 @@ describe('appCheck()', function () {
   });
   describe('getToken())', function () {
     it('token fetch attempt should work', async function () {
+      await firebase.appCheck().activate('ignored', false);
       // Our tests configure a debug provider with shared secret so we should get a valid token
       const { token } = await firebase.appCheck().getToken();
       token.should.not.equal('');
@@ -69,24 +70,6 @@ describe('appCheck()', function () {
         await firebase.appCheck().activate('ignored', false);
       } catch (e) {
         return Promise.reject(e);
-      }
-    });
-    // Dynamic providers are not possible on iOS, so the debug provider is always working
-    it('token fetch attempt should work but fail attestation', async function () {
-      if (device.getPlatform() === 'android') {
-        try {
-          // Activating on Android clobbers the shared secret in the debug provider shared secret, should fail now
-          await firebase.appCheck().getToken(true);
-          return Promise.reject(
-            'Should have thrown after resetting shared secret on debug provider',
-          );
-        } catch (e) {
-          e.message.should.containEql('[appCheck/token-error]');
-          e.message.should.containEql('App attestation failed');
-          return Promise.resolve();
-        }
-      } else {
-        this.skip();
       }
     });
   });

--- a/tests/android/app/src/androidTest/java/com/invertase/testing/DetoxTest.java
+++ b/tests/android/app/src/androidTest/java/com/invertase/testing/DetoxTest.java
@@ -28,40 +28,8 @@ public class DetoxTest {
 
   @Test
   public void runDetoxTests() {
-
-    try {
-      // 1) Detox makes it extremely difficult to pass unencoded arguments directly to the instrumentation runner on Android:
-      // https://github.com/wix/Detox/issues/2933
-      // 
-      // 2) AppCheck will only let you set a debug AppCheck token in CI via their test helpers via instrumentation runner args
-      // https://firebase.google.com/docs/app-check/android/debug-provider#ci
-      // 
-      // Here we avoid the Detox argument-passing / AppCheck argument-reading difficulty by directly putting the String in.
-      // 
-      // This is unwanted in nearly all scenarios as it leaks an AppCheck token, but the react-native-firebase test
-      // project does not have AppCheck set to enforcing, so this is okay for this project.
-      //
-      // This has a great potential for leaking your token in a real app that wants to enforce and rely on AppCheck.
-      Class<?> testHelperClass = DebugAppCheckTestHelper.class;
-      Method[] methods = testHelperClass.getDeclaredMethods();
-      for (int i = 0; i < methods.length; i++) {
-        if (methods[i].getName().equals("fromString")) {
-          Method testHelperMethod = methods[i];
-          testHelperMethod.setAccessible(true);
-          DebugAppCheckTestHelper debugAppCheckTestHelper = 
-            (DebugAppCheckTestHelper)testHelperMethod.invoke(null, "698956B2-187B-49C6-9E25-C3F3530EEBAF");
-          debugAppCheckTestHelper.withDebugProvider(() -> {
-
-            // This is the standard Detox androidTest implementation:
-            Detox.runTests(mActivityRule);
-
-            dumpCoverageData();
-          });
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to force AppCheck debug token: ", e);
-    }
+    Detox.runTests(mActivityRule);
+    dumpCoverageData();
   }
 
   // If you send '-e coverage' as part of the instrumentation command line, it should dump coverage as the Instrumentation finishes.


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Debugging react-native applications with AppCheck is problematic on Android:

1. It relies running our code on a real android device; 
2. It also required an added extra step of `$adb logcat | grep DebugAppCheckProvider ` to extract the secret token that must then be pushed to the Firebase console. This token changes often and made the developper experience and operations much more harder.
3. Configuring the secret token on CI relied on pushing code instead of environment variables.

This PR is a solution for that, and here is the summary of the solution:

1. By default, the behaviour is the same as what we had before -- that is default to use the DebugAppCheckProviderFactory.
2. If a FIREBASE_APP_CHECK_DEBUG_TOKEN env var is provided and we're in debug mode -- use that instead of the default.
3. If not in debug mode, use the SafetyNetAppCheckProviderFactory -- like before.

*IMPORTANT*
Please note that I removed a test that was no longer passing because app-check doesn't fail app-attestation on android emulators with the new method anymore. See https://github.com/invertase/react-native-firebase/pull/6026/files#diff-406415e4817a8b2d1b8cd632fffc7af195be1fe7ec0a560fd0a47df5d7b03ddaL74-L91

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

1. https://github.com/invertase/react-native-firebase/discussions/5660

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

```
gabriel@mt react-native-firebase % yarn tests:android:test
yarn run v1.22.15
$ cd tests && yarn detox test --configuration android.emu.debug
$ /Users/gabriel/Workspace/react-native-firebase/tests/node_modules/.bin/detox test --configuration android.emu.debug
detox[25576] INFO:  [test.js] mocha --config e2e/.mocharc.js --configuration android.emu.debug --grep :ios: --invert --use-custom-logger true e2e


detox[25577] INFO:  at node_modules/jet/lib/node/vm.js:78:11
 [✈️] debugger has connected! Downloading app JS bundle...
detox[25577] INFO:  at node_modules/jet/lib/node/console.js:16:15
 Mapping auth host "localhost" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.
detox[25577] INFO:  at node_modules/jet/lib/node/console.js:16:15
 Mapping firestore host to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.
detox[25577] INFO:  at node_modules/jet/lib/node/console.js:16:15
 Mapping storage host to "10.0.2.2" for android emulators. Use real IP on real devices.
detox[25577] INFO:  at node_modules/jet/lib/node/console.js:16:15
 Mapping functions host "localhost" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.
  appCheck()
    config
      - should configure token auto refresh in Info.plist on ios
    setTokenAutoRefresh())
      ✔ should set token refresh
detox[25577] INFO:  at node_modules/jet/lib/node/console.js:16:15
 Running "testing" with {"rootTag":11}
    getToken())
detox[25577] INFO:  at e2e/init.js:40:15

detox[25577] WARN:  at e2e/init.js:41:15
 ⚠️ A test failed:
detox[25577] WARN:  at e2e/init.js:42:15
 ️   ->  token fetch attempt should work
detox[25577] WARN:  at e2e/init.js:49:13
 ️   ->  Retrying in 5 seconds ... (1)
      ✔ token fetch attempt should work (2142ms)
    activate())
      ✔ should activate with default provider and default token refresh

detox[25577] INFO:  at e2e/init.js:55:11
  ✨ Tests Complete ✨
detox[25577] INFO:  at e2e/init.js:77:15
 Coverage data downloaded to: ./android/app/build/output/coverage//emulator_coverage.ec

  3 passing (18s)
  1 pending

✨  Done in 19.15s.
```


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire: 