### PR TITLE
fix(analytics, ios): handle RNFirebaseAnalyticsWithoutAdIdSupport == false Podfile case correctly

### DIFF
--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  if defined?($RNFirebaseAnalyticsWithoutAdIdSupport)
+  if defined?($RNFirebaseAnalyticsWithoutAdIdSupport) && ($RNFirebaseAnalyticsWithoutAdIdSupport == true)
     Pod::UI.puts "#{s.name}: Using Firebase/AnalyticsWithoutAdIdSupport pod in place of default Firebase/Analytics"
 
     # Releasing as non-breaking change as it is optional but it raises minimum requirements, validate just in case


### PR DESCRIPTION
### Description

Right know it looks only if it is defined and not if it set as true, same error as in older appsflyer-react-native-plugin xD

### Release Summary

Fix RNFirebaseAnalyticsWithoutAdIdSupport flag in Podfile

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change; (Hard to decide I would say yes because it will change someones dependencies after upgrade)
  - [X] Yes
  - [ ] No
