### PR TITLE
fix(ios, app): macOS 12.3 removed python, use python3

### DIFF
--- a/packages/app/ios_config.sh
+++ b/packages/app/ios_config.sh
@@ -79,7 +79,8 @@ if [[ ${_SEARCH_RESULT} ]]; then
   _RN_ROOT_EXISTS=$(ruby -e "require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]" || echo '')
 
   if [[ ${_RN_ROOT_EXISTS} ]]; then
-    _JSON_OUTPUT_BASE64=$(python -c 'import json,sys,base64;print(base64.b64encode(json.dumps(json.loads(open('"'${_SEARCH_RESULT}'"').read())['${_JSON_ROOT}'])))' || echo "e30=")
+    if ! python3 --version >/dev/null 2>&1; then echo "python3 not found, firebase.json file processing error." && exit 1; fi
+    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('"'${_SEARCH_RESULT}'"', '"'rb'"').read())['${_JSON_ROOT}']), '"'utf-8'"')).decode())' || echo "e30=")
   fi
 
   _PLIST_ENTRY_KEYS+=("firebase_json_raw")


### PR DESCRIPTION
### Description

macOS 12.3 (released March 24, about a month ago) removed the python2 installation (binary of `python`)
Our ios config script depended on that binary existing and silently failed / false-positived if it did not exist, with symptom being that on ios the config used all default values.

I do a check for python3 existence now and forward-ported the python2 code to python3 so our firebase.json parsing works again. Likely needs the same thing for react-native-google-mobile-ads...

This was only visible on macOS 12.3 machines running our e2e harness (where this functionality is probed) or by eagle-eyed developers who noticed the problem. A related change will move CI to macos-12 runners (just now available!) to make sure it fails on them, then I'll rebase against this to make sure it works...

### Related issues

Fixes #6226
Fixes #6203

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
