### PR TITLE
test(database, e2e): remove workaround for emulator rules

### DIFF
--- a/packages/database/e2e/helpers.js
+++ b/packages/database/e2e/helpers.js
@@ -1,10 +1,7 @@
-const testingUtils = require('@firebase/rules-unit-testing');
-
 // TODO make more unique?
 const ID = Date.now();
 
 const PATH = `tests/${ID}`;
-const DB_NAME = 'react-native-firebase-testing';
 const DB_RULES = `{ "rules": {".read": false, ".write": false, "tests": {".read": true, ".write": true } } }`;
 
 const CONTENT = {
@@ -38,11 +35,6 @@ exports.seed = function seed(path) {
   return Promise.all([
     firebase.database().ref(`${path}/types`).set(CONTENT.TYPES),
     firebase.database().ref(`${path}/query`).set(CONTENT.QUERY),
-    // The database emulator does not load rules correctly. We force them pre-test.
-    testingUtils.initializeTestEnvironment({
-      projectId: 'react-native-firebase-testing',
-      database: { databaseName: DB_NAME, rules: DB_RULES, host: 'localhost', port: 9000 },
-    }),
   ]);
 };
 


### PR DESCRIPTION
### Description

It seems that the latest version of the Emulator loads the database rules correctly, which means we can get rid of the workarounds.

The `e2e` tests run successfully after updating the `helpers.js` file.

### Related issues
https://github.com/invertase/react-native-firebase/issues/5876

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary
Remove workarounds in e2e for database Emulator

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [X] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥