### PR TITLE
feat(android): bump firebase-android-sdk to 30.5.0 + gradle plugins

### DIFF
--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -91,11 +91,11 @@ dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   // TODO remove the specific version once it is out of beta and participates in bom versioning
-  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta03'
+  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta04'
   // TODO demonstrate how to only include this in certain build variants
   // - perhaps have firebase.json name the variants to include, then roll through variants here and only
   //   add the dependency to variants that match? Or... (PRs welcome...)
-  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta03'
+  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta04'
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -69,14 +69,14 @@
     },
     "android": {
       "minSdk": 19,
-      "targetSdk": 31,
-      "compileSdk": 31,
-      "buildTools": "30.0.3",
-      "firebase": "30.1.0",
-      "firebaseCrashlyticsGradle": "2.9.0",
-      "firebasePerfGradle": "1.4.1",
-      "gmsGoogleServicesGradle": "4.3.10",
-      "playServicesAuth": "20.2.0"
+      "targetSdk": 33,
+      "compileSdk": 33,
+      "buildTools": "33.0.0",
+      "firebase": "30.5.0",
+      "firebaseCrashlyticsGradle": "2.9.2",
+      "firebasePerfGradle": "1.4.2",
+      "gmsGoogleServicesGradle": "4.3.14",
+      "playServicesAuth": "20.3.0"
     }
   }
 }

--- a/packages/app/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -138,7 +138,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.gms:google-services:4.3.10'
+        classpath 'com.google.gms:google-services:4.3.14'
         classpath(\\"com.android.tools.build:gradle:4.1.0\\")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.0'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
         classpath(\\"com.android.tools.build:gradle:4.1.0\\")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/perf/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/perf/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:perf-plugin:1.4.1'
+        classpath 'com.google.firebase:perf-plugin:1.4.2'
         classpath(\\"com.android.tools.build:gradle:4.1.0\\")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -1,25 +1,25 @@
 buildscript {
-  ext.buildToolsVersion = '31.0.0'
+  ext.buildToolsVersion = '33.0.0'
   ext.minSdkVersion = 21
-  ext.compileSdkVersion = 31
-  ext.targetSdkVersion = 31
+  ext.compileSdkVersion = 33
+  ext.targetSdkVersion = 33
   ext.ndkVersion = '21.4.7075529'
 
-  ext.kotlinVersion = '1.6.0' // https://kotlinlang.org/releases.html
-  ext.supportLibVersion = '1.7.0' // this maps to androidx.core https://developer.android.com/jetpack/androidx/releases/core
+  ext.kotlinVersion = '1.7.10' // https://kotlinlang.org/releases.html
+  ext.supportLibVersion = '1.9.0' // this maps to androidx.core https://developer.android.com/jetpack/androidx/releases/core
   //noinspection GradleDependency  https://github.com/facebook/react-native/pull/30061
   // Can bump to 1.4.0 when react-native 0.68 ships https://github.com/facebook/react-native/commit/e21f8ec34984551f87a306672160cc88e67e4793
-  ext.appCompatVersion = '1.4.0' // this maps to androidx.appcompat https://developer.android.com/jetpack/androidx/releases/appcompat
+  ext.appCompatVersion = '1.5.1' // this maps to androidx.appcompat https://developer.android.com/jetpack/androidx/releases/appcompat
   ext.supportVersion = ext.supportLibVersion
   ext.frescoVersion = '2.6.0' // https://github.com/facebook/fresco/releases
   ext.fragmentVersion = '1.4.0' // https://developer.android.com/jetpack/androidx/releases/fragment
   ext.vectordrawableVersion = '1.1.0' // https://developer.android.com/jetpack/androidx/releases/vectordrawable
-  ext.androidxAnnotationVersion = '1.3.0' // https://developer.android.com/jetpack/androidx/releases/annotation
-  ext.googlePlayServicesLocationVersion = '19.0.1' // https://developers.google.com/android/guides/setup
-  ext.googlePlayServicesVersion = '18.0.1' // play-services-base
-  ext.googlePlayServicesAuthVersion = '20.2.0' // play-services-auth
+  ext.androidxAnnotationVersion = '1.4.0' // https://developer.android.com/jetpack/androidx/releases/annotation
+  ext.googlePlayServicesLocationVersion = '20.0.0' // https://developers.google.com/android/guides/setup
+  ext.googlePlayServicesVersion = '18.1.0' // play-services-base
+  ext.googlePlayServicesAuthVersion = '20.3.0' // play-services-auth
   ext.googlePlayServicesVisionVersion = '20.1.3' // play-services-vision
-  ext.mediaCompatVersion = '1.4.3' // https://developer.android.com/jetpack/androidx/releases/media
+  ext.mediaCompatVersion = '1.6.0' // https://developer.android.com/jetpack/androidx/releases/media
   ext.supportV4Version = '1.0.0' // https://developer.android.com/jetpack/androidx/releases/legacy androidx.legacy:legacy-support-v4
   ext.swiperefreshlayoutVersion = '1.1.0' // https://developer.android.com/jetpack/androidx/releases/swiperefreshlayout
 
@@ -31,12 +31,12 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.gms:google-services:4.3.10' // https://developers.google.com/android/guides/google-services-plugin
+    classpath 'com.google.gms:google-services:4.3.14' // https://developers.google.com/android/guides/google-services-plugin
     classpath 'com.android.tools.build:gradle:7.0.4'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.4.1'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.0'
-    classpath 'com.google.firebase:firebase-appdistribution-gradle:3.0.2'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+    classpath 'com.google.firebase:firebase-appdistribution-gradle:3.0.3'
   }
 }
 


### PR DESCRIPTION
### Description

Bumping android dependencies since they can still move within the release constraints of the v14 branch here

### Release Summary


one conventional commit...

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

`yarn tests:jest` && `yarn tests:android:test`

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
