### PR TITLE
fix(auth): allow emulator hostnames to contain hyphens

### DIFF
--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -42,6 +42,11 @@ describe('Auth', function () {
       const bar = auth().useEmulator('http://127.0.0.1:9099');
       expect(bar).toEqual(['10.0.2.2', 9099]);
     });
+
+    it('useEmulator allows hyphens in the hostname', function () {
+      const result = auth().useEmulator('http://my-host:9099');
+      expect(result).toEqual(['my-host', 9099]);
+    });
   });
 
   describe('tenantId', function () {

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -381,7 +381,7 @@ class FirebaseAuthModule extends FirebaseModule {
     }
 
     // Native calls take the host and port split out
-    const hostPortRegex = /^http:\/\/([\w\d.]+):(\d+)$/;
+    const hostPortRegex = /^http:\/\/([\w\d-.]+):(\d+)$/;
     const urlMatches = _url.match(hostPortRegex);
     if (!urlMatches) {
       throw new Error('firebase.auth().useEmulator() unable to parse host and port from URL');


### PR DESCRIPTION
### Description

(Please be nice - first open source PR ever 😬)

This PR update allows the use of hyphens within the hostname of auth emulators.
Many hostnames contain hyphens in them. Currently, the auth emulator ensures the provided hostname matches a regex which does _not_ allow hyphens.

### Related issues

Fixes #6140 

### Release Summary

Allow auth emulator hostnames to contain hyphens.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

New unit test added, ensuring hyphens are allowed in auth emulator hostnames.
