### PR TITLE
docs(remote-config): ConfigSettings example should use fetchTimeMillis

### DIFF
--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -252,7 +252,7 @@ export namespace FirebaseRemoteConfigTypes {
    *
    * ```js
    * await firebase.remoteConfig().setConfigSettings({
-   *    fetchTimeoutMillis: 6000,
+   *    fetchTimeMillis: 6000,
    * });
    * ```
    */


### PR DESCRIPTION
Thanks to @jeafgilbert for pointing it out!
