### PR TITLE
fix(firestore, android): temporarily use newer-than-bom firestore

### DIFF
--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -90,7 +90,10 @@ repositories {
 dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
-  implementation "com.google.firebase:firebase-firestore"
+  // TODO - remove this once we have access to a BOM > 29.2.0
+  // See https://github.com/invertase/react-native-firebase/issues/6158
+  // See https://github.com/firebase/firebase-android-sdk/issues/3557
+  implementation "com.google.firebase:firebase-firestore:24.1.1"
 }
 
 ReactNative.shared.applyPackageVersion()


### PR DESCRIPTION

### Description

firebase-android-sdk 29.2.0 has a problem with firestore reconnecting after being in the background, fixed in firestore versions included in bom 29.2.1 and higher

Unfortunately we have an auth emulator issue where we cannot access the 29.2.1 or higher boms yet

So we will temporarily bump firestore to a specific / non-bom version - the newest one before bom 30.0.0 to fix #6158 until upstream issue with auth emu is resolved

### Related issues

Fixes #6158 until we can use a newer firebase-android-sdk
See https://github.com/firebase/firebase-android-sdk/issues/3557

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


### Test Plan

Added the specific / override version based on newest non-30-bom version from firebase android release notes page, ran android e2e test harness locally

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
