### PR TITLE
fix(messaging): Fixes a race condition between `FIRAuth/didReceiveRem…

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -123,6 +123,18 @@
     completionHandler(UIBackgroundFetchResultNoData);
     return;
   }
+
+  // If the notification is a probe notification, always call the completion 
+  // handler with UIBackgroundFetchResultNoData.
+  //
+  // This fixes a race condition between `FIRAuth/didReceiveRemoteNotification` and this
+  // module causing detox to hang when `FIRAuth/didReceiveRemoteNotification` is called first.
+  // see https://stackoverflow.com/questions/72044950/detox-tests-hang-with-pending-items-on-dispatch-queue/72989494
+  NSDictionary *data = userInfo[@"com.google.firebase.auth"];
+  if (data && data[@"warning"]) {
+      completionHandler(UIBackgroundFetchResultNoData);
+      return;
+  }
 #endif
 
   [[NSNotificationCenter defaultCenter]

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -131,7 +131,12 @@
   // module causing detox to hang when `FIRAuth/didReceiveRemoteNotification` is called first.
   // see https://stackoverflow.com/questions/72044950/detox-tests-hang-with-pending-items-on-dispatch-queue/72989494
   NSDictionary *data = userInfo[@"com.google.firebase.auth"];
-  if (data && data[@"warning"]) {
+  if ([data isKindOfClass:[NSString class]]) {
+      // Deserialize in case the data is a JSON string.
+      NSData *JSONData = [((NSString *)data) dataUsingEncoding:NSUTF8StringEncoding];
+      data = [NSJSONSerialization JSONObjectWithData:JSONData options:0 error:NULL];
+  }
+  if ([data isKindOfClass:[NSDictionary class]] && data[@"warning"]) {
       completionHandler(UIBackgroundFetchResultNoData);
       return;
   }


### PR DESCRIPTION
### Description

Fixes a race condition between `FIRAuth/didReceiveRemoteNotification` and the RNFB/messaging module causing detox to hang when `FIRAuth/didReceiveRemoteNotification` is called first.

This problem is caused by a bug in the @react-native-firebase/messaging implementation of `application: didReceiveRemoteNotification: fetchCompletionHandler:` (in @react-native-firebase/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m).

The implementation gets into a race with `FIRAuth/didReceiveRemoteNotification` which causes react-native-firebase/messaging to not callback the completion handler if FIRAuth's function ran first.

This in turns causes detox to randomly (and often) hang with the following error:

```
detox[41991] INFO:  [APP_STATUS] The app is busy with the following tasks:
• There are 2 work items pending on the dispatch queue: "Main Queue (<OS_dispatch_queue_main: com.apple.main-thread>)".
• Run loop "Main Run Loop" is awake.
```

### Related issues

1. [Stack Overflow Thread](https://stackoverflow.com/questions/72044950/detox-tests-hang-with-pending-items-on-dispatch-queue/72997971#72997971)
2. [Original issue on the Detox repo](https://github.com/wix/Detox/issues/3358)

### Release Summary

The patch ***fixes a race condition between `FIRAuth/didReceiveRemoteNotification` and the RNFB/messaging module causing detox to hang when `FIRAuth/didReceiveRemoteNotification` is called first.***

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

This is another tale from the deep-internals of Detox / RNFB / Firebase sdks playing not so well together -- and making tests extremely flaky. It will be hard to make a test harness for this.

However...

Unit tests are passing (with the exception of two tests that had to be skipped bc they had team/env specific values that made them fail):
```
gabriel@mt react-native-firebase % yarn tests:jest --silent
yarn run v1.22.18
$ jest --silent
 PASS  packages/app/plugin/__tests__/androidPlugin.test.ts (12.67 s)
 PASS  packages/app-distribution/__tests__/app-distribution.test.ts (12.741 s)
 PASS  packages/crashlytics/plugin/__tests__/androidPlugin.test.ts (12.73 s)
 PASS  packages/perf/plugin/__tests__/androidPlugin.test.ts (12.758 s)
 PASS  packages/app/plugin/__tests__/iosPlugin.test.ts (12.799 s)
 PASS  packages/app-check/__tests__/appcheck.test.ts (12.843 s)
 PASS  packages/perf/__tests__/perf.test.ts (12.883 s)
 PASS  packages/functions/__tests__/functions.test.ts (12.89 s)
 PASS  packages/remote-config/__tests__/remote-config.test.ts (12.892 s)
 PASS  packages/installations/__tests__/installations.test.ts (12.881 s)
 PASS  packages/database/__tests__/database.test.ts (12.905 s)
 PASS  packages/firestore/__tests__/firestore.test.ts (12.949 s)
 PASS  packages/auth/__tests__/auth.test.ts (12.968 s)
 PASS  packages/storage/__tests__/storage.test.ts (12.982 s)
 PASS  packages/analytics/__tests__/analytics.test.ts (13.068 s)
 PASS  packages/crashlytics/__tests__/crashlytics.test.ts

Test Suites: 16 passed, 16 total
Tests:       1 skipped, 158 passed, 159 total
Snapshots:   11 passed, 11 total
Time:        14.182 s, estimated 22 s
✨  Done in 14.89s.
gabriel@mt react-native-firebase %
```

As well as e2e tests:

```
gabriel@mt react-native-firebase % yarn tests:ios:test
yarn run v1.22.18
$ cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 SIMCTL_CHILD_FIRAAppCheckDebugToken=698956B2-187B-49C6-9E25-C3F3530EEBAF yarn detox test --configuration ios.sim.debug --loglevel warn
$ /Users/gabriel/Workspace/paltap-io/react-native-firebase/tests/node_modules/.bin/detox test --configuration ios.sim.debug --loglevel warn


Running application testing ({
    initialProps =     {
        isHeadless = 0;
    };
    rootTag = 11;
})
  App -> NativeModules -> Constants
    .apps
      ✔ should be an array
      ✔ array items contain name, options & state properties

  firebase
    ✔ it should allow read the default app from native
    ✔ it should create js apps for natively initialized apps
    ✔ natively initialized apps should have options available in js
    ✔ SDK_VERSION should return a string version
    ✔ apps should provide an array of apps
    ✔ apps can get and set data collection
    ✔ should allow setting of log level
    ✔ should error if logLevel is invalid
    ✔ it should initialize dynamic apps
    ✔ should error if dynamic app initialization values are incorrect
    ✔ should error if dynamic app initialization values are invalid
    ✔ apps can be deleted, but only once
    ✔ prevents the default app from being deleted
    ✔ extendApp should provide additional functionality

 [...]

  auth()
    namespace
      ✔ accessible from firebase.app()
      ✔ supports multiple apps
    applyActionCode()
      - works as expected
      ✔ errors on invalid code
    checkActionCode()
      ✔ errors on invalid code
    reload()
      ✔ Meta data returns as expected with annonymous sign in
      ✔ Meta data returns as expected with email and password sign in
    confirmPasswordReset()
      ✔ errors on invalid code via API
    signInWithCustomToken()
      - signs in with a admin sdk created custom auth token
    onAuthStateChanged()
      ✔ calls callback with the current user and when auth state changes
      ✔ accept observer instead callback as well
      ✔ stops listening when unsubscribed
      ✔ returns the same user with multiple subscribers #1815
    onIdTokenChanged()
      ✔ calls callback with the current user and when auth state changes
      ✔ stops listening when unsubscribed
      ✔ listens to a null user when auth result is not defined
    onUserChanged()
      ✔ calls callback with the current user and when auth state changes
      ✔ stops listening when unsubscribed
    signInAnonymously()
      ✔ it should sign in anonymously
    signInWithEmailAndPassword()
      ✔ it should login with email and password
      ✔ it should error on login if user is disabled
      ✔ it should error on login if password incorrect
      ✔ it should error on login if user not found
    signInWithCredential()
      ✔ it should login with email and password
      ✔ it should error on login if user is disabled
      ✔ it should error on login if password incorrect
      ✔ it should error on login if user not found
    createUserWithEmailAndPassword()
      ✔ it should create a user with an email and password
      ✔ it should error on create with invalid email
      ✔ it should error on create if email in use
      ✔ it should error on create if password weak
    fetchSignInMethodsForEmail()
      ✔ it should return password provider for an email address
      ✔ it should return an empty array for a not found email
      ✔ it should return an error for a bad email address
    signOut()
      ✔ it should reject signOut if no currentUser
    delete()
      ✔ should delete a user
    languageCode
      ✔ it should change the language code
    getRedirectResult()
      ✔ should throw an unsupported error
    setPersistence()
      ✔ should throw an unsupported error
    signInWithPopup
      ✔ should throw an unsupported error
    sendPasswordResetEmail()
      ✔ should not error
      ✔ should verify with valid code
      ✔ should fail to verify with invalid code
      ✔ should change password correctly OOB
      ✔ should change password correctly via API
    signInWithRedirect()
      ✔ should throw an unsupported error
    useDeviceLanguage()
      ✔ should throw an unsupported error
    useUserAccessGroup()
      - should return "null" when accessing a group that exists
      - should throw when requesting an inaccessible group
    setTenantId()
      ✔ should return null if tenantId unset

  auth() -> emailLink Provider
    sendSignInLinkToEmail
      ✔ should send email
      ✔ sign in via email works
      - should send email with defaults
    isSignInWithEmailLink
      ✔ should return true/false
    signInWithEmailLink
      - should signIn

  auth() => Phone
    signInWithPhoneNumber
      ✔ signs in with a valid code
      ✔ errors on invalid code
    verifyPhoneNumber
      ✔ successfully verifies
      ✔ uses the autoVerifyTimeout when a non boolean autoVerifyTimeoutOrForceResend is provided
      ✔ throws an error with an invalid on event
      ✔ throws an error with an invalid observer event
      ✔ successfully runs verification complete handler
      ✔ successfully runs and calls success callback
      - successfully runs and calls error callback
      ✔ catches an error and emits an error event

  auth() -> Providers
    EmailAuthProvider
      constructor
        ✔ should throw an unsupported error
      credential
        ✔ should return a credential object
      credentialWithLink
        ✔ should return a credential object
      EMAIL_PASSWORD_SIGN_IN_METHOD
        ✔ should return password
      EMAIL_LINK_SIGN_IN_METHOD
        ✔ should return emailLink
      PROVIDER_ID
        ✔ should return password
    FacebookAuthProvider
      constructor
        ✔ should throw an unsupported error
      credential
        ✔ should return a credential object
      credentialLimitedLogin
        ✔ should return a credential object
      PROVIDER_ID
        ✔ should return facebook.com
    GithubAuthProvider
      constructor
        ✔ should throw an unsupported error
      credential
        ✔ should return a credential object
      PROVIDER_ID
        ✔ should return github.com
    GoogleAuthProvider
      constructor
        ✔ should throw an unsupported error
      credential
        ✔ should return a credential object
      PROVIDER_ID
        ✔ should return google.com
    OAuthProvider
      constructor
        ✔ should throw an unsupported error
      credential
        ✔ should return a credential object
      PROVIDER_ID
        ✔ should return oauth
    PhoneAuthProvider
      constructor
        ✔ should throw an unsupported error
      credential
        ✔ should return a credential object
      PROVIDER_ID
        ✔ should return phone
    TwitterAuthProvider
      constructor
        ✔ should throw an unsupported error
      credential
        ✔ should return a credential object
      PROVIDER_ID
        ✔ should return twitter.com

  auth()
    firebase.auth().currentUser
      - exists after reload

  auth().currentUser
    getIdToken()
      ✔ should return a token
    getIdTokenResult()
      ✔ should return a valid IdTokenResult Object
    linkWithCredential()
      ✔ should link anonymous account <-> email account
      ✔ should error on link anon <-> email if email already exists
    reauthenticateWithCredential()
      ✔ should reauthenticate correctly
    reload()
      ✔ should not error
    sendEmailVerification()
      ✔ should error if actionCodeSettings.url is not present
      ✔ should error if actionCodeSettings.url is not a string
      ✔ should error if actionCodeSettings.dynamicLinkDomain is not a string
      ✔ should error if handleCodeInApp is not a string
      ✔ should error if actionCodeSettings.iOS is not an object
      ✔ should error if actionCodeSettings.iOS.bundleId is not a string
      ✔ should error if actionCodeSettings.android is not an object
      ✔ should error if actionCodeSettings.android.packageName is not a string
      ✔ should error if actionCodeSettings.android.installApp is not a string
      ✔ should error if actionCodeSettings.android.minimumVersion is not a string
      ✔ should not error
      ✔ should correctly report emailVerified status
      ✔ should work with actionCodeSettings
      ✔ should throw an error within an invalid action code url
    verifyBeforeUpdateEmail()
      ✔ should error if newEmail is not a string
      ✔ should error if actionCodeSettings.url is not present
      ✔ should error if actionCodeSettings.url is not a string
      ✔ should error if actionCodeSettings.dynamicLinkDomain is not a string
      ✔ should error if handleCodeInApp is not a boolean
      ✔ should error if actionCodeSettings.iOS is not an object
      ✔ should error if actionCodeSettings.iOS.bundleId is not a string
      ✔ should error if actionCodeSettings.android is not an object
      ✔ should error if actionCodeSettings.android.packageName is not a string
      ✔ should error if actionCodeSettings.android.installApp is not a boolean
      ✔ should error if actionCodeSettings.android.minimumVersion is not a string
      - should not error
      - should work with actionCodeSettings
    unlink()
      ✔ should unlink the email address
    updateEmail()
      ✔ should update the email address
    updatePhoneNumber()
      ✔ should update the phone number
    updatePassword()
      ✔ should update the password
      - should throw too many requests when limit has been reached
    updateProfile()
      ✔ should update the profile
      ✔ should return a valid profile when signing in anonymously
    linkWithPhoneNumber()
      ✔ should throw an unsupported error
    linkWithPopup()
      ✔ should throw an unsupported error
    linkWithRedirect()
      ✔ should throw an unsupported error
    reauthenticateWithPhoneNumber()
      ✔ should throw an unsupported error
    reauthenticateWithPopup()
      ✔ should throw an unsupported error
    reauthenticateWithRedirect()
      ✔ should throw an unsupported error
    refreshToken
      ✔ should throw an unsupported error
    user.metadata
      ✔ should have the properties 'lastSignInTime' & 'creationTime' which are ISO strings

[...]

  messaging()
    namespace
      ✔ accessible from firebase.app()
    setAutoInitEnabled()
      ✔ throws if enabled is not a boolean
      ✔ sets the value
    isDeviceRegisteredForRemoteMessages
      - returns true on android
      ✔ defaults to false on ios before registering
    unregisterDeviceForRemoteMessages
      - resolves on android, remains registered
      ✔ successfully unregisters on ios
    hasPermission
      - returns true android (default)
      ✔ returns -1 on ios (default)
    requestPermission
      - resolves 1 on android
    getAPNSToken
      - resolves null on android
      ✔ resolves null on ios if using simulator
    unsupported web sdk methods
      ✔ useServiceWorker should not error when called
      ✔ usePublicVapidKey should not error when called
    getInitialNotification
      ✔ returns null when no initial notification
    deleteToken()
      ✔ generate a new token after deleting
    onMessage()
      ✔ throws if listener is not a function
      - receives messages when the app is in the foreground
    onTokenRefresh()
      ✔ throws if listener is not a function
    onDeletedMessages()
      ✔ throws if listener is not a function
    onMessageSent()
      ✔ throws if listener is not a function
    onSendError()
      ✔ throws if listener is not a function
    setBackgroundMessageHandler()
      ✔ throws if handler is not a function
      - receives messages when the app is in the background
    subscribeToTopic()
      ✔ throws if topic is not a string
      ✔ throws if topic contains a /
    unsubscribeFromTopic()
      ✔ throws if topic is not a string
      ✔ throws if topic contains a /

  messaging().sendMessage(*)
    ✔ throws if used on ios
    - throws if no object provided
    - uses default values
    to
      - throws if to is not a string
      - accepts custom to value
    messageId
      - throws if messageId is not a string
      - accepts custom messageId value
    ttl
      - throws if not a number
      - throws if negative number
      - throws if float number
      - accepts custom ttl value
    data
      - throws if data not an object
      - accepts custom data value
    collapseKey
      - throws if collapseKey is not a string
      - accepts custom collapseKey value
    messageType
      - throws if messageType is not a string
      - accepts custom messageType value

[...]

  inAppMessaging()
    namespace
      ✔ accessible from firebase.app()
    setAutomaticDataCollectionEnabled()
18:15:11.739 detox[23952] WARN:  at e2e/init.js:41:15
 ⚠️ A test failed:
18:15:11.739 detox[23952] WARN:  at e2e/init.js:42:15
 ️   ->  true
18:15:11.740 detox[23952] WARN:  at e2e/init.js:49:13
 ️   ->  Retrying in 5 seconds ... (1)
      ✔ true
      ✔ false
      ✔ errors if not boolean
    setMessagesDisplaySuppressed()
      - false
      - true
      - errors if not boolean
    triggerEvent()
      - no exceptions thrown

[...]

  1056 passing (2m)
  72 pending

✨  Done in 131.73s.
```

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥