### PR TITLE
fix(analytics): allow manual tracking of ad_impression

### DIFF
--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -40,7 +40,7 @@ const ReservedEventNames = [
   'ad_activeview',
   'ad_click',
   'ad_exposure',
-  'ad_impression',
+  // 'ad_impression', // manual ad_impression logging is allowed, See #6307
   'ad_query',
   'ad_reward',
   'adunit_exposure',


### PR DESCRIPTION
### Description

ad_impression events are allowed through by the native SDKs despite being reserved words, and this is the recommended way to track ad impressions on certain platforms per upstream docs

### Related issues

Fixes #6307
Supercedes, thus closes #6312

### Release Summary

Conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Reporting user made change locally and tested it - reserved word passes cleanly through native SDKs and shows up in analytics

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
