### PR TITLE
fix(ios, crashlytics): depend on FirebaseCoreExtension

### DIFF
--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |s|
 
   # Firebase dependencies
   s.dependency          'Firebase/Crashlytics', firebase_sdk_version
+  s.dependency          'FirebaseCoreExtension', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"


### PR DESCRIPTION

### Description

Crashlytics uses headers from this extension cocoapod, but it is only brought-in
automatically by Storage and Functions currently. Depend on it directly


### Related issues

https://github.com/invertase/react-native-firebase/issues/6322#issuecomment-1168902482


### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Hoping for user feedback from @brascene if adding this in the podspec works in place of pulling in functions or storage packages just for this workaround

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
