### PR TITLE
feat(functions): implement getCallableFromUrl(url) 

### DIFF
--- a/packages/functions/android/src/main/java/io/invertase/firebase/functions/UniversalFirebaseFunctionsModule.java
+++ b/packages/functions/android/src/main/java/io/invertase/firebase/functions/UniversalFirebaseFunctionsModule.java
@@ -25,6 +25,7 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.functions.FirebaseFunctions;
 import com.google.firebase.functions.HttpsCallableReference;
 import io.invertase.firebase.common.UniversalFirebaseModule;
+import java.net.URL;
 import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("WeakerAccess")
@@ -53,6 +54,35 @@ public class UniversalFirebaseFunctionsModule extends UniversalFirebaseModule {
           FirebaseFunctions functionsInstance = FirebaseFunctions.getInstance(firebaseApp, region);
 
           HttpsCallableReference httpReference = functionsInstance.getHttpsCallable(name);
+
+          if (options.hasKey("timeout")) {
+            httpReference.setTimeout((long) options.getInt("timeout"), TimeUnit.SECONDS);
+          }
+
+          if (host != null) {
+            functionsInstance.useEmulator(host, port);
+          }
+
+          return Tasks.await(httpReference.call(data)).getData();
+        });
+  }
+
+  Task<Object> httpsCallableFromUrl(
+      String appName,
+      String region,
+      String host,
+      Integer port,
+      String url,
+      Object data,
+      ReadableMap options) {
+    return Tasks.call(
+        getExecutor(),
+        () -> {
+          FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+          FirebaseFunctions functionsInstance = FirebaseFunctions.getInstance(firebaseApp, region);
+          URL parsedUrl = new URL(url);
+          HttpsCallableReference httpReference =
+              functionsInstance.getHttpsCallableFromUrl(parsedUrl);
 
           if (options.hasKey("timeout")) {
             httpReference.setTimeout((long) options.getInt("timeout"), TimeUnit.SECONDS);

--- a/packages/functions/e2e/functions.e2e.js
+++ b/packages/functions/e2e/functions.e2e.js
@@ -100,6 +100,22 @@ describe('functions()', function () {
     });
   });
 
+  describe('httpsCallableFromUrl()', function () {
+    it('Calls a function by URL', async function () {
+      let hostname = 'localhost';
+      if (device.getPlatform() === 'android') {
+        hostname = '10.0.2.2';
+      }
+      const functionRunner = firebase
+        .functions()
+        .httpsCallableFromUrl(
+          `http://${hostname}:5001/react-native-firebase-testing/us-central1/helloWorld`,
+        );
+      const response = await functionRunner();
+      response.data.should.equal('Hello from Firebase!');
+    });
+  });
+
   describe('httpsCallable(fnName)(args)', function () {
     it('accepts primitive args: undefined', async function () {
       const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegion');

--- a/packages/functions/lib/index.d.ts
+++ b/packages/functions/lib/index.d.ts
@@ -339,6 +339,29 @@ export namespace FirebaseFunctionsTypes {
     httpsCallable(name: string, options?: HttpsCallableOptions): HttpsCallable;
 
     /**
+     * Gets an `HttpsCallable` instance that refers to the function with the given
+     * URL.
+     *
+     * #### Example
+     *
+     * ```js
+     * const instance = firebase.functions().httpsCallable('order');
+     *
+     * try {
+     *  const response = await instance({
+     *    id: '12345',
+     *  });
+     * } catch (e) {
+     *  console.error(e);
+     * }
+     * ```
+     *
+     * @param name The name of the https callable function.
+     * @return The `HttpsCallable` instance.
+     */
+    httpsCallableFromUrl(url: string, options?: HttpsCallableOptions): HttpsCallable;
+
+    /**
      * Changes this instance to point to a Cloud Functions emulator running locally.
      *
      * See https://firebase.google.com/docs/functions/local-emulator

--- a/packages/functions/lib/index.js
+++ b/packages/functions/lib/index.js
@@ -93,6 +93,39 @@ class FirebaseFunctionsModule extends FirebaseModule {
     };
   }
 
+  httpsCallableFromUrl(url, options = {}) {
+    if (options.timeout) {
+      if (isNumber(options.timeout)) {
+        options.timeout = options.timeout / 1000;
+      } else {
+        throw new Error('HttpsCallableOptions.timeout expected a Number in milliseconds');
+      }
+    }
+
+    return data => {
+      const nativePromise = this.native.httpsCallableFromUrl(
+        this._useFunctionsEmulatorHost,
+        this._useFunctionsEmulatorPort,
+        url,
+        {
+          data,
+        },
+        options,
+      );
+      return nativePromise.catch(nativeError => {
+        const { code, message, details } = nativeError.userInfo || {};
+        return Promise.reject(
+          new HttpsError(
+            HttpsErrorCode[code] || HttpsErrorCode.UNKNOWN,
+            message || nativeError.message,
+            details || null,
+            nativeError,
+          ),
+        );
+      });
+    };
+  }
+
   useFunctionsEmulator(origin) {
     [_, host, port] = /https?\:.*\/\/([^:]+):?(\d+)?/.exec(origin);
     if (!port) {

--- a/tests/app.js
+++ b/tests/app.js
@@ -46,7 +46,7 @@ firebase.database().useEmulator('localhost', 9000);
 firebase.auth().useEmulator('http://localhost:9099');
 firebase.firestore().useEmulator('localhost', 8080);
 firebase.storage().useEmulator('localhost', 9199);
-firebase.functions().useFunctionsEmulator('http://localhost:5001');
+firebase.functions().useEmulator('localhost', 5001);
 
 // Firestore caches docuuments locally (a great feature!) and that confounds tests
 // as data from previous runs pollutes following runs until re-install the app. Clear it.

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1159,74 +1159,74 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNFBAnalytics (16.1.0):
+  - RNFBAnalytics (16.1.1):
     - Firebase/Analytics (= 10.0.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (16.1.0):
+  - RNFBApp (16.1.1):
     - Firebase/CoreOnly (= 10.0.0)
     - React-Core
-  - RNFBAppCheck (16.1.0):
+  - RNFBAppCheck (16.1.1):
     - Firebase/AppCheck (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (16.1.0):
+  - RNFBAppDistribution (16.1.1):
     - Firebase/AppDistribution (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (16.1.0):
+  - RNFBAuth (16.1.1):
     - Firebase/Auth (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (16.1.0):
+  - RNFBCrashlytics (16.1.1):
     - Firebase/Crashlytics (= 10.0.0)
     - FirebaseCoreExtension (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (16.1.0):
+  - RNFBDatabase (16.1.1):
     - Firebase/Database (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (16.1.0):
+  - RNFBDynamicLinks (16.1.1):
     - Firebase/DynamicLinks (= 10.0.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (16.1.0):
+  - RNFBFirestore (16.1.1):
     - Firebase/Firestore (= 10.0.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (16.1.0):
+  - RNFBFunctions (16.1.1):
     - Firebase/Functions (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (16.1.0):
+  - RNFBInAppMessaging (16.1.1):
     - Firebase/InAppMessaging (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (16.1.0):
+  - RNFBInstallations (16.1.1):
     - Firebase/Installations (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (16.1.0):
+  - RNFBMessaging (16.1.1):
     - Firebase/Messaging (= 10.0.0)
     - FirebaseCoreExtension (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBML (16.1.0):
+  - RNFBML (16.1.1):
     - React-Core
     - RNFBApp
-  - RNFBPerf (16.1.0):
+  - RNFBPerf (16.1.1):
     - Firebase/Performance (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (16.1.0):
+  - RNFBRemoteConfig (16.1.1):
     - Firebase/RemoteConfig (= 10.0.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (16.1.0):
+  - RNFBStorage (16.1.1):
     - Firebase/Storage (= 10.0.0)
     - React-Core
     - RNFBApp
@@ -1492,23 +1492,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNFBAnalytics: 1fe9514fb60c67c03b8e97e4a6bd5dcff0593c4b
-  RNFBApp: 77c14486c6fa0681e9e8582f994e974a9a0cbc0c
-  RNFBAppCheck: 2e737b121b6e6ee1f18ade03034f3c2ed5c93dcd
-  RNFBAppDistribution: 18992fbc2234cd8acef1cad73fe155d74ed6055a
-  RNFBAuth: 89b90fe658267adedc2281b0196825a2b3b8d873
-  RNFBCrashlytics: a2b1540d4dd9f9caeb2ecf79e44cc325653b240e
-  RNFBDatabase: c3014512d4fa0300197376e38b3eb96ea0e67545
-  RNFBDynamicLinks: e44dca20821694c6fca9174a94704f09eb75c73c
-  RNFBFirestore: 345b56f96176c1f6e0720547bcccb3b5a7f71167
-  RNFBFunctions: 331b1c77a6a2e1bc0a732fbf8270be452dd215c3
-  RNFBInAppMessaging: c8e050f9d178882de9e8d637d6d36536e87a7a33
-  RNFBInstallations: 5150331e9e8ba6babcda5cd0ca81f4af7b447f2b
-  RNFBMessaging: d810999b1144b936f8953dd339a4815e4266e5ca
-  RNFBML: b8dfb9e50e983b9dcc2153d1e53577e6d2969ed3
-  RNFBPerf: 4bd02aec54212d7868b1244da62bbaa2a76645f9
-  RNFBRemoteConfig: ce6a77d368127bf14f71b6b63a4629846d7be0f5
-  RNFBStorage: cac6842f7644bfadda8447f62620723b2b813be5
+  RNFBAnalytics: 2d587e8723db994d3f2a09cbed1f93e97378302e
+  RNFBApp: ffbdeba57ae0b5556305c2496da19f601016219b
+  RNFBAppCheck: 975e7700151437dca30751a40139c2eff23b8a15
+  RNFBAppDistribution: 0ea904a402d4c3d2d864a80971d74611888fb659
+  RNFBAuth: 0db50ec4731130eeaed12216b8f08591466bd95b
+  RNFBCrashlytics: 7f27c13d95d1906dedc089c54bf91690ce5eb44f
+  RNFBDatabase: cee99b714c4888fe705917062c618ca70bf79834
+  RNFBDynamicLinks: 1f2b5a202102df2fe07c4a53203795d292bec623
+  RNFBFirestore: b6786d863735c1b0f2bb83b54cad3babd211a395
+  RNFBFunctions: d8485174b45010ca8638ae343e0a96effc976b8d
+  RNFBInAppMessaging: b893241cc4e105dd72d5c3537506f3810fc3c6f4
+  RNFBInstallations: 7f581fe0f7a5fc2238a43b7264d9af9318cb0c22
+  RNFBMessaging: 09959156082755c091ee3e917d47a6896645d570
+  RNFBML: 5c6d1fcd445e270958812180f826f18d0022a6bb
+  RNFBPerf: c8bda50ca3b8cf927b2347b25e7d2dca31a38c39
+  RNFBRemoteConfig: f776afc93e5a91e9e7a9b4fb6bbd738a1c912f23
+  RNFBStorage: 5558ce02958592bfeb60b7de5743b37a67b1de74
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: cdac7095831bb39f8d76539f83a3580addb30d8b


### PR DESCRIPTION
### Description

Implemented the new `getCallableFromUrl(url)` method (currently only in firebase-js-sdk@9 but the API is easy enough)

This is a requirement currently for those playing with v2 functions since they publish on non-standard URLs

### Related issues

Fixes #6622
Fixes #6543

### Release Summary

Conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Developed the feature using e2e rig as a testbed, so it's got built in tests

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
