### PR TITLE
fix(app, expo): Support RN 0.68 Obj-C++ AppDelegate

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -56,7 +56,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.18",
+    "@expo/config-plugins": "^4.1.1",
     "opencollective-postinstall": "^2.0.1",
     "superstruct": "^0.6.2"
   },

--- a/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -344,3 +344,140 @@ static void InitializeFlipper(UIApplication *application) {
 @end
 "
 `;
+
+exports[`Config Plugin iOS Tests works with AppDelegate.mm (RN 0.68+) 1`] = `
+"// RN 0.68.1, Expo SDK 45 template
+// The main difference between this and the SDK 44 one is that this is
+// using React Native 0.68 and is written in Objective-C++
+
+#import \\"AppDelegate.h\\"
+@import Firebase;
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#import <React/RCTAppSetupUtils.h>
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <React/RCTFabricSurfaceHostingProxyRootView.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <react/config/ReactNativeConfig.h>
+
+@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+  RCTTurboModuleManager *_turboModuleManager;
+  RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
+  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
+  facebook::react::ContextContainer::Shared _contextContainer;
+}
+@end
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  RCTAppSetupPrepareApp(application);
+
+// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-ecd111c37e49fdd1ed6354203cd6b1e2a38cccda
+[FIRApp configure];
+// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+
+#if RCT_NEW_ARCH_ENABLED
+  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+  _contextContainer->insert(\\"ReactNativeConfig\\", _reactNativeConfig);
+  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
+  bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
+#endif
+
+  UIView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@\\"main\\" initialProperties:nil];
+
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@\\"index\\"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@\\"main\\" withExtension:@\\"jsbundle\\"];
+#endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  BOOL result = [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
+}
+
+#if RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                             delegate:self
+                                                            jsInvoker:bridge.jsCallInvoker];
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#endif
+
+@end
+"
+`;

--- a/packages/app/plugin/__tests__/fixtures/AppDelegate_sdk45.mm
+++ b/packages/app/plugin/__tests__/fixtures/AppDelegate_sdk45.mm
@@ -1,0 +1,129 @@
+// RN 0.68.1, Expo SDK 45 template
+// The main difference between this and the SDK 44 one is that this is
+// using React Native 0.68 and is written in Objective-C++
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#import <React/RCTAppSetupUtils.h>
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <React/RCTFabricSurfaceHostingProxyRootView.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <react/config/ReactNativeConfig.h>
+
+@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+  RCTTurboModuleManager *_turboModuleManager;
+  RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
+  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
+  facebook::react::ContextContainer::Shared _contextContainer;
+}
+@end
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  RCTAppSetupPrepareApp(application);
+
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+
+#if RCT_NEW_ARCH_ENABLED
+  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+  _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
+  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
+  bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
+#endif
+
+  UIView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  BOOL result = [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
+}
+
+#if RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                             delegate:self
+                                                            jsInvoker:bridge.jsCallInvoker];
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#endif
+
+@end

--- a/packages/app/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/app/plugin/__tests__/iosPlugin.test.ts
@@ -1,9 +1,15 @@
+import { IOSConfig } from '@expo/config-plugins';
+import { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
 import fs from 'fs/promises';
 import path from 'path';
 
-import { modifyObjcAppDelegate } from '../src/ios/appDelegate';
+import { modifyAppDelegateAsync, modifyObjcAppDelegate } from '../src/ios/appDelegate';
 
 describe('Config Plugin iOS Tests', function () {
+  beforeEach(function () {
+    jest.resetAllMocks();
+  });
+
   it('tests changes made to old AppDelegate.m (SDK 42)', async function () {
     const appDelegate = await fs.readFile(path.join(__dirname, './fixtures/AppDelegate_sdk42.m'), {
       encoding: 'utf8',
@@ -40,5 +46,43 @@ describe('Config Plugin iOS Tests', function () {
     );
     const result = modifyObjcAppDelegate(appDelegate);
     expect(result).toMatchSnapshot();
+  });
+
+  it('works with AppDelegate.mm (RN 0.68+)', async function () {
+    const appDelegate = await fs.readFile(path.join(__dirname, './fixtures/AppDelegate_sdk45.mm'), {
+      encoding: 'utf8',
+    });
+    const result = modifyObjcAppDelegate(appDelegate);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('detects Objective-C++ AppDelegate.mm', async function () {
+    jest.spyOn(fs, 'writeFile').mockImplementation();
+
+    const appDelegatePath = path.join(__dirname, './fixtures/AppDelegate_sdk45.mm');
+    const appDelegateFileInfo = IOSConfig.Paths.getFileInfo(
+      appDelegatePath,
+    ) as AppDelegateProjectFile;
+
+    await modifyAppDelegateAsync(appDelegateFileInfo);
+
+    // expect file contents to be modified
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      appDelegateFileInfo.path,
+      expect.not.stringContaining(appDelegateFileInfo.contents),
+    );
+  });
+
+  it("doesn't support Swift AppDelegate", async function () {
+    jest.spyOn(fs, 'writeFile').mockImplementation();
+
+    const appDelegateFileInfo: AppDelegateProjectFile = {
+      path: '.',
+      language: 'swift',
+      contents: 'some dummy content',
+    };
+
+    await expect(modifyAppDelegateAsync(appDelegateFileInfo)).rejects.toThrow();
+    expect(fs.writeFile).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -73,7 +73,7 @@ export const withFirebaseAppDelegate: ConfigPlugin = config => {
     async config => {
       const fileInfo = IOSConfig.Paths.getAppDelegate(config.modRequest.projectRoot);
       let contents = await fs.promises.readFile(fileInfo.path, 'utf-8');
-      if (fileInfo.language === 'objc') {
+      if (['objc', 'objcpp'].includes(fileInfo.language)) {
         contents = modifyObjcAppDelegate(contents);
       } else {
         // TODO: Support Swift

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -69,15 +69,15 @@ export function modifyObjcAppDelegate(contents: string): string {
 }
 
 export async function modifyAppDelegateAsync(appDelegateFileInfo: AppDelegateProjectFile) {
-  const { language, path } = appDelegateFileInfo;
-  let contents = appDelegateFileInfo.contents;
+  const { language, path, contents } = appDelegateFileInfo;
+
   if (['objc', 'objcpp'].includes(language)) {
-    contents = modifyObjcAppDelegate(contents);
+    const newContents = modifyObjcAppDelegate(contents);
+    await fs.promises.writeFile(path, newContents);
   } else {
     // TODO: Support Swift
     throw new Error(`Cannot add Firebase code to AppDelegate of language "${language}"`);
   }
-  await fs.promises.writeFile(path, contents);
 }
 
 export const withFirebaseAppDelegate: ConfigPlugin = config => {

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -1,4 +1,5 @@
 import { ConfigPlugin, IOSConfig, WarningAggregator, withDangerousMod } from '@expo/config-plugins';
+import { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
 import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
 import fs from 'fs';
 
@@ -67,22 +68,24 @@ export function modifyObjcAppDelegate(contents: string): string {
   }
 }
 
+export async function modifyAppDelegateAsync(appDelegateFileInfo: AppDelegateProjectFile) {
+  const { language, path } = appDelegateFileInfo;
+  let contents = appDelegateFileInfo.contents;
+  if (['objc', 'objcpp'].includes(language)) {
+    contents = modifyObjcAppDelegate(contents);
+  } else {
+    // TODO: Support Swift
+    throw new Error(`Cannot add Firebase code to AppDelegate of language "${language}"`);
+  }
+  await fs.promises.writeFile(path, contents);
+}
+
 export const withFirebaseAppDelegate: ConfigPlugin = config => {
   return withDangerousMod(config, [
     'ios',
     async config => {
       const fileInfo = IOSConfig.Paths.getAppDelegate(config.modRequest.projectRoot);
-      let contents = await fs.promises.readFile(fileInfo.path, 'utf-8');
-      if (['objc', 'objcpp'].includes(fileInfo.language)) {
-        contents = modifyObjcAppDelegate(contents);
-      } else {
-        // TODO: Support Swift
-        throw new Error(
-          `Cannot add Firebase code to AppDelegate of language "${fileInfo.language}"`,
-        );
-      }
-      await fs.promises.writeFile(fileInfo.path, contents);
-
+      await modifyAppDelegateAsync(fileInfo);
       return config;
     },
   ]);

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -32,7 +32,7 @@
     "@react-native-firebase/app": "14.8.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.18",
+    "@expo/config-plugins": "^4.1.1",
     "stacktrace-js": "^2.0.0"
   },
   "publishConfig": {

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -32,7 +32,7 @@
     "@react-native-firebase/app": "14.8.0"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.18"
+    "@expo/config-plugins": "^4.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1101,20 +1101,19 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@expo/config-plugins@^4.0.18":
-  version "4.0.18"
-  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.0.18.tgz#80cf6a3aed83e78f714ad097d80e5a7cca48591a"
-  integrity sha512-tW4bnrnKhn+PPHF8wf1KAoubICAVUHW8CcagvyFqaRIzeh6yavMIOsQShxOVTbgx7LzSyymZ1nEs45yCGAiMfA==
+"@expo/config-plugins@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-4.1.1.tgz#ffb20b3d2be4e2509e8bf846721641dc072718c7"
+  integrity sha512-lo3tVxRhwM9jfxPHJcURsH5WvU26kX12h5EB3C7kjVhgdQPLkvT8Jk8Cx0KSL8MXKcry2xQvZ2uuwWLkMeplJw==
   dependencies:
     "@expo/config-types" "^44.0.0"
-    "@expo/json-file" "8.2.34"
-    "@expo/plist" "0.0.17"
+    "@expo/json-file" "8.2.35"
+    "@expo/plist" "0.0.18"
     "@expo/sdk-runtime-versions" "^1.0.0"
     "@react-native/normalize-color" "^2.0.0"
     chalk "^4.1.2"
     debug "^4.3.1"
     find-up "~5.0.0"
-    fs-extra "9.0.0"
     getenv "^1.0.0"
     glob "7.1.6"
     resolve-from "^5.0.0"
@@ -1128,19 +1127,19 @@
   resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-44.0.0.tgz#d3480fe2c99f9e895dae4ebba58b74ed72d03e26"
   integrity sha512-d+gpdKOAhqaD5RmcMzGgKzNtvE1w+GCqpFQNSXLliYlXjj+Tv0eL8EPeAdPtvke0vowpPFwd5McXLA90dgY6Jg==
 
-"@expo/json-file@8.2.34":
-  version "8.2.34"
-  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.34.tgz#2f24e90a677195f7a81e167115460eb2902c3130"
-  integrity sha512-ZxtBodAZGxdLtgKzmsC+8ViUxt1mhFW642Clu2OuG3f6PAyAFsU/SqEGag9wKFaD3x3Wt8VhL+3y5fMJmUFgPw==
+"@expo/json-file@8.2.35":
+  version "8.2.35"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.35.tgz#d0f0c74cdde2ae26686708912cf23ff81a8d67ac"
+  integrity sha512-cQFLGSNRRFbN9EIhVDpMCYuzXbrHUOmKEqitBR+nrU6surjKGsOsN9Ubyn/L/LAGlFvT293E4XY5zsOtJyiPZQ==
   dependencies:
     "@babel/code-frame" "~7.10.4"
     json5 "^1.0.1"
     write-file-atomic "^2.3.0"
 
-"@expo/plist@0.0.17":
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.17.tgz#0f6c594e116f45a28f5ed20998dadb5f3429f88b"
-  integrity sha512-5Ul3d/YOYE6mfum0jCE25XUnkKHZ5vGlU/X2275ZmCtGrpRn1Fl8Nq+jQKSaks3NqTfxdyXROi/TgH8Zxeg2wg==
+"@expo/plist@0.0.18":
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.18.tgz#9abcde78df703a88f6d9fa1a557ee2f045d178b0"
+  integrity sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w==
   dependencies:
     "@xmldom/xmldom" "~0.7.0"
     base64-js "^1.2.3"
@@ -6653,16 +6652,6 @@ fs-constants@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
-
-fs-extra@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
-  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
 
 fs-extra@^1.0.0:
   version "1.0.0"
@@ -13793,11 +13782,6 @@ universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-universalify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
-  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Description

Expo SDK 45 will be based on React Native 0.68, which has AppDelegate written in Objective-C++ (Renamed `AppDelegate.m` -> `AppDelegate.mm`). The file content changes are fortunately insignificant for us.

- Bumped `@expo/config-plugins` to `4.1.1` which already supports Objective-C++ App delegates ([commit](https://github.com/expo/expo-cli/commit/d4a3c6c2b975fc4aa632a33a4331a1048a8c7a92))
- **The only significant change in the plugin code**: `if (language === 'objc')` changed to `if (['objc', 'objcpp'].includes(language))`
- Rest of the PR are the tests - did a small refactor and added some tests to check proper language support.

> Hopefully no more changes are required for plugins to work with upcoming SDK 45, but I'll keep an eye on it

### Release Summary

- Expo iOS plugin now supports React Native 0.68 Objective-C++ `AppDelegate.mm` and SDK 45.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Unit tests pass (`yarn tests:jest`)
