### PR TITLE
fix(messaging, getToken): add options for messaging instance

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -29,6 +29,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.google.android.gms.tasks.Tasks;
+import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.RemoteMessage;
 import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
@@ -120,8 +121,9 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void getToken(Promise promise) {
-    Tasks.call(getExecutor(), () -> Tasks.await(FirebaseMessaging.getInstance().getToken()))
+  public void getToken(String appName, String senderId, Promise promise) {
+    FirebaseMessaging messagingInstance = FirebaseApp.getInstance(appName).get(FirebaseMessaging.class);
+    Tasks.call(getExecutor(), () -> Tasks.await(messagingInstance.getToken()))
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -133,11 +135,12 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void deleteToken(Promise promise) {
+  public void deleteToken(String appName, String senderId, Promise promise) {
+    FirebaseMessaging messagingInstance = FirebaseApp.getInstance(appName).get(FirebaseMessaging.class);
     Tasks.call(
             getExecutor(),
             () -> {
-              Tasks.await(FirebaseMessaging.getInstance().deleteToken());
+              Tasks.await(messagingInstance.deleteToken());
               return null;
             })
         .addOnCompleteListener(

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -107,7 +107,11 @@ RCT_EXPORT_METHOD(signalBackgroundMessageHandlerSet) {
   }
 }
 
-RCT_EXPORT_METHOD(getToken : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(getToken
+                  : (NSString *)appName
+                  : (NSString *)senderId
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
 #if !(TARGET_IPHONE_SIMULATOR)
   if ([UIApplication sharedApplication].isRegisteredForRemoteNotifications == NO) {
     [RNFBSharedUtils
@@ -123,23 +127,30 @@ RCT_EXPORT_METHOD(getToken : (RCTPromiseResolveBlock)resolve : (RCTPromiseReject
 #endif
 
   [[FIRMessaging messaging]
-      tokenWithCompletion:^(NSString *_Nullable token, NSError *_Nullable error) {
-        if (error) {
-          [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
-        } else {
-          resolve(token);
-        }
-      }];
+      retrieveFCMTokenForSenderID:senderId
+                       completion:^(NSString *_Nullable token, NSError *_Nullable error) {
+                         if (error) {
+                           [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
+                         } else {
+                           resolve(token);
+                         }
+                       }];
 }
 
-RCT_EXPORT_METHOD(deleteToken : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {
-  [[FIRMessaging messaging] deleteTokenWithCompletion:^(NSError *_Nullable error) {
-    if (error) {
-      [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
-    } else {
-      resolve([NSNull null]);
-    }
-  }];
+RCT_EXPORT_METHOD(deleteToken
+                  : (NSString *)appName
+                  : (NSString *)senderId
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  [[FIRMessaging messaging] deleteFCMTokenForSenderID:senderId
+                                           completion:^(NSError *_Nullable error) {
+                                             if (error) {
+                                               [RNFBSharedUtils rejectPromiseWithNSError:reject
+                                                                                   error:error];
+                                             } else {
+                                               resolve([NSNull null]);
+                                             }
+                                           }];
 }
 
 RCT_EXPORT_METHOD(getAPNSToken : (RCTPromiseResolveBlock)resolve : (RCTPromiseRejectBlock)reject) {

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -143,6 +143,25 @@ export namespace FirebaseMessagingTypes {
     threadId?: string;
   }
 
+  /**
+   * Options for `getToken()`, `deleteToken()`
+   */
+  export interface TokenOptions {
+    /**
+     * The app name of the FirebaseApp instance.
+     *
+     * @platform android Android
+     */
+    appName?: string;
+
+    /**
+     * The senderID for a particular Firebase project.
+     *
+     * @platform ios iOS
+     */
+    senderId?: string;
+  }
+
   export interface Notification {
     /**
      * The notification title.
@@ -579,8 +598,7 @@ export namespace FirebaseMessagingTypes {
     getDidOpenSettingsForNotification(): Promise<boolean>;
 
     /**
-     * Returns an FCM token for this device. Optionally you can specify a custom authorized entity
-     * or scope to tailor tokens to your own use-case.
+     * Returns an FCM token for this device. Optionally you can specify a custom options to your own use-case.
      *
      * It is recommended you call this method on app start and update your backend with the new token.
      *
@@ -602,8 +620,10 @@ export namespace FirebaseMessagingTypes {
      *     fcmTokens: firebase.firestore.FieldValues.arrayUnion(fcmToken),
      *   });
      * ```
+     *
+     * @param options Options to override senderId (iOS) and projectId (Android).
      */
-    getToken(): Promise<string>;
+    getToken(options?: TokenOptions): Promise<string>;
 
     /**
      * Returns wether the root view is headless or not
@@ -623,8 +643,10 @@ export namespace FirebaseMessagingTypes {
      * ```js
      * await firebase.messaging().deleteToken();
      * ```
+     *
+     * @param options Options to override senderId (iOS) and projectId (Android).
      */
-    deleteToken(): Promise<void>;
+    deleteToken(options?: TokenOptions): Promise<void>;
 
     /**
      * When any FCM payload is received, the listener callback is called with a `RemoteMessage`.

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -23,6 +23,7 @@ import {
   isIOS,
   isObject,
   isString,
+  isUndefined,
 } from '@react-native-firebase/app/lib/common';
 import {
   createModuleNamespace,
@@ -154,12 +155,34 @@ class FirebaseMessagingModule extends FirebaseModule {
     return this.native.getIsHeadless();
   }
 
-  getToken() {
-    return this.native.getToken();
+  getToken({ appName, senderId } = {}) {
+    if (!isUndefined(appName) && !isString(appName)) {
+      throw new Error("firebase.messaging().getToken(*) 'projectId' expected a string.");
+    }
+
+    if (!isUndefined(senderId) && !isString(senderId)) {
+      throw new Error("firebase.messaging().getToken(*) 'senderId' expected a string.");
+    }
+
+    return this.native.getToken(
+      appName || this.app.name,
+      senderId || this.app.options.messagingSenderId,
+    );
   }
 
-  deleteToken() {
-    return this.native.deleteToken();
+  deleteToken({ appName, senderId } = {}) {
+    if (!isUndefined(appName) && !isString(appName)) {
+      throw new Error("firebase.messaging().deleteToken(*) 'projectId' expected a string.");
+    }
+
+    if (!isUndefined(senderId) && !isString(senderId)) {
+      throw new Error("firebase.messaging().deleteToken(*) 'senderId' expected a string.");
+    }
+
+    return this.native.deleteToken(
+      appName || this.app.name,
+      senderId || this.app.options.messagingSenderId,
+    );
   }
 
   onMessage(listener) {


### PR DESCRIPTION
### Description

Adds `projectId` and `senderId` token options to set messaging instance to use with FCM (see attached issue)
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

Fixes #6173
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary
Adds options for `getToken()` to use specific messaging instances. NOTE: BREAKING ARGUMENTS from prior v11 authorizedEntity/scope.
<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
