### PR TITLE
feat(app check): Replaced SafetyNet with play integrity in android

### DIFF
--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -93,7 +93,7 @@ repositories {
 dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion('firebase', 'bom')}")
-  implementation "com.google.firebase:firebase-appcheck-safetynet"
+  implementation 'com.google.firebase:firebase-appcheck-playintegrity'
   implementation "com.google.firebase:firebase-appcheck-debug"
 }
 

--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
@@ -26,7 +26,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.AppCheckProviderFactory;
 import com.google.firebase.appcheck.FirebaseAppCheck;
 import com.google.firebase.appcheck.debug.DebugAppCheckProviderFactory;
-import com.google.firebase.appcheck.safetynet.SafetyNetAppCheckProviderFactory;
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
 import java.lang.reflect.*;
 
@@ -75,7 +75,7 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
 
       } else {
         firebaseAppCheck.installAppCheckProviderFactory(
-            SafetyNetAppCheckProviderFactory.getInstance());
+          PlayIntegrityAppCheckProviderFactory.getInstance());
       }
     } catch (Exception e) {
       rejectPromiseWithCodeAndMessage(promise, "unknown", "internal-error", "unimplemented");


### PR DESCRIPTION
### Description

- Replaced SafetyNet with Play Integrity as SafetyNet is deprecated now in favour of play integrity.
Reference - [https://firebase.google.com/docs/app-check/android/safetynet-provider](url)
- No change required for iOS

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No

:fire:
