### PR TITLE
docs(auth, social): Play Store APIs required for google sign in

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -301,4 +301,4 @@ async function onGoogleButtonPress() {
 Upon successful sign-in, any [`onAuthStateChanged`](/auth/usage#listening-to-authentication-state) listeners will trigger
 with the new authentication state of the user.
 
-If you are testing this feature on an android emulator ensure that the emulate has Google Play Enabled, Installed and Updated.
+If you are testing this feature on an android emulator ensure that the emulate is either the Google APIs or Google Play flavor.

--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -285,6 +285,8 @@ import auth from '@react-native-firebase/auth';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
 
 async function onGoogleButtonPress() {
+  // Check if your device supports Google Play
+  await GoogleSignin.hasPlayServices({ showPlayServicesUpdateDialog: true });
   // Get the users ID token
   const { idToken } = await GoogleSignin.signIn();
 
@@ -298,3 +300,5 @@ async function onGoogleButtonPress() {
 
 Upon successful sign-in, any [`onAuthStateChanged`](/auth/usage#listening-to-authentication-state) listeners will trigger
 with the new authentication state of the user.
+
+If you are testing this feature on an android emulator ensure that the emulate has Google Play Enabled, Installed and Updated.


### PR DESCRIPTION
### Description
For google authentication Google Play store is required to be installed and updated to prevents errors like [Error: A non-recoverable sign in failure occurred]

On emulator this error are common **[Error: A non-recoverable sign in failure occurred]**  and this can be caused by the emulator not supporting Google Play Service. 
To Resolve this ensure the emulator supports Google Play Service and is updated 

### Related issues

Bug  **[Error: A non-recoverable sign in failure occurred]** 

### Release Summary

Google Pay Service is required by react-native-google-signin library

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ X] Yes
- My change supports the following platforms;
  - [ X] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
