### PR TITLE
fix(app, sdk): firebase-android-sdk 30.3.1 / firebase-ios-sdk 9.4.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -211,7 +211,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "30.3.0"
+        bom           : "30.3.1"
       ],
     ],
   ])
@@ -226,7 +226,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '9.3.0'
+$FirebaseSDKVersion = '9.4.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -65,13 +65,13 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "9.3.0"
+      "firebase": "9.4.0"
     },
     "android": {
       "minSdk": 19,
       "targetSdk": 31,
       "compileSdk": 31,
-      "firebase": "30.3.0",
+      "firebase": "30.3.1",
       "firebaseCrashlyticsGradle": "2.9.1",
       "firebasePerfGradle": "1.4.1",
       "gmsGoogleServicesGradle": "4.3.13",

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -612,59 +612,59 @@ PODS:
     - React-Core (= 0.67.3)
     - React-jsi (= 0.67.3)
     - ReactCommon/turbomodule/core (= 0.67.3)
-  - Firebase/Analytics (9.3.0):
+  - Firebase/Analytics (9.4.0):
     - Firebase/Core
-  - Firebase/AppCheck (9.3.0):
+  - Firebase/AppCheck (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 9.3.0)
-  - Firebase/AppDistribution (9.3.0):
+    - FirebaseAppCheck (~> 9.4.0)
+  - Firebase/AppDistribution (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 9.3.0-beta)
-  - Firebase/Auth (9.3.0):
+    - FirebaseAppDistribution (~> 9.4.0-beta)
+  - Firebase/Auth (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 9.3.0)
-  - Firebase/Core (9.3.0):
+    - FirebaseAuth (~> 9.4.0)
+  - Firebase/Core (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 9.3.0)
-  - Firebase/CoreOnly (9.3.0):
-    - FirebaseCore (= 9.3.0)
-  - Firebase/Crashlytics (9.3.0):
+    - FirebaseAnalytics (~> 9.4.0)
+  - Firebase/CoreOnly (9.4.0):
+    - FirebaseCore (= 9.4.0)
+  - Firebase/Crashlytics (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 9.3.0)
-  - Firebase/Database (9.3.0):
+    - FirebaseCrashlytics (~> 9.4.0)
+  - Firebase/Database (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 9.3.0)
-  - Firebase/DynamicLinks (9.3.0):
+    - FirebaseDatabase (~> 9.4.0)
+  - Firebase/DynamicLinks (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 9.3.0)
-  - Firebase/Firestore (9.3.0):
+    - FirebaseDynamicLinks (~> 9.4.0)
+  - Firebase/Firestore (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 9.3.0)
-  - Firebase/Functions (9.3.0):
+    - FirebaseFirestore (~> 9.4.0)
+  - Firebase/Functions (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 9.3.0)
-  - Firebase/InAppMessaging (9.3.0):
+    - FirebaseFunctions (~> 9.4.0)
+  - Firebase/InAppMessaging (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 9.3.0-beta)
-  - Firebase/Installations (9.3.0):
+    - FirebaseInAppMessaging (~> 9.4.0-beta)
+  - Firebase/Installations (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 9.3.0)
-  - Firebase/Messaging (9.3.0):
+    - FirebaseInstallations (~> 9.4.0)
+  - Firebase/Messaging (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 9.3.0)
-  - Firebase/Performance (9.3.0):
+    - FirebaseMessaging (~> 9.4.0)
+  - Firebase/Performance (9.4.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 9.3.0)
-  - Firebase/RemoteConfig (9.3.0):
+    - FirebasePerformance (~> 9.4.0)
+  - Firebase/RemoteConfig (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 9.3.0)
-  - Firebase/Storage (9.3.0):
+    - FirebaseRemoteConfig (~> 9.4.0)
+  - Firebase/Storage (9.4.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 9.3.0)
-  - FirebaseABTesting (9.3.0):
+    - FirebaseStorage (~> 9.4.0)
+  - FirebaseABTesting (9.4.0):
     - FirebaseCore (~> 9.0)
-  - FirebaseAnalytics (9.3.0):
-    - FirebaseAnalytics/AdIdSupport (= 9.3.0)
+  - FirebaseAnalytics (9.4.0):
+    - FirebaseAnalytics/AdIdSupport (= 9.4.0)
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
@@ -672,59 +672,59 @@ PODS:
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (9.3.0):
+  - FirebaseAnalytics/AdIdSupport (9.4.0):
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
-    - GoogleAppMeasurement (= 9.3.0)
+    - GoogleAppMeasurement (= 9.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAppCheck (9.3.0):
+  - FirebaseAppCheck (9.4.0):
     - FirebaseCore (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - PromisesObjC (~> 2.1)
-  - FirebaseAppCheckInterop (9.3.0)
-  - FirebaseAppDistribution (9.3.0-beta):
+  - FirebaseAppCheckInterop (9.4.0)
+  - FirebaseAppDistribution (9.4.0-beta):
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
-  - FirebaseAuth (9.3.0):
+  - FirebaseAuth (9.4.0):
     - FirebaseCore (~> 9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/Environment (~> 7.7)
     - GTMSessionFetcher/Core (< 3.0, >= 1.7)
-  - FirebaseAuthInterop (9.3.0)
-  - FirebaseCore (9.3.0):
+  - FirebaseAuthInterop (9.4.0)
+  - FirebaseCore (9.4.0):
     - FirebaseCoreDiagnostics (~> 9.0)
     - FirebaseCoreInternal (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (9.3.0):
+  - FirebaseCoreDiagnostics (9.4.0):
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseCoreExtension (9.3.0):
+  - FirebaseCoreExtension (9.4.0):
     - FirebaseCore (~> 9.0)
-  - FirebaseCoreInternal (9.3.0):
+  - FirebaseCoreInternal (9.4.0):
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-  - FirebaseCrashlytics (9.3.0):
+  - FirebaseCrashlytics (9.4.0):
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (9.3.0):
+  - FirebaseDatabase (9.4.0):
     - FirebaseCore (~> 9.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (9.3.0):
+  - FirebaseDynamicLinks (9.4.0):
     - FirebaseCore (~> 9.0)
-  - FirebaseFirestore (9.3.0):
+  - FirebaseFirestore (9.4.0):
     - abseil/algorithm (~> 1.20211102.0)
     - abseil/base (~> 1.20211102.0)
     - abseil/container/flat_hash_map (~> 1.20211102.0)
@@ -737,7 +737,7 @@ PODS:
     - "gRPC-C++ (~> 1.44.0)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseFunctions (9.3.0):
+  - FirebaseFunctions (9.4.0):
     - FirebaseAppCheckInterop (~> 9.0)
     - FirebaseAuthInterop (~> 9.0)
     - FirebaseCore (~> 9.0)
@@ -745,18 +745,18 @@ PODS:
     - FirebaseMessagingInterop (~> 9.0)
     - FirebaseSharedSwift (~> 9.0)
     - GTMSessionFetcher/Core (< 3.0, >= 1.7)
-  - FirebaseInAppMessaging (9.3.0-beta):
+  - FirebaseInAppMessaging (9.4.0-beta):
     - FirebaseABTesting (~> 9.0)
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (9.3.0):
+  - FirebaseInstallations (9.4.0):
     - FirebaseCore (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (9.3.0):
+  - FirebaseMessaging (9.4.0):
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - GoogleDataTransport (< 10.0.0, >= 9.1.4)
@@ -765,8 +765,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseMessagingInterop (9.3.0)
-  - FirebasePerformance (9.3.0):
+  - FirebaseMessagingInterop (9.4.0)
+  - FirebasePerformance (9.4.0):
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - FirebaseRemoteConfig (~> 9.0)
@@ -775,46 +775,46 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (9.3.0):
+  - FirebaseRemoteConfig (9.4.0):
     - FirebaseABTesting (~> 9.0)
     - FirebaseCore (~> 9.0)
     - FirebaseInstallations (~> 9.0)
     - GoogleUtilities/Environment (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
-  - FirebaseSharedSwift (9.3.0)
-  - FirebaseStorage (9.3.0):
+  - FirebaseSharedSwift (9.4.0)
+  - FirebaseStorage (9.4.0):
     - FirebaseAppCheckInterop (~> 9.0)
     - FirebaseAuthInterop (~> 9.0)
     - FirebaseCore (~> 9.0)
     - FirebaseCoreExtension (~> 9.0)
     - FirebaseStorageInternal (~> 9.0)
-  - FirebaseStorageInternal (9.3.0):
+  - FirebaseStorageInternal (9.4.0):
     - FirebaseCore (~> 9.0)
     - GTMSessionFetcher/Core (< 3.0, >= 1.7)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (9.3.0):
-    - GoogleAppMeasurement/AdIdSupport (= 9.3.0)
+  - GoogleAppMeasurement (9.4.0):
+    - GoogleAppMeasurement/AdIdSupport (= 9.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (9.3.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 9.3.0)
+  - GoogleAppMeasurement/AdIdSupport (9.4.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 9.4.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (9.3.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (9.4.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
     - GoogleUtilities/MethodSwizzler (~> 7.7)
     - GoogleUtilities/Network (~> 7.7)
     - "GoogleUtilities/NSData+zlib (~> 7.7)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurementOnDeviceConversion (9.3.0)
-  - GoogleDataTransport (9.1.4):
+  - GoogleAppMeasurementOnDeviceConversion (9.4.0)
+  - GoogleDataTransport (9.2.0):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
@@ -1168,73 +1168,73 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNFBAnalytics (15.1.1):
-    - Firebase/Analytics (= 9.3.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 9.3.0)
+  - RNFBAnalytics (15.2.0):
+    - Firebase/Analytics (= 9.4.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (15.1.1):
-    - Firebase/CoreOnly (= 9.3.0)
+  - RNFBApp (15.2.0):
+    - Firebase/CoreOnly (= 9.4.0)
     - React-Core
-  - RNFBAppCheck (15.1.1):
-    - Firebase/AppCheck (= 9.3.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (15.1.1):
-    - Firebase/AppDistribution (= 9.3.0)
+  - RNFBAppCheck (15.2.0):
+    - Firebase/AppCheck (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (15.1.1):
-    - Firebase/Auth (= 9.3.0)
+  - RNFBAppDistribution (15.2.0):
+    - Firebase/AppDistribution (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (15.1.1):
-    - Firebase/Crashlytics (= 9.3.0)
-    - FirebaseCoreExtension (= 9.3.0)
+  - RNFBAuth (15.2.0):
+    - Firebase/Auth (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (15.1.1):
-    - Firebase/Database (= 9.3.0)
+  - RNFBCrashlytics (15.2.0):
+    - Firebase/Crashlytics (= 9.4.0)
+    - FirebaseCoreExtension (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (15.1.1):
-    - Firebase/DynamicLinks (= 9.3.0)
+  - RNFBDatabase (15.2.0):
+    - Firebase/Database (= 9.4.0)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (15.2.0):
+    - Firebase/DynamicLinks (= 9.4.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (15.1.1):
-    - Firebase/Firestore (= 9.3.0)
+  - RNFBFirestore (15.2.0):
+    - Firebase/Firestore (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (15.1.1):
-    - Firebase/Functions (= 9.3.0)
+  - RNFBFunctions (15.2.0):
+    - Firebase/Functions (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (15.1.1):
-    - Firebase/InAppMessaging (= 9.3.0)
+  - RNFBInAppMessaging (15.2.0):
+    - Firebase/InAppMessaging (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (15.1.1):
-    - Firebase/Installations (= 9.3.0)
+  - RNFBInstallations (15.2.0):
+    - Firebase/Installations (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (15.1.1):
-    - Firebase/Messaging (= 9.3.0)
+  - RNFBMessaging (15.2.0):
+    - Firebase/Messaging (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBML (15.1.1):
+  - RNFBML (15.2.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (15.1.1):
-    - Firebase/Performance (= 9.3.0)
+  - RNFBPerf (15.2.0):
+    - Firebase/Performance (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (15.1.1):
-    - Firebase/RemoteConfig (= 9.3.0)
+  - RNFBRemoteConfig (15.2.0):
+    - Firebase/RemoteConfig (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (15.1.1):
-    - Firebase/Storage (= 9.3.0)
+  - RNFBStorage (15.2.0):
+    - Firebase/Storage (= 9.4.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -1439,37 +1439,37 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   FBLazyVector: 808f741ddb0896a20e5b98cc665f5b3413b072e2
   FBReactNativeSpec: 94473205b8741b61402e8c51716dea34aa3f5b2f
-  Firebase: ef75abb1cdbc746d5a38f4e26c422c807b189b8c
-  FirebaseABTesting: d7383da017eff5dc4fccb40987fa76271fd1cdbf
-  FirebaseAnalytics: bf46f5163f44097ce2c789de0b3e6f87f1da834a
-  FirebaseAppCheck: dea36639a4270b6deedc6f012302b84a3a22fe89
-  FirebaseAppCheckInterop: f6b9670fb1360cf12006ca426e9c3b9a35317d17
-  FirebaseAppDistribution: 24c57a37ddfd53899433862bf415290f564e4b2d
-  FirebaseAuth: 9ebc3577fe0acf9092df21ac314024b70aebf21e
-  FirebaseAuthInterop: 79826b4edc64e1d10135947866ad4437657e8696
-  FirebaseCore: c088995ece701a021a48a1348ea0174877de2a6a
-  FirebaseCoreDiagnostics: 060eb57cc56dfaf40b1b1b5874a5c17c41ce79f8
-  FirebaseCoreExtension: 900b065a4970c31ce8de4e966cee910188e3a07b
-  FirebaseCoreInternal: 635d1c9a612a6502b6377a0c92af83758076ffff
-  FirebaseCrashlytics: 65a5b349e664e986e6c7486b0a9b5ed8c11d0491
-  FirebaseDatabase: 92350185966ddd283842aa9ca07e188691f3b8ad
-  FirebaseDynamicLinks: af0acc2d1fa117a074e84a3c06a1d9f817443490
-  FirebaseFirestore: 5a72aa925528f67469b16a54a6cfc369467197e4
-  FirebaseFunctions: 817616e838ef76f985314d0e1e8caa0bb5c19daf
-  FirebaseInAppMessaging: 955fdc1506f4645984c7b02098ab29e802c3c6b8
-  FirebaseInstallations: 54b40022cb06e462740c9f2b9fbe38b5e78a825a
-  FirebaseMessaging: 2f6e38b6133059eb796ec224104f09379298a8c3
-  FirebaseMessagingInterop: af98663efee05115924de2f4123321183c3a2be6
-  FirebasePerformance: 18bb0984808ec429fae69fb5f1da4a68f57605b1
-  FirebaseRemoteConfig: 0a644c924b3339bcf3bc3ea253206f171672308e
-  FirebaseSharedSwift: 8becafc1096ca5703ac03065ed80496023880ac0
-  FirebaseStorage: 1414d27e15fa04f6350ef6602accef0e951c8bca
-  FirebaseStorageInternal: f1a6d64cace780580d2b8ffa0a0c8cf3c376f3f8
+  Firebase: 7703fc4022824b6d6db1bf7bea58d13b8e17ec46
+  FirebaseABTesting: e59eec91fafce74a0f5261809ed0025b7e450db1
+  FirebaseAnalytics: a1a24e72b7ba7f47045a4633f1abb545c07bd29c
+  FirebaseAppCheck: aaacc3c6beaba35564344c694608e272bd9e9cb1
+  FirebaseAppCheckInterop: 63119cdfc94b16c3e9421513c17f597aee2ea225
+  FirebaseAppDistribution: 03aa4e55b7b6c920319f0f07506ba58d65f8cbe3
+  FirebaseAuth: ae5d4402e1516497357d909162b091b3ca2a2e9c
+  FirebaseAuthInterop: 826d3d772b554e3675ceaab8c665008277ca9d1c
+  FirebaseCore: 9a2b10270a854731c4d4d8a97d0aa8380ec3458d
+  FirebaseCoreDiagnostics: aaa87098082c4d4bdd1a9557b1186d18ca85ce8c
+  FirebaseCoreExtension: 2cf8c542b54ad3c2d4b746c22e8828b670dcd9b0
+  FirebaseCoreInternal: a13302b0088fbf5f38b79b6ece49c2af7d3e05d6
+  FirebaseCrashlytics: 121ea1d37f4906c94c4c9307297af5121b98b789
+  FirebaseDatabase: e93f5441b549ea4492a8d8a0c7d612ac46c1b12a
+  FirebaseDynamicLinks: 311bb05788180e31a502bd0d413215413a4b3357
+  FirebaseFirestore: 945196dd78f4e92de6fc47b38569a1e7088af81f
+  FirebaseFunctions: cea54b689fb87b59b692989c0a5472c36df98aa1
+  FirebaseInAppMessaging: f6e2095f66788c7f2dc8ec27e81a1143ed96c30e
+  FirebaseInstallations: 61db1054e688d2bdc4e2b3f744c1b086e913b742
+  FirebaseMessaging: 4e220eddd356181469ba2ec5f7d5fafbc2312841
+  FirebaseMessagingInterop: a4bec680b953ddde5be175f4a2afce89c38cdc5f
+  FirebasePerformance: 89697044484c366e9b3214163e10034a4b42353b
+  FirebaseRemoteConfig: 6d9982bc64548a6e3c1b497b9fa53938ad135f2d
+  FirebaseSharedSwift: 812ad75bf1a79968b2da3d75fdde9ce7cd172301
+  FirebaseStorage: 160ba975dd3452d9c59a3bf5ea9bf70ff96bd3c2
+  FirebaseStorageInternal: 425c7dc7de44d9b7e07a9f8d6515bab0f1266b87
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 85ecdd10ee8d8ec362ef519a6a45ff9aa27b2e85
-  GoogleAppMeasurement: b907bdad775b6975a8108762345b2cfbf1a93c37
-  GoogleAppMeasurementOnDeviceConversion: 788bae5f42379414c136ed0b294905e06ae7f7b2
-  GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
+  GoogleAppMeasurement: 5d69e04287fc2c10cc43724bfa4bf31fc12c3dff
+  GoogleAppMeasurementOnDeviceConversion: fb9899389fdd3b8cdfbefe330fd0137bfb874153
+  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   "gRPC-C++": 9675f953ace2b3de7c506039d77be1f2e77a8db2
   gRPC-Core: 943e491cb0d45598b0b0eb9e910c88080369290b
@@ -1503,23 +1503,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNFBAnalytics: 9899917f18288b6661a49b7f71f61579044a53fc
-  RNFBApp: bea007c207266e6e09c9bfe8400e8b2309d3a8e1
-  RNFBAppCheck: d5ca10a40d71a2b5def2e8bd420e4e8258d9539e
-  RNFBAppDistribution: b427c01955c168cd555ae30972d7f2dc92f53104
-  RNFBAuth: 5d2a2853b9342e71713be79bf378a49d6782d7da
-  RNFBCrashlytics: 4c400feaceb2e7d684bb0e16651347ad4af258f0
-  RNFBDatabase: b6131af2ab51e66197e253eeff9c4a800748b383
-  RNFBDynamicLinks: b67ec5275c4f6b8b8431167ae04533375a46b546
-  RNFBFirestore: 8e261da129f5f56583dc743c7d835ea14cb0df1a
-  RNFBFunctions: e673d2df33c05ddaa4b6241d2e364cc92ef8f01c
-  RNFBInAppMessaging: 6411dd5d392c3d15ac27515f7ca4125659804d23
-  RNFBInstallations: d45364bad92c94007b798aeb6ee223b1aac46080
-  RNFBMessaging: 947147114b0a5b1b5e36caaf50af043989cd5e54
-  RNFBML: a045eec6960f3c05ecc8d1488c8330d1cc6fd36a
-  RNFBPerf: 572875cf7acb4f13ffc54d8b884d283a48c41be9
-  RNFBRemoteConfig: 75e39c913ba8784343c01a5e07c8fbdedaa18a4a
-  RNFBStorage: e8a72b0d09b8de09575921c149476e5c60fb35f4
+  RNFBAnalytics: 7922ff61612ef5824ffa304eab7597a5b9debadf
+  RNFBApp: d8fc3483a330a030fcba292c6b1e44fa61103068
+  RNFBAppCheck: f484699ae71af46a810448190f0f7b120ab6cbf5
+  RNFBAppDistribution: dc9e6a46d30f5b7df1675cfecf32862920f67051
+  RNFBAuth: f6ca52666737173988b9bd1b7755c0814293a162
+  RNFBCrashlytics: 5dff2d371b230851585a47431cd908e5e337d040
+  RNFBDatabase: 64b8aacdb049918f8662cf38365276611ad41ddf
+  RNFBDynamicLinks: 08c16ce233d4fbd575fd0252db657ecfbe3ad431
+  RNFBFirestore: 717545cb26def641053f302e3579a375f241b975
+  RNFBFunctions: 516b34e6d1a341d949eec0d17d04dd2c1bbcf878
+  RNFBInAppMessaging: 727675796434c4789e2e85016e2f2275f671fd7d
+  RNFBInstallations: eed4472a84be5551ee4f9e7a13ea712045a1f91d
+  RNFBMessaging: 22be8193acba262c75df0442efac75294d53a828
+  RNFBML: 175666a1ca6fdd8e8dd3fc8924f177fce23eaa3f
+  RNFBPerf: bceb5374058a5f68a5bc9c2e3a4b85a384163bbb
+  RNFBRemoteConfig: d48ec4530bed5149e39caeb8a0b0828d9003750f
+  RNFBStorage: 035b18474e62c736b526a4c43aa3c34e5fcfafde
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: cdac7095831bb39f8d76539f83a3580addb30d8b


### PR DESCRIPTION

### Description

patch release ingestion of firebase-android-sdk to fix an issue here that blocks Huawei folks (and some Play store) folks from using crashlytics on android

### Related issues

Related: https://github.com/firebase/firebase-android-sdk/issues/3826
Fixes #6327


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
