### PR TITLE
feat(messaging): add support for setDeliveryMetricsExportToBigQuery

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -221,10 +221,29 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
             });
   }
 
+  @ReactMethod
+  public void setDeliveryMetricsExportToBigQuery(Boolean enabled, Promise promise) {
+    Tasks.call(
+            getExecutor(),
+            () -> {
+              FirebaseMessaging.getInstance().setDeliveryMetricsExportToBigQuery(enabled);
+              return null;
+            })
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                promise.resolve(FirebaseMessaging.getInstance().deliveryMetricsExportToBigQueryEnabled());
+              } else {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+              }
+            });
+  }
+
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
     constants.put("isAutoInitEnabled", FirebaseMessaging.getInstance().isAutoInitEnabled());
+    constants.put("isDeliveryMetricsExportToBigQueryEnabled", FirebaseMessaging.getInstance().deliveryMetricsExportToBigQueryEnabled());
     return constants;
   }
 

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -320,4 +320,30 @@ describe('messaging()', function () {
       }
     });
   });
+
+  describe('setDeliveryMetricsExportToBigQuery()', function () {
+    afterEach(async function () {
+      await firebase.messaging().setDeliveryMetricsExportToBigQuery(false);
+    });
+
+    it('throws if enabled is not a boolean', function () {
+      try {
+        firebase.messaging().setDeliveryMetricsExportToBigQuery(123);
+        return Promise.reject(new Error('Did not throw Error.'));
+      } catch (e) {
+        e.message.should.containEql("'enabled' expected a boolean value");
+        return Promise.resolve();
+      }
+    });
+
+    it('sets the value', async function () {
+      should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
+      await firebase.messaging().setDeliveryMetricsExportToBigQuery(true);
+      should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, true);
+
+      // Set it back to the default value for future runs in re-use mode
+      await firebase.messaging().setDeliveryMetricsExportToBigQuery(false);
+      should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
+    });
+  });
 });

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.h
@@ -21,4 +21,6 @@
 @interface RNFBMessagingModule : NSObject <RCTBridgeModule>
 + (NSDictionary *_Nonnull)addCustomPropsToUserProps:(NSDictionary *_Nullable)userProps
                                   withLaunchOptions:(NSDictionary *_Nullable)launchOptions;
+@property BOOL isDeliveryMetricsExportToBigQueryEnabled;
+
 @end

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -66,6 +66,8 @@ RCT_EXPORT_MODULE();
       @([RCTConvert BOOL:@([FIRMessaging messaging].autoInitEnabled)]);
   constants[@"isRegisteredForRemoteNotifications"] = @(
       [RCTConvert BOOL:@([[UIApplication sharedApplication] isRegisteredForRemoteNotifications])]);
+  constants[@"isDeliveryMetricsExportToBigQueryEnabled"] =
+      @([RCTConvert BOOL:@(_isDeliveryMetricsExportToBigQueryEnabled)]);
   return constants;
 }
 
@@ -367,6 +369,19 @@ RCT_EXPORT_METHOD(unsubscribeFromTopic
                                           resolve(nil);
                                         }
                                       }];
+}
+
+RCT_EXPORT_METHOD(setDeliveryMetricsExportToBigQuery
+                  : (BOOL)enabled
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  @try {
+    _isDeliveryMetricsExportToBigQueryEnabled = enabled;
+  } @catch (NSException *exception) {
+    return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
+  }
+
+  return resolve([NSNull null]);
 }
 
 @end

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -1009,7 +1009,7 @@ export namespace FirebaseMessagingTypes {
      * await firebase.messaging().setDeliveryMetricsExportToBigQuery(true);
      * ```
      *
-     * @param enabled A boolean value to enable or disable exports message delivery metrics to BigQuery.
+     * @param enabled A boolean value to enable or disable exporting of message delivery metrics to BigQuery.
      */
     setDeliveryMetricsExportToBigQuery(enabled: boolean): Promise<void>;
   }

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -995,6 +995,23 @@ export namespace FirebaseMessagingTypes {
      * @param topic The topic name.
      */
     unsubscribeFromTopic(topic: string): Promise<void>;
+
+    /**
+     * Sets whether message delivery metrics are exported to BigQuery is enabled or disabled.
+     *
+     * The value is false by default. Set this to true to allow exporting of message delivery metrics to BigQuery.
+     *
+     *
+     * #### Example
+     *
+     * ```js
+     * // Enable exports of message delivery metrics to BigQuery
+     * await firebase.messaging().setDeliveryMetricsExportToBigQuery(true);
+     * ```
+     *
+     * @param enabled A boolean value to enable or disable exports message delivery metrics to BigQuery.
+     */
+    setDeliveryMetricsExportToBigQuery(enabled: boolean): Promise<void>;
   }
 }
 

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -68,6 +68,10 @@ class FirebaseMessagingModule extends FirebaseModule {
     super(...args);
     this._isAutoInitEnabled =
       this.native.isAutoInitEnabled != null ? this.native.isAutoInitEnabled : true;
+    this._isDeliveryMetricsExportToBigQueryEnabled =
+      this.native.isDeliveryMetricsExportToBigQueryEnabled != null
+        ? this.native.isDeliveryMetricsExportToBigQueryEnabled
+        : false;
     this._isRegisteredForRemoteNotifications =
       this.native.isRegisteredForRemoteNotifications != null
         ? this.native.isRegisteredForRemoteNotifications
@@ -125,6 +129,10 @@ class FirebaseMessagingModule extends FirebaseModule {
     }
 
     return this._isRegisteredForRemoteNotifications;
+  }
+
+  get isDeliveryMetricsExportToBigQueryEnabled() {
+    return this._isDeliveryMetricsExportToBigQueryEnabled;
   }
 
   setAutoInitEnabled(enabled) {
@@ -428,6 +436,17 @@ class FirebaseMessagingModule extends FirebaseModule {
     console.warn(
       'firebase.messaging().usePublicVapidKey() is not supported on react-native-firebase.',
     );
+  }
+
+  setDeliveryMetricsExportToBigQuery(enabled) {
+    if (!isBoolean(enabled)) {
+      throw new Error(
+        "firebase.messaging().setDeliveryMetricsExportToBigQuery(*) 'enabled' expected a boolean value.",
+      );
+    }
+
+    this._isDeliveryMetricsExportToBigQueryEnabled = enabled;
+    return this.native.setDeliveryMetricsExportToBigQuery(enabled);
   }
 }
 


### PR DESCRIPTION
### Description

We have had very specific requirements to send out push notifications using FCM and have implemented an in-house solution using the Firebase Admin SDK. However, we don't get access to the message delivery information in the Firebase Console anymore and want to use BigQuery to analyse this information.

Reading through [the documentation](https://firebase.google.com/docs/cloud-messaging/understand-delivery?platform=android#enable-message-delivery-data-export) we found that the message delivery data export needs to be enabled on the device (after asking for consent of course) and both [ios](https://firebase.google.com/docs/reference/ios/firebasemessaging/api/reference/Classes/FIRMessagingExtensionHelper#-exportdeliverymetricstobigquerywithmessageinfo:) and [android](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/FirebaseMessaging#public-method-summary) native methods are not exposed as per the RNFirebase documentation. 

With this PR, we can use `setDeliveryMetricsExportToBigQuery` method to pass down the status (a boolean value) and have used `deliveryMetricsExportToBigQueryEnabled()` method that exist already on android to return the updated status whilst iOS does not have a similar method, `isDeliveryMetricsExportToBigQueryEnabled` is introduced that holds the most up-to-date status that can be used as per your requirement.

### Related issues
n/a

### Release Summary
n/a

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes :fire:
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


### Test Plan

1. iOS test cases
<img width="852" alt="ios" src="https://user-images.githubusercontent.com/1639119/189808451-0873303b-9f9e-4385-8e5c-d5ad430839b5.png">

2. Android test cases
<img width="864" alt="android" src="https://user-images.githubusercontent.com/1639119/189808476-60a19057-c12a-406a-b3e2-9ae63faa2c5f.png">


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
