### PR TITLE
fix(auth, types): verifyPasswordResetCode returns Promise<string> with email address

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1645,7 +1645,7 @@ export namespace FirebaseAuthTypes {
      * #### Example
      *
      * ```js
-     * await firebase.auth().verifyPasswordResetCode('ABCD');
+     * const verifiedEmail = await firebase.auth().verifyPasswordResetCode('ABCD');
      * ```
      *
      * @error auth/expired-action-code Thrown if the password reset code has expired.
@@ -1653,8 +1653,9 @@ export namespace FirebaseAuthTypes {
      * @error auth/user-disabled Thrown if the user corresponding to the given password reset code has been disabled.
      * @error auth/user-not-found Thrown if there is no user corresponding to the password reset code. This may have happened if the user was deleted between when the code was issued and when this method was called.
      * @param code A password reset code.
+     * @returns {string} The user's email address if valid
      */
-    verifyPasswordResetCode(code: string): Promise<void>;
+    verifyPasswordResetCode(code: string): Promise<string>;
     /**
      * Switch userAccessGroup and current user to the given accessGroup and the user stored in it.
      * Sign in a user with any sign in method, and the same current user is available in all


### PR DESCRIPTION
Function verifyPasswordResetCode does return the email address string if valid, therefore, update the TypeScript definition to match.

### Description

verifyPasswordResetCode does return string result, without the correct typing, we are forced to ignore the linting warning.

### Related issues

n/a

### Release Summary

n/a

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
