### PR TITLE
fix(database, android): revert android database double-emulator protection

### DIFF
--- a/packages/database/android/src/main/java/io/invertase/firebase/database/UniversalFirebaseDatabaseCommon.java
+++ b/packages/database/android/src/main/java/io/invertase/firebase/database/UniversalFirebaseDatabaseCommon.java
@@ -47,13 +47,9 @@ public class UniversalFirebaseDatabaseCommon {
 
     HashMap emulatorConfig = getEmulatorConfig(appName, dbURL);
 
-    if (emulatorConfig != null && emulatorConfig.get("configured") == null) {
+    if (emulatorConfig != null) {
       firebaseDatabase.useEmulator(
           (String) emulatorConfig.get("host"), (Integer) emulatorConfig.get("port"));
-      // The underlying SDK may only be configured once, but with hot-reloads in the
-      // javascript bundle, javascript cannot hold SDK configuration state. Keep track here
-      // so we only configure once
-      emulatorConfig.put("configured", "true");
     }
 
     return firebaseDatabase;

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -39,19 +39,25 @@ buildscript {
   }
 }
 
-def REACT_NATIVE_VERSION = new File(['node', '--print',"JSON.parse(require('fs').readFileSync(require.resolve('react-native/package.json'), 'utf-8')).version"].execute(null, rootDir).text.trim())
-
 allprojects {
   println "${project.name} ${projectDir} ${rootDir}"
 
-
-  configurations.all {
-    resolutionStrategy {
-      force "com.facebook.react:react-native:" + REACT_NATIVE_VERSION
-    }
-  }
-
   repositories {
+    exclusiveContent {
+      // We get React Native's Android binaries exclusively through npm,
+      // from a local Maven repo inside node_modules/react-native/.
+      // (The use of exclusiveContent prevents looking elsewhere like Maven Central
+      // and potentially getting a wrong version.)
+      filter {
+        includeGroup "com.facebook.react"
+      }
+      forRepository {
+        maven {
+          url "$rootDir/../node_modules/react-native/android"
+        }
+      }
+    }
+
     maven {
       // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
       url("$rootDir/../node_modules/react-native/android")
@@ -64,13 +70,7 @@ allprojects {
     //   // Detox as an .aar file (we're going to use it as a compile dependency though, to patch it)
     //   url "$rootDir/../node_modules/detox/Detox-android"
     // }
-    mavenCentral {
-      // We don't want to fetch react-native from Maven Central as there are
-      // older versions over there.
-      content {
-        excludeGroup "com.facebook.react"
-      }
-    }
+    mavenCentral()
     google()
     maven { url 'https://www.jitpack.io' }
   }


### PR DESCRIPTION
### Description

2 commits -

1- move to current "best known solution" for telling gradle where to get react-native dep
2- Fixes #6665 by reverting android portion of double-emulator prevention for database, it caused a regression

---

Test plan:

1- android builds or it doesn't - it builds so this fix is good
2- user reporting #6665 verifies that the fix works when applied locally via patch-package

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
