### PR TITLE
fix(emulator): protect against double useEmulator calls natively

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -75,6 +75,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   private static final String TAG = "Auth";
   private static HashMap<String, FirebaseAuth.AuthStateListener> mAuthListeners = new HashMap<>();
   private static HashMap<String, FirebaseAuth.IdTokenListener> mIdTokenListeners = new HashMap<>();
+  private static HashMap<String, String> emulatorConfigs = new HashMap<>();
   private String mVerificationId;
   private String mLastPhoneNumber;
   private PhoneAuthProvider.ForceResendingToken mForceResendingToken;
@@ -1561,10 +1562,13 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
 
   @ReactMethod
   public void useEmulator(String appName, String host, int port) {
-    Log.d(TAG, "useEmulator");
-    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
-    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
-    firebaseAuth.useEmulator(host, port);
+
+    if (emulatorConfigs.get(appName) == null) {
+      emulatorConfigs.put(appName, "true");
+      FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+      FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+      firebaseAuth.useEmulator(host, port);
+    }
   }
 
   /* ------------------

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -50,6 +50,7 @@ static NSString *const PHONE_AUTH_STATE_CHANGED_EVENT = @"phone_auth_state_chang
 
 static __strong NSMutableDictionary *authStateHandlers;
 static __strong NSMutableDictionary *idTokenHandlers;
+static __strong NSMutableDictionary *emulatorConfigs;
 // Used for caching credentials between method calls.
 static __strong NSMutableDictionary<NSString *, FIRAuthCredential *> *credentials;
 
@@ -69,6 +70,7 @@ RCT_EXPORT_MODULE();
   dispatch_once(&onceToken, ^{
     authStateHandlers = [[NSMutableDictionary alloc] init];
     idTokenHandlers = [[NSMutableDictionary alloc] init];
+    emulatorConfigs = [[NSMutableDictionary alloc] init];
     credentials = [[NSMutableDictionary alloc] init];
   });
   return self;
@@ -940,7 +942,10 @@ RCT_EXPORT_METHOD(useEmulator
                   : (FIRApp *)firebaseApp
                   : (nonnull NSString *)host
                   : (NSInteger)port) {
-  [[FIRAuth authWithApp:firebaseApp] useEmulatorWithHost:host port:port];
+  if (!emulatorConfigs[firebaseApp.name]) {
+    [[FIRAuth authWithApp:firebaseApp] useEmulatorWithHost:host port:port];
+    emulatorConfigs[firebaseApp.name] = @YES;
+  }
 }
 
 - (FIRAuthCredential *)getCredentialForProvider:(NSString *)provider

--- a/packages/database/android/src/main/java/io/invertase/firebase/database/UniversalFirebaseDatabaseCommon.java
+++ b/packages/database/android/src/main/java/io/invertase/firebase/database/UniversalFirebaseDatabaseCommon.java
@@ -46,9 +46,14 @@ public class UniversalFirebaseDatabaseCommon {
     setDatabaseConfig(firebaseDatabase, appName, dbURL);
 
     HashMap emulatorConfig = getEmulatorConfig(appName, dbURL);
-    if (emulatorConfig != null) {
+
+    if (emulatorConfig != null && emulatorConfig.get("configured") == null) {
       firebaseDatabase.useEmulator(
           (String) emulatorConfig.get("host"), (Integer) emulatorConfig.get("port"));
+      // The underlying SDK may only be configured once, but with hot-reloads in the
+      // javascript bundle, javascript cannot hold SDK configuration state. Keep track here
+      // so we only configure once
+      emulatorConfig.put("configured", "true");
     }
 
     return firebaseDatabase;

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
@@ -28,10 +28,13 @@ import com.google.firebase.firestore.LoadBundleTask;
 import io.invertase.firebase.common.UniversalFirebaseModule;
 import io.invertase.firebase.common.UniversalFirebasePreferences;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
 public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
+
+  private static HashMap<String, String> emulatorConfigs = new HashMap<>();
 
   UniversalFirebaseFirestoreModule(Context context, String serviceName) {
     super(context, serviceName);
@@ -49,7 +52,10 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
     return Tasks.call(
         getExecutor(),
         () -> {
-          getFirestoreForApp(appName).useEmulator(host, port);
+          if (emulatorConfigs.get(appName) == null) {
+            emulatorConfigs.put(appName, "true");
+            getFirestoreForApp(appName).useEmulator(host, port);
+          }
           return null;
         });
   }

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -20,6 +20,8 @@
 #import "RNFBFirestoreCommon.h"
 #import "RNFBPreferences.h"
 
+NSMutableDictionary *emulatorConfigs;
+
 @implementation RNFBFirestoreModule
 #pragma mark -
 #pragma mark Module Setup
@@ -142,13 +144,19 @@ RCT_EXPORT_METHOD(useEmulator
                   : (FIRApp *)firebaseApp
                   : (nonnull NSString *)host
                   : (NSInteger)port) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
-  [firestore useEmulatorWithHost:host port:port];
+  if (emulatorConfigs == nil) {
+    emulatorConfigs = [[NSMutableDictionary alloc] init];
+  }
+  if (!emulatorConfigs[firebaseApp.name]) {
+    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+    [firestore useEmulatorWithHost:host port:port];
+    emulatorConfigs[firebaseApp.name] = @YES;
 
-  // It is not sufficient to just use emulator. You have toggle SSL off too.
-  FIRFirestoreSettings *settings = firestore.settings;
-  settings.sslEnabled = FALSE;
-  firestore.settings = settings;
+    // It is not sufficient to just use emulator. You have toggle SSL off too.
+    FIRFirestoreSettings *settings = firestore.settings;
+    settings.sslEnabled = FALSE;
+    firestore.settings = settings;
+  }
 }
 
 RCT_EXPORT_METHOD(waitForPendingWrites

--- a/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
+++ b/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
@@ -44,6 +44,8 @@ import java.util.Objects;
 public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule {
   private static final String TAG = "Storage";
 
+  private static HashMap<String, String> emulatorConfigs = new HashMap<>();
+
   ReactNativeFirebaseStorageModule(ReactApplicationContext reactContext) {
     super(reactContext, TAG);
   }
@@ -282,7 +284,10 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
   public void useEmulator(String appName, String host, int port, Promise promise) {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
     FirebaseStorage firebaseStorage = FirebaseStorage.getInstance(firebaseApp);
-    firebaseStorage.useEmulator(host, port);
+    if (emulatorConfigs.get(appName) == null) {
+      firebaseStorage.useEmulator(host, port);
+      emulatorConfigs.put(appName, "true");
+    }
     promise.resolve(null);
   }
 

--- a/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
+++ b/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
@@ -54,7 +54,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     super.onCatalystInstanceDestroy();
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#delete */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#delete
+   */
   @ReactMethod
   public void delete(String appName, String url, final Promise promise) {
     try {
@@ -97,7 +99,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     }
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#getMetadata */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#getMetadata
+   */
   @ReactMethod
   public void getMetadata(String appName, String url, Promise promise) {
     try {
@@ -118,7 +122,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     }
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#list */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#list
+   */
   @ReactMethod
   public void list(String appName, String url, ReadableMap listOptions, Promise promise) {
     try {
@@ -148,7 +154,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     }
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#listAll */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#listAll
+   */
   @ReactMethod
   public void listAll(String appName, String url, Promise promise) {
     try {
@@ -267,7 +275,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     promise.resolve(null);
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Storage#useEmulator */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Storage#useEmulator
+   */
   @ReactMethod
   public void useEmulator(String appName, String host, int port, Promise promise) {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
@@ -276,7 +286,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     promise.resolve(null);
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#writeToFile */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#writeToFile
+   */
   @ReactMethod
   public void writeToFile(
       String appName, String url, String localFilePath, int taskId, Promise promise) {
@@ -300,7 +312,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     }
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#putString */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#putString
+   */
   @ReactMethod
   public void putString(
       String appName,
@@ -321,7 +335,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
     }
   }
 
-  /** @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#putFile */
+  /**
+   * @link https://firebase.google.com/docs/reference/js/firebase.storage.Reference#putFile
+   */
   @ReactMethod
   public void putFile(
       String appName,

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1159,74 +1159,74 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNFBAnalytics (15.7.0):
+  - RNFBAnalytics (16.0.0):
     - Firebase/Analytics (= 10.0.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (15.7.0):
+  - RNFBApp (16.0.0):
     - Firebase/CoreOnly (= 10.0.0)
     - React-Core
-  - RNFBAppCheck (15.7.0):
+  - RNFBAppCheck (16.0.0):
     - Firebase/AppCheck (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (15.7.0):
+  - RNFBAppDistribution (16.0.0):
     - Firebase/AppDistribution (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (15.7.0):
+  - RNFBAuth (16.0.0):
     - Firebase/Auth (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (15.7.0):
+  - RNFBCrashlytics (16.0.0):
     - Firebase/Crashlytics (= 10.0.0)
     - FirebaseCoreExtension (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (15.7.0):
+  - RNFBDatabase (16.0.0):
     - Firebase/Database (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (15.7.0):
+  - RNFBDynamicLinks (16.0.0):
     - Firebase/DynamicLinks (= 10.0.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (15.7.0):
+  - RNFBFirestore (16.0.0):
     - Firebase/Firestore (= 10.0.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (15.7.0):
+  - RNFBFunctions (16.0.0):
     - Firebase/Functions (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (15.7.0):
+  - RNFBInAppMessaging (16.0.0):
     - Firebase/InAppMessaging (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (15.7.0):
+  - RNFBInstallations (16.0.0):
     - Firebase/Installations (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (15.7.0):
+  - RNFBMessaging (16.0.0):
     - Firebase/Messaging (= 10.0.0)
     - FirebaseCoreExtension (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBML (15.7.0):
+  - RNFBML (16.0.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (15.7.0):
+  - RNFBPerf (16.0.0):
     - Firebase/Performance (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (15.7.0):
+  - RNFBRemoteConfig (16.0.0):
     - Firebase/RemoteConfig (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (15.7.0):
+  - RNFBStorage (16.0.0):
     - Firebase/Storage (= 10.0.0)
     - React-Core
     - RNFBApp
@@ -1492,23 +1492,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNFBAnalytics: 4d1a1f221f4f3871ffb13c2eac79395861463610
-  RNFBApp: 426300c2e2bceede9dcd6c098fd87e44b7aa2fe8
-  RNFBAppCheck: 788541ec473c8ce0bccbb9f357182136c7692734
-  RNFBAppDistribution: 9875cb4aec9bdf8a45c94b437001f7be0ac582ef
-  RNFBAuth: 768248b3edfcbf10a131f3ecd35a36778d35fdab
-  RNFBCrashlytics: 9d8e2b9d8b0c2191593205815fa8a64730b7625b
-  RNFBDatabase: 3d6a3760f8062c64e305fd6fa887d86ae971af35
-  RNFBDynamicLinks: 40eb939f7c40ac214924fae46c1263672a3782ca
-  RNFBFirestore: c3df8f2c56e3ab8cf94746e68ed6718e37acf97c
-  RNFBFunctions: 47a06930f9eb6c414ef25305359da7df6a3324f7
-  RNFBInAppMessaging: 2377020c6e6905cf0e548bd3758dcc46db0d075d
-  RNFBInstallations: 9641bd5a0a2ffd677d8b379c1080b5dce489bc34
-  RNFBMessaging: ec5eca4c4d4932d88cb4823e363024017b33fbe5
-  RNFBML: 5333c575857f268e9dae8aabe1ac0a59624ea9b8
-  RNFBPerf: 68d0a1fc3a81cb42dd44d54299cc501102e1572c
-  RNFBRemoteConfig: 776642fae97bb8e875f6e286628919417d9eee93
-  RNFBStorage: 87974e0a7343c4e334bc3b4dc96095d75939dc35
+  RNFBAnalytics: 539275de64045c52092fb0d457027ce1d3b6b8f2
+  RNFBApp: f4864aead5f908ef7b5af68f4cd226dc9b9dbd1f
+  RNFBAppCheck: d77d3f68c9bb8e63143187345f37bb41027e71ea
+  RNFBAppDistribution: 68076fbe5fa68203183987950a44339aa1f091f4
+  RNFBAuth: 03c23f6d63bab53f0820ca8924744f002d6aa3a8
+  RNFBCrashlytics: 4a7ca69509960fcc9fe27170407c6d2f259b0751
+  RNFBDatabase: ddbfff5a6122a79bfd3bb611e1ee59253bf4b147
+  RNFBDynamicLinks: 2af5c8daf6e7a01879d432b00ecee675d191212e
+  RNFBFirestore: 1ce854fe1b770f77652ef986c39df6e166398b67
+  RNFBFunctions: a1a93baacfef7ba829d3b00f7edb20d3f57f9b72
+  RNFBInAppMessaging: 6b9a1f0d7b34f1d4355018c525bba05f0e9112c9
+  RNFBInstallations: 9f8fd4d44856138ab5fe184ba076a589e57b6f17
+  RNFBMessaging: 6ae9b05dfd6d078389bf28006297695d079ec74d
+  RNFBML: f58b150c93f83062748083a15a5ccb28c68b35d2
+  RNFBPerf: 13189b5831081b79b940ff1629b5d8e9398a4489
+  RNFBRemoteConfig: 1bfadb3c008572a6f98bfcc851caac267ba28f24
+  RNFBStorage: 263359ebcd0b12287871b07c6bae782258d8bd8f
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: cdac7095831bb39f8d76539f83a3580addb30d8b


### PR DESCRIPTION
### Description

Most of the useEmulator calls (except functions?) are "call once only" with the native SDKs throwing errors or otherwise being upset by second calls

However, javascript bundles hot-reload so they cannot determine if they have already called useEmulator or not 

### Related issues

Noted in the specific commits targeted
Fixes #5860
Fixes #5650
Fixes #5723

### Release Summary

a bunch of `fix` conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
