### PR TITLE
docs(spellcheck): fix spellcheck issues

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -9,6 +9,7 @@ APIs
 APIs.
 AppAttest
 AppCheck
+AppDelegate.m
 APNs
 AirPods
 async

--- a/docs/releases/v6.4.0.md
+++ b/docs/releases/v6.4.0.md
@@ -61,7 +61,7 @@ date: 2020-04-03
 - `Android`: ensure a default notification color is always present when user does not set one
 - `iOS`: calling `registerDeviceForRemoteMessages`/`registerForRemoteNotifications` was incorrectly causing permissions to be requested before explicitly requesting them via the messaging API
 - `iOS`: registering the device was not being called if it was already registered internally.
-  - Devices should **always** register with `registerDeviceForRemoteMessages`, as per Apple guidelines, irregardless of current registration status.
+  - Devices should **always** register with `registerDeviceForRemoteMessages`, as per Apple guidelines, regardless of current registration status.
   - Make sure you **always** call `registerDeviceForRemoteMessages` during your app initialization on iOS
 - `iOS`: in cases where requesting an FCM with the default `scope` & `authorizedEntity`, the underlying code now uses the recommended `instanceIDWithHandler` vs `tokenWithAuthorizedEntity`.
   - This fixes an issue where FCM would throw a `"The operation couldn’t be completed"` error ([`#2657`](https://github.com/invertase/react-native-firebase/issues/2657))


### PR DESCRIPTION
### Description

We appear to have suffered some sort of entropy in the spellcheck area, this fixes it

### Related issues

https://github.com/invertase/react-native-firebase/actions/workflows/docs.yml

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
