### PR TITLE
fix(messaging, ios): eliminate auth/messaging notification race

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -123,6 +123,18 @@
     completionHandler(UIBackgroundFetchResultNoData);
     return;
   }
+
+  // If the notification is a probe notification, always call the completion 
+  // handler with UIBackgroundFetchResultNoData.
+  //
+  // This fixes a race condition between `FIRAuth/didReceiveRemoteNotification` and this
+  // module causing detox to hang when `FIRAuth/didReceiveRemoteNotification` is called first.
+  // see https://stackoverflow.com/questions/72044950/detox-tests-hang-with-pending-items-on-dispatch-queue/72989494
+  NSDictionary *data = userInfo[@"com.google.firebase.auth"];
+  if (data && data[@"warning"]) {
+      completionHandler(UIBackgroundFetchResultNoData);
+      return;
+  }
 #endif
 
   [[NSNotificationCenter defaultCenter]

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -131,7 +131,12 @@
   // module causing detox to hang when `FIRAuth/didReceiveRemoteNotification` is called first.
   // see https://stackoverflow.com/questions/72044950/detox-tests-hang-with-pending-items-on-dispatch-queue/72989494
   NSDictionary *data = userInfo[@"com.google.firebase.auth"];
-  if (data && data[@"warning"]) {
+  if ([data isKindOfClass:[NSString class]]) {
+      // Deserialize in case the data is a JSON string.
+      NSData *JSONData = [((NSString *)data) dataUsingEncoding:NSUTF8StringEncoding];
+      data = [NSJSONSerialization JSONObjectWithData:JSONData options:0 error:NULL];
+  }
+  if ([data isKindOfClass:[NSDictionary class]] && data[@"warning"]) {
       completionHandler(UIBackgroundFetchResultNoData);
       return;
   }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -124,21 +124,22 @@
     return;
   }
 
-  // If the notification is a probe notification, always call the completion 
+  // If the notification is a probe notification, always call the completion
   // handler with UIBackgroundFetchResultNoData.
   //
   // This fixes a race condition between `FIRAuth/didReceiveRemoteNotification` and this
   // module causing detox to hang when `FIRAuth/didReceiveRemoteNotification` is called first.
-  // see https://stackoverflow.com/questions/72044950/detox-tests-hang-with-pending-items-on-dispatch-queue/72989494
+  // see
+  // https://stackoverflow.com/questions/72044950/detox-tests-hang-with-pending-items-on-dispatch-queue/72989494
   NSDictionary *data = userInfo[@"com.google.firebase.auth"];
   if ([data isKindOfClass:[NSString class]]) {
-      // Deserialize in case the data is a JSON string.
-      NSData *JSONData = [((NSString *)data) dataUsingEncoding:NSUTF8StringEncoding];
-      data = [NSJSONSerialization JSONObjectWithData:JSONData options:0 error:NULL];
+    // Deserialize in case the data is a JSON string.
+    NSData *JSONData = [((NSString *)data) dataUsingEncoding:NSUTF8StringEncoding];
+    data = [NSJSONSerialization JSONObjectWithData:JSONData options:0 error:NULL];
   }
   if ([data isKindOfClass:[NSDictionary class]] && data[@"warning"]) {
-      completionHandler(UIBackgroundFetchResultNoData);
-      return;
+    completionHandler(UIBackgroundFetchResultNoData);
+    return;
   }
 #endif
 


### PR DESCRIPTION
### Description

This carries over the fantastic work from and supercedes #6392 from @glesperance 

It eliminates a race between auth and messaging on probe notifications, as documented in that PR

### Release Summary

squash merge / PR title for conventional commits / semantic release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Apparently in use in production per discussion related PR, received a look from firebase-ios-sdk maintainers as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
