### PR TITLE
docs(messaging, ios): slice the ios-setup doc into sidebar

### DIFF
--- a/docs/messaging/ios-permissions.md
+++ b/docs/messaging/ios-permissions.md
@@ -2,7 +2,7 @@
 title: iOS Permissions
 description: Request permissions from your users to allow notifications to be displayed.
 next: /messaging/notifications
-previous: /messaging/usage
+previous: /messaging/usage/ios-setup
 ---
 
 ## Understanding permissions

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -2,7 +2,7 @@
 title: Cloud Messaging
 description: Installation and getting started with Cloud Messaging.
 icon: //static.invertase.io/assets/firebase/cloud-messaging.svg
-next: /messaging/ios-permissions
+next: /messaging/usage/ios-setup
 previous: /functions/writing-deploying-functions
 ---
 

--- a/docs/messaging/usage/ios-setup.md
+++ b/docs/messaging/usage/ios-setup.md
@@ -1,6 +1,8 @@
 ---
 title: iOS Messaging Setup
 description: iOS requires additional configuration steps to be completed before you can receive messages.
+next: /messaging/ios-permissions
+previous: /messaging/usage
 ---
 
 Integrating the Cloud Messaging module on iOS devices requires additional setup before your devices receive messages.

--- a/docs/sidebar.yaml
+++ b/docs/sidebar.yaml
@@ -60,6 +60,8 @@
 - - Cloud Messaging
   - - - Usage
       - '/messaging/usage'
+    - - iOS Project Setup
+      - '/messaging/usage/ios-setup'
     - - iOS Permissions
       - '/messaging/ios-permissions'
     - - Notifications


### PR DESCRIPTION
### Description

The ios extra setup instructions were linked from the main usage doc but warrant their own sidebar entry I think, since they are vital to module usage on iOS (unlike the manual linking instructions which are not vital for anyone anymore)

### Related issues

Fixes #6214 - @taylorkline - if you could check the Vercel deploy on this and see if it was what you were thinking (once it is disployed) that would be great!

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
