### PR TITLE
feat(ios, sdk): bump to firebase-ios-sdk 8.13.0 as independent release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -192,7 +192,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "29.0.4"
+        bom           : "29.2.1"
       ],
     ],
   ])
@@ -207,7 +207,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '8.11.0'
+$FirebaseSDKVersion = '8.13.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tests:ios:test-reuse": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 SIMCTL_CHILD_FIRAAppCheckDebugToken=\"698956B2-187B-49C6-9E25-C3F3530EEBAF\" yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
     "tests:ios:test-cover": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 SIMCTL_CHILD_FIRAAppCheckDebugToken=698956B2-187B-49C6-9E25-C3F3530EEBAF ./node_modules/.bin/nyc yarn detox test --configuration ios.sim.debug --loglevel warn",
     "tests:ios:test-cover-reuse": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 SIMCTL_CHILD_FIRAAppCheckDebugToken=698956B2-187B-49C6-9E25-C3F3530EEBAF node_modules/.bin/nyc yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
-    "tests:ios:pod:install": "cd tests && cd ios && rm -rf ReactNativeFirebaseDemo.xcworkspace && rm -f Podfile.lock && pod install --repo-update && cd ..",
+    "tests:ios:pod:install": "cd tests && rm -rf ios/ReactNativeFirebaseDemo.xcworkspace && yarn pod-install",
     "format:markdown": "prettier --write \"docs/**/*.md\""
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -65,7 +65,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "8.12.1"
+      "firebase": "8.13.0"
     },
     "android": {
       "minSdk": 19,

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -354,59 +354,59 @@ PODS:
     - React-Core (= 0.67.3)
     - React-jsi (= 0.67.3)
     - ReactCommon/turbomodule/core (= 0.67.3)
-  - Firebase/Analytics (8.12.1):
+  - Firebase/Analytics (8.13.0):
     - Firebase/Core
-  - Firebase/AppCheck (8.12.1):
+  - Firebase/AppCheck (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 8.12.0-beta)
-  - Firebase/AppDistribution (8.12.1):
+    - FirebaseAppCheck (~> 8.13.0-beta)
+  - Firebase/AppDistribution (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 8.12.0-beta)
-  - Firebase/Auth (8.12.1):
+    - FirebaseAppDistribution (~> 8.13.0-beta)
+  - Firebase/Auth (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 8.12.0)
-  - Firebase/Core (8.12.1):
+    - FirebaseAuth (~> 8.13.0)
+  - Firebase/Core (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 8.12.0)
-  - Firebase/CoreOnly (8.12.1):
-    - FirebaseCore (= 8.12.1)
-  - Firebase/Crashlytics (8.12.1):
+    - FirebaseAnalytics (~> 8.13.0)
+  - Firebase/CoreOnly (8.13.0):
+    - FirebaseCore (= 8.13.0)
+  - Firebase/Crashlytics (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 8.12.0)
-  - Firebase/Database (8.12.1):
+    - FirebaseCrashlytics (~> 8.13.0)
+  - Firebase/Database (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 8.12.0)
-  - Firebase/DynamicLinks (8.12.1):
+    - FirebaseDatabase (~> 8.13.0)
+  - Firebase/DynamicLinks (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 8.12.0)
-  - Firebase/Firestore (8.12.1):
+    - FirebaseDynamicLinks (~> 8.13.0)
+  - Firebase/Firestore (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 8.12.1)
-  - Firebase/Functions (8.12.1):
+    - FirebaseFirestore (~> 8.13.0)
+  - Firebase/Functions (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 8.12.0)
-  - Firebase/InAppMessaging (8.12.1):
+    - FirebaseFunctions (~> 8.13.0)
+  - Firebase/InAppMessaging (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 8.12.0-beta)
-  - Firebase/Installations (8.12.1):
+    - FirebaseInAppMessaging (~> 8.13.0-beta)
+  - Firebase/Installations (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 8.12.0)
-  - Firebase/Messaging (8.12.1):
+    - FirebaseInstallations (~> 8.13.0)
+  - Firebase/Messaging (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.12.0)
-  - Firebase/Performance (8.12.1):
+    - FirebaseMessaging (~> 8.13.0)
+  - Firebase/Performance (8.13.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 8.12.0)
-  - Firebase/RemoteConfig (8.12.1):
+    - FirebasePerformance (~> 8.13.0)
+  - Firebase/RemoteConfig (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 8.12.0)
-  - Firebase/Storage (8.12.1):
+    - FirebaseRemoteConfig (~> 8.13.0)
+  - Firebase/Storage (8.13.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 8.12.0)
-  - FirebaseABTesting (8.13.0):
+    - FirebaseStorage (~> 8.13.0)
+  - FirebaseABTesting (8.14.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseAnalytics (8.12.0):
-    - FirebaseAnalytics/AdIdSupport (= 8.12.0)
+  - FirebaseAnalytics (8.13.0):
+    - FirebaseAnalytics/AdIdSupport (= 8.13.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
@@ -414,52 +414,52 @@ PODS:
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (8.12.0):
+  - FirebaseAnalytics/AdIdSupport (8.13.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
-    - GoogleAppMeasurement (= 8.12.0)
+    - GoogleAppMeasurement (= 8.13.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - FirebaseAppCheck (8.12.0-beta):
+  - FirebaseAppCheck (8.13.0-beta):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseAppDistribution (8.12.0-beta):
+  - FirebaseAppDistribution (8.13.0-beta):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
-  - FirebaseAuth (8.12.0):
+  - FirebaseAuth (8.13.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/Environment (~> 7.7)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseCore (8.12.1):
+  - FirebaseCore (8.13.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.13.0):
+  - FirebaseCoreDiagnostics (8.14.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseCrashlytics (8.12.0):
+  - FirebaseCrashlytics (8.13.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseDatabase (8.12.0):
+  - FirebaseDatabase (8.13.0):
     - FirebaseCore (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (8.12.0):
+  - FirebaseDynamicLinks (8.13.0):
     - FirebaseCore (~> 8.0)
-  - FirebaseFirestore (8.12.1):
+  - FirebaseFirestore (8.13.0):
     - abseil/algorithm (= 0.20200225.0)
     - abseil/base (= 0.20200225.0)
     - abseil/container/flat_hash_map (= 0.20200225.0)
@@ -472,21 +472,21 @@ PODS:
     - "gRPC-C++ (~> 1.28.0)"
     - leveldb-library (~> 1.22)
     - nanopb (~> 2.30908.0)
-  - FirebaseFunctions (8.12.0):
+  - FirebaseFunctions (8.13.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
-  - FirebaseInAppMessaging (8.12.0-beta):
+  - FirebaseInAppMessaging (8.13.0-beta):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.12.0):
+  - FirebaseInstallations (8.13.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.12.0):
+  - FirebaseMessaging (8.13.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
@@ -495,7 +495,7 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebasePerformance (8.12.0):
+  - FirebasePerformance (8.13.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - FirebaseRemoteConfig (~> 8.0)
@@ -504,32 +504,32 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseRemoteConfig (8.12.0):
+  - FirebaseRemoteConfig (8.13.0):
     - FirebaseABTesting (~> 8.0)
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-  - FirebaseStorage (8.12.0):
+  - FirebaseStorage (8.13.0):
     - FirebaseCore (~> 8.0)
     - GTMSessionFetcher/Core (~> 1.5)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (8.12.0):
-    - GoogleAppMeasurement/AdIdSupport (= 8.12.0)
+  - GoogleAppMeasurement (8.13.0):
+    - GoogleAppMeasurement/AdIdSupport (= 8.13.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (8.12.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.12.0)
+  - GoogleAppMeasurement/AdIdSupport (8.13.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 8.13.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (~> 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (8.12.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (8.13.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
@@ -583,7 +583,7 @@ PODS:
     - BoringSSL-GRPC (= 0.0.7)
     - gRPC-Core/Interface (= 1.28.2)
   - gRPC-Core/Interface (1.28.2)
-  - GTMSessionFetcher/Core (1.7.0)
+  - GTMSessionFetcher/Core (1.7.1)
   - Jet (0.8.0):
     - React
   - leveldb-library (1.22.1)
@@ -857,70 +857,70 @@ PODS:
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
   - RNFBAnalytics (14.5.1):
-    - Firebase/Analytics (= 8.12.1)
+    - Firebase/Analytics (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBApp (14.5.1):
-    - Firebase/CoreOnly (= 8.12.1)
+    - Firebase/CoreOnly (= 8.13.0)
     - React-Core
   - RNFBAppCheck (14.5.1):
-    - Firebase/AppCheck (= 8.12.1)
+    - Firebase/AppCheck (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBAppDistribution (14.5.1):
-    - Firebase/AppDistribution (= 8.12.1)
+    - Firebase/AppDistribution (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBAuth (14.5.1):
-    - Firebase/Auth (= 8.12.1)
+    - Firebase/Auth (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBCrashlytics (14.5.1):
-    - Firebase/Crashlytics (= 8.12.1)
+    - Firebase/Crashlytics (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBDatabase (14.5.1):
-    - Firebase/Database (= 8.12.1)
+    - Firebase/Database (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBDynamicLinks (14.5.1):
-    - Firebase/DynamicLinks (= 8.12.1)
+    - Firebase/DynamicLinks (= 8.13.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
   - RNFBFirestore (14.5.1):
-    - Firebase/Firestore (= 8.12.1)
+    - Firebase/Firestore (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBFunctions (14.5.1):
-    - Firebase/Functions (= 8.12.1)
+    - Firebase/Functions (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBInAppMessaging (14.5.1):
-    - Firebase/InAppMessaging (= 8.12.1)
+    - Firebase/InAppMessaging (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBInstallations (14.5.1):
-    - Firebase/Installations (= 8.12.1)
+    - Firebase/Installations (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBMessaging (14.5.1):
-    - Firebase/Messaging (= 8.12.1)
+    - Firebase/Messaging (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBML (14.5.1):
     - React-Core
     - RNFBApp
   - RNFBPerf (14.5.1):
-    - Firebase/Performance (= 8.12.1)
+    - Firebase/Performance (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBRemoteConfig (14.5.1):
-    - Firebase/RemoteConfig (= 8.12.1)
+    - Firebase/RemoteConfig (= 8.13.0)
     - React-Core
     - RNFBApp
   - RNFBStorage (14.5.1):
-    - Firebase/Storage (= 8.12.1)
+    - Firebase/Storage (= 8.13.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -1116,33 +1116,33 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 808f741ddb0896a20e5b98cc665f5b3413b072e2
   FBReactNativeSpec: 94473205b8741b61402e8c51716dea34aa3f5b2f
-  Firebase: 580d09e8edafc3073ebf09c03fd42e4d80d35fe9
-  FirebaseABTesting: c390fb900b9dd6e9c04888e34dda8e9e84b07195
-  FirebaseAnalytics: bd10d7706ba8d6e01ea2816f8fe9e9b881cb0918
-  FirebaseAppCheck: b91624d3f8c262eae9bfc1486b640d8c13787abc
-  FirebaseAppDistribution: d1cf955c7e2d08567646b3eb453309d4ae850b23
-  FirebaseAuth: 5250d7bdba35e57cc34ec7ddc525f82b2757f2a0
-  FirebaseCore: 8138de860a90ca7eec5e324da5788fb0ebf1d93c
-  FirebaseCoreDiagnostics: c2836d254a8f0bbb4121ff18f2c2ea39d118fd08
-  FirebaseCrashlytics: 7952ffd988006128325510664b99dc8ca5851dff
-  FirebaseDatabase: f130b3d45b2a7a0b86059734d5bd67353df8d32f
-  FirebaseDynamicLinks: 98a5f0fe542245a89ec55f646d2581298c29219d
-  FirebaseFirestore: dfeb58916ee3ae0ef2453d4849a683672705920c
-  FirebaseFunctions: aead53cdd81ce7371043b79250060546c25f9c7c
-  FirebaseInAppMessaging: 871e8d04ed0d1ca77c9c0e4c246c13d010d7a8de
-  FirebaseInstallations: 25764cf322e77f99449395870a65b2bef88e1545
-  FirebaseMessaging: 23db8bf05585e929ada8af0f0968933c25252808
-  FirebasePerformance: 2e8861c96657ba16d6512f23a1bc43a7e4aa891e
-  FirebaseRemoteConfig: f174a7091ac8e69bf6d0de2bae2212edb922a0ab
-  FirebaseStorage: 4b75458c35d8b728e4c1fc1371942997456ab299
+  Firebase: ee9b1d9b1801371e29f5591eda89eb5a314ab599
+  FirebaseABTesting: aaa0e096c9fc9972ce6806d596e8fcc077d4371f
+  FirebaseAnalytics: 2be3cc52ac310759f28861aec9d459c851370cdb
+  FirebaseAppCheck: d73d17281ebe42e273d77a384a8f7a7e7f45ba57
+  FirebaseAppDistribution: 762e874d2b3b043a0ccaafd5b6abcf863db45a62
+  FirebaseAuth: ee43cf9474641c673a3a215ac92ab99e5630620c
+  FirebaseCore: c7e3fa30492e50ccdeef280bf0d5584af38da3e1
+  FirebaseCoreDiagnostics: fd0c8490f34287229c1d6c103d3a55f81ec85712
+  FirebaseCrashlytics: 3b6eafb7e508c26d37ff7a256d0f74406f7e47bd
+  FirebaseDatabase: c610ab55bcb033d5eb3d17acba57301068a28497
+  FirebaseDynamicLinks: 3f104565e38e839aed4b06760e913a5f936f34fb
+  FirebaseFirestore: 11d872a1e6f745f5ab52b96a218c60bfc6cbd770
+  FirebaseFunctions: 70ad685853e225677aa4f2a0710ac77a7e7ff3f5
+  FirebaseInAppMessaging: 78ecb145bf4b14335c7f9f70435e2b0b6e386ff8
+  FirebaseInstallations: 60edbf7e11d91ae4c751d26c200dfd037099abe0
+  FirebaseMessaging: 8cddb4c478663611d58c03b353e10dd0ed6468f6
+  FirebasePerformance: 328709d341193ab106ce5b7bb5c3e1a4de6920f2
+  FirebaseRemoteConfig: 39462033ba6fe7979eb49499f40f07feaa016b0a
+  FirebaseStorage: 0f115042c1596f5df5a80b67cf414d8f028ccddd
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
-  GoogleAppMeasurement: ae033c3aad67e68294369373056b4d74cc8ae0d6
+  GoogleAppMeasurement: 135c2fbcf5038e0f37dbce04fa641a702fc275d1
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   "gRPC-C++": 13d8ccef97d5c3c441b7e3c529ef28ebee86fad2
   gRPC-Core: 4afa11bfbedf7cdecd04de535a9e046893404ed5
-  GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
+  GTMSessionFetcher: 4577a4cc914a5a07c40a8a0ad0acc22080418c2d
   Jet: 8b8c4620ed89e5ba53bfa36f2c11adaeac9d9c76
   leveldb-library: 50c7b45cbd7bf543c81a468fe557a16ae3db8729
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
@@ -1171,23 +1171,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNFBAnalytics: 74cd9c60531ed33e5347b2dccafa172ae1a851a4
-  RNFBApp: 5bae3002117e55f3c9aa0fb38175dd16c8046c90
-  RNFBAppCheck: c59c77fa5c46115b7b760e85aeba4dbea1adfb8d
-  RNFBAppDistribution: dbd4a831d48c3eb1fbb6e68adc5b2ecb889fa871
-  RNFBAuth: ed314ff1732011c23041570ac4a98bc6070f9f4d
-  RNFBCrashlytics: 33615211c6c6c4039ae71849091f6ac38ab65aba
-  RNFBDatabase: 3c0f5efe76714ca3a8838250fdefe26a85f3380e
-  RNFBDynamicLinks: af1099d827079101afece32aba470ae50d519217
-  RNFBFirestore: 6103ff28c04b6a71faaca286a7f778914c3c7bb4
-  RNFBFunctions: ce53e6f983b38fb87af9934632218a687319212a
-  RNFBInAppMessaging: 35d740fb11d8eb81a14e8839812756b7c668dcb5
-  RNFBInstallations: 14c3902aee90229d71176a3491640e0fac76d4aa
-  RNFBMessaging: ae6c40883868cd01fa802395174ec7d61cfa0920
+  RNFBAnalytics: e33a57920148ff3750adc6142b062c280c2187c1
+  RNFBApp: 1f22410169d3d36cde46398df4003775560cc704
+  RNFBAppCheck: b0698ce3baf30bde2c3605c8f4ae9fd720042c8b
+  RNFBAppDistribution: 9a7697db5564fee066e01e26e7f1e8af83a308fe
+  RNFBAuth: 4247d9fdde12302416ef6649e58d443e4af4767e
+  RNFBCrashlytics: 9f7dae2790e5cf21a6a0eed2a07f3810ee755647
+  RNFBDatabase: 735170ddb8f547defbe80ff8b209b259c0a68a82
+  RNFBDynamicLinks: a8488eae3c1bbad01bd585055916e1bee14f4824
+  RNFBFirestore: 6bd791bb82a7d1700bec8bc26bbd88923df7013c
+  RNFBFunctions: 9742700f393f81c87185a3dd1d2daa6df782ddc9
+  RNFBInAppMessaging: 21cec8de2856bd5d6e3119495eb31e357b1fb4d1
+  RNFBInstallations: b6f1b07dad86e1dd36f29fb0e1822de72c8544cb
+  RNFBMessaging: dde7059b4027d909995f5c9f963732a155a35772
   RNFBML: f55a47d076c2aaa69eb6f21cf08403a67d10a58e
-  RNFBPerf: 477d2da67a1beb6da31b3993cf50940c0eac348e
-  RNFBRemoteConfig: 925da61d7b4a76561fb7a1f7397727659dafcc93
-  RNFBStorage: 495f37ba9f233e3be134c8bc0f31ff011a9eecec
+  RNFBPerf: 801239c34a52fb76e346911d8a91c999022824f4
+  RNFBRemoteConfig: 4bd5501c8a89e8c804e95af5e5945a9cc513a88b
+  RNFBStorage: 30ad7c7c29c0d2811e54e3a4f5e934cb08fad8b8
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: a4854589561b42da6b3b0726136a46ac6aef3ebd

--- a/tests/package.json
+++ b/tests/package.json
@@ -45,6 +45,7 @@
     "mocha": "^9.2.1",
     "nyc": "^15.0.1",
     "patch-package": "^6.4.7",
+    "pod-install": "^0.1.32",
     "react-native-codegen": "^0.0.13",
     "react-native-port-patcher": "^1.0.4",
     "should": "^13.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11298,6 +11298,11 @@ plist@^3.0.2, plist@^3.0.4:
     base64-js "^1.5.1"
     xmlbuilder "^9.0.7"
 
+pod-install@^0.1.32:
+  version "0.1.32"
+  resolved "https://registry.yarnpkg.com/pod-install/-/pod-install-0.1.32.tgz#2cafa6c0f7428738a560e0495a02e1e5778a944d"
+  integrity sha512-o0qH9bcpzJW43d3pFQfs1+k7Su6oQGUugejmgg05X+i4fpFLPITsbOWzm5CHlWOc5RcSLOh0CzAbqni/k8cNeg==
+
 portfinder@^1.0.23:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"


### PR DESCRIPTION
### Description

Planning a release with just 8.13.0 from firebase-ios-sdk in case people need to triage a problem in different iOS releases

Release with 8.14.0 will follow

firebase-android-sdk update still blocked on triage in #6122 but this gets iOS releases out the door


### Test Plan

Full local test runs of E2E, CI will prove it out as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
