### PR TITLE
feat(auth): Add multi-factor support for the sign-in flow

### DIFF
--- a/docs/auth/multi-factor-auth.md
+++ b/docs/auth/multi-factor-auth.md
@@ -11,6 +11,46 @@ Make sure to follow [the official Identity Platform
 documentation](https://cloud.google.com/identity-platform/docs/ios/mfa#enabling_multi-factor_authentication)
 to enable multi-factor authentication for your project and verify your app.
 
+# Enroll a new factor
+
+> Before a user can enroll a second factor they need to verify their email. See
+> [`User`](/reference/auth/user#sendEmailVerification) interface is returned.
+
+Begin by obtaining a [`MultiFactorUser`](/reference/auth/multifactoruser)
+instance for the current user. This is the entry point for most multi-factor
+operations:
+
+```js
+import auth from '@react-native-firebase/auth';
+const multiFactorUser = await auth.multiFactor(auth());
+```
+
+Request the session identifier and use the phone number obtained from the user
+to send a verification code:
+
+```js
+const session = await multiFactorUser.getSession();
+const phoneOptions = {
+  phoneNumber,
+  session,
+};
+
+// Sends a text message to the user
+const verificationId = await auth().verifyPhoneNumberForMultiFactor(phoneOptions);
+```
+
+Once the user has provided the verification code received by text message, you
+can complete the process:
+
+```js
+const cred = auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+const multiFactorAssertion = auth.PhoneMultiFactorGenerator.assertion(cred);
+await multiFactorUser.enroll(multiFactorAssertion, 'Optional display name for the user);
+```
+
+You can inspect [`User#multiFactor`](/reference/auth/user#multiFactor) for
+information about the user's enrolled factors.
+
 # Sign-in flow using multi-factor
 
 Ensure the account has already enrolled a second factor. Begin by calling the

--- a/docs/auth/multi-factor-auth.md
+++ b/docs/auth/multi-factor-auth.md
@@ -1,0 +1,140 @@
+---
+title: Multi-factor Auth
+description: Increase security by adding Multi-factor authentication to your app.
+next: /firestore/usage
+previous: /auth/phone-auth
+---
+
+# iOS Setup
+
+Make sure to follow [the official Identity Platform
+documentation](https://cloud.google.com/identity-platform/docs/ios/mfa#enabling_multi-factor_authentication)
+to enable multi-factor authentication for your project and verify your app.
+
+# Sign-in flow using multi-factor
+
+Ensure the account has already enrolled a second factor. Begin by calling the
+default sign-in methods, for example email and password. If the account requires
+a second factor to complete login, an exception will be raised:
+
+```js
+import auth from '@react-native-firebase/auth';
+
+auth()
+  .signInWithEmailAndPassword(email, password)
+  .then(() => {
+    // User has not enrolled a second factor
+  })
+  .catch(error => {
+    const { code } = error;
+    // Make sure to check if multi factor authentication is required
+    if (code === 'auth/multi-factor-auth-required') {
+      return;
+    }
+
+    // Other error
+  });
+```
+
+Using the error object you can obtain a
+[`MultiFactorResolver`](/reference/auth/multifactorresolver) instance and
+continue the flow:
+
+```js
+const resolver = auth.getMultiFactorResolver(auth(), error);
+```
+
+The resolver object has all the required information to prompt the user for a
+specific factor:
+
+```js
+if (resolver.hints.length > 1) {
+  // Use resolver.hints to display a list of second factors to the user
+}
+
+// Currently only phone based factors are supported
+if (resolver.hints[0].factorId === auth.PhoneMultiFactorGenerator.FACTOR_ID) {
+  // Continue with the sign-in flow
+}
+```
+
+Using a multi-factor hint and the session information you can send a
+verification code to the user:
+
+```js
+const hint = resolver.hints[0];
+const sessionId = resolver.session;
+
+auth()
+  .verifyPhoneNumberWithMultiFactorInfo(hint, sessionId) // triggers the message to the user
+  .then(verificationId => setVerificationId(verificationId));
+```
+
+Once the user has entered the verification code you can create a multi-factor
+assertion and finish the flow:
+
+```js
+const credential = auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+
+const multiFactorAssertion = auth.PhoneMultiFactorGenerator.assertion(credential);
+
+resolver.resolveSignIn(multiFactorAssertion).then(userCredential => {
+  // additionally onAuthStateChanged will be triggered as well
+});
+```
+
+Upon successful sign-in, any
+[`onAuthStateChanged`](/auth/usage#listening-to-authentication-state) listeners
+will trigger with the new authentication state of the user.
+
+To put the example together:
+
+```js
+import auth from '@react-native-firebase/auth';
+
+const authInstance = auth();
+
+authInstance
+  .signInWithEmailAndPassword(email, password)
+  .then(() => {
+    // User has not enrolled a second factor
+  })
+  .catch(error => {
+    const { code } = error;
+    // Make sure to check if multi factor authentication is required
+    if (code !== 'auth/multi-factor-auth-required') {
+      const resolver = auth.getMultiFactorResolver(authInstance, error);
+
+      if (resolver.hints.length > 1) {
+        // Use resolver.hints to display a list of second factors to the user
+      }
+
+      // Currently only phone based factors are supported
+      if (resolver.hints[0].factorId === auth.PhoneMultiFactorGenerator.FACTOR_ID) {
+        const hint = resolver.hints[0];
+        const sessionId = resolver.session;
+
+        authInstance
+          .verifyPhoneNumberWithMultiFactorInfo(hint, sessionId) // triggers the message to the user
+          .then(verificationId => setVerificationId(verificationId));
+
+        // Request verificationCode from user
+
+        const credential = auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+
+        const multiFactorAssertion = auth.PhoneMultiFactorGenerator.assertion(credential);
+
+        resolver.resolveSignIn(multiFactorAssertion).then(userCredential => {
+          // additionally onAuthStateChanged will be triggered as well
+        });
+      }
+    }
+  });
+```
+
+# Testing
+
+You can define test phone numbers and corresponding verification codes. The
+official[official
+guide](https://cloud.google.com/identity-platform/docs/ios/mfa#enabling_multi-factor_authentication)
+contains more information on setting this up.

--- a/docs/auth/phone-auth.md
+++ b/docs/auth/phone-auth.md
@@ -1,7 +1,7 @@
 ---
 title: Phone Authentication
 description: Sign-in users with their phone number.
-next: /firestore/usage
+next: /auth/multi-factor-auth
 previous: /auth/social-auth
 ---
 

--- a/docs/firestore/usage/index.md
+++ b/docs/firestore/usage/index.md
@@ -3,7 +3,7 @@ title: Cloud Firestore
 description: Installation and getting started with Firestore.
 icon: //static.invertase.io/assets/firebase/cloud-firestore.svg
 next: /firestore/usage-with-flatlists
-previous: /auth/phone-auth
+previous: /auth/multi-factor-auth
 ---
 
 # Installation

--- a/docs/sidebar.yaml
+++ b/docs/sidebar.yaml
@@ -38,6 +38,8 @@
       - '/auth/social-auth'
     - - Phone Auth
       - '/auth/phone-auth'
+    - - Multi-factor Auth
+      - '/auth/multi-factor-auth'
   - '//static.invertase.io/assets/firebase/authentication.svg'
 - - Cloud Firestore
   - - - Usage

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseModule.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseModule.java
@@ -48,7 +48,9 @@ public class ReactNativeFirebaseModule extends ReactContextBaseJavaModule
     WritableMap userInfoMap = Arguments.createMap();
     userInfoMap.putString("code", code);
     userInfoMap.putString("message", message);
-    userInfoMap.putMap("resolver", resolver);
+    if (resolver != null) {
+      userInfoMap.putMap("resolver", resolver);
+    }
     promise.reject(code, message, userInfoMap);
   }
 

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseModule.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseModule.java
@@ -43,6 +43,15 @@ public class ReactNativeFirebaseModule extends ReactContextBaseJavaModule
     promise.reject(exception, SharedUtils.getExceptionMap(exception));
   }
 
+  public static void rejectPromiseWithCodeAndMessage(
+      Promise promise, String code, String message, ReadableMap resolver) {
+    WritableMap userInfoMap = Arguments.createMap();
+    userInfoMap.putString("code", code);
+    userInfoMap.putString("message", message);
+    userInfoMap.putMap("resolver", resolver);
+    promise.reject(code, message, userInfoMap);
+  }
+
   public static void rejectPromiseWithCodeAndMessage(Promise promise, String code, String message) {
     WritableMap userInfoMap = Arguments.createMap();
     userInfoMap.putString("code", code);

--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from '@jest/globals';
 
 import auth, { firebase } from '../lib';
 
+// @ts-ignore - We don't mind missing types here
+import { NativeFirebaseError } from '../../app/lib/internal';
+
 describe('Auth', function () {
   describe('namespace', function () {
     it('accessible from firebase.app()', function () {
@@ -67,6 +70,52 @@ describe('Auth', function () {
         expect(e.message).toBe("firebase.auth().setTenantId(*) expected 'tenantId' to be a string");
         return Promise.resolve('Error catched');
       }
+    });
+  });
+
+  describe('getMultiFactorResolver', function () {
+    it('should return null if no resolver object is found', function () {
+      const unknownError = NativeFirebaseError.fromEvent(
+        {
+          code: 'unknown',
+        },
+        'auth',
+      );
+      const actual = auth.getMultiFactorResolver(auth(), unknownError);
+      expect(actual).toBe(null);
+    });
+
+    it('should return null if resolver object is null', function () {
+      const unknownError = NativeFirebaseError.fromEvent(
+        {
+          code: 'unknown',
+          resolver: null,
+        },
+        'auth',
+      );
+      const actual = auth.getMultiFactorResolver(firebase.app().auth(), unknownError);
+      expect(actual).toBe(null);
+    });
+
+    it('should return the resolver object if its found', function () {
+      const resolver = { session: '', hints: [] };
+      const errorWithResolver = NativeFirebaseError.fromEvent(
+        {
+          code: 'multi-factor-auth-required',
+          resolver,
+        },
+        'auth',
+      );
+      const actual = auth.getMultiFactorResolver(firebase.app().auth(), errorWithResolver);
+      // Using expect(actual).toEqual(resolver) causes unexpected errors:
+      //  You attempted to use "firebase.app('[DEFAULT]').appCheck" but this module could not be found.
+      expect(actual).not.toBeNull();
+      // @ts-ignore We know actual is not null
+      expect(actual.session).toEqual(resolver.session);
+      // @ts-ignore We know actual is not null
+      expect(actual.hints).toEqual(resolver.hints);
+      // @ts-ignore We know actual is not null
+      expect(actual._auth).not.toBeNull();
     });
   });
 });

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -21,6 +21,7 @@ import android.app.Activity;
 import android.net.Uri;
 import android.os.Parcel;
 import android.util.Log;
+import androidx.annotation.NonNull;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -42,6 +43,7 @@ import com.google.firebase.auth.FacebookAuthProvider;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
+import com.google.firebase.auth.FirebaseAuthMultiFactorException;
 import com.google.firebase.auth.FirebaseAuthProvider;
 import com.google.firebase.auth.FirebaseAuthSettings;
 import com.google.firebase.auth.FirebaseUser;
@@ -49,9 +51,15 @@ import com.google.firebase.auth.FirebaseUserMetadata;
 import com.google.firebase.auth.GetTokenResult;
 import com.google.firebase.auth.GithubAuthProvider;
 import com.google.firebase.auth.GoogleAuthProvider;
+import com.google.firebase.auth.MultiFactorAssertion;
+import com.google.firebase.auth.MultiFactorInfo;
+import com.google.firebase.auth.MultiFactorResolver;
 import com.google.firebase.auth.OAuthProvider;
 import com.google.firebase.auth.PhoneAuthCredential;
+import com.google.firebase.auth.PhoneAuthOptions;
 import com.google.firebase.auth.PhoneAuthProvider;
+import com.google.firebase.auth.PhoneMultiFactorGenerator;
+import com.google.firebase.auth.PhoneMultiFactorInfo;
 import com.google.firebase.auth.TwitterAuthProvider;
 import com.google.firebase.auth.UserInfo;
 import com.google.firebase.auth.UserProfileChangeRequest;
@@ -59,6 +67,8 @@ import io.invertase.firebase.common.ReactNativeFirebaseEvent;
 import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
 import io.invertase.firebase.common.SharedUtils;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -72,6 +82,12 @@ import javax.annotation.Nullable;
 
 @SuppressWarnings({"ThrowableResultOfMethodCallIgnored", "JavaDoc"})
 class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
+  // Easier to use would be Instant and DateTimeFormatter, but these are only available in API 26+
+  // According to https://stackoverflow.com/a/2202300 this is not the optimal solution, but we only
+  // get a unix timestamp so we can hardcode the timezone.
+  public static final SimpleDateFormat ISO_8601_FORMATTER =
+      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+
   private static final String TAG = "Auth";
   private static HashMap<String, FirebaseAuth.AuthStateListener> mAuthListeners = new HashMap<>();
   private static HashMap<String, FirebaseAuth.IdTokenListener> mIdTokenListeners = new HashMap<>();
@@ -79,6 +95,8 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   private String mLastPhoneNumber;
   private PhoneAuthProvider.ForceResendingToken mForceResendingToken;
   private PhoneAuthCredential mCredential;
+
+  private final HashMap<String, MultiFactorResolver> mCachedResolvers = new HashMap<>();
 
   ReactNativeFirebaseAuthModule(ReactApplicationContext reactContext) {
     super(reactContext, TAG);
@@ -119,6 +137,8 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       firebaseAuth.removeIdTokenListener(mAuthListener);
       idTokenListenerIterator.remove();
     }
+
+    mCachedResolvers.clear();
   }
 
   /** Add a new auth state listener - if one doesn't exist already */
@@ -929,6 +949,126 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
+  public void verifyPhoneNumberWithMultiFactorInfo(
+      final String appName, final String hintUid, final String sessionKey, final Promise promise) {
+    final MultiFactorResolver resolver = mCachedResolvers.get(sessionKey);
+    if (resolver == null) {
+      // See https://firebase.google.com/docs/reference/node/firebase.auth.multifactorresolver for
+      // the error code
+      rejectPromiseWithCodeAndMessage(
+          promise,
+          "invalid-multi-factor-session",
+          "No resolver for session found. Is the session id correct?");
+      return;
+    }
+
+    MultiFactorInfo selectedHint = null;
+    for (MultiFactorInfo multiFactorInfo : resolver.getHints()) {
+      if (hintUid.equals(multiFactorInfo.getUid())) {
+        selectedHint = multiFactorInfo;
+        break;
+      }
+    }
+
+    if (selectedHint == null) {
+      rejectPromiseWithCodeAndMessage(promise, "unknown", "Requested multi-factor hint not found.");
+      return;
+    }
+
+    if (!PhoneMultiFactorGenerator.FACTOR_ID.equals(selectedHint.getFactorId())) {
+      rejectPromiseWithCodeAndMessage(
+          promise, "unknown", "Unsupported second factor. Only phone factors are supported.");
+      return;
+    }
+
+    final Activity activity = getCurrentActivity();
+    final PhoneAuthOptions phoneAuthOptions =
+        PhoneAuthOptions.newBuilder()
+            .setActivity(activity)
+            .setMultiFactorHint((PhoneMultiFactorInfo) selectedHint)
+            .setTimeout(30L, TimeUnit.SECONDS)
+            .setMultiFactorSession(resolver.getSession())
+            .setCallbacks(
+                new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
+                  @Override
+                  public void onCodeSent(
+                      @NonNull String verificationId,
+                      @NonNull PhoneAuthProvider.ForceResendingToken forceResendingToken) {
+                    promise.resolve(verificationId);
+                  }
+
+                  @Override
+                  public void onVerificationCompleted(
+                      @NonNull PhoneAuthCredential phoneAuthCredential) {
+                    resolveMultiFactorCredential(phoneAuthCredential, sessionKey, promise);
+                  }
+
+                  @Override
+                  public void onVerificationFailed(@NonNull FirebaseException e) {
+                    promiseRejectAuthException(promise, e);
+                  }
+                })
+            .build();
+
+    PhoneAuthProvider.verifyPhoneNumber(phoneAuthOptions);
+  }
+
+  /**
+   * This method is intended to resolve a {@link PhoneAuthCredential} obtained through a
+   * multi-factor authentication flow. A credential can either be obtained using:
+   *
+   * <ul>
+   *   <li>{@link PhoneAuthProvider#getCredential(String, String)}
+   *   <li>or {@link
+   *       com.google.firebase.auth.PhoneAuthProvider.OnVerificationStateChangedCallbacks#onVerificationCompleted(PhoneAuthCredential)}
+   * </ul>
+   *
+   * @param authCredential
+   * @param sessionKey An identifier for the session the flow belongs to. Used to look up the {@link
+   *     MultiFactorResolver}
+   * @param promise
+   */
+  private void resolveMultiFactorCredential(
+      final PhoneAuthCredential authCredential, final String sessionKey, final Promise promise) {
+    final MultiFactorAssertion multiFactorAssertion =
+        PhoneMultiFactorGenerator.getAssertion(authCredential);
+
+    final MultiFactorResolver resolver = mCachedResolvers.get(sessionKey);
+    if (resolver == null) {
+      rejectPromiseWithCodeAndMessage(
+          promise,
+          "invalid-multi-factor-session",
+          "No resolver for session found. Is the session id correct?");
+      return;
+    }
+
+    resolver
+        .resolveSignIn(multiFactorAssertion)
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                AuthResult authResult = task.getResult();
+                promiseWithAuthResult(authResult, promise);
+              } else {
+                promiseRejectAuthException(promise, task.getException());
+              }
+            });
+  }
+
+  @ReactMethod
+  public void resolveMultiFactorSignIn(
+      final String appName,
+      final String session,
+      final String verificationId,
+      final String verificationCode,
+      final Promise promise) {
+
+    final PhoneAuthCredential credential =
+        PhoneAuthProvider.getCredential(verificationId, verificationCode);
+    resolveMultiFactorCredential(credential, session, promise);
+  }
+
+  @ReactMethod
   public void confirmationResultConfirm(
       String appName, final String verificationCode, final Promise promise) {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
@@ -1650,7 +1790,8 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
    */
   private void promiseRejectAuthException(Promise promise, Exception exception) {
     WritableMap error = getJSError(exception);
-    rejectPromiseWithCodeAndMessage(promise, error.getString("code"), error.getString("message"));
+    rejectPromiseWithCodeAndMessage(
+        promise, error.getString("code"), error.getString("message"), error.getMap("resolver"));
   }
 
   /**
@@ -1735,6 +1876,18 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
             break;
         }
       }
+    }
+
+    if (exception instanceof FirebaseAuthMultiFactorException) {
+      final FirebaseAuthMultiFactorException multiFactorException =
+          (FirebaseAuthMultiFactorException) exception;
+      // Make sure the error code conforms to the Web API. See
+      // https://firebase.google.com/docs/auth/web/multi-factor#signing_users_in_with_a_second_factor
+      code = "MULTI_FACTOR_AUTH_REQUIRED";
+      final MultiFactorResolver resolver = multiFactorException.getResolver();
+      final String sessionId = Integer.toString(resolver.getSession().hashCode());
+      mCachedResolvers.put(sessionId, resolver);
+      error.putMap("resolver", resolverToMap(sessionId, resolver));
     }
 
     if (code.equals("UNKNOWN")) {
@@ -1877,7 +2030,40 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     }
     userMap.putMap("metadata", metadataMap);
 
+    final WritableArray enrolledFactors = Arguments.createArray();
+    for (final MultiFactorInfo hint : user.getMultiFactor().getEnrolledFactors()) {
+      enrolledFactors.pushMap(multiFactorInfoToMap(hint));
+    }
+    final WritableMap multiFactorMap = Arguments.createMap();
+    multiFactorMap.putArray("enrolledFactors", enrolledFactors);
+    userMap.putMap("multiFactor", multiFactorMap);
+
     return userMap;
+  }
+
+  @NonNull
+  private WritableMap resolverToMap(final String sessionId, final MultiFactorResolver resolver) {
+    final WritableMap result = Arguments.createMap();
+    final WritableArray hints = Arguments.createArray();
+    for (MultiFactorInfo hint : resolver.getHints()) {
+      hints.pushMap(multiFactorInfoToMap(hint));
+    }
+
+    result.putArray("hints", hints);
+    result.putString("session", sessionId);
+    return result;
+  }
+
+  @NonNull
+  private WritableMap multiFactorInfoToMap(MultiFactorInfo hint) {
+    final WritableMap hintMap = Arguments.createMap();
+    final Date enrollmentTime = new Date(hint.getEnrollmentTimestamp() * 1000);
+    hintMap.putString("displayName", hint.getDisplayName());
+    hintMap.putString("enrollmentTime", ISO_8601_FORMATTER.format(enrollmentTime));
+    hintMap.putString("factorId", hint.getFactorId());
+    hintMap.putString("uid", hint.getUid());
+
+    return hintMap;
   }
 
   private ActionCodeSettings buildActionCodeSettings(ReadableMap actionCodeSettings) {

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -54,10 +54,12 @@ import com.google.firebase.auth.GoogleAuthProvider;
 import com.google.firebase.auth.MultiFactorAssertion;
 import com.google.firebase.auth.MultiFactorInfo;
 import com.google.firebase.auth.MultiFactorResolver;
+import com.google.firebase.auth.MultiFactorSession;
 import com.google.firebase.auth.OAuthProvider;
 import com.google.firebase.auth.PhoneAuthCredential;
 import com.google.firebase.auth.PhoneAuthOptions;
 import com.google.firebase.auth.PhoneAuthProvider;
+import com.google.firebase.auth.PhoneMultiFactorAssertion;
 import com.google.firebase.auth.PhoneMultiFactorGenerator;
 import com.google.firebase.auth.PhoneMultiFactorInfo;
 import com.google.firebase.auth.TwitterAuthProvider;
@@ -97,6 +99,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   private PhoneAuthCredential mCredential;
 
   private final HashMap<String, MultiFactorResolver> mCachedResolvers = new HashMap<>();
+  private final HashMap<String, MultiFactorSession> mMultiFactorSessions = new HashMap<>();
 
   ReactNativeFirebaseAuthModule(ReactApplicationContext reactContext) {
     super(reactContext, TAG);
@@ -139,6 +142,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     }
 
     mCachedResolvers.clear();
+    mMultiFactorSessions.clear();
   }
 
   /** Add a new auth state listener - if one doesn't exist already */
@@ -949,6 +953,29 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
+  public void getSession(final String appName, final Promise promise) {
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+    firebaseAuth
+        .getCurrentUser()
+        .getMultiFactor()
+        .getSession()
+        .addOnCompleteListener(
+            task -> {
+              if (!task.isSuccessful()) {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+                return;
+              }
+
+              final MultiFactorSession session = task.getResult();
+              final String sessionId = Integer.toString(session.hashCode());
+              mMultiFactorSessions.put(sessionId, session);
+
+              promise.resolve(sessionId);
+            });
+  }
+
+  @ReactMethod
   public void verifyPhoneNumberWithMultiFactorInfo(
       final String appName, final String hintUid, final String sessionKey, final Promise promise) {
     final MultiFactorResolver resolver = mCachedResolvers.get(sessionKey);
@@ -1013,6 +1040,82 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     PhoneAuthProvider.verifyPhoneNumber(phoneAuthOptions);
   }
 
+  @ReactMethod
+  public void verifyPhoneNumberForMultiFactor(
+      final String appName,
+      final String phoneNumber,
+      final String sessionKey,
+      final Promise promise) {
+    final MultiFactorSession multiFactorSession = mMultiFactorSessions.get(sessionKey);
+    if (multiFactorSession == null) {
+      rejectPromiseWithCodeAndMessage(promise, "unknown", "can't find session for provided key");
+      return;
+    }
+
+    final PhoneAuthOptions phoneAuthOptions =
+        PhoneAuthOptions.newBuilder()
+            .setPhoneNumber(phoneNumber)
+            .setActivity(getCurrentActivity())
+            .setTimeout(30L, TimeUnit.SECONDS)
+            .setMultiFactorSession(multiFactorSession)
+            .requireSmsValidation(true)
+            .setCallbacks(
+                new PhoneAuthProvider.OnVerificationStateChangedCallbacks() {
+                  @Override
+                  public void onVerificationCompleted(
+                      @NonNull PhoneAuthCredential phoneAuthCredential) {
+                    // We can't handle this flow in the JS part if we want to be compatible with
+                    // the firebase-js-sdk. If we set the requireSmsValidation option to true
+                    // this code should not be executed.
+                    rejectPromiseWithCodeAndMessage(
+                        promise, "not-implemented", "This is currently not supported.");
+                  }
+
+                  @Override
+                  public void onVerificationFailed(@NonNull FirebaseException e) {
+                    promiseRejectAuthException(promise, e);
+                  }
+
+                  @Override
+                  public void onCodeSent(
+                      @NonNull String verificationId,
+                      @NonNull PhoneAuthProvider.ForceResendingToken forceResendingToken) {
+                    promise.resolve(verificationId);
+                  }
+                })
+            .build();
+
+    PhoneAuthProvider.verifyPhoneNumber(phoneAuthOptions);
+  }
+
+  @ReactMethod
+  public void finalizeMultiFactorEnrollment(
+      final String appName,
+      final String verificationId,
+      final String verificationCode,
+      @Nullable final String displayName,
+      final Promise promise) {
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+
+    final PhoneAuthCredential phoneAuthCredential =
+        PhoneAuthProvider.getCredential(verificationId, verificationCode);
+    final PhoneMultiFactorAssertion assertion =
+        PhoneMultiFactorGenerator.getAssertion(phoneAuthCredential);
+    firebaseAuth
+        .getCurrentUser()
+        .getMultiFactor()
+        .enroll(assertion, displayName)
+        .addOnCompleteListener(
+            task -> {
+              if (!task.isSuccessful()) {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+              }
+
+              // Need to reload user to make it all visible?
+              promise.resolve("yes");
+            });
+  }
   /**
    * This method is intended to resolve a {@link PhoneAuthCredential} obtained through a
    * multi-factor authentication flow. A credential can either be obtained using:
@@ -1777,6 +1880,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       authResultMap.putMap("user", userMap);
 
       promise.resolve(authResultMap);
+
     } else {
       promiseNoUser(promise, true);
     }
@@ -1790,8 +1894,14 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
    */
   private void promiseRejectAuthException(Promise promise, Exception exception) {
     WritableMap error = getJSError(exception);
+    final String sessionId = error.getString("sessionId");
+    final MultiFactorResolver multiFactorResolver = mCachedResolvers.get(sessionId);
+    WritableMap resolverAsMap = Arguments.createMap();
+    if (multiFactorResolver != null) {
+      resolverAsMap = resolverToMap(sessionId, multiFactorResolver);
+    }
     rejectPromiseWithCodeAndMessage(
-        promise, error.getString("code"), error.getString("message"), error.getMap("resolver"));
+        promise, error.getString("code"), error.getString("message"), resolverAsMap);
   }
 
   /**
@@ -1887,7 +1997,9 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       final MultiFactorResolver resolver = multiFactorException.getResolver();
       final String sessionId = Integer.toString(resolver.getSession().hashCode());
       mCachedResolvers.put(sessionId, resolver);
-      error.putMap("resolver", resolverToMap(sessionId, resolver));
+      // Passing around a resolver ReadableMap leads to issues when trying to send the data back by
+      // calling Promise#reject. Building the map just before sending solves that issue.
+      error.putString("sessionId", sessionId);
     }
 
     if (code.equals("UNKNOWN")) {
@@ -1900,6 +2012,18 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
         code = "TOO_MANY_REQUESTS";
         message = message;
       }
+    }
+
+    // Some message need to be rewritten to match error messages from the Web SDK
+    switch (code) {
+      case "ERROR_UNVERIFIED_EMAIL":
+        message = "This operation requires a verified email.";
+        break;
+      case "ERROR_UNSUPPORTED_FIRST_FACTOR":
+        message =
+            "Enrolling a second factor or signing in with a multi-factor account requires sign-in"
+                + " with a supported first factor.";
+        break;
     }
 
     code = code.toLowerCase(Locale.ROOT).replace("error_", "").replace('_', '-');

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -998,7 +998,10 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     }
 
     if (selectedHint == null) {
-      rejectPromiseWithCodeAndMessage(promise, "unknown", "Requested multi-factor hint not found.");
+      rejectPromiseWithCodeAndMessage(
+          promise,
+          "multi-factor-info-not-found",
+          "The user does not have a second factor matching the identifier provided.");
       return;
     }
 

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -2024,6 +2024,12 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
             "Enrolling a second factor or signing in with a multi-factor account requires sign-in"
                 + " with a supported first factor.";
         break;
+      case "ERROR_INVALID_PHONE_NUMBER":
+        message =
+            "The format of the phone number provided is incorrect. Please enter the phone number in"
+                + " a format that can be parsed into E.164 format. E.164 phone numbers are written"
+                + " in the format [+][country code][subscriber number including area code].";
+        break;
     }
 
     code = code.toLowerCase(Locale.ROOT).replace("error_", "").replace('_', '-');

--- a/packages/auth/e2e/helpers.js
+++ b/packages/auth/e2e/helpers.js
@@ -28,9 +28,10 @@ const callRestApi = async function callRestAPI(url, rawResult = false) {
   });
 };
 
-exports.getRandomPhoneNumber = function getRandomPhoneNumber() {
+function getRandomPhoneNumber() {
   return '+593' + Utils.randString(9, '#19');
-};
+}
+exports.getRandomPhoneNumber = getRandomPhoneNumber;
 
 exports.clearAllUsers = async function clearAllUsers() {
   // console.log('auth::helpers::clearAllUsers');
@@ -86,7 +87,7 @@ exports.disableUser = async function disableUser(userId) {
   }
 };
 
-exports.getLastSmsCode = async function getLastSmsCode(specificPhone) {
+async function getLastSmsCode(specificPhone) {
   let lastSmsCode = null;
   try {
     // console.log('auth::e2e:helpers:getLastSmsCode - start');
@@ -123,9 +124,10 @@ exports.getLastSmsCode = async function getLastSmsCode(specificPhone) {
   }
   // console.log('getLastSmsCode returning code: ' + lastSmsCode);
   return lastSmsCode;
-};
+}
+exports.getLastSmsCode = getLastSmsCode;
 
-exports.getLastOob = async function getLastOob(specificEmail) {
+async function getLastOob(specificEmail) {
   let lastOob = null;
   try {
     // console.log('auth::e2e:helpers:getLastOob - start');
@@ -162,7 +164,8 @@ exports.getLastOob = async function getLastOob(specificEmail) {
   }
   // console.log('getLastOob returning code: ' + JSON.stringify(lastOob, null, 2);
   return lastOob;
-};
+}
+exports.getLastOob = getLastOob;
 
 exports.resetPassword = async function resetPassword(oobCode, newPassword) {
   const resetPasswordUrl =
@@ -175,7 +178,7 @@ exports.resetPassword = async function resetPassword(oobCode, newPassword) {
   return await callRestApi(resetPasswordUrl);
 };
 
-exports.verifyEmail = async function verifyEmail(oobCode) {
+async function verifyEmail(oobCode) {
   const verifyEmailUrl =
     'http://' +
     getE2eEmulatorHost() +
@@ -183,9 +186,69 @@ exports.verifyEmail = async function verifyEmail(oobCode) {
     oobCode +
     '&apiKey=fake-api-key';
   return await callRestApi(verifyEmailUrl);
-};
+}
+exports.verifyEmail = verifyEmail;
 
 // This URL comes from the Auth Emulator's oobCode blocks
 exports.signInUser = async function signInUser(oobUrl) {
   return await callRestApi(oobUrl, true);
+};
+
+async function createVerifiedUser(email, password) {
+  await firebase.auth().createUserWithEmailAndPassword(email, password);
+  await firebase.auth().currentUser.sendEmailVerification();
+  const { oobCode } = await getLastOob(email);
+  await verifyEmail(oobCode);
+  await firebase.auth().currentUser.reload();
+}
+exports.createVerifiedUser = createVerifiedUser;
+
+/**
+ * Create a new user with a second factor enrolled. Returns phoneNumber, email and password
+ * for testing purposes. The session used to enroll the factor is terminated. You'll have to
+ * sign in using `firebase.auth().signInWithEmailAndPassword()`.
+ */
+exports.createUserWithMultiFactor = async function createUserWithMultiFactor() {
+  const email = 'verified@example.com';
+  const password = 'test123';
+  await createVerifiedUser(email, password);
+  const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+  const session = await multiFactorUser.getSession();
+  const phoneNumber = getRandomPhoneNumber();
+  const verificationId = await firebase
+    .auth()
+    .verifyPhoneNumberForMultiFactor({ phoneNumber, session });
+  const verificationCode = await getLastSmsCode(phoneNumber);
+  const cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+  const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+  await multiFactorUser.enroll(multiFactorAssertion, 'Hint displayName');
+  await firebase.auth().signOut();
+
+  return Promise.resolve({
+    phoneNumber,
+    email,
+    password,
+  });
+};
+
+exports.signInUserWithMultiFactor = async function signInUserWithMultiFactor(
+  email,
+  password,
+  phoneNumber,
+) {
+  try {
+    await firebase.auth().signInWithEmailAndPassword(email, password);
+  } catch (e) {
+    e.message.should.equal(
+      '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
+    );
+    const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+    let verificationId = await firebase
+      .auth()
+      .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
+    let verificationCode = await getLastSmsCode(phoneNumber);
+    const credential = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+    let multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
+    return resolver.resolveSignIn(multiFactorAssertion);
+  }
 };

--- a/packages/auth/e2e/multiFactor.e2e.js
+++ b/packages/auth/e2e/multiFactor.e2e.js
@@ -447,5 +447,23 @@ describe('multi-factor', function () {
         new Error('Enrolling a second factor when using phone authentication is not supported.'),
       );
     });
+    it('can not enroll when phone number is missing + sign', async function () {
+      await createVerifiedUser('verified@example.com', 'test123');
+      const multiFactorUser = firebase.auth.multiFactor(firebase.auth());
+      const session = await multiFactorUser.getSession();
+      try {
+        await firebase.auth().verifyPhoneNumberForMultiFactor({ phoneNumber: '491575', session });
+      } catch (e) {
+        e.code.should.equal('auth/invalid-phone-number');
+        e.message.should.equal(
+          '[auth/invalid-phone-number] The format of the phone number provided is incorrect. Please enter the ' +
+            'phone number in a format that can be parsed into E.164 format. E.164 ' +
+            'phone numbers are written in the format [+][country code][subscriber ' +
+            'number including area code].',
+        );
+        return Promise.resolve();
+      }
+      return Promise.reject();
+    });
   });
 });

--- a/packages/auth/e2e/multiFactor.e2e.js
+++ b/packages/auth/e2e/multiFactor.e2e.js
@@ -1,0 +1,405 @@
+const {
+  clearAllUsers,
+  getLastSmsCode,
+  createUserWithMultiFactor,
+  createVerifiedUser,
+  getRandomPhoneNumber,
+  signInUserWithMultiFactor,
+} = require('./helpers');
+
+const TEST_EMAIL = 'test@example.com';
+const TEST_PASS = 'test1234';
+
+describe('multi-factor', function () {
+  beforeEach(async function () {
+    await clearAllUsers();
+    await firebase.auth().createUserWithEmailAndPassword(TEST_EMAIL, TEST_PASS);
+    if (firebase.auth().currentUser) {
+      await firebase.auth().signOut();
+      await Utils.sleep(50);
+    }
+  });
+  it('has no multi-factor information if not enrolled', async function () {
+    await firebase.auth().signInWithEmailAndPassword(TEST_EMAIL, TEST_PASS);
+    const { multiFactor } = firebase.auth().currentUser;
+    multiFactor.should.be.an.Object();
+    multiFactor.enrolledFactors.should.be.an.Array();
+    multiFactor.enrolledFactors.length.should.equal(0);
+    return Promise.resolve();
+  });
+
+  describe('sign-in', function () {
+    it('requires multi-factor auth when enrolled', async function () {
+      const { phoneNumber, email, password } = await createUserWithMultiFactor();
+
+      try {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+      } catch (e) {
+        e.message.should.equal(
+          '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
+        );
+        const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        resolver.should.be.an.Object();
+        resolver.hints.should.be.an.Array();
+        resolver.hints.length.should.equal(1);
+        resolver.session.should.be.a.String();
+
+        const verificationId = await firebase
+          .auth()
+          .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
+        verificationId.should.be.a.String();
+
+        const verificationCode = await getLastSmsCode(phoneNumber);
+        const credential = firebase.auth.PhoneAuthProvider.credential(
+          verificationId,
+          verificationCode,
+        );
+        const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
+        return resolver
+          .resolveSignIn(multiFactorAssertion)
+          .then(userCreds => {
+            userCreds.should.be.an.Object();
+            userCreds.user.should.be.an.Object();
+            userCreds.user.email.should.equal('verified@example.com');
+            userCreds.user.multiFactor.should.be.an.Object();
+            userCreds.user.multiFactor.enrolledFactors.length.should.equal(1);
+            return Promise.resolve();
+          })
+          .catch(e => {
+            return Promise.reject(e);
+          });
+      }
+
+      return Promise.reject(new Error('Multi-factor users need to handle an exception on sign-in'));
+    });
+    it('reports an error when providing an invalid sms code', async function () {
+      const { phoneNumber, email, password } = await createUserWithMultiFactor();
+
+      try {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+      } catch (e) {
+        e.message.should.equal(
+          '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
+        );
+        const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        const verificationId = await firebase
+          .auth()
+          .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
+
+        const credential = firebase.auth.PhoneAuthProvider.credential(verificationId, 'incorrect');
+        const assertion = firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
+        try {
+          await resolver.resolveSignIn(assertion);
+        } catch (e) {
+          e.message.should.equal(
+            '[auth/invalid-verification-code] The sms verification code used to create the phone auth credential is invalid. Please resend the verification code sms and be sure use the verification code provided by the user.',
+          );
+
+          const verificationId = await firebase
+            .auth()
+            .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
+          const verificationCode = await getLastSmsCode(phoneNumber);
+          const credential = firebase.auth.PhoneAuthProvider.credential(
+            verificationId,
+            verificationCode,
+          );
+          const assertion = firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
+          await resolver.resolveSignIn(assertion);
+          firebase.auth().currentUser.email.should.equal(email);
+          return Promise.resolve();
+        }
+      }
+      return Promise.reject();
+    });
+    it('reports an error when providing an invalid verification code', async function () {
+      const { phoneNumber, email, password } = await createUserWithMultiFactor();
+
+      try {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+      } catch (e) {
+        e.message.should.equal(
+          '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
+        );
+        const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        await firebase
+          .auth()
+          .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
+        const verificationCode = await getLastSmsCode(phoneNumber);
+
+        const credential = firebase.auth.PhoneAuthProvider.credential(
+          'incorrect',
+          verificationCode,
+        );
+        const assertion = firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
+        try {
+          await resolver.resolveSignIn(assertion);
+        } catch (e) {
+          e.message.should.equal(
+            '[auth/invalid-verification-id] The verification ID used to create the phone auth credential is invalid.',
+          );
+
+          return Promise.resolve();
+        }
+      }
+      return Promise.reject();
+    });
+  });
+
+  describe('enroll', function () {
+    it("can't enroll an existing user without verified email", async function () {
+      await firebase.auth().signInWithEmailAndPassword(TEST_EMAIL, TEST_PASS);
+
+      try {
+        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+        const session = await multiFactorUser.getSession();
+        await firebase
+          .auth()
+          .verifyPhoneNumberForMultiFactor({ phoneNumber: getRandomPhoneNumber(), session });
+      } catch (e) {
+        e.message.should.equal('[auth/unverified-email] This operation requires a verified email.');
+        e.code.should.equal('auth/unverified-email');
+        return Promise.resolve();
+      }
+
+      return Promise.reject(new Error('Should throw error for unverified user.'));
+    });
+
+    it('can enroll new factor', async function () {
+      try {
+        await createVerifiedUser('verified@example.com', 'test123');
+        const phoneNumber = getRandomPhoneNumber();
+
+        should.deepEqual(firebase.auth().currentUser.multiFactor.enrolledFactors, []);
+        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+
+        const session = await multiFactorUser.getSession();
+
+        const verificationId = await firebase
+          .auth()
+          .verifyPhoneNumberForMultiFactor({ phoneNumber, session });
+        const verificationCode = await getLastSmsCode(phoneNumber);
+        const cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+        const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+        await multiFactorUser.enroll(multiFactorAssertion, 'Hint displayName');
+
+        const enrolledFactors = firebase.auth().currentUser.multiFactor.enrolledFactors;
+        enrolledFactors.length.should.equal(1);
+        enrolledFactors[0].displayName.should.equal('Hint displayName');
+        enrolledFactors[0].factorId.should.equal('phone');
+        enrolledFactors[0].uid.should.be.a.String();
+        enrolledFactors[0].enrollmentTime.should.be.a.String();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+      return Promise.resolve();
+    });
+    it('can enroll new factor without display name', async function () {
+      try {
+        await createVerifiedUser('verified@example.com', 'test123');
+        const phoneNumber = getRandomPhoneNumber();
+
+        should.deepEqual(firebase.auth().currentUser.multiFactor.enrolledFactors, []);
+        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+
+        const session = await multiFactorUser.getSession();
+
+        const verificationId = await firebase
+          .auth()
+          .verifyPhoneNumberForMultiFactor({ phoneNumber, session });
+        const verificationCode = await getLastSmsCode(phoneNumber);
+        const cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+        const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+        await multiFactorUser.enroll(multiFactorAssertion);
+
+        const enrolledFactors = firebase.auth().currentUser.multiFactor.enrolledFactors;
+        enrolledFactors.length.should.equal(1);
+        should.equal(enrolledFactors[0].displayName, null);
+      } catch (e) {
+        return Promise.reject(e);
+      }
+      return Promise.resolve();
+    });
+    it('can enroll multiple factors', async function () {
+      const { email, password, phoneNumber } = await createUserWithMultiFactor();
+      await signInUserWithMultiFactor(email, password, phoneNumber);
+
+      const anotherNumber = getRandomPhoneNumber();
+      const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+
+      const session = await multiFactorUser.getSession();
+      const verificationId = await firebase
+        .auth()
+        .verifyPhoneNumberForMultiFactor({ phoneNumber: anotherNumber, session });
+      const verificationCode = await getLastSmsCode(anotherNumber);
+      const cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+      const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+      const displayName = 'Another displayName';
+      await multiFactorUser.enroll(multiFactorAssertion, displayName);
+
+      const enrolledFactors = firebase.auth().currentUser.multiFactor.enrolledFactors;
+      enrolledFactors.length.should.equal(2);
+      const matchingFactor = enrolledFactors.find(factor => factor.displayName === displayName);
+      matchingFactor.should.be.an.Object();
+      matchingFactor.uid.should.be.a.String();
+      matchingFactor.enrollmentTime.should.be.a.String();
+      matchingFactor.factorId.should.equal('phone');
+
+      return Promise.resolve();
+    });
+    it('can not enroll the same factor twice', async function () {
+      // This test should probably be implemented but doesn't work:
+      // Every time the same phone number requests a verification code,
+      // the emulator endpoint does not return a code, even though the emulator log
+      // prints a code.
+      /*
+        await clearAllUsers();
+        const { email, password, phoneNumber } = await createUserWithMultiFactor();
+        await signInUserWithMultiFactor(email, password, phoneNumber);
+        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+        const session = await multiFactorUser.getSession();
+
+        const verificationId = await firebase
+          .auth()
+          .verifyPhoneNumberForMultiFactor({ phoneNumber, session });
+        const verificationCode = await getLastSmsCode(phoneNumber);
+
+        const cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+        const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+        const displayName = 'Another displayName';
+        try {
+          await multiFactorUser.enroll(multiFactorAssertion, displayName);
+        } catch (e) {
+          console.error(e);
+          return Promise.resolve();
+        }
+        return Promise.reject();
+        */
+    });
+
+    it('throws an error for wrong verification id', async function () {
+      const { phoneNumber, email, password } = await createUserWithMultiFactor();
+
+      // GIVEN a MultiFactorResolver
+      let resolver = null;
+      try {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+        return Promise.reject();
+      } catch (e) {
+        e.message.should.equal(
+          '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
+        );
+        resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+      }
+      await firebase
+        .auth()
+        .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
+
+      // AND I request a verification code
+      const verificationCode = await getLastSmsCode(phoneNumber);
+      // AND I use an incorrect verificationId
+      const credential = firebase.auth.PhoneAuthProvider.credential(
+        'wrongVerificationId',
+        verificationCode,
+      );
+      const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
+
+      try {
+        // WHEN I try to resolve the sign-in
+        await resolver.resolveSignIn(multiFactorAssertion);
+      } catch (e) {
+        // THEN an error message is thrown
+        e.message.should.equal(
+          '[auth/invalid-verification-id] The verification ID used to create the phone auth credential is invalid.',
+        );
+        return Promise.resolve();
+      }
+      return Promise.reject();
+    });
+    it('throws an error for unknown sessions', async function () {
+      const { email, password } = await createUserWithMultiFactor();
+      let resolver = null;
+      try {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+        return Promise.reject();
+      } catch (e) {
+        e.message.should.equal(
+          '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
+        );
+        resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+      }
+
+      try {
+        await firebase
+          .auth()
+          .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], 'unknown-session');
+      } catch (e) {
+        // THEN an error message is thrown
+        e.message.should.equal(
+          '[auth/invalid-multi-factor-session] No resolver for session found. Is the session id correct?',
+        );
+        return Promise.resolve();
+      }
+      return Promise.reject();
+    });
+    it('throws an error for unknown verification code', async function () {
+      const { email, password } = await createUserWithMultiFactor();
+
+      // GIVEN a MultiFactorResolver
+      let resolver = null;
+      try {
+        await firebase.auth().signInWithEmailAndPassword(email, password);
+        return Promise.reject();
+      } catch (e) {
+        e.message.should.equal(
+          '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
+        );
+        resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+      }
+      const verificationId = await firebase
+        .auth()
+        .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
+
+      // AND I use an incorrect verificationId
+      const credential = firebase.auth.PhoneAuthProvider.credential(
+        verificationId,
+        'wrong-verification-code',
+      );
+      const multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(credential);
+
+      try {
+        // WHEN I try to resolve the sign-in
+        await resolver.resolveSignIn(multiFactorAssertion);
+      } catch (e) {
+        // THEN an error message is thrown
+        e.message.should.equal(
+          '[auth/invalid-verification-code] The sms verification code used to create the phone auth credential is invalid. Please resend the verification code sms and be sure use the verification code provided by the user.',
+        );
+        return Promise.resolve();
+      }
+      return Promise.reject();
+    });
+
+    it('can not enroll with phone authentication (unsupported primary factor)', async function () {
+      // GIVEN a user that only signs in with phone
+      const testPhone = getRandomPhoneNumber();
+      const confirmResult = await firebase.auth().signInWithPhoneNumber(testPhone);
+      const lastSmsCode = await getLastSmsCode(testPhone);
+      await confirmResult.confirm(lastSmsCode);
+
+      // WHEN they attempt to enroll a second factor
+      const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+      const session = await multiFactorUser.getSession();
+      try {
+        await firebase.auth().verifyPhoneNumberForMultiFactor({ phoneNumber: '+1123123', session });
+      } catch (e) {
+        e.message.should.equal(
+          '[auth/unsupported-first-factor] Enrolling a second factor or signing in with a multi-factor account requires sign-in with a supported first factor.',
+        );
+        return Promise.resolve();
+      }
+      return Promise.reject(
+        new Error('Enrolling a second factor when using phone authentication is not supported.'),
+      );
+    });
+  });
+});

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
@@ -82,4 +82,5 @@ NSString* const AuthErrorCode_toJSErrorCode[] = {
     [FIRAuthErrorCodeNullUser] = @"null-user",
     [FIRAuthErrorCodeKeychainError] = @"keychain-error",
     [FIRAuthErrorCodeInternalError] = @"internal-error",
-    [FIRAuthErrorCodeMalformedJWT] = @"malformed-jwt"};
+    [FIRAuthErrorCodeMalformedJWT] = @"malformed-jwt",
+    [FIRAuthErrorCodeSecondFactorRequired] = @"multi-factor-auth-required"};

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -756,8 +756,17 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
   }
   FIRMultiFactorSession *session = cachedResolver[sessionKey].session;
   NSPredicate *findByUid = [NSPredicate predicateWithFormat:@"UID == %@", hintUid];
-  FIRPhoneMultiFactorInfo *hint =
+  FIRMultiFactorInfo *_Nullable hint =
       [[cachedResolver[sessionKey].hints filteredArrayUsingPredicate:findByUid] firstObject];
+  if (hint == nil) {
+    [RNFBSharedUtils rejectPromiseWithUserInfo:reject
+                                      userInfo:(NSMutableDictionary *)@{
+                                        @"code" : @"multi-factor-info-not-found",
+                                        @"message" : @"The user does not have a second factor "
+                                                     @"matching the identifier provided."
+                                      }];
+    return;
+  }
 
   [FIRPhoneAuthProvider.provider
       verifyPhoneNumberWithMultiFactorInfo:hint
@@ -772,6 +781,7 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
                                   }
                                 }];
 }
+
 RCT_EXPORT_METHOD(verifyPhoneNumberForMultiFactor
                   : (FIRApp *)firebaseApp
                   : (NSString *)phoneNumber

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1156,7 +1156,7 @@ RCT_EXPORT_METHOD(useEmulator
   };
 }
 
-- (NSString *)getJSFactorId:(NSString *)factorId {
+- (NSString *)getJSFactorId:(NSString *)factorId {
   if ([factorId isEqualToString:@"1"]) {
     // Only phone is supported by the front-end so far
     return @"phone";
@@ -1247,6 +1247,12 @@ RCT_EXPORT_METHOD(useEmulator
       break;
     case FIRAuthErrorCodeInternalError:
       message = @"An internal error has occurred, please try again.";
+      break;
+    case FIRAuthErrorCodeInvalidPhoneNumber:
+      message = @"The format of the phone number provided is incorrect. "
+                @"Please enter the phone number in a format that can be parsed into E.164 format. "
+                @"E.164 phone numbers are written in the format [+][country code][subscriber "
+                @"number including area code].";
       break;
     default:
       break;

--- a/packages/auth/lib/MultiFactorResolver.js
+++ b/packages/auth/lib/MultiFactorResolver.js
@@ -1,0 +1,15 @@
+/**
+ * Base class to facilitate multi-factor authentication.
+ */
+export default class MultiFactorResolver {
+  constructor(auth, resolver) {
+    this._auth = auth;
+    this.hints = resolver.hints;
+    this.session = resolver.session;
+  }
+
+  resolveSignIn(assertion) {
+    const { token, secret } = assertion;
+    return this._auth.resolveMultiFactorSignIn(this.session, token, secret);
+  }
+}

--- a/packages/auth/lib/PhoneMultiFactorGenerator.js
+++ b/packages/auth/lib/PhoneMultiFactorGenerator.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export default class PhoneMultiFactorGenerator {
+  static FACTOR_ID = 'phone';
+
+  constructor() {
+    throw new Error(
+      '`new PhoneMultiFactorGenerator()` is not supported on the native Firebase SDKs.',
+    );
+  }
+
+  static assertion(credential) {
+    // There is no logic here, we mainly do this for API compatibility
+    // (following the Web API).
+    const { token, secret } = credential;
+    return { token, secret };
+  }
+}

--- a/packages/auth/lib/User.js
+++ b/packages/auth/lib/User.js
@@ -48,6 +48,10 @@ export default class User {
     };
   }
 
+  get multiFactor() {
+    return this._user.multiFactor || null;
+  }
+
   get phoneNumber() {
     return this._user.phoneNumber || null;
   }

--- a/packages/auth/lib/getMultiFactorResolver.js
+++ b/packages/auth/lib/getMultiFactorResolver.js
@@ -1,0 +1,19 @@
+import MultiFactorResolver from './MultiFactorResolver.js';
+
+/**
+ * Create a new resolver based on an auth instance and error
+ * object.
+ *
+ * Returns null if no resolver object can be found on the error.
+ */
+export function getMultiFactorResolver(auth, error) {
+  if (
+    error.hasOwnProperty('userInfo') &&
+    error.userInfo.hasOwnProperty('resolver') &&
+    error.userInfo.resolver
+  ) {
+    return new MultiFactorResolver(auth, error.userInfo.resolver);
+  }
+
+  return null;
+}

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -210,23 +210,6 @@ export namespace FirebaseAuthTypes {
    * firebase.auth.X
    */
   export interface Statics {
-    /**
-     * Try and obtain a #{@link MultiFactorResolver} instance based on an error.
-     * Returns null if no resolver object could be found.
-     *
-     * #### Example
-     *
-     * ```js
-     * const auth = firebase.auth();
-     * auth.signInWithEmailAndPassword(email, password).then((user) => {
-     *   // signed in
-     * }).catch((error) => {
-     *   if (error.code === 'auth/multi-factor-auth-required') {
-     *     const resolver = getMultiFactorResolver(auth, error);
-     *   }
-     * });
-     * ```
-     */
     getMultiFactorResolver: getMultiFactorResolver;
     /**
      * Email and password auth provider implementation.
@@ -458,6 +441,23 @@ export namespace FirebaseAuthTypes {
     resolveSignIn(assertion: MultiFactorAssertion): Promise<UserCredential>;
   }
 
+  /**
+   * Try and obtain a #{@link MultiFactorResolver} instance based on an error.
+   * Returns null if no resolver object could be found.
+   *
+   * #### Example
+   *
+   * ```js
+   * const auth = firebase.auth();
+   * auth.signInWithEmailAndPassword(email, password).then((user) => {
+   *   // signed in
+   * }).catch((error) => {
+   *   if (error.code === 'auth/multi-factor-auth-required') {
+   *     const resolver = getMultiFactorResolver(auth, error);
+   *   }
+   * });
+   * ```
+   */
   export type getMultiFactorResolver = (
     auth: FirebaseAuthTypes.Module,
     error: unknown,

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -464,6 +464,32 @@ export namespace FirebaseAuthTypes {
   ) => MultiFactorResolver | null;
 
   /**
+   * The entry point for most multi-factor operations.
+   */
+  export interface MultiFactorUser {
+    /**
+     * Returns the user's enrolled factors.
+     */
+    enrolledFactors: MultiFactorInfo[];
+
+    /**
+     * Return the session id for this user.
+     */
+    getSession(): Promise<string>;
+
+    /**
+     * Enroll an additional factor. Provide an optional display name that can be shown to the user.
+     * The method will ensure the user state is reloaded after successfully enrolling a factor.
+     */
+    enroll(assertion: MultiFactorAssertion, displayName?: string): Promise<void>;
+  }
+
+  /**
+   * Return the #{@link MultiFactorUser} instance for the current user.
+   */
+  export type multiFactor = (auth: FirebaseAuthTypes.Module) => Promise<MultiFactorUser>;
+
+  /**
    * Holds information about the user's enrolled factors.
    *
    * #### Example

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -42,6 +42,7 @@ import Settings from './Settings';
 import User from './User';
 import version from './version';
 import { getMultiFactorResolver } from './getMultiFactorResolver';
+import { multiFactor } from './multiFactor';
 
 const statics = {
   AppleAuthProvider,
@@ -60,6 +61,7 @@ const statics = {
     ERROR: 'error',
   },
   getMultiFactorResolver,
+  multiFactor,
 };
 
 const namespace = 'auth';
@@ -256,6 +258,11 @@ class FirebaseAuthModule extends FirebaseModule {
 
   verifyPhoneNumberWithMultiFactorInfo(multiFactorHint, session) {
     return this.native.verifyPhoneNumberWithMultiFactorInfo(multiFactorHint.uid, session);
+  }
+
+  verifyPhoneNumberForMultiFactor(phoneInfoOptions) {
+    const { phoneNumber, session } = phoneInfoOptions;
+    return this.native.verifyPhoneNumberForMultiFactor(phoneNumber, session);
   }
 
   resolveMultiFactorSignIn(session, verificationId, verificationCode) {

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -35,11 +35,13 @@ import GithubAuthProvider from './providers/GithubAuthProvider';
 import GoogleAuthProvider from './providers/GoogleAuthProvider';
 import OAuthProvider from './providers/OAuthProvider';
 import PhoneAuthProvider from './providers/PhoneAuthProvider';
+import PhoneMultiFactorGenerator from './PhoneMultiFactorGenerator';
 import TwitterAuthProvider from './providers/TwitterAuthProvider';
 import AppleAuthProvider from './providers/AppleAuthProvider';
 import Settings from './Settings';
 import User from './User';
 import version from './version';
+import { getMultiFactorResolver } from './getMultiFactorResolver';
 
 const statics = {
   AppleAuthProvider,
@@ -49,6 +51,7 @@ const statics = {
   GithubAuthProvider,
   TwitterAuthProvider,
   FacebookAuthProvider,
+  PhoneMultiFactorGenerator,
   OAuthProvider,
   PhoneAuthState: {
     CODE_SENT: 'sent',
@@ -56,6 +59,7 @@ const statics = {
     AUTO_VERIFIED: 'verified',
     ERROR: 'error',
   },
+  getMultiFactorResolver,
 };
 
 const namespace = 'auth';
@@ -248,6 +252,18 @@ class FirebaseAuthModule extends FirebaseModule {
     }
 
     return new PhoneAuthListener(this, phoneNumber, _autoVerifyTimeout, _forceResend);
+  }
+
+  verifyPhoneNumberWithMultiFactorInfo(multiFactorHint, session) {
+    return this.native.verifyPhoneNumberWithMultiFactorInfo(multiFactorHint.uid, session);
+  }
+
+  resolveMultiFactorSignIn(session, verificationId, verificationCode) {
+    return this.native
+      .resolveMultiFactorSignIn(session, verificationId, verificationCode)
+      .then(userCredential => {
+        return this._setUserCredential(userCredential);
+      });
   }
 
   createUserWithEmailAndPassword(email, password) {

--- a/packages/auth/lib/multiFactor.js
+++ b/packages/auth/lib/multiFactor.js
@@ -1,0 +1,35 @@
+/**
+ * Return a MultiFactorUser instance the gateway to multi-factor operations.
+ */
+export function multiFactor(auth) {
+  return new MultiFactorUser(auth);
+}
+
+export class MultiFactorUser {
+  constructor(auth) {
+    this._auth = auth;
+    this._user = auth.currentUser;
+    this.enrolledFactor = auth.currentUser.multiFactor.enrolledFactors;
+  }
+
+  getSession() {
+    return this._auth.native.getSession();
+  }
+
+  /**
+   * Finalize the enrollment process for the given multi-factor assertion.
+   * Optionally set a displayName. This method will reload the current user
+   * profile, which is necessary to see the multi-factor changes.
+   */
+  async enroll(multiFactorAssertion, displayName) {
+    const { token, secret } = multiFactorAssertion;
+    await this._auth.native.finalizeMultiFactorEnrollment(token, secret, displayName);
+
+    // We need to reload the user otherwise the changes are not visible
+    return this._auth.currentUser.reload();
+  }
+
+  unenroll() {
+    return Promise.reject(new Error('No implemented yet.'));
+  }
+}


### PR DESCRIPTION
### Description

At Kyan Health we are using `react-native-firebase` for our mobile apps. We plan to roll out multi-factor authentication to our users soon. After implementing the necessary code on the web (using the original Firebase libraries) we were missing multi-factor support for the apps.

I'm aware that there are a few small todos left in the code. Nonetheless I'd appreciate some early feedback from the maintainers to see how we can get the PR merged. :)

#### Open questions on our side:
* I'm not sure if I'm supposed to add a license header to new files. Let me know and I'm happy to copy the existing header into the newly created files.
*  I'm running into a lot of trouble with testing the iOS part against the Firebase emulator. I marked these tests with `:android:`. I have the feeling that this is not properly implemented on Firebase' side. Testing against a real life Firebase project doesn't run into issues with missing multi-factor authentication. I also find it strange the the Firebase emulator prints a different SMS code message for iOS devices (masks the phone number). Any thought or hints how to solve this problem? 😇 

### Related issues

I'm aware of:

* #4166 Adding multi-factor information to the user object IMHO makes only sense if sign-in is supported, otherwise I believe it is not possible to obtain a valid session and the multi-factor information.
* #5372 Does provide multi-factor enrolment and sign-in flow. I believe our PR follows the official API closer (https://cloud.google.com/identity-platform/docs/web/mfa), but implements only sign-in and skips the some of the error message conversion.

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

* e2e tests run
* I could verify the multi-factor enrollment and sign-in with a real world Firebase project (iOS)
🔥 