### PR TITLE
fix(storage, android)!: android now updates customMetadata as a group

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -122,7 +122,8 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
 
   @ReactMethod
   public void getToken(String appName, String senderId, Promise promise) {
-    FirebaseMessaging messagingInstance = FirebaseApp.getInstance(appName).get(FirebaseMessaging.class);
+    FirebaseMessaging messagingInstance =
+        FirebaseApp.getInstance(appName).get(FirebaseMessaging.class);
     Tasks.call(getExecutor(), () -> Tasks.await(messagingInstance.getToken()))
         .addOnCompleteListener(
             task -> {
@@ -136,7 +137,8 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
 
   @ReactMethod
   public void deleteToken(String appName, String senderId, Promise promise) {
-    FirebaseMessaging messagingInstance = FirebaseApp.getInstance(appName).get(FirebaseMessaging.class);
+    FirebaseMessaging messagingInstance =
+        FirebaseApp.getInstance(appName).get(FirebaseMessaging.class);
     Tasks.call(
             getExecutor(),
             () -> {

--- a/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageUploadTask.java
+++ b/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageUploadTask.java
@@ -186,7 +186,7 @@ class ReactNativeFirebaseStorageUploadTask extends ReactNativeFirebaseStorageTas
 
   /** Put String or Data from JavaScript */
   void begin(ExecutorService executor, String string, String format, ReadableMap metadataMap) {
-    StorageMetadata metadata = buildMetadataFromMap(metadataMap, null);
+    StorageMetadata metadata = buildMetadataFromMap(metadataMap, null, null);
     uploadTask = storageReference.putBytes(uploadStringToByteArray(string, format), metadata);
     setStorageTask(uploadTask);
     addEventListeners(executor);
@@ -195,7 +195,7 @@ class ReactNativeFirebaseStorageUploadTask extends ReactNativeFirebaseStorageTas
   /** Put File from JavaScript */
   void begin(ExecutorService executor, String localFilePath, ReadableMap metadataMap) {
     Uri fileUri = SharedUtils.getUri(localFilePath);
-    StorageMetadata metadata = buildMetadataFromMap(metadataMap, fileUri);
+    StorageMetadata metadata = buildMetadataFromMap(metadataMap, fileUri, null);
     uploadTask = storageReference.putFile(fileUri, metadata);
     setStorageTask(uploadTask);
     addEventListeners(executor);

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -168,23 +168,18 @@ describe('storage() -> StorageReference', function () {
       }
     });
 
-    // Not throwing against the storage emulator on android?
     it('throws error if no read permission', async function () {
-      if (device.getPlatform() === 'ios') {
-        const storageReference = firebase.storage().ref(WRITE_ONLY_NAME);
+      const storageReference = firebase.storage().ref(WRITE_ONLY_NAME);
 
-        try {
-          await storageReference.getDownloadURL();
-          return Promise.reject(new Error('Did not throw'));
-        } catch (error) {
-          error.code.should.equal('storage/unauthorized');
-          error.message.should.equal(
-            '[storage/unauthorized] User is not authorized to perform the desired action.',
-          );
-          return Promise.resolve();
-        }
-      } else {
-        this.skip();
+      try {
+        await storageReference.getDownloadURL();
+        return Promise.reject(new Error('Did not throw'));
+      } catch (error) {
+        error.code.should.equal('storage/unauthorized');
+        error.message.should.equal(
+          '[storage/unauthorized] User is not authorized to perform the desired action.',
+        );
+        return Promise.resolve();
       }
     });
   });

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -353,75 +353,129 @@ describe('storage() -> StorageReference', function () {
 
   describe('updateMetadata', function () {
     it('should return the updated metadata for a file', async function () {
-      const storageReference = firebase.storage().ref(WRITE_ONLY_NAME);
-      const metadata = await storageReference.updateMetadata({
-        contentType: 'image/jpeg',
-        cacheControl: 'true',
-        contentDisposition: 'disposed',
-        contentEncoding: 'encoded',
-        contentLanguage: 'martian',
+      const storageReference = firebase.storage().ref(`${PATH}/list/file1.txt`);
+      let metadata = await storageReference.updateMetadata({
+        cacheControl: 'cache-control',
+        contentDisposition: 'content-disposition',
+        contentEncoding: 'application/octet-stream',
+        contentLanguage: 'de',
+        contentType: 'content-type-a',
         customMetadata: {
-          hello: 'world',
+          a: 'b',
+          y: 'z',
         },
       });
 
-      metadata.customMetadata.hello.should.equal('world');
+      // Things that are set automagically for us
       metadata.generation.should.be.a.String();
-      metadata.fullPath.should.equal(WRITE_ONLY_NAME);
-      metadata.name.should.equal(WRITE_ONLY_NAME);
+      metadata.fullPath.should.equal(`${PATH}/list/file1.txt`);
+      if (device.getPlatform() === 'android') {
+        // FIXME on android file comes through as fully-qualified
+        // TODO log issue with firebase-tools repository
+        metadata.name.should.equal('file1.txt');
+      } else {
+        metadata.name.should.equal(`${PATH}/list/file1.txt`);
+      }
       metadata.size.should.be.a.Number();
       should.equal(metadata.size > 0, true);
       metadata.updated.should.be.a.String();
       metadata.timeCreated.should.be.a.String();
-      metadata.contentEncoding.should.be.a.String();
-      metadata.contentDisposition.should.be.a.String();
-      if (device.getPlatform() === 'android') {
-        // FIXME on iOS this is '' (empty) now different in firebase-tools 10.2.2?
-        metadata.contentType.should.equal('image/jpeg');
-      }
-      metadata.bucket.should.equal(`${firebase.app().options.projectId}.appspot.com`);
       metadata.metageneration.should.be.a.String();
       metadata.md5Hash.should.be.a.String();
-      if (device.getPlatform() === 'android') {
-        // FIXME on iOS this comes back null ?
-        should.equal(metadata.cacheControl, 'true');
-      }
-      if (device.getPlatform() === 'android') {
-        // FIXME on iOS this comes back null ?
-        should.equal(metadata.contentLanguage, 'martian');
-      }
+      metadata.bucket.should.equal(`${firebase.app().options.projectId}.appspot.com`);
+
+      // Things we just updated
+      metadata.cacheControl.should.equals('cache-control');
+      metadata.contentDisposition.should.equal('content-disposition');
+      metadata.contentEncoding.should.equal('application/octet-stream');
+      metadata.contentLanguage.should.equal('de');
+      metadata.contentType.should.equal('content-type-a');
       metadata.customMetadata.should.be.an.Object();
+      metadata.customMetadata.a.should.equal('b');
+      metadata.customMetadata.y.should.equal('z');
+      Object.keys(metadata.customMetadata).length.should.equal(2);
+
+      // Now let's make sure removing metadata works
+      metadata = await storageReference.updateMetadata({
+        contentType: null,
+        cacheControl: null,
+        contentDisposition: null,
+        contentEncoding: null,
+        contentLanguage: null,
+        customMetadata: null,
+      });
+
+      // Things that are set automagically for us and are not updatable
+      metadata.generation.should.be.a.String();
+      metadata.fullPath.should.equal(`${PATH}/list/file1.txt`);
+      if (device.getPlatform() === 'android') {
+        // FIXME on android file comes through as fully-qualified
+        // TODO log issue with firebase-tools repository
+        metadata.name.should.equal('file1.txt');
+      } else {
+        metadata.name.should.equal(`${PATH}/list/file1.txt`);
+      }
+      metadata.size.should.be.a.Number();
+      should.equal(metadata.size > 0, true);
+      metadata.updated.should.be.a.String();
+      metadata.timeCreated.should.be.a.String();
+      metadata.metageneration.should.be.a.String();
+      metadata.md5Hash.should.be.a.String();
+      metadata.bucket.should.equal(`${firebase.app().options.projectId}.appspot.com`);
+
+      // Things that we may set (or remove)
+      // FIXME for storage emulator values are not cleared. Works against cloud
+      // TODO log issue with firebase-tools repository
+      // should.equal(metadata.cacheControl, undefined); // fails on android against storage emulator
+      // should.equal(metadata.contentDisposition, undefined); // fails on android against storage emulator
+      // should.equal(metadata.contentEncoding, 'identity'); // fails on android against storage emulator
+      // should.equal(metadata.contentLanguage, undefined); // fails on android against storage emulator
+      // should.equal(metadata.contentType, undefined); // fails on android against storage emulator
+      // should.equal(metadata.customMetadata, undefined); // fails on android against storage emulator
     });
 
-    // FIXME not working against android on emulator? it returns the string 'null' for the cleared customMetadata value
-    it('should set removed customMetadata properties to null', async function () {
-      if (device.getPlatform() === 'ios') {
-        const storageReference = firebase.storage().ref(WRITE_ONLY_NAME);
-        const metadata = await storageReference.updateMetadata({
-          contentType: 'text/plain',
-          customMetadata: {
-            removeMe: 'please',
-          },
-        });
+    it('should set update or remove customMetadata properties correctly', async function () {
+      const storageReference = firebase.storage().ref(`${PATH}/list/file1.txt`);
+      let metadata = await storageReference.updateMetadata({
+        contentType: 'application/octet-stream',
+        customMetadata: {
+          keepMe: 'please',
+          removeMeFirstTime: 'please',
+          removeMeSecondTime: 'please',
+        },
+      });
 
-        metadata.customMetadata.removeMe.should.equal('please');
+      Object.keys(metadata.customMetadata).length.should.equal(3);
+      metadata.customMetadata.keepMe.should.equal('please');
+      metadata.customMetadata.removeMeFirstTime.should.equal('please');
+      metadata.customMetadata.removeMeSecondTime.should.equal('please');
 
-        const metadataAfterRemove = await storageReference.updateMetadata({
-          contentType: 'text/plain',
-          customMetadata: {
-            removeMe: null,
-          },
-        });
+      metadata = await storageReference.updateMetadata({
+        contentType: 'application/octet-stream',
+        customMetadata: {
+          keepMe: 'please',
+          removeMeFirstTime: null,
+          removeMeSecondTime: 'please',
+        },
+      });
 
-        // FIXME this is failing the part that fails
-        should.equal(metadataAfterRemove.customMetadata.removeMe, undefined);
-      } else {
-        this.skip();
-      }
+      Object.keys(metadata.customMetadata).length.should.equal(2);
+      metadata.customMetadata.keepMe.should.equal('please');
+      metadata.customMetadata.removeMeSecondTime.should.equal('please');
+
+      metadata = await storageReference.updateMetadata({
+        contentType: 'application/octet-stream',
+        customMetadata: {
+          keepMe: 'please',
+        },
+      });
+
+      Object.keys(metadata.customMetadata).length.should.equal(1);
+      metadata.customMetadata.keepMe.should.equal('please');
     });
 
     it('should error if updateMetadata includes md5hash', async function () {
-      const storageReference = firebase.storage().ref(WRITE_ONLY_NAME);
+      const storageReference = firebase.storage().ref(`${PATH}/list/file1.txt`);
       try {
         await storageReference.updateMetadata({
           md5hash: '0xDEADBEEF',
@@ -549,8 +603,8 @@ describe('storage() -> StorageReference', function () {
         md5hash: '123412341234',
         cacheControl: 'true',
         contentDisposition: 'disposed',
-        contentEncoding: 'encoded',
-        contentLanguage: 'martian',
+        contentEncoding: 'application/octet-stream',
+        contentLanguage: 'de',
         customMetadata: {
           customMetadata1: 'metadata1value',
         },
@@ -605,6 +659,7 @@ describe('storage() -> StorageReference', function () {
       }
     });
 
+    // FIXME this works against the cloud on iOS but will actually crash the storage emulator
     xit('allows valid metadata properties for upload', async function () {
       const storageReference = firebase.storage().ref(`${PATH}/metadataTest.jpeg`);
       await storageReference.put(new jet.context.window.ArrayBuffer(), {
@@ -612,8 +667,8 @@ describe('storage() -> StorageReference', function () {
         md5hash: '123412341234',
         cacheControl: 'true',
         contentDisposition: 'disposed',
-        contentEncoding: 'encoded',
-        contentLanguage: 'martian',
+        contentEncoding: 'application/octet-stream',
+        contentLanguage: 'de',
         customMetadata: {
           customMetadata1: 'metadata1value',
         },

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -191,8 +191,11 @@ describe('storage() -> StorageReference', function () {
       metadata.generation.should.be.a.String();
       metadata.fullPath.should.equal(`${PATH}/list/file1.txt`);
       if (device.getPlatform() === 'android') {
-        // FIXME - iOS on emulator this is fullPath not name ?
         metadata.name.should.equal('file1.txt');
+      } else {
+        // FIXME on ios file comes through as fully-qualified
+        // https://github.com/firebase/firebase-ios-sdk/issues/9849#issuecomment-1159819958
+        metadata.name.should.equal(`${PATH}/list/file1.txt`);
       }
       metadata.size.should.be.a.Number();
       should.equal(metadata.size > 0, true);
@@ -204,6 +207,8 @@ describe('storage() -> StorageReference', function () {
       metadata.bucket.should.equal(`${firebase.app().options.projectId}.appspot.com`);
       metadata.metageneration.should.be.a.String();
       metadata.md5Hash.should.be.a.String();
+      // TODO against cloud storage cacheControl comes back null/undefined by default. Emulator has a difference
+      // https://github.com/firebase/firebase-tools/issues/3398#issuecomment-1159821364
       should.equal(metadata.cacheControl, 'public, max-age=3600');
       should.equal(metadata.contentLanguage, null);
       should.equal(metadata.customMetadata, null);
@@ -370,10 +375,10 @@ describe('storage() -> StorageReference', function () {
       metadata.generation.should.be.a.String();
       metadata.fullPath.should.equal(`${PATH}/list/file1.txt`);
       if (device.getPlatform() === 'android') {
-        // FIXME on android file comes through as fully-qualified
-        // TODO log issue with firebase-tools repository
         metadata.name.should.equal('file1.txt');
       } else {
+        // FIXME on ios file comes through as fully-qualified
+        // https://github.com/firebase/firebase-ios-sdk/issues/9849#issuecomment-1159819958
         metadata.name.should.equal(`${PATH}/list/file1.txt`);
       }
       metadata.size.should.be.a.Number();
@@ -409,10 +414,10 @@ describe('storage() -> StorageReference', function () {
       metadata.generation.should.be.a.String();
       metadata.fullPath.should.equal(`${PATH}/list/file1.txt`);
       if (device.getPlatform() === 'android') {
-        // FIXME on android file comes through as fully-qualified
-        // TODO log issue with firebase-tools repository
         metadata.name.should.equal('file1.txt');
       } else {
+        // FIXME on ios file comes through as fully-qualified
+        // https://github.com/firebase/firebase-ios-sdk/issues/9849#issuecomment-1159819958
         metadata.name.should.equal(`${PATH}/list/file1.txt`);
       }
       metadata.size.should.be.a.Number();
@@ -425,7 +430,7 @@ describe('storage() -> StorageReference', function () {
 
       // Things that we may set (or remove)
       // FIXME for storage emulator values are not cleared. Works against cloud
-      // TODO log issue with firebase-tools repository
+      // https://github.com/firebase/firebase-tools/issues/3398#issuecomment-1159821364
       // should.equal(metadata.cacheControl, undefined); // fails on android against storage emulator
       // should.equal(metadata.contentDisposition, undefined); // fails on android against storage emulator
       // should.equal(metadata.contentEncoding, 'identity'); // fails on android against storage emulator

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -200,10 +200,7 @@ describe('storage() -> StorageReference', function () {
       metadata.timeCreated.should.be.a.String();
       metadata.contentEncoding.should.be.a.String();
       metadata.contentDisposition.should.be.a.String();
-      // if (device.getPlatform() === 'android') {
-      // FIXME - on iOS and android emulator this is '' (empty) now (new in firebase-tools 10.2.2 ?
-      //   metadata.contentType.should.equal('text/plain');
-      // }
+      metadata.contentType.should.equal('text/plain');
       metadata.bucket.should.equal(`${firebase.app().options.projectId}.appspot.com`);
       metadata.metageneration.should.be.a.String();
       metadata.md5Hash.should.be.a.String();

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -18,6 +18,10 @@
 const { PATH, seed, WRITE_ONLY_NAME } = require('./helpers');
 
 describe('storage() -> StorageReference', function () {
+  before(async function () {
+    await seed(PATH);
+  });
+
   describe('toString()', function () {
     it('returns the correct bucket path to the file', function () {
       const app = firebase.app();
@@ -136,9 +140,6 @@ describe('storage() -> StorageReference', function () {
   });
 
   describe('getDownloadURL', function () {
-    before(async function () {
-      await seed(PATH);
-    });
     it('should return a download url for a file', async function () {
       // This is frequently flaky in CI - but works sometimes. Skipping only in CI for now.
       if (!isCI) {

--- a/packages/storage/ios/RNFBStorage/RNFBStorageCommon.h
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageCommon.h
@@ -56,7 +56,8 @@
 
 + (NSString *)getTaskStatus:(FIRStorageTaskStatus)status;
 
-+ (FIRStorageMetadata *)buildMetadataFromMap:(NSDictionary *)metadata;
++ (FIRStorageMetadata *)buildMetadataFromMap:(NSDictionary *)metadata
+                            existingMetadata:(FIRStorageMetadata *)existingMetadata;
 
 + (NSArray *)getErrorCodeMessage:(NSError *)error;
 

--- a/packages/storage/ios/RNFBStorage/RNFBStorageCommon.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageCommon.m
@@ -417,7 +417,11 @@
         code = @"invalid-device-file-path";
         message = @"The specified device file path is invalid or is restricted.";
       } else {
-        message = @"An unknown error has occurred.";
+        if (userInfo[@"ResponseBody"]) {
+          message = [NSString stringWithFormat:@"An unknown error has occurred. (underlying reason '%@')", userInfo[@"ResponseBody"]];
+        } else {
+          message = @"An unknown error has occurred.";
+        }
       }
       break;
     case FIRStorageErrorCodeObjectNotFound:

--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -143,17 +143,26 @@ RCT_EXPORT_METHOD(updateMetadata
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   FIRStorageReference *storageReference = [self getReferenceFromUrl:url app:firebaseApp];
-  FIRStorageMetadata *storageMetadata = [RNFBStorageCommon buildMetadataFromMap:metadata];
 
-  [storageReference
-      updateMetadata:storageMetadata
-          completion:^(FIRStorageMetadata *_Nullable metadata, NSError *_Nullable error) {
-            if (error != nil) {
-              [self promiseRejectStorageException:reject error:error];
-            } else {
-              resolve([RNFBStorageCommon metadataToDict:metadata]);
-            }
-          }];
+  [storageReference metadataWithCompletion:^(FIRStorageMetadata *_Nullable fetchedMetadata,
+                                             NSError *_Nullable error) {
+    if (error != nil) {
+      [self promiseRejectStorageException:reject error:error];
+    } else {
+      FIRStorageMetadata *storageMetadata =
+          [RNFBStorageCommon buildMetadataFromMap:metadata existingMetadata:fetchedMetadata];
+
+      [storageReference updateMetadata:storageMetadata
+                            completion:^(FIRStorageMetadata *_Nullable updatedMetadata,
+                                         NSError *_Nullable error) {
+                              if (error != nil) {
+                                [self promiseRejectStorageException:reject error:error];
+                              } else {
+                                resolve([RNFBStorageCommon metadataToDict:updatedMetadata]);
+                              }
+                            }];
+    }
+  }];
 }
 
 /**
@@ -391,7 +400,8 @@ RCT_EXPORT_METHOD(putFile
                   : (nonnull NSNumber *)taskId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRStorageMetadata *storageMetadata = [RNFBStorageCommon buildMetadataFromMap:metadata];
+  FIRStorageMetadata *storageMetadata = [RNFBStorageCommon buildMetadataFromMap:metadata
+                                                               existingMetadata:nil];
   FIRStorageReference *storageReference = [self getReferenceFromUrl:url app:firebaseApp];
 
   [RNFBStorageCommon
@@ -462,7 +472,8 @@ RCT_EXPORT_METHOD(putString
                   : (nonnull NSNumber *)taskId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRStorageMetadata *storageMetadata = [RNFBStorageCommon buildMetadataFromMap:metadata];
+  FIRStorageMetadata *storageMetadata = [RNFBStorageCommon buildMetadataFromMap:metadata
+                                                               existingMetadata:nil];
   FIRStorageReference *storageReference = [self getReferenceFromUrl:url app:firebaseApp];
 
   __block FIRStorageUploadTask *uploadTask;

--- a/packages/storage/lib/index.d.ts
+++ b/packages/storage/lib/index.d.ts
@@ -323,7 +323,7 @@ export namespace FirebaseStorageTypes {
     /**
      * Additional user-defined custom metadata for this storage object.
      *
-     * String values only are supported for custom metadata property values.
+     * All values must be strings. Set to null to delete all. Any keys ommitted during update will be removed.
      *
      * #### Example
      *

--- a/packages/storage/lib/utils.js
+++ b/packages/storage/lib/utils.js
@@ -88,9 +88,9 @@ export function validateMetadata(metadata, update = true) {
           `firebase.storage.SettableMetadata invalid property '${key}' should be a string or null value.`,
         );
       }
-    } else if (!isObject(value)) {
+    } else if (!isObject(value) && !isNull(value)) {
       throw new Error(
-        'firebase.storage.SettableMetadata.customMetadata must be an object of keys and string values.',
+        'firebase.storage.SettableMetadata.customMetadata must be an object of keys and string values or null value.',
       );
     }
   }

--- a/tests/app.js
+++ b/tests/app.js
@@ -37,7 +37,6 @@ import '@react-native-firebase/storage';
 import jet from 'jet/platform/react-native';
 import React from 'react';
 import { AppRegistry, Button, NativeModules, Text, View } from 'react-native';
-import { Platform } from 'react-native';
 
 jet.exposeContextProperty('NativeModules', NativeModules);
 jet.exposeContextProperty('NativeEventEmitter', NativeEventEmitter);


### PR DESCRIPTION
### Description

StorageMetadata.customMetadata is an interesting beast. This PR resolves a number of problems with it so that we behave the same way as web, despite android and ios platforms differing in their behavior.

The basic idea is that customMetadata is typed as `Map<String, String>` on web, meaning you may never send a null in there, which implies that you may not use a null value to indicate a single key/value pair should be removed.

Rather, you update the customMetadata all at once as a single unit, passing in the whole map of customMetadata you want to keep as part of the update. Any keys you omit will be removed, and sending in null for customMetadata removes the whole map.

iOS used to allow per-key null to remove keys, but with v9 they are enforcing non-null with Swift so that doesn't work.
android allows per-key null to remove it, but that's not the same as web or firebase-ios-sdk v9

So here we converge all platforms so that all entries coming in are String/String, null deletes the customMetadata entirely, and any keys missing from user-supplied customMetadata are removed

Additionally, setting/deletion of all the other settable keys has been verified and behaves the same cross-platform.

### Related issues

https://github.com/firebase/firebase-ios-sdk/issues/9849

### Release Summary

Each commit is conventional, in particular since this is a breaking change, the actual breaking change has a special commit message which should provide direct advice on affected users.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Test Plan

So much testing, the e2e test was the primary driver of this change to begin with, and I used it extensively to validate the changes

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
