### PR TITLE
feat(auth, ios): Add support for Facebook Limited Login

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -136,6 +136,47 @@ async function onFacebookButtonPress() {
 }
 ```
 
+### Facebook Limited Login (iOS only)
+
+To use Facebook Limited Login instead of "classic" Facebook Login, the `onFacebookButtonPress` can then be implemented as follows:
+
+```js
+import auth from '@react-native-firebase/auth';
+import { LoginManager, AuthenticationToken } from 'react-native-fbsdk-next';
+import { sha256 } from 'react-native-sha256';
+
+async function onFacebookButtonPress() {
+  // Create a nonce and the corresponding
+  // sha256 hash of the nonce
+  const nonce = '123456';
+  const nonceSha256 = await sha256(nonce);
+  // Attempt login with permissions and limited login
+  const result = await LoginManager.logInWithPermissions(
+    ['public_profile', 'email'],
+    'limited',
+    nonceSha256,
+  );
+
+  if (result.isCancelled) {
+    throw 'User cancelled the login process';
+  }
+
+  // Once signed in, get the users AuthenticationToken
+  const data = await AuthenticationToken.getAuthenticationTokenIOS();
+
+  if (!data) {
+    throw 'Something went wrong obtaining authentication token';
+  }
+
+  // Create a Firebase credential with the AuthenticationToken
+  // and the nonce (Firebase will validates the hash against the nonce)
+  const facebookCredential = auth.FacebookAuthProvider.credential(data.authenticationToken, nonce);
+
+  // Sign-in the user with the credential
+  return auth().signInWithCredential(facebookCredential);
+}
+```
+
 Upon successful sign-in, any [`onAuthStateChanged`](/auth/usage#listening-to-authentication-state) listeners will trigger
 with the new authentication state of the user.
 

--- a/packages/auth/e2e/provider.e2e.js
+++ b/packages/auth/e2e/provider.e2e.js
@@ -75,6 +75,17 @@ describe('auth() -> Providers', function () {
       });
     });
 
+    describe('credentialLimitedLogin', function () {
+      it('should return a credential object', function () {
+        const token = '123456';
+        const nonce = '654321';
+        const credential = firebase.auth.FacebookAuthProvider.credential(token, nonce);
+        credential.providerId.should.equal('facebook.com');
+        credential.token.should.equal(token);
+        credential.secret.should.equal(nonce);
+      });
+    });
+
     describe('PROVIDER_ID', function () {
       it('should return facebook.com', function () {
         firebase.auth.FacebookAuthProvider.PROVIDER_ID.should.equal('facebook.com');

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -953,6 +953,11 @@ RCT_EXPORT_METHOD(useEmulator
     credential = credentials[authToken];
   } else if ([provider compare:@"twitter.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIRTwitterAuthProvider credentialWithToken:authToken secret:authTokenSecret];
+  } else if ([provider compare:@"facebook.com" options:NSCaseInsensitiveSearch] == NSOrderedSame &&
+             ![authTokenSecret isEqualToString:@""]) {
+    credential = [FIROAuthProvider credentialWithProviderID:provider
+                                                    IDToken:authToken
+                                                   rawNonce:authTokenSecret];
   } else if ([provider compare:@"facebook.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIRFacebookAuthProvider credentialWithAccessToken:authToken];
   } else if ([provider compare:@"google.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {

--- a/packages/auth/lib/providers/FacebookAuthProvider.js
+++ b/packages/auth/lib/providers/FacebookAuthProvider.js
@@ -26,10 +26,10 @@ export default class FacebookAuthProvider {
     return providerId;
   }
 
-  static credential(token) {
+  static credential(token, secret = '') {
     return {
       token,
-      secret: '',
+      secret,
       providerId,
     };
   }


### PR DESCRIPTION
### Description

Add support for [Facebook Limited Login](https://developers.facebook.com/docs/facebook-login/limited-login), as well as some testing and documentation around that feature.

### Related issues

Fixes #5441.

### Release Summary

Add support for Facebook Limited Login.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Using this patchset in one of my own apps, login into Facebook w/ and w/o limited login is still functional:

```
userStateChanged to {
    "displayName": "Martin Maze",
    "email": null,
    "emailVerified": false,
    "isAnonymous": false,
    "metadata": {
        "creationTime": 1644870528653,
        "lastSignInTime": 1644875913305
    },
    "phoneNumber": null,
    "photoURL": "https://graph.facebook.com/137XXXXXXXXXX/picture",
    "providerData": [[Object]],
    "providerId": "firebase",
    "refreshToken": "AI....",
    "tenantId": null,
    "uid": "XXXYYYZZZZ"
}
```

🔥
