### PR TITLE
chore(dynamic-links): add build commands to package.json

### DIFF
--- a/packages/dynamic-links/package.json
+++ b/packages/dynamic-links/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "genversion --semi lib/version.js",
     "build:clean": "rimraf android/build && rimraf ios/build",
-    "prepare": "yarn run build"
+    "build:plugin": "rimraf plugin/build && tsc --build plugin",
+    "lint:plugin": "eslint plugin/src/*",
+    "prepare": "yarn run build && npm run build:plugin"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description
This pull request adds missing build commands from #6650 

### Related issues
#2660 
#4548
https://github.com/invertase/react-native-firebase/issues/4548#issuecomment-1252028059

### Release Summary
chore(dynamic-links): add build commands to package.json

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

To test, add the @react-native-firebase/dynamic-links plugin to the list of RNFB plugins, and verify the AppDelegate has been modified.  

Functionally, real world dynamic link matching is inherently hard to test due to the end-to-end nature of the app install process.  My best recommendation for testing here is
* generate a dynamic link that points to your app that is live on the App Store
* return to the Home Screen 
* install a dev version of your app which contains the fix 
* verify getInitialLink is called and contains your expected payload