### PR TITLE
fix(app, android): use firebase-android-sdk 31.0.1

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -215,7 +215,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "31.0.0"
+        bom           : "31.0.1"
       ],
     ],
   ])

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
       "minSdk": 19,
       "targetSdk": 33,
       "compileSdk": 33,
-      "firebase": "31.0.0",
+      "firebase": "31.0.1",
       "firebaseCrashlyticsGradle": "2.9.2",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.14",

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1159,74 +1159,74 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNFBAnalytics (16.0.0):
+  - RNFBAnalytics (16.1.0):
     - Firebase/Analytics (= 10.0.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (16.0.0):
+  - RNFBApp (16.1.0):
     - Firebase/CoreOnly (= 10.0.0)
     - React-Core
-  - RNFBAppCheck (16.0.0):
+  - RNFBAppCheck (16.1.0):
     - Firebase/AppCheck (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (16.0.0):
+  - RNFBAppDistribution (16.1.0):
     - Firebase/AppDistribution (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (16.0.0):
+  - RNFBAuth (16.1.0):
     - Firebase/Auth (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (16.0.0):
+  - RNFBCrashlytics (16.1.0):
     - Firebase/Crashlytics (= 10.0.0)
     - FirebaseCoreExtension (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (16.0.0):
+  - RNFBDatabase (16.1.0):
     - Firebase/Database (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (16.0.0):
+  - RNFBDynamicLinks (16.1.0):
     - Firebase/DynamicLinks (= 10.0.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (16.0.0):
+  - RNFBFirestore (16.1.0):
     - Firebase/Firestore (= 10.0.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (16.0.0):
+  - RNFBFunctions (16.1.0):
     - Firebase/Functions (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (16.0.0):
+  - RNFBInAppMessaging (16.1.0):
     - Firebase/InAppMessaging (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (16.0.0):
+  - RNFBInstallations (16.1.0):
     - Firebase/Installations (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (16.0.0):
+  - RNFBMessaging (16.1.0):
     - Firebase/Messaging (= 10.0.0)
     - FirebaseCoreExtension (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBML (16.0.0):
+  - RNFBML (16.1.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (16.0.0):
+  - RNFBPerf (16.1.0):
     - Firebase/Performance (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (16.0.0):
+  - RNFBRemoteConfig (16.1.0):
     - Firebase/RemoteConfig (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (16.0.0):
+  - RNFBStorage (16.1.0):
     - Firebase/Storage (= 10.0.0)
     - React-Core
     - RNFBApp
@@ -1492,23 +1492,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNFBAnalytics: 539275de64045c52092fb0d457027ce1d3b6b8f2
-  RNFBApp: f4864aead5f908ef7b5af68f4cd226dc9b9dbd1f
-  RNFBAppCheck: d77d3f68c9bb8e63143187345f37bb41027e71ea
-  RNFBAppDistribution: 68076fbe5fa68203183987950a44339aa1f091f4
-  RNFBAuth: 03c23f6d63bab53f0820ca8924744f002d6aa3a8
-  RNFBCrashlytics: 4a7ca69509960fcc9fe27170407c6d2f259b0751
-  RNFBDatabase: ddbfff5a6122a79bfd3bb611e1ee59253bf4b147
-  RNFBDynamicLinks: 2af5c8daf6e7a01879d432b00ecee675d191212e
-  RNFBFirestore: 1ce854fe1b770f77652ef986c39df6e166398b67
-  RNFBFunctions: a1a93baacfef7ba829d3b00f7edb20d3f57f9b72
-  RNFBInAppMessaging: 6b9a1f0d7b34f1d4355018c525bba05f0e9112c9
-  RNFBInstallations: 9f8fd4d44856138ab5fe184ba076a589e57b6f17
-  RNFBMessaging: 6ae9b05dfd6d078389bf28006297695d079ec74d
-  RNFBML: f58b150c93f83062748083a15a5ccb28c68b35d2
-  RNFBPerf: 13189b5831081b79b940ff1629b5d8e9398a4489
-  RNFBRemoteConfig: 1bfadb3c008572a6f98bfcc851caac267ba28f24
-  RNFBStorage: 263359ebcd0b12287871b07c6bae782258d8bd8f
+  RNFBAnalytics: 1fe9514fb60c67c03b8e97e4a6bd5dcff0593c4b
+  RNFBApp: 77c14486c6fa0681e9e8582f994e974a9a0cbc0c
+  RNFBAppCheck: 2e737b121b6e6ee1f18ade03034f3c2ed5c93dcd
+  RNFBAppDistribution: 18992fbc2234cd8acef1cad73fe155d74ed6055a
+  RNFBAuth: 89b90fe658267adedc2281b0196825a2b3b8d873
+  RNFBCrashlytics: a2b1540d4dd9f9caeb2ecf79e44cc325653b240e
+  RNFBDatabase: c3014512d4fa0300197376e38b3eb96ea0e67545
+  RNFBDynamicLinks: e44dca20821694c6fca9174a94704f09eb75c73c
+  RNFBFirestore: 345b56f96176c1f6e0720547bcccb3b5a7f71167
+  RNFBFunctions: 331b1c77a6a2e1bc0a732fbf8270be452dd215c3
+  RNFBInAppMessaging: c8e050f9d178882de9e8d637d6d36536e87a7a33
+  RNFBInstallations: 5150331e9e8ba6babcda5cd0ca81f4af7b447f2b
+  RNFBMessaging: d810999b1144b936f8953dd339a4815e4266e5ca
+  RNFBML: b8dfb9e50e983b9dcc2153d1e53577e6d2969ed3
+  RNFBPerf: 4bd02aec54212d7868b1244da62bbaa2a76645f9
+  RNFBRemoteConfig: ce6a77d368127bf14f71b6b63a4629846d7be0f5
+  RNFBStorage: cac6842f7644bfadda8447f62620723b2b813be5
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: cdac7095831bb39f8d76539f83a3580addb30d8b


### PR DESCRIPTION
### Description

Fix the crashlytics upstream crash bug by including new patch release

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
