### PR TITLE
fix(messaging): add missing PRIORITY_MIN value it JS part

### DIFF
--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -41,6 +41,7 @@ const statics = {
     PROVISIONAL: 2,
   },
   NotificationAndroidPriority: {
+    PRIORITY_MIN: -2,
     PRIORITY_LOW: -1,
     PRIORITY_DEFAULT: 0,
     PRIORITY_HIGH: 1,


### PR DESCRIPTION
### Description

`messaging.NotificationAndroidPriority.PRIORITY_MIN` was `undefined`

### Related issues

Fixes #6027

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan



---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
