### PR TITLE
fix(android): specify that android services are not exported

### DIFF
--- a/packages/app/android/src/main/AndroidManifest.xml
+++ b/packages/app/android/src/main/AndroidManifest.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="io.invertase.firebase">
 
   <application>
     <meta-data android:name="app_data_collection_default_enabled" android:value="${firebaseJsonDataCollectionDefaultEnabled}"/>
-    <service android:name="com.google.firebase.components.ComponentDiscoveryService">
+    <service
+      android:name="com.google.firebase.components.ComponentDiscoveryService"
+      android:directBootAware="true"
+      android:exported="false"
+      tools:targetApi="n"
+    >
       <meta-data
         android:name="com.google.firebase.components:io.invertase.firebase.app.ReactNativeFirebaseAppRegistrar"
         android:value="com.google.firebase.components.ComponentRegistrar" />

--- a/packages/messaging/android/src/main/AndroidManifest.xml
+++ b/packages/messaging/android/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
   <application>
-    <service android:name=".ReactNativeFirebaseMessagingHeadlessService" />
+    <service android:name=".ReactNativeFirebaseMessagingHeadlessService"
+              android:exported="false" />
     <service android:name=".ReactNativeFirebaseMessagingService"
              android:exported="false">
       <intent-filter>


### PR DESCRIPTION
### Description

@gustavoggs Noticed in #6288 that we did not have exported status specified in our app service

We do not have any intent-filters on the service, so it is not strictly required (and thus this is not fixing a bug per se) but it is best to explicit

https://developer.android.com/about/versions/12/behavior-changes-12#exported

Additionally, app is directBootAware - this mirrors upstream definition:
https://github.com/firebase/firebase-android-sdk/blob/ad135d8c3c1243b4c673e17bc032ee1052fb2a22/firebase-common/src/main/AndroidManifest.xml#L10-L12

There was a service in messaging that defaulted to false because it had no intent-filter before either, specifying it explicitly as well

### Related issues

Supercedes and thus closes #6288

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
