### PR TITLE
feat(auth): Create config plugin for Phone Auth iOS

### DIFF
--- a/docs/auth/phone-auth.md
+++ b/docs/auth/phone-auth.md
@@ -25,6 +25,8 @@ Phone auth requires app verification, and the automatic app verification process
 
 For reliable automated testing, you may want to disable both automatic and fallback reCAPTCHA app verification for your app. To do this, [you may disable app verification in AuthSettings](https://rnfirebase.io/reference/auth/authsettings#appVerificationDisabledForTesting) prior to calling any phone auth methods.
 
+> If you're using Expo, make sure to add the `@react-native-firebase/auth` config plugin to your `app.json` or `app.config.js`. It handles the iOS installation steps for you. For instructions on how to do that, view the [Expo](/#expo) installation section. (This is only required if you're both using Phone Auth and building for iOS, if you aren't doing both then there is no need for this.)
+
 # Android Setup
 
 Ensure that all parts of step 1 and 2 from [the official firebase Android phone auth docs](https://firebase.google.com/docs/auth/android/phone-auth#enable-phone-number-sign-in-for-your-firebase-project) have been followed.

--- a/packages/auth/Test.plist
+++ b/packages/auth/Test.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>841284211066-ul98nuau89sdahnqj77lg78aregstqa8.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.841284211066-ul98nuau89sdahnqj77lg78aregstqa8</string>
+	<key>API_KEY</key>
+	<string>AIzaSyB3Bech_UPBOA4isDiJZOrrO8ZTfqhejkE</string>
+	<key>GCM_SENDER_ID</key>
+	<string>841284211066</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.chatles.app.dev</string>
+	<key>PROJECT_ID</key>
+	<string>chatles-backend</string>
+	<key>STORAGE_BUCKET</key>
+	<string>chatles-backend.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:841284211066:ios:0d07e11a0da2370fb086c3</string>
+</dict>
+</plist>

--- a/packages/auth/app.plugin.js
+++ b/packages/auth/app.plugin.js
@@ -1,0 +1,19 @@
+const plist = require('plist');
+const fs = require('fs');
+const { withInfoPlist } = require('@expo/config-plugins')
+const path = require('path')
+
+const withIosPhoneAuth = (config, id) => {
+    return withInfoPlist(config, config => {
+        if (!config.ios?.googleServicesFile) throw new Error('Path to GoogleService-Info.plist is not defined. Please specify the `expo.ios.googleServicesFile` field in app.json.');
+        const googleServicesFile = path.resolve(config.modRequest.projectRoot, config.ios?.googleServicesFile)
+        const obj = plist.parse(fs.readFileSync(googleServicesFile, 'utf8'))
+        config.modResults.CFBundleURLTypes.push({
+            CFBundleURLSchemes: [`app-${obj.GOOGLE_APP_ID.replace(/:/g, "-")}`],
+        })
+        return config
+    })
+}
+
+module.exports = withIosPhoneAuth;
+

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -26,5 +26,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "plist": "^3.0.4"
   }
 }


### PR DESCRIPTION
### Description

I have added a config plugin to @react-native-firebase/auth for when Expo users need to use Phone Auth in iOS as well as add its documentation.
I have run into this problem and spent a lot of time in order to find the solution and I want to share my solution with other developers.
Related to #5787 

### Release Summary

Add config plugin for Expo users building for iOS as well as its documentation.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

1. Initialize Expo Project
2. Place GoogleServices-Info.plist in root of project
3. Add GoogleServices-Info.plist file path to app.json ios.googleServicesFile
4. Add "@react-native-firebase/auth" to app.json plugins
5. Run `expo prebuild -p ios --clean --no-install`
6. Check to see if a custom URL scheme was added to Info.plist (typically starts with "app-1-")
7. Review the doc

