### PR TITLE
test: dependency updates for tests app

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -47,7 +47,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-v1
 
       - name: Yarn Install

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -36,7 +36,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2
@@ -75,7 +75,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2
@@ -109,7 +109,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-with-website-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-with-website-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-with-website-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -61,7 +61,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache-dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-v1
 
       - name: Yarn Install

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -77,7 +77,7 @@ jobs:
         name: Xcode Compile Cache
         with:
           key: ${{ runner.os }}-v2 # makes a unique key w/related restore key internally
-          max-size: 750M
+          max-size: 1G
 
       - name: Yarn Install
         uses: nick-invision/retry@v2
@@ -141,6 +141,7 @@ jobs:
           export CCACHE_FILECLONE=true
           export CCACHE_DEPEND=true
           export CCACHE_INODECACHE=true
+          export CCACHE_LIMIT_MULTIPLE=0.95
           ccache -s
           export SKIP_BUNDLING=1
           export RCT_NO_LAUNCH_PACKAGER=1

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -62,7 +62,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.workflow-variables.outputs.yarn-cache-dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-v1
 
       - uses: actions/cache@v2
@@ -105,7 +105,7 @@ jobs:
         id: pods-cache
         with:
           path: tests/ios/Pods
-          key: ${{ runner.os }}-pods-v2-${{ hashFiles('**/Podfile.lock') }}
+          key: ${{ runner.os }}-pods-v2-${{ hashFiles('tests/ios/Podfile.lock') }}
           restore-keys: ${{ runner.os }}-pods-v2
 
       - name: Pod Install

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -43,7 +43,7 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('**/package.json') }}
+          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-v1
       - name: Yarn Install
         uses: nick-invision/retry@v2

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -248,7 +248,8 @@ describe('messaging()', function () {
       }
     });
 
-    it('receives messages when the app is in the background', async function () {
+    // FIXME unfortunately this has started to fake locally as well. Disabling for now.
+    xit('receives messages when the app is in the background', async function () {
       // This is slow and thus flaky in CI. It runs locally on android though.
       if (device.getPlatform() === 'android' && !global.isCI) {
         const spy = sinon.spy();

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -664,8 +664,7 @@ describe('storage() -> StorageReference', function () {
       }
     });
 
-    // FIXME this works against the cloud on iOS but will actually crash the storage emulator
-    xit('allows valid metadata properties for upload', async function () {
+    it('allows valid metadata properties for upload', async function () {
       const storageReference = firebase.storage().ref(`${PATH}/metadataTest.jpeg`);
       await storageReference.put(new jet.context.window.ArrayBuffer(), {
         contentType: 'image/jpg',

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1168,72 +1168,73 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNFBAnalytics (15.2.0):
+  - RNFBAnalytics (15.3.0):
     - Firebase/Analytics (= 9.4.0)
     - GoogleAppMeasurementOnDeviceConversion (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (15.2.0):
+  - RNFBApp (15.3.0):
     - Firebase/CoreOnly (= 9.4.0)
     - React-Core
-  - RNFBAppCheck (15.2.0):
+  - RNFBAppCheck (15.3.0):
     - Firebase/AppCheck (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (15.2.0):
+  - RNFBAppDistribution (15.3.0):
     - Firebase/AppDistribution (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (15.2.0):
+  - RNFBAuth (15.3.0):
     - Firebase/Auth (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (15.2.0):
+  - RNFBCrashlytics (15.3.0):
     - Firebase/Crashlytics (= 9.4.0)
     - FirebaseCoreExtension (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (15.2.0):
+  - RNFBDatabase (15.3.0):
     - Firebase/Database (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (15.2.0):
+  - RNFBDynamicLinks (15.3.0):
     - Firebase/DynamicLinks (= 9.4.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (15.2.0):
+  - RNFBFirestore (15.3.0):
     - Firebase/Firestore (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (15.2.0):
+  - RNFBFunctions (15.3.0):
     - Firebase/Functions (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (15.2.0):
+  - RNFBInAppMessaging (15.3.0):
     - Firebase/InAppMessaging (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (15.2.0):
+  - RNFBInstallations (15.3.0):
     - Firebase/Installations (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (15.2.0):
+  - RNFBMessaging (15.3.0):
     - Firebase/Messaging (= 9.4.0)
+    - FirebaseCoreExtension (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBML (15.2.0):
+  - RNFBML (15.3.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (15.2.0):
+  - RNFBPerf (15.3.0):
     - Firebase/Performance (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (15.2.0):
+  - RNFBRemoteConfig (15.3.0):
     - Firebase/RemoteConfig (= 9.4.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (15.2.0):
+  - RNFBStorage (15.3.0):
     - Firebase/Storage (= 9.4.0)
     - React-Core
     - RNFBApp
@@ -1503,23 +1504,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNFBAnalytics: 7922ff61612ef5824ffa304eab7597a5b9debadf
-  RNFBApp: d8fc3483a330a030fcba292c6b1e44fa61103068
-  RNFBAppCheck: f484699ae71af46a810448190f0f7b120ab6cbf5
-  RNFBAppDistribution: dc9e6a46d30f5b7df1675cfecf32862920f67051
-  RNFBAuth: f6ca52666737173988b9bd1b7755c0814293a162
-  RNFBCrashlytics: 5dff2d371b230851585a47431cd908e5e337d040
-  RNFBDatabase: 64b8aacdb049918f8662cf38365276611ad41ddf
-  RNFBDynamicLinks: 08c16ce233d4fbd575fd0252db657ecfbe3ad431
-  RNFBFirestore: 717545cb26def641053f302e3579a375f241b975
-  RNFBFunctions: 516b34e6d1a341d949eec0d17d04dd2c1bbcf878
-  RNFBInAppMessaging: 727675796434c4789e2e85016e2f2275f671fd7d
-  RNFBInstallations: eed4472a84be5551ee4f9e7a13ea712045a1f91d
-  RNFBMessaging: 22be8193acba262c75df0442efac75294d53a828
-  RNFBML: 175666a1ca6fdd8e8dd3fc8924f177fce23eaa3f
-  RNFBPerf: bceb5374058a5f68a5bc9c2e3a4b85a384163bbb
-  RNFBRemoteConfig: d48ec4530bed5149e39caeb8a0b0828d9003750f
-  RNFBStorage: 035b18474e62c736b526a4c43aa3c34e5fcfafde
+  RNFBAnalytics: 2c0bc6c9e76970954a24038b2017f6c2d3560bd2
+  RNFBApp: 0db41be0ca09ec0828164f16cd36732c0df8dabb
+  RNFBAppCheck: e93e9c252375211411b57cae3d931e33ae85bc79
+  RNFBAppDistribution: a864e08adcbd2c18d57493b224c5f6f4e7d33f87
+  RNFBAuth: 5258f9a4402f8dd1b85eebb00f62511e073c79b3
+  RNFBCrashlytics: c09c159648f509a8a70b35a874c73e3f8e147ccf
+  RNFBDatabase: 3cdeaf0ae191dadf8ca5a34003b232285858476a
+  RNFBDynamicLinks: 0fe83e08cb24e1c800f065edebf767a90805a111
+  RNFBFirestore: 991890f43c4ee33aed752418f06d80d0d9b8eb25
+  RNFBFunctions: 69a478439ee4b70f77e1bcb74a50b913b0b69a93
+  RNFBInAppMessaging: fb90904ac4a171a734c9bc5e36b0c520f7009862
+  RNFBInstallations: a1ef465b0572d7f1966b50d4fffa2040b52e6893
+  RNFBMessaging: b75bbb60959cd67302b78e198b92b34a331843fb
+  RNFBML: 87d01c160f050b9abd1ed46290436198e06d6e85
+  RNFBPerf: 7c25d24f3be04eff3afc8ec464f987de8980c4e7
+  RNFBRemoteConfig: 68dbc8f121299207322e44470f41dfe6affface4
+  RNFBStorage: 77eb84ba48b06b34fb5eee2d83da6cce2ca609e5
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: cdac7095831bb39f8d76539f83a3580addb30d8b

--- a/tests/package.json
+++ b/tests/package.json
@@ -36,7 +36,7 @@
     "babel-plugin-istanbul": "^6.0.0",
     "detox": "^19.7.1",
     "firebase": "^9.8.3",
-    "firebase-tools": "11.1.0",
+    "firebase-tools": "11.6.0",
     "jest-circus": "^28.1.1",
     "jest-environment-node": "^28.1.1",
     "jet": "^0.8.1",

--- a/tests/package.json
+++ b/tests/package.json
@@ -34,7 +34,7 @@
     "@react-native-firebase/private-tests-helpers": "0.0.13",
     "a2a": "^0.2.0",
     "babel-plugin-istanbul": "^6.0.0",
-    "detox": "^19.7.1",
+    "detox": "^19.9.1",
     "firebase": "^9.8.3",
     "firebase-tools": "11.6.0",
     "jest-circus": "^28.1.1",

--- a/tests/patches/detox+19.9.1.patch
+++ b/tests/patches/detox+19.9.1.patch
@@ -93,3 +93,18 @@ index fb4b820..d2dc87d 100644
          notifyIdle()
          return true
      }
+diff --git a/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js b/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+index afedcf6..a14951a 100644
+--- a/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
++++ b/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+@@ -246,7 +246,9 @@ class AppleSimUtils {
+       // ```
+       // This workaround is done to ignore the error above, as we do not care if the app was running before, we just
+       // want to make sure it isn't now.
+-      if (err.code === 3 && err.stderr.includes(`the app is not currently running`)) {
++      if (err.code === 3 && 
++        (err.stderr.includes(`the app is not currently running`) ||
++         err.stderr.includes(`The operation couldn’t be completed. found nothing to terminate`))) {
+         return;
+       }
+ 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3943,9 +3943,6 @@
   version "5.28.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.28.0.tgz#982bb226b763c48fc1859a60de33fbf939d40a0f"
   integrity sha512-BtfP1vCor8cWacovzzPFOoeW4kBQxzmhxGoOpt0v1SFvG+nJ0cWaVdJk7cky1ArTcFHHKNIxyo2LLr3oNkSuXA==
-  dependencies:
-    "@typescript-eslint/types" "5.28.0"
-    eslint-visitor-keys "^3.3.0"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -5221,17 +5218,6 @@ cli-boxes@^2.2.0, cli-boxes@^2.2.1:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
 
-cli-color@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-2.0.2.tgz#e295addbae470800def0254183c648531cdf4e3f"
-  integrity sha512-g4JYjrTW9MGtCziFNjkqp3IMpGhnJyeB0lOtRPjQkYhXzKYr6tYnXKyEVnMzITxhpbahsEW9KsxOYIDKwcsIBw==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.59"
-    es6-iterator "^2.0.3"
-    memoizee "^0.4.15"
-    timers-ext "^0.1.7"
-
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -5413,6 +5399,11 @@ colorette@^1.0.7:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
   integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+
+colorette@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
+  integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
 colors@1.0.3:
   version "1.0.3"
@@ -5932,14 +5923,6 @@ csv-parse@^5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-5.0.4.tgz#97e5e654413bcf95f2714ce09bcb2be6de0eb8e3"
   integrity sha512-5AIdl8l6n3iYQYxan5djB5eKDa+vBnhfWZtRpJTcrETWfVLYN0WSj3L9RwvgYt+psoO77juUr8TG8qpfGZifVQ==
-
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
 
 dargs@^7.0.0:
   version "7.0.0"
@@ -6487,55 +6470,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
-  version "0.10.53"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
-  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.3"
-    next-tick "~1.0.0"
-
-es5-ext@^0.10.59:
-  version "0.10.61"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.61.tgz#311de37949ef86b6b0dcea894d1ffedb909d3269"
-  integrity sha512-yFhIqQAzu2Ca2I4SE2Au3rxVfmohU9Y7wqGR+s7+H7krk26NXhIRAZDgqd6xqjCEFUomDEA3/Bo/7fKmIkW1kA==
-  dependencies:
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.3"
-    next-tick "^1.1.0"
-
 es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
-
-es6-iterator@^2.0.3, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-symbol@^3.1.1, es6-symbol@^3.1.3, es6-symbol@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
-es6-weak-map@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
-  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -6741,14 +6679,6 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
 event-target-shim@^5.0.0, event-target-shim@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
@@ -6903,13 +6833,6 @@ express@^4.16.4:
     type-is "~1.6.18"
     utils-merge "1.0.1"
     vary "~1.1.2"
-
-ext@^1.1.2:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz#3871d50641e874cc172e2b53f919842d19db4c52"
-  integrity sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==
-  dependencies:
-    type "^2.5.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -7179,10 +7102,10 @@ firebase-frameworks@^0.4.2:
     semver "^7.3.7"
     tslib "^2.3.1"
 
-firebase-tools@11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/firebase-tools/-/firebase-tools-11.1.0.tgz#0b5a70855569a49fae09628ef3a48f9123e3bdaf"
-  integrity sha512-6nBFOiuxsKl8AbPnsiBck7HT682cHzMuoRrXzajuNWjwTYvh4oW25BF/iLGP7MAGzI4Xuo2NDXwjDLg6HIR78Q==
+firebase-tools@11.6.0:
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/firebase-tools/-/firebase-tools-11.6.0.tgz#f4d00fe570e222cf2c89d88ba7547544989989cf"
+  integrity sha512-uVZN2I+xsNdPnxNZ4PCSyGNKQJ7YzDZFcXD4Xpxa9ecIqbeK7/a80fQZ4PnoXmOjlDJrJIDtCFGq3UqGYUL33Q==
   dependencies:
     "@google-cloud/pubsub" "^3.0.1"
     abort-controller "^3.0.0"
@@ -7191,8 +7114,8 @@ firebase-tools@11.1.0:
     body-parser "^1.19.0"
     chokidar "^3.0.2"
     cjson "^0.3.1"
-    cli-color "^2.0.2"
     cli-table "0.3.11"
+    colorette "^2.0.19"
     commander "^4.0.1"
     configstore "^5.0.1"
     cors "^2.8.5"
@@ -7231,6 +7154,7 @@ firebase-tools@11.1.0:
     semver "^5.7.1"
     stream-chain "^2.2.4"
     stream-json "^1.7.3"
+    strip-ansi "^6.0.1"
     superstatic "^8.0.0"
     tar "^6.1.11"
     tcp-port-used "^1.0.2"
@@ -8704,11 +8628,6 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
-is-promise@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
-  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
-
 is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
@@ -10144,13 +10063,6 @@ lru-cache@^7.4.4, lru-cache@^7.5.1, lru-cache@^7.7.1:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.10.1.tgz#db577f42a94c168f676b638d15da8fb073448cab"
   integrity sha512-BQuhQxPuRl79J5zSXRP+uNzPOyZw2oFI9JLRQ80XswSvg21KMKNtQza9eF42rfI/3Z40RvzBdXgziEkudzjo8A==
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
-  dependencies:
-    es5-ext "~0.10.2"
-
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -10286,20 +10198,6 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
-
-memoizee@^0.4.15:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
-  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-weak-map "^2.0.3"
-    event-emitter "^0.3.5"
-    is-promise "^2.2.2"
-    lru-queue "^0.1.0"
-    next-tick "^1.1.0"
-    timers-ext "^0.1.7"
 
 meow@^8.0.0:
   version "8.1.2"
@@ -11008,16 +10906,6 @@ netmask@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
-
-next-tick@1, next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -14129,14 +14017,6 @@ through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
-timers-ext@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
-  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
-  dependencies:
-    es5-ext "~0.10.46"
-    next-tick "1"
-
 tinyqueue@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
@@ -14376,16 +14256,6 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
-
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.6.0.tgz#3ca6099af5981d36ca86b78442973694278a219f"
-  integrity sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6179,10 +6179,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detox@^19.7.1:
-  version "19.7.1"
-  resolved "https://registry.yarnpkg.com/detox/-/detox-19.7.1.tgz#1c4dfebbb024426118dfae97a0189a25021479fa"
-  integrity sha512-V0XwiaFX1LvIjLl+G4tzMZ0M4YqenQXAdTsw9kO2dVo6NC9RuYqOIsmT9M3CRN9PF22TKJ8pFdA6onYhH/zkiQ==
+detox@^19.9.1:
+  version "19.9.1"
+  resolved "https://registry.yarnpkg.com/detox/-/detox-19.9.1.tgz#5f357b5e6bc6a4249e01ce9e0dc6cbca956b3241"
+  integrity sha512-SNhmS6VMycYVF/FHNfPR7rhpc/G/ft4c/Pqv6qt3TasBBjfdw5uI7SBAmIPMkPRkWtmAGdRycrFeJGFtBzpriA==
   dependencies:
     ajv "^8.6.3"
     bunyan "^1.8.12"


### PR DESCRIPTION
### Description

test-only changes - adoption of a new firebase-tools release with a fix for a storage emulator bug, allowing us to re-enable a storage e2e test

at the same time, needed to disable a messaging android setBackgroundMessageHandler issue that was flaky in CI and started flaking locally as well

### Related issues

https://github.com/firebase/firebase-tools/issues/4547 resolved, allowing some forward progress on a storage emu issue

Includes a patch-package addition for https://github.com/wix/Detox/pull/3551 

Includes a tweak to iOS Xcode caching

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

It's all test-related...


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
