### PR TITLE
docs(crashlytics): Add link to iOS symbol upload docs

### DIFF
--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -26,6 +26,10 @@ Once installed, you must complete the following additional setup steps for Andro
 
 - [Android Additional Setup](/crashlytics/android-setup).
 
+To get readable iOS crash reports in the Crashlytics dashboard, you must setup debug symbol upload:
+
+- [iOS Additional Setup](https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?platform=ios).
+
 > If you're using Expo, make sure to add the `@react-native-firebase/crashlytics` config plugin to your `app.json` or `app.config.js`. It handles the Android installation steps for you. For instructions on how to do that, view the [Expo](/#expo) installation section.
 
 If you're using an older version of React Native without autolinking support, or wish to integrate into an existing project,


### PR DESCRIPTION
### Description

Currently docs are missing needed steps for iOS debug symbol upload, which you really want to have on crashlytics. I've added a link to firebase official documentation.


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- This is a breaking change;
  - [ ] Yes
  - [x] No
