### PR TITLE
docs(messaging, ios): add Background App Refresh / message handler interaction note

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -319,7 +319,6 @@ If OFF, `setBackgroundMessageHandler` will not be triggered.
 
 <img src="https://user-images.githubusercontent.com/86952204/169194303-29c10a55-8412-4eb3-960f-35703d984484.png" width="200">
 
-
 ### Topics
 
 Topics are a mechanism which allow a device to subscribe and unsubscribe from named PubSub channels, all managed via FCM.

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -311,6 +311,15 @@ messaging()
 
 On Android, the `isHeadless` prop will not exist.
 
+#### iOS Background Limitation
+
+On iOS device, user is able to toggle Background App Refresh in device's Settings. (Auto OFF if device is in Low Power Mode)
+
+If OFF, `setBackgroundMessageHandler` will not be triggered.
+
+<img src="https://user-images.githubusercontent.com/86952204/169194303-29c10a55-8412-4eb3-960f-35703d984484.png" width="200">
+
+
 ### Topics
 
 Topics are a mechanism which allow a device to subscribe and unsubscribe from named PubSub channels, all managed via FCM.

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -313,11 +313,9 @@ On Android, the `isHeadless` prop will not exist.
 
 #### iOS Background Limitation
 
-On iOS device, user is able to toggle Background App Refresh in device's Settings. (Auto OFF if device is in Low Power Mode)
+On iOS devices, the user is able to toggle Background App Refresh in device's Settings. Furthermore, the Background App Refresh setting will automatically be off if the device is in low power mode.
 
-If OFF, `setBackgroundMessageHandler` will not be triggered.
-
-<img src="https://user-images.githubusercontent.com/86952204/169194303-29c10a55-8412-4eb3-960f-35703d984484.png" width="200">
+If the iOS Background App Refresh mode is off, your handler configured in `setBackgroundMessageHandler` will not be triggered.
 
 ### Topics
 


### PR DESCRIPTION
### Description
Updated document to include Background App Refresh manual toggle on iOS devices. My understanding is in this scenario, `setBackgroundMessageHandler` would not trigger and the app will fallback to QUIT state's flow.

### Related issues
resolves #5656

### Release Summary
Updated document to include Background App Refresh manual toggle on iOS devices.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes. Btw the contributor guide URL is invalid..
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
