### PR TITLE
feat(analytics): add getSessionId

### DIFF
--- a/packages/analytics/android/src/main/java/io/invertase/firebase/analytics/UniversalFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/main/java/io/invertase/firebase/analytics/UniversalFirebaseAnalyticsModule.java
@@ -60,6 +60,10 @@ public class UniversalFirebaseAnalyticsModule extends UniversalFirebaseModule {
     return FirebaseAnalytics.getInstance(getContext()).getAppInstanceId();
   }
 
+  Task<Long> getSessionId() {
+    return FirebaseAnalytics.getInstance(getContext()).getSessionId();
+  }
+
   Task<Void> setUserId(String id) {
     return Tasks.call(
         () -> {

--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -94,6 +94,21 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
+  public void getSessionId(Promise promise) {
+    module
+        .getSessionId()
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                Long result = task.getResult();
+                promise.resolve(result != null ? result.doubleValue() : null);
+              } else {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+              }
+            });
+  }
+
+  @ReactMethod
   public void setUserId(String id, Promise promise) {
     module
         .setUserId(id)

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -115,7 +115,7 @@ RCT_EXPORT_METHOD(setSessionTimeoutDuration
                   : (double)milliseconds resolver
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
-  // Do nothing - this only exists in android
+  [FIRAnalytics setSessionTimeoutInterval:milliseconds / 1000];
   return resolve([NSNull null]);
 }
 

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -125,6 +125,19 @@ RCT_EXPORT_METHOD(getAppInstanceId
   return resolve([FIRAnalytics appInstanceID]);
 }
 
+RCT_EXPORT_METHOD(getSessionId
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject) {
+  [FIRAnalytics sessionIDWithCompletion:^(int64_t sessionID, NSError *_Nullable error) {
+    if (error) {
+      DLog(@"Error getting session ID: %@", error);
+      return resolve([NSNull null]);
+    } else {
+      return resolve([NSNumber numberWithLongLong:sessionID]);
+    }
+  }];
+}
+
 RCT_EXPORT_METHOD(setDefaultEventParameters
                   : (NSDictionary *)params resolver
                   : (RCTPromiseResolveBlock)resolve rejecter

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -870,6 +870,20 @@ export namespace FirebaseAnalyticsTypes {
     getAppInstanceId(): Promise<string | null>;
 
     /**
+     * Retrieves the session id from the client.
+     * On iOS, Firebase SDK may return an error that is handled internally and may take many minutes to return a valid value. Check native debug logs for more details.
+     *
+     * #### Example
+     *
+     * ```js
+     * const sessionId = await firebase.analytics().getSessionId();
+     * ```
+     *
+     * @returns Returns the session id or null if session is expired, null on android if FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE has been set to FirebaseAnalytics.ConsentStatus.DENIED and null on iOS if ConsentType.analyticsStorage has been set to ConsentStatus.denied.
+     */
+    getSessionId(): Promise<number | null>;
+
+    /**
      * Gives a user a unique identification.
      *
      * #### Example

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -43,6 +43,7 @@ export {
   setAnalyticsCollectionEnabled,
   setSessionTimeoutDuration,
   getAppInstanceId,
+  getSessionId,
   setUserId,
   setUserProperty,
   setUserProperties,
@@ -194,6 +195,10 @@ class FirebaseAnalyticsModule extends FirebaseModule {
 
   getAppInstanceId() {
     return this.native.getAppInstanceId();
+  }
+
+  getSessionId() {
+    return this.native.getSessionId();
   }
 
   setUserId(id) {

--- a/packages/analytics/modular/index.js
+++ b/packages/analytics/modular/index.js
@@ -71,6 +71,16 @@ export function getAppInstanceId(analytics) {
   return analytics.getAppInstanceId();
 }
 /**
+ * Retrieves the session id from the client.
+ * On iOS, Firebase SDK may return an error that is handled internally and may take many minutes to return a valid value. Check native debug logs for more details.
+ *
+ * @param analytics Analytics instance.
+ * @returns Returns the session id or null if session is expired, null on android if FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE has been set to FirebaseAnalytics.ConsentStatus.DENIED and null on iOS if ConsentType.analyticsStorage has been set to ConsentStatus.denied.
+ */
+export function getSessionId(analytics) {
+  return analytics.getSessionId();
+}
+/**
  * Gives a user a unique identification.
  *
  * @param analytics Analytics instance.


### PR DESCRIPTION
### Description

Firerbase Analytics SDKs provide an getSessionId method, and getting this value can help app developers to do cross environment trackings (e.g. Posting events using Google's measurement protocol).

So I implemented a React Native binding for this method.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

analytics: implement getSessionId

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

I made an demo app to test on devices:

![Simulator Screen Shot - iPhone 14 - 2022-10-26 at 04 12 59](https://user-images.githubusercontent.com/14349/197931608-9ef3e904-8754-42ed-82d5-548611a7493f.png)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
