### PR TITLE
feat(auth, android): add android for disable app verification feature

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -243,6 +243,23 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     promise.resolve(null);
   }
 
+  /**
+   * Disable app verification for the running of tests
+   * @param appName
+   * @param disabled
+   * @param promise
+   */
+  @ReactMethod
+  public void setAppVerificationDisabledForTesting(
+    String appName, boolean disabled, Promise promise) {
+    Log.d(TAG, "setAppVerificationDisabledForTesting");
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+    FirebaseAuthSettings firebaseAuthSettings = firebaseAuth.getFirebaseAuthSettings();
+    firebaseAuthSettings.setAppVerificationDisabledForTesting(disabled);
+    promise.resolve(null);
+  }
+
   @ReactMethod
   public void signOut(String appName, Promise promise) {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);

--- a/packages/auth/lib/Settings.js
+++ b/packages/auth/lib/Settings.js
@@ -28,10 +28,8 @@ export default class Settings {
   }
 
   set appVerificationDisabledForTesting(disabled) {
-    if (isIOS) {
-      this._appVerificationDisabledForTesting = disabled;
-      this._auth.native.setAppVerificationDisabledForTesting(disabled);
-    }
+    this._appVerificationDisabledForTesting = disabled;
+    this._auth.native.setAppVerificationDisabledForTesting(disabled);
   }
 
   setAutoRetrievedSmsCodeForPhoneNumber(phoneNumber, smsCode) {

--- a/packages/auth/lib/Settings.js
+++ b/packages/auth/lib/Settings.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { isAndroid, isIOS } from '@react-native-firebase/app/lib/common';
+import { isAndroid } from '@react-native-firebase/app/lib/common';
 
 export default class Settings {
   constructor(auth) {

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -826,11 +826,10 @@ export namespace FirebaseAuthTypes {
    */
   export interface AuthSettings {
     /**
-     * iOS only flag to disable app verification for the purpose of testing phone authentication. For this property to take effect, it needs to be set before rendering a reCAPTCHA app verifier. When this is disabled, a mock reCAPTCHA is rendered instead. This is useful for manual testing during development or for automated integration tests.
+     * Flag to disable app verification for the purpose of testing phone authentication. For this property to take effect, it needs to be set before rendering a reCAPTCHA app verifier. When this is disabled, a mock reCAPTCHA is rendered instead. This is useful for manual testing during development or for automated integration tests.
      *
      * > In order to use this feature, you will need to [whitelist your phone number](https://firebase.google.com/docs/auth/web/phone-auth#test-with-whitelisted-phone-numbers) via the Firebase Console.
      *
-     * @ios
      * @param disabled Boolean value representing whether app verification should be disabled for testing.
      */
     appVerificationDisabledForTesting: boolean;


### PR DESCRIPTION
### Description

At the moment it is only possible to disable the app verification on the iOS platform for testing.
As I wanted to create e2e tests for the android version of my app, I created the necessary code changes to make this flag also possible on the Android platform. 😄
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

No related Issue as far as I now.
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

auth: appVerificationDisabledForTesting now also settable for Android platform
<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

:fire: