### PR TITLE
fix(android, sdk): bump firebase-android-sdk to 30.0.2

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -72,7 +72,7 @@
       "targetSdk": 31,
       "compileSdk": 31,
       "buildTools": "30.0.3",
-      "firebase": "30.0.1",
+      "firebase": "30.0.2",
       "firebaseCrashlyticsGradle": "2.8.1",
       "firebasePerfGradle": "1.4.1",
       "gmsGoogleServicesGradle": "4.3.10",


### PR DESCRIPTION

Apparently a pretty serious crash bug that evades crashlytics in 30.0.1