### PR TITLE
fix(messaging, ios): Support Ephemeral authorization state

### DIFF
--- a/docs/messaging/ios-permissions.md
+++ b/docs/messaging/ios-permissions.md
@@ -98,6 +98,7 @@ The value returned is a number value, which can be mapped to one of the followin
 - `0` = `messaging.AuthorizationStatus.DENIED`: The user has denied notification permissions.
 - `1` = `messaging.AuthorizationStatus.AUTHORIZED`: The user has accept the permission & it is enabled.
 - `2` = `messaging.AuthorizationStatus.PROVISIONAL`: [Provisional authorization](#provisional-authorization) has been granted.
+- `3` = `messaging.AuthorizationStatus.EPHEMERAL`: The app is authorized to create notifications for a limited amount of time. Used for app clips.
 
 To help improve the chances of the user granting your app permission, it is recommended that permission is requested at a time which makes
 sense during the flow of your application (e.g. starting a new chat), where the user would expect to receive such notifications.

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -320,12 +320,12 @@ RCT_EXPORT_METHOD(hasPermission : (RCTPromiseResolveBlock)resolve : (RCTPromiseR
               authorizedStatus = @2;
             }
           }
-        
-        if (@available(iOS 14.0, macCatalyst 14.0, *)) {
-          if (settings.authorizationStatus == UNAuthorizationStatusEphemeral) {
-            authorizedStatus = @3;
+
+          if (@available(iOS 14.0, macCatalyst 14.0, *)) {
+            if (settings.authorizationStatus == UNAuthorizationStatusEphemeral) {
+              authorizedStatus = @3;
+            }
           }
-        }
 
           resolve(authorizedStatus);
         }];

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -321,7 +321,7 @@ RCT_EXPORT_METHOD(hasPermission : (RCTPromiseResolveBlock)resolve : (RCTPromiseR
             }
           }
         
-        if (@available(iOS 14.0, *)) {
+        if (@available(iOS 14.0, macCatalyst 14.0, *)) {
           if (settings.authorizationStatus == UNAuthorizationStatusEphemeral) {
             authorizedStatus = @3;
           }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -320,6 +320,12 @@ RCT_EXPORT_METHOD(hasPermission : (RCTPromiseResolveBlock)resolve : (RCTPromiseR
               authorizedStatus = @2;
             }
           }
+        
+        if (@available(iOS 14.0, *)) {
+          if (settings.authorizationStatus == UNAuthorizationStatusEphemeral) {
+            authorizedStatus = @3;
+          }
+        }
 
           resolve(authorizedStatus);
         }];

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -501,6 +501,13 @@ export namespace FirebaseMessagingTypes {
      * @platform ios iOS >= 12
      */
     PROVISIONAL = 2,
+
+    /**
+     * The app is authorized to create notifications for a limited amount of time.
+     * Used in App Clips.
+     * @platform ios iOS >= 14
+     */
+    EPHEMERAL = 3,
   }
 
   /**

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -40,6 +40,7 @@ const statics = {
     DENIED: 0,
     AUTHORIZED: 1,
     PROVISIONAL: 2,
+    EPHEMERAL: 3,
   },
   NotificationAndroidPriority: {
     PRIORITY_MIN: -2,


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Adds support for the authorization status `UNAuthorizationStatusEphemeral` that was introduced with iOS 14. This status can be returned for App Clips, and means that notifications are allowed for a limited amount of time. See https://developer.apple.com/documentation/app_clips/enabling_notifications_in_app_clips

### Related issues

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
