### PR TITLE
docs(app-check): expo-dev-client support for App Check docs

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -54,6 +54,7 @@ EEA
 Ehesp
 enum
 ESLint
+expo-dev-client
 Fastlane
 FCM
 firebase

--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -116,3 +116,32 @@ When you want to test using an Android virtual device -or- when you prefer to (r
         $  FIREBASE_APP_CHECK_DEBUG_TOKEN="XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" react-native run-android
 
 Please note that once the android app has successfully passed the app-checks controls on the device, it will keep passing them, whether you rebuild without the secret token or not. To completely reset app-check, you must first uninstall, and then re-build / install.
+
+#### C) When using Expo Development Client
+
+When using expo-dev-client, the process is a little different, especially on an android emulator.
+
+1.  In the [Project Settings > App Check](https://console.firebase.google.com/project/_/settings/appcheck) section of the Firebase console, choose _Manage debug tokens_ from your app's overflow menu. Then, register a new debug token by clicking the _Add debug token_ button, then _Generate token_.
+2.  Pass the token you created in the previous step by supplying a `FIREBASE_APP_CHECK_DEBUG_TOKEN` environment variable in your eas.json development profile:
+
+```json
+{
+  ...
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "env": {
+        ...
+        "FIREBASE_APP_CHECK_DEBUG_TOKEN": "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"
+      }
+    },
+    ...
+  },
+  ...
+}
+```
+
+3.  Rebuild your development client:
+
+        $  eas build --profile development --platform android


### PR DESCRIPTION
### Description

Add explanation on how to configure App Check for testing on android emulators when using EAS expo-dev-client.
This allows people using expo-dev-client on an emulator to use Firebase App Check's Debug provider

### Release Summary

Edit docs/app-check/usage/index.md to add explanation for using App Check debugging with expo-dev-client.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Review the doc.
