### PR TITLE
docs(getting-started): update note about `use_frameworks`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,7 @@ $RNFirebaseAsStaticFramework = true
 
 Expo users may use [expo-build-properties](https://docs.expo.dev/versions/v45.0.0/sdk/build-properties/#pluginconfigtypeios) to turn on `use_frameworks`. We are unsure how Expo users add variables to a Podfile and may need a community contribution to the config-plugin here to do so, PRs welcome!
 
-> Note `use_frameworks` [is _not_ compatible with Flipper, Hermes, React Native New Architecture or react-native 0.69.0](https://github.com/reactwg/react-native-releases/discussions/21#discussioncomment-2924919). There is already [a patch-package patch available for 0.69.0](https://github.com/mikehardy/rnfbdemo/blob/main/patches/react-native%2B0.69.0.patch) that makes it work with and without Hermes and it will be released with 0.69.1. Community support to help fix `use_frameworks` support for Hermes and New Architecture is welcome!
+> Note `use_frameworks` [is _not_ compatible with Flipper](https://github.com/reactwg/react-native-releases/discussions/21#discussioncomment-2924919). A fix was put in place in [react-native release 0.69.1](https://github.com/facebook/react-native/releases/tag/v0.69.1) that makes it work with and without Hermes. To use without Flipper, comment out the `:flipper_configuration` line in your Podfile. Community support to help fix `use_frameworks` support for New Architecture is welcome!
 
 ### 4. Autolinking & rebuilding
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,7 @@ $RNFirebaseAsStaticFramework = true
 
 Expo users may use [expo-build-properties](https://docs.expo.dev/versions/v45.0.0/sdk/build-properties/#pluginconfigtypeios) to turn on `use_frameworks`. We are unsure how Expo users add variables to a Podfile and may need a community contribution to the config-plugin here to do so, PRs welcome!
 
-> Note `use_frameworks` [is _not_ compatible with Flipper](https://github.com/reactwg/react-native-releases/discussions/21#discussioncomment-2924919). A fix was put in place in [react-native release 0.69.1](https://github.com/facebook/react-native/releases/tag/v0.69.1) that makes it work with and without Hermes. To use without Flipper, comment out the `:flipper_configuration` line in your Podfile. Community support to help fix `use_frameworks` support for New Architecture is welcome!
+> Note `use_frameworks` [is _not_ compatible with Flipper](https://github.com/reactwg/react-native-releases/discussions/21#discussioncomment-2924919). A fix was put in place in [react-native release 0.69.1](https://github.com/facebook/react-native/releases/tag/v0.69.1) that makes it work with and without Hermes. To use it with Hermes make sure you have set static linkage with `use_frameworks! :linkage => :static`. To use without Flipper, comment out the `:flipper_configuration` line in your Podfile. Community support to help fix `use_frameworks` support for New Architecture is welcome!
 
 ### 4. Autolinking & rebuilding
 


### PR DESCRIPTION
### Description

I've been going through upgrading our app to the latest version of react native (from 0.63 to 0.69.4) and saw the note about `use_frameworks` not being supported. The link to the patch workaround is no longer valid and the fix has been merged in. This PR updates to the note to show the release where it was fixed and notes that `Flipper` is still not supported

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
