### PR TITLE
fix(ios, messaging): depend directly on FirebaseCoreExtension pod

### DIFF
--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -28,6 +28,7 @@ Pod::Spec.new do |s|
   s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion
@@ -35,6 +36,7 @@ Pod::Spec.new do |s|
 
   # Firebase dependencies
   s.dependency          'Firebase/Messaging', firebase_sdk_version
+  s.dependency          'FirebaseCoreExtension', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"


### PR DESCRIPTION
### Description

Messaging is having a build failure currently, it needs a direct dependency on the FirebaseCoreExtension pod apparently, if you use the pod without storage, functions or `@react-native-firebase/crashlytics` (which has the dep already)

This may affect other RNFB modules as well, no attempt has been made yet to triage other modules built in isolation (that is, with `@react-native-firebase/app` only)

### Related issues

Fixes #6403
Related #6352

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Perhaps @LozytskyiA can check the result of the patch-package action here

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
