### PR TITLE
fix: *merge* setting to true irrespective of value passed

### DIFF
--- a/packages/firestore/lib/utils/index.js
+++ b/packages/firestore/lib/utils/index.js
@@ -91,7 +91,7 @@ export function parseSetOptions(options) {
       throw new Error("'options.merge' must be a boolean value.");
     }
 
-    out.merge = true;
+    out.merge = options.merge;
   }
 
   if (!isUndefined(options.mergeFields)) {


### PR DESCRIPTION

### Description
_*merge* option is being set to true, even if false is passed! This can result in unexpected results!_
As per documentations, [SetOptions](https://rnfirebase.io/reference/firestore/setoptions) merge can be one of "undefined", "true" or "false". But in the current implementation the false(boolean) value is mistreated as true only!
Fixed the SetOptions *merge* to handle false value.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- This is a breaking change;
  - [ ] Yes
  - [x] No
