### PR TITLE
chore(ios): Prevent warnings when RNFirebaseAnalyticsWithoutAdIdSupport is false

### DIFF
--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -44,8 +44,10 @@ Pod::Spec.new do |s|
 
     s.dependency          'Firebase/AnalyticsWithoutAdIdSupport', firebase_sdk_version
   else
-    Pod::UI.puts "#{s.name}: Using default Firebase/Analytics with Ad Ids. May require App Tracking Transparency. Not allowed for Kids apps."
-    Pod::UI.puts "#{s.name}: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids."
+    if !defined?($RNFirebaseAnalyticsWithoutAdIdSupport)
+      Pod::UI.puts "#{s.name}: Using default Firebase/Analytics with Ad Ids. May require App Tracking Transparency. Not allowed for Kids apps."
+      Pod::UI.puts "#{s.name}: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids."
+    end
     s.dependency          'Firebase/Analytics', firebase_sdk_version
   end
 


### PR DESCRIPTION
When RNFirebaseAnalyticsWithoutAdIdSupport is set to false in Podfile, there should be no warning printed.

### Description

There is a warning that is printed anytime this variable is undefined or not true. That is helpful when the variable is undefined, but there's no reason to print the warning if a dev has explicitly set it to false.

### Related issues

N/A

### Release Summary

Only print RNFirebaseAnalyticsWithoutAdIdSupport warning if it is not defined

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android` (N/A)
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e` (N/A)
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__` (N/A)
- [ ] I have updated TypeScript types that are affected by my change. (N/A)
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

- [ ] remove any mention of RNFirebaseAnalyticsWithoutAdIdSupport from Podfile, run `pod install` and confirm warning is printed
- [ ] set RNFirebaseAnalyticsWithoutAdIdSupport = true in Podfile, run `pod install` and confirm warning is NOT printed
- [ ] set RNFirebaseAnalyticsWithoutAdIdSupport = false in Podfile, run `pod install` and confirm warning is NOT printed
