### PR TITLE
feat: add GeoPoint toJSON() method

### DIFF
--- a/packages/firestore/e2e/GeoPoint.e2e.js
+++ b/packages/firestore/e2e/GeoPoint.e2e.js
@@ -106,6 +106,17 @@ describe('firestore.GeoPoint', function () {
       equal.should.equal(true);
     });
   });
+
+  describe('toJSON()', function () {
+    it('returns a json representation of the GeoPoint', function () {
+      const geo = new firebase.firestore.GeoPoint(100, 200);
+      geo.toJSON().should.deepEqual({
+        latitude: 100,
+        longitude: 200,
+      });
+    });
+  });
+
   it('sets & returns correctly', async function () {
     const ref = firebase.firestore().doc(`${COLLECTION}/geopoint`);
     await ref.set({

--- a/packages/firestore/lib/FirestoreGeoPoint.js
+++ b/packages/firestore/lib/FirestoreGeoPoint.js
@@ -66,4 +66,11 @@ export default class FirestoreGeoPoint {
 
     return this._latitude === other._latitude && this._longitude === other._longitude;
   }
+
+  toJSON() {
+    return {
+      latitude: this._latitude,
+      longitude: this._longitude,
+    };
+  }
 }

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -808,6 +808,11 @@ export namespace FirebaseFirestoreTypes {
      * @param other The `GeoPoint` to compare against.
      */
     isEqual(other: GeoPoint): boolean;
+
+    /**
+     * Returns a JSON-serializable representation of this GeoPoint.
+     */
+    toJSON(): { latitude: number; longitude: number };
   }
 
   /**


### PR DESCRIPTION
### Description

Adds a `toJSON()` method to a `GeoPoint` instance.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

![image](https://user-images.githubusercontent.com/842078/181772980-2cc8f71d-7463-459f-bd4e-a7ca7b6861a0.png)