### PR TITLE
feat(dynamic-links, ios): performDiagnostics API for troubleshooting

### DIFF
--- a/docs/dynamic-links/usage/index.md
+++ b/docs/dynamic-links/usage/index.md
@@ -135,6 +135,8 @@ The iOS Notes app is a good place to paste your dynamic link and test it opens y
 
 6. Make sure your [deep link parameter](https://firebase.google.com/docs/dynamic-links/create-manually?authuser=0#parameters) is properly URL-encoded, especially if it contains a query string.
 
+7. Try the `performDiagnostics` API on the Dynamic Links module, while running the app on a real device and watching output from either Xcode or Console app. You may search for "Links" and you will see the diagnostic output.
+
 ## Android Setup
 
 1. Create a SHA-256 fingerprint using these [instructions](https://developers.google.com/android/guides/client-auth) for your app, and add to your app in your Firebase console.

--- a/packages/dynamic-links/e2e/dynamicLinks.e2e.js
+++ b/packages/dynamic-links/e2e/dynamicLinks.e2e.js
@@ -237,4 +237,10 @@ describe('dynamicLinks()', function () {
       }
     });
   });
+
+  describe('performDiagnostics()', function () {
+    it('should perform diagnostics without error', async function () {
+      firebase.dynamicLinks().performDiagnostics();
+    });
+  });
 });

--- a/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
+++ b/packages/dynamic-links/ios/RNFBDynamicLinks/RNFBDynamicLinksModule.m
@@ -228,6 +228,8 @@ RCT_EXPORT_METHOD(getInitialLink
   }
 }
 
+RCT_EXPORT_METHOD(performDiagnostics) { [FIRDynamicLinks performDiagnosticsWithCompletion:nil]; }
+
 RCT_EXPORT_METHOD(resolveLink
                   : (NSString *)link
                   : (RCTPromiseResolveBlock)resolve

--- a/packages/dynamic-links/lib/index.d.ts
+++ b/packages/dynamic-links/lib/index.d.ts
@@ -550,6 +550,15 @@ export namespace FirebaseDynamicLinksTypes {
     onLink(listener: (link: DynamicLink) => void): () => void;
 
     /**
+     * Perform built-in diagnostics on iOS. This is best performed on a real device running
+     * a build from Xcode so you may see the output easily. Alternatively it should be visible
+     * in Console.app with an iPhone plugged into a macOS computer
+     *
+     * NOTE: iOS only
+     */
+    performDiagnostics(): void;
+
+    /**
      * Resolve a given dynamic link (short or long) directly.
      *
      * This mimics the result of external link resolution, app open, and the DynamicLink you

--- a/packages/dynamic-links/lib/index.js
+++ b/packages/dynamic-links/lib/index.js
@@ -20,6 +20,7 @@ import {
   FirebaseModule,
   getFirebaseRoot,
 } from '@react-native-firebase/app/lib/internal';
+import { isIOS } from '@react-native-firebase/app/lib/common';
 import builder from './builder';
 import version from './version';
 
@@ -84,6 +85,14 @@ class FirebaseLinksModule extends FirebaseModule {
     return () => {
       subscription.remove();
     };
+  }
+
+  performDiagnostics() {
+    if (isIOS) {
+      return this.native.performDiagnostics();
+    }
+
+    Promise.resolve();
   }
 
   resolveLink(link) {


### PR DESCRIPTION
### Description

Noticed while triaging an issue that there was an easy to cover API for firebase-ios-sdk to show dynamic link diagnostics

Output looks like:

```
---- Firebase Dynamic Links diagnostic output start ----
Firebase Dynamic Links framework version 8.15.0
System information: OS iOS, OS version 15.2, model iPhone
Current date 2022-05-26 01:05:05 +0000
Device locale en-US (raw en_US), timezone America/Guayaquil
WARNING: iOS Simulator does not support Universal Links. Firebase Dynamic Links SDK functionality will be limited. Some FDL features may be missing or will not work correctly.
ERROR: Specified custom URL scheme is io.invertase.testing but Info.plist do not contain such scheme in CFBundleURLTypes key.
performDiagnostic detected 1 ERRORS.
---- Firebase Dynamic Links diagnostic output end ----
```

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Ran it locally, saw the output above from the test I added. Added docs to cover as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
