### PR TITLE
feat(android, sdk): use firebase-android-sdk 30.2.0

### DIFF
--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -40,7 +40,7 @@ buildscript {
   // ..
   dependencies {
     // ..
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.0'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.1'
   }
   // ..
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ First, add the `google-services` plugin as a dependency inside of your `/android
 buildscript {
   dependencies {
     // ... other dependencies
-    classpath 'com.google.gms:google-services:4.3.10'
+    classpath 'com.google.gms:google-services:4.3.12'
     // Add me --- /\
   }
 }
@@ -212,7 +212,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "30.1.0"
+        bom           : "30.2.0"
       ],
     ],
   ])
@@ -227,7 +227,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '8.15.0'
+$FirebaseSDKVersion = '9.2.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -72,10 +72,10 @@
       "targetSdk": 31,
       "compileSdk": 31,
       "buildTools": "30.0.3",
-      "firebase": "30.1.0",
-      "firebaseCrashlyticsGradle": "2.9.0",
+      "firebase": "30.2.0",
+      "firebaseCrashlyticsGradle": "2.9.1",
       "firebasePerfGradle": "1.4.1",
-      "gmsGoogleServicesGradle": "4.3.10",
+      "gmsGoogleServicesGradle": "4.3.12",
       "playServicesAuth": "20.2.0"
     }
   }

--- a/packages/app/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -138,7 +138,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.gms:google-services:4.3.12'
         classpath(\\"com.android.tools.build:gradle:4.1.0\\")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.0'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.1'
         classpath(\\"com.android.tools.build:gradle:4.1.0\\")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -31,11 +31,11 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.gms:google-services:4.3.10' // https://developers.google.com/android/guides/google-services-plugin
+    classpath 'com.google.gms:google-services:4.3.12' // https://developers.google.com/android/guides/google-services-plugin
     classpath 'com.android.tools.build:gradle:7.0.4'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.4.1'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.0'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.1'
     classpath 'com.google.firebase:firebase-appdistribution-gradle:3.0.2'
   }
 }


### PR DESCRIPTION

### Description

https://firebase.google.com/support/release-notes/android#2022-06-23

- includes new crashlytics and google-services android plugins

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

`yarn tests:android:test` run locally, appears to work fine

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
