### PR TITLE
fix(expo, ios): expo plugin added import multiple times

### DIFF
--- a/packages/app/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/app/plugin/__tests__/iosPlugin.test.ts
@@ -85,4 +85,22 @@ describe('Config Plugin iOS Tests', function () {
     await expect(modifyAppDelegateAsync(appDelegateFileInfo)).rejects.toThrow();
     expect(fs.writeFile).not.toHaveBeenCalled();
   });
+
+  it('does not add the firebase import multiple times', async function () {
+    const singleImport = '#import "AppDelegate.h"\n#import <Firebase/Firebase.h>';
+    const doubleImport = singleImport + '\n#import <Firebase/Firebase.h>';
+
+    const appDelegate = await fs.readFile(path.join(__dirname, './fixtures/AppDelegate_sdk45.mm'), {
+      encoding: 'utf8',
+    });
+    expect(appDelegate).not.toContain(singleImport);
+
+    const onceModifiedAppDelegate = modifyObjcAppDelegate(appDelegate);
+    expect(onceModifiedAppDelegate).toContain(singleImport);
+    expect(onceModifiedAppDelegate).not.toContain(doubleImport);
+
+    const twiceModifiedAppDelegate = modifyObjcAppDelegate(onceModifiedAppDelegate);
+    expect(twiceModifiedAppDelegate).toContain(singleImport);
+    expect(twiceModifiedAppDelegate).not.toContain(doubleImport);
+  });
 });

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -15,7 +15,7 @@ const fallbackInvocationLineMatcher =
 
 export function modifyObjcAppDelegate(contents: string): string {
   // Add import
-  if (!contents.includes('@import Firebase;')) {
+  if (!contents.includes('#import <Firebase/Firebase.h>')) {
     contents = contents.replace(
       /#import "AppDelegate.h"/g,
       `#import "AppDelegate.h"


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
This PR fixes a regression introduced in #6223 and reported in #6477.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #6477

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I added a test that fails without the changes and succeeds with them :)

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
