### PR TITLE
fix(dynamic-links): expo config plugin conflict with main firebase app plugin

### DIFF
--- a/packages/dynamic-links/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/dynamic-links/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -41,9 +41,9 @@ static void InitializeFlipper(UIApplication *application) {
   InitializeFlipper(application);
 #endif
   
-// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
+// @generated begin @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
 [RNFBDynamicLinksAppDelegateInterceptor sharedInstance];
-// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions
+// @generated end @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
   id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
@@ -134,9 +134,9 @@ static void InitializeFlipper(UIApplication *application) {
   InitializeFlipper(application);
 #endif
   
-// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
+// @generated begin @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
 [RNFBDynamicLinksAppDelegateInterceptor sharedInstance];
-// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions
+// @generated end @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions
   RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
   rootView.backgroundColor = [UIColor whiteColor];
@@ -287,9 +287,9 @@ static void InitializeFlipper(UIApplication *application) {
   InitializeFlipper(application);
 #endif
   
-// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
+// @generated begin @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
 [RNFBDynamicLinksAppDelegateInterceptor sharedInstance];
-// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions
+// @generated end @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions
   self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];
   self.launchOptions = launchOptions;
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
@@ -386,9 +386,9 @@ exports[`Config Plugin iOS Tests works with AppDelegate.mm (RN 0.68+) 1`] = `
 {
   RCTAppSetupPrepareApp(application);
 
-// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
+// @generated begin @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-5b7813c3af090f886568429140e982730142dbe7
 [RNFBDynamicLinksAppDelegateInterceptor sharedInstance];
-// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions
+// @generated end @react-native-firebase/dynamic-links-didFinishLaunchingWithOptions
   RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
 
 #if RCT_NEW_ARCH_ENABLED

--- a/packages/dynamic-links/plugin/src/ios/appDelegate.ts
+++ b/packages/dynamic-links/plugin/src/ios/appDelegate.ts
@@ -42,7 +42,7 @@ export function modifyObjcAppDelegate(contents: string): string {
   // Add invocation
   try {
     return mergeContents({
-      tag: '@react-native-firebase/app-didFinishLaunchingWithOptions',
+      tag: '@react-native-firebase/dynamic-links-didFinishLaunchingWithOptions',
       src: contents,
       newSrc: methodInvocationBlock,
       anchor: methodInvocationLineMatcher,


### PR DESCRIPTION
### Description

The dynamic links workaround on iOS applying `[RNFBDynamicLinksAppDelegateInterceptor sharedInstance];` in `didFinishLaunchingWithOptions` is not properly injected when used along `@react-native-firebase/app` expo plugin because the header tag is the same.

### Related issues

Related to https://github.com/invertase/react-native-firebase/issues/4548#issuecomment-1252028059 as it allows to use with expo the given workaround mentioned by the doc

### Release Summary

fix dynamic-links expo plugin

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
