### PR TITLE
fix: update Expo plugin to be compatible with objcpp

### DIFF
--- a/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m (SDK 43) 1`
 // creating a bare React Native app (without Expo)
 
 #import \\"AppDelegate.h\\"
-#import <Firebase/Firebase.h>;
+#import <Firebase/Firebase.h>
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -99,7 +99,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with Expo R
 // It has the RCTBridge to be created by Expo ReactDelegate
 
 #import \\"AppDelegate.h\\"
-#import <Firebase/Firebase.h>;
+#import <Firebase/Firebase.h>
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -189,7 +189,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with fallba
 // some parts omitted to be short
 
 #import \\"AppDelegate.h\\"
-#import <Firebase/Firebase.h>;
+#import <Firebase/Firebase.h>
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -240,7 +240,7 @@ exports[`Config Plugin iOS Tests tests changes made to old AppDelegate.m (SDK 42
 // It expects the old react-native-unimodules architecture (UM* prefix)
 
 #import \\"AppDelegate.h\\"
-#import <Firebase/Firebase.h>;
+#import <Firebase/Firebase.h>
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -351,7 +351,7 @@ exports[`Config Plugin iOS Tests works with AppDelegate.mm (RN 0.68+) 1`] = `
 // using React Native 0.68 and is written in Objective-C++
 
 #import \\"AppDelegate.h\\"
-#import <Firebase/Firebase.h>;
+#import <Firebase/Firebase.h>
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>

--- a/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -99,7 +99,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with Expo R
 // It has the RCTBridge to be created by Expo ReactDelegate
 
 #import \\"AppDelegate.h\\"
-@import Firebase;
+#import Firebase;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -189,7 +189,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with fallba
 // some parts omitted to be short
 
 #import \\"AppDelegate.h\\"
-@import Firebase;
+#import Firebase;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -240,7 +240,7 @@ exports[`Config Plugin iOS Tests tests changes made to old AppDelegate.m (SDK 42
 // It expects the old react-native-unimodules architecture (UM* prefix)
 
 #import \\"AppDelegate.h\\"
-@import Firebase;
+#import Firebase;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -351,7 +351,7 @@ exports[`Config Plugin iOS Tests works with AppDelegate.mm (RN 0.68+) 1`] = `
 // using React Native 0.68 and is written in Objective-C++
 
 #import \\"AppDelegate.h\\"
-@import Firebase;
+#import Firebase;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>

--- a/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m (SDK 43) 1`
 // creating a bare React Native app (without Expo)
 
 #import \\"AppDelegate.h\\"
-#import Firebase;
+#import <Firebase/Firebase.h>;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -99,7 +99,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with Expo R
 // It has the RCTBridge to be created by Expo ReactDelegate
 
 #import \\"AppDelegate.h\\"
-#import Firebase;
+#import <Firebase/Firebase.h>;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -189,7 +189,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m with fallba
 // some parts omitted to be short
 
 #import \\"AppDelegate.h\\"
-#import Firebase;
+#import <Firebase/Firebase.h>;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -240,7 +240,7 @@ exports[`Config Plugin iOS Tests tests changes made to old AppDelegate.m (SDK 42
 // It expects the old react-native-unimodules architecture (UM* prefix)
 
 #import \\"AppDelegate.h\\"
-#import Firebase;
+#import <Firebase/Firebase.h>;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>
@@ -351,7 +351,7 @@ exports[`Config Plugin iOS Tests works with AppDelegate.mm (RN 0.68+) 1`] = `
 // using React Native 0.68 and is written in Objective-C++
 
 #import \\"AppDelegate.h\\"
-#import Firebase;
+#import <Firebase/Firebase.h>;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>

--- a/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -6,7 +6,7 @@ exports[`Config Plugin iOS Tests tests changes made to AppDelegate.m (SDK 43) 1`
 // creating a bare React Native app (without Expo)
 
 #import \\"AppDelegate.h\\"
-@import Firebase;
+#import Firebase;
 
 #import <React/RCTBridge.h>
 #import <React/RCTBundleURLProvider.h>

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -19,7 +19,7 @@ export function modifyObjcAppDelegate(contents: string): string {
     contents = contents.replace(
       /#import "AppDelegate.h"/g,
       `#import "AppDelegate.h"
-#import Firebase;`,
+#import <Firebase/Firebase.h>;`,
     );
   }
 

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -19,7 +19,7 @@ export function modifyObjcAppDelegate(contents: string): string {
     contents = contents.replace(
       /#import "AppDelegate.h"/g,
       `#import "AppDelegate.h"
-#import <Firebase/Firebase.h>;`,
+#import <Firebase/Firebase.h>`,
     );
   }
 

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -19,7 +19,7 @@ export function modifyObjcAppDelegate(contents: string): string {
     contents = contents.replace(
       /#import "AppDelegate.h"/g,
       `#import "AppDelegate.h"
-@import Firebase;`,
+#import Firebase;`,
     );
   }
 


### PR DESCRIPTION
### Description

Expo SDK 45, which is now in beta, has switched to using `objcpp` for `AppDelegate` on iOS. The current import syntax, using `@import`, is incompatible with this. Therefore, SDK 45 beta users using the config plugin are experiencing build issues. This change is backwards compatible with `cpp`, Firebase switched to it 2 years ago (https://github.com/firebase/FirebaseUI-iOS/issues/875 and the linked PR in that issue).

### Related issues

Fixes #6221 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
