### PR TITLE
fix(firestore, count): add countFromServer API, delegates to count

### DIFF
--- a/packages/firestore/e2e/Aggregate/count.e2e.js
+++ b/packages/firestore/e2e/Aggregate/count.e2e.js
@@ -48,6 +48,21 @@ describe('firestore().collection().count()', function () {
     const qs = await colRef.count().get();
     qs.data().count.should.eql(3);
   });
+  it('gets countFromServer of collection reference - unfiltered', async function () {
+    const colRef = firebase.firestore().collection(`${COLLECTION}/count/collection`);
+
+    const doc1 = colRef.doc('doc1');
+    const doc2 = colRef.doc('doc2');
+    const doc3 = colRef.doc('doc3');
+    await Promise.all([
+      doc1.set({ foo: 1, bar: { value: 1 } }),
+      doc2.set({ foo: 2, bar: { value: 2 } }),
+      doc3.set({ foo: 3, bar: { value: 3 } }),
+    ]);
+
+    const qs = await colRef.countFromServer().get();
+    qs.data().count.should.eql(3);
+  });
   it('gets correct count of collection reference - where equal', async function () {
     const colRef = firebase.firestore().collection(`${COLLECTION}/count/collection`);
 

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -140,6 +140,10 @@ export default class FirestoreQuery {
     );
   }
 
+  countFromServer() {
+    return this.count();
+  }
+
   endAt(docOrField, ...fields) {
     return new FirestoreQuery(
       this._firestore,

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -942,6 +942,11 @@ export namespace FirebaseFirestoreTypes {
     count(): AggregateQuery<{ count: AggregateField<number> }>;
 
     /**
+     * Same as count()
+     */
+    countFromServer(): AggregateQuery<{ count: AggregateField<number> }>;
+
+    /**
      * Creates and returns a new Query that ends at the provided document (inclusive). The end
      * position is relative to the order of the query. The document must contain all of the
      * fields provided in the orderBy of this query.


### PR DESCRIPTION
keeps us closer to JS API, Fixes #6654



### Test Plan

I added a test based on existing e2e count tests to make sure the API functions, it does

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
