### PR TITLE
fix(ios, expo): use modern import style, required by Expo 44+

### DIFF
--- a/packages/app/scripts/genversion-ios.js
+++ b/packages/app/scripts/genversion-ios.js
@@ -20,7 +20,7 @@ const template = `/**
  *
  */
 
-#import "RCTVersion.h"
+#import <React/RCTVersion.h>
 
 // generated file - do not modify or commit
 NSString* const RNFBVersionString = @"VERSION";


### PR DESCRIPTION
### Description

Expo 44+ enforces use of new import style for React headers, and they
are supported far enough back in time on react-native versions this should
not be breaking for anyone

### Related issues

Fixes #5965 

### Release Summary

single commit, it's conventionsl

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

It's an iOS import style change, either it compiles or it does not. Compiles in local testing, e2e will check as well of course

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
