### PR TITLE
docs(README): fix typo #6186

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 **React Native Firebase** is a collection of official React Native modules connecting you to Firebase services; each module is a light-weight JavaScript layer connecting you to the native Firebase SDKs for both iOS and Android.
 
-React Native Firebase is built with four key principals in mind;
+React Native Firebase is built with four key principles in mind;
 
 - 🧪 **Well tested**
   - every module is extensively tested to >95% coverage


### PR DESCRIPTION
Fixes #6186 
In the React-Native Firebase Documentation is the a spelling mistake of **principals** . Instead of principals there will be principles.
Readme Link :  https://github.com/invertase/react-native-firebase
Screenshot for reference : 
![Screenshot from 2022-04-07 20-37-47](https://user-images.githubusercontent.com/99062463/162250768-fc144488-f669-4fcb-90d7-2f2fddd23512.png)

