### PR TITLE
fix(auth, multifactor): put multiFactor and getMultiFactorResolver on auth()

### DIFF
--- a/docs/auth/multi-factor-auth.md
+++ b/docs/auth/multi-factor-auth.md
@@ -22,7 +22,7 @@ operations:
 
 ```js
 import auth from '@react-native-firebase/auth';
-const multiFactorUser = await auth.multiFactor(auth());
+const multiFactorUser = await auth().multiFactor(auth().currentUser);
 ```
 
 Request the session identifier and use the phone number obtained from the user
@@ -81,7 +81,7 @@ Using the error object you can obtain a
 continue the flow:
 
 ```js
-const resolver = auth.getMultiFactorResolver(auth(), error);
+const resolver = auth().getMultiFactorResolver(error);
 ```
 
 The resolver object has all the required information to prompt the user for a
@@ -143,7 +143,7 @@ authInstance
     const { code } = error;
     // Make sure to check if multi factor authentication is required
     if (code !== 'auth/multi-factor-auth-required') {
-      const resolver = auth.getMultiFactorResolver(authInstance, error);
+      const resolver = auth.getMultiFactorResolver(error);
 
       if (resolver.hints.length > 1) {
         // Use resolver.hints to display a list of second factors to the user

--- a/packages/auth/e2e/helpers.js
+++ b/packages/auth/e2e/helpers.js
@@ -212,7 +212,7 @@ exports.createUserWithMultiFactor = async function createUserWithMultiFactor() {
   const email = 'verified@example.com';
   const password = 'test123';
   await createVerifiedUser(email, password);
-  const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+  const multiFactorUser = await firebase.auth().multiFactor(firebase.auth().currentUser);
   const session = await multiFactorUser.getSession();
   const phoneNumber = getRandomPhoneNumber();
   const verificationId = await firebase
@@ -242,7 +242,7 @@ exports.signInUserWithMultiFactor = async function signInUserWithMultiFactor(
     e.message.should.equal(
       '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
     );
-    const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+    const resolver = firebase.auth().getMultiFactorResolver(e);
     let verificationId = await firebase
       .auth()
       .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);

--- a/packages/auth/e2e/multiFactor.e2e.js
+++ b/packages/auth/e2e/multiFactor.e2e.js
@@ -41,7 +41,7 @@ describe('multi-factor', function () {
         e.message.should.equal(
           '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
         );
-        const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        const resolver = firebase.auth().getMultiFactorResolver(e);
         resolver.should.be.an.Object();
         resolver.hints.should.be.an.Array();
         resolver.hints.length.should.equal(1);
@@ -93,7 +93,7 @@ describe('multi-factor', function () {
         e.message.should.equal(
           '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
         );
-        const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        const resolver = firebase.auth().getMultiFactorResolver(e);
         const verificationId = await firebase
           .auth()
           .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
@@ -137,7 +137,7 @@ describe('multi-factor', function () {
         e.message.should.equal(
           '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
         );
-        const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        const resolver = firebase.auth().getMultiFactorResolver(e);
         await firebase
           .auth()
           .verifyPhoneNumberWithMultiFactorInfo(resolver.hints[0], resolver.session);
@@ -169,7 +169,7 @@ describe('multi-factor', function () {
         e.message.should.equal(
           '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
         );
-        const resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        const resolver = firebase.auth().getMultiFactorResolver(e);
         const unknownFactor = {
           uid: 'notknown',
         };
@@ -199,7 +199,7 @@ describe('multi-factor', function () {
       await firebase.auth().signInWithEmailAndPassword(TEST_EMAIL, TEST_PASS);
 
       try {
-        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+        const multiFactorUser = await firebase.auth().multiFactor(firebase.auth().currentUser);
         const session = await multiFactorUser.getSession();
         await firebase
           .auth()
@@ -223,7 +223,7 @@ describe('multi-factor', function () {
         const phoneNumber = getRandomPhoneNumber();
 
         should.deepEqual(firebase.auth().currentUser.multiFactor.enrolledFactors, []);
-        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+        const multiFactorUser = await firebase.auth().multiFactor(firebase.auth().currentUser);
 
         const session = await multiFactorUser.getSession();
 
@@ -256,7 +256,7 @@ describe('multi-factor', function () {
         const phoneNumber = getRandomPhoneNumber();
 
         should.deepEqual(firebase.auth().currentUser.multiFactor.enrolledFactors, []);
-        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+        const multiFactorUser = await firebase.auth().multiFactor(firebase.auth().currentUser);
 
         const session = await multiFactorUser.getSession();
 
@@ -285,7 +285,7 @@ describe('multi-factor', function () {
       await signInUserWithMultiFactor(email, password, phoneNumber);
 
       const anotherNumber = getRandomPhoneNumber();
-      const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+      const multiFactorUser = await firebase.auth().multiFactor(firebase.auth().currentUser);
 
       const session = await multiFactorUser.getSession();
       const verificationId = await firebase
@@ -318,7 +318,7 @@ describe('multi-factor', function () {
         await clearAllUsers();
         const { email, password, phoneNumber } = await createUserWithMultiFactor();
         await signInUserWithMultiFactor(email, password, phoneNumber);
-        const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+        const multiFactorUser = await firebase.auth().multiFactor(firebase.auth().currentUser);
         const session = await multiFactorUser.getSession();
 
         const verificationId = await firebase
@@ -355,7 +355,7 @@ describe('multi-factor', function () {
         e.message.should.equal(
           '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
         );
-        resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        resolver = firebase.auth().getMultiFactorResolver(e);
       }
       await firebase
         .auth()
@@ -392,7 +392,7 @@ describe('multi-factor', function () {
         e.message.should.equal(
           '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
         );
-        resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        resolver = firebase.auth().getMultiFactorResolver(e);
       }
 
       try {
@@ -420,7 +420,7 @@ describe('multi-factor', function () {
         e.message.should.equal(
           '[auth/multi-factor-auth-required] Please complete a second factor challenge to finish signing into this account.',
         );
-        resolver = firebase.auth.getMultiFactorResolver(firebase.auth(), e);
+        resolver = firebase.auth().getMultiFactorResolver(e);
       }
       const verificationId = await firebase
         .auth()
@@ -461,7 +461,7 @@ describe('multi-factor', function () {
       await confirmResult.confirm(lastSmsCode);
 
       // WHEN they attempt to enroll a second factor
-      const multiFactorUser = await firebase.auth.multiFactor(firebase.auth());
+      const multiFactorUser = await firebase.auth().multiFactor(firebase.auth().currentUser);
       const session = await multiFactorUser.getSession();
       try {
         await firebase.auth().verifyPhoneNumberForMultiFactor({ phoneNumber: '+1123123', session });
@@ -477,7 +477,7 @@ describe('multi-factor', function () {
     });
     it('can not enroll when phone number is missing + sign', async function () {
       await createVerifiedUser('verified@example.com', 'test123');
-      const multiFactorUser = firebase.auth.multiFactor(firebase.auth());
+      const multiFactorUser = firebase.auth().multiFactor(firebase.auth().currentUser);
       const session = await multiFactorUser.getSession();
       try {
         await firebase.auth().verifyPhoneNumberForMultiFactor({ phoneNumber: '491575', session });

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1871,6 +1871,19 @@ export namespace FirebaseAuthTypes {
      * @param url: emulator URL, must have host and port (eg, 'http://localhost:9099')
      */
     useEmulator(url: string): void;
+    /**
+     * Provides a MultiFactorResolver suitable for completion of a multi-factor flow.
+     *
+     * @param error: The MultiFactorError raised during a sign-in, or reauthentication operation.
+     */
+    getMultiFactorResolver(error: MultiFactorError): MultiFactorResolver;
+    /**
+     * The MultiFactorUser corresponding to the user.
+     *
+     * This is used to access all multi-factor properties and operations related to the user.
+     * @param user The user.
+     */
+    multiFactor(user: User): MultiFactorUser;
   }
 }
 

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -42,7 +42,7 @@ import Settings from './Settings';
 import User from './User';
 import version from './version';
 import { getMultiFactorResolver } from './getMultiFactorResolver';
-import { multiFactor } from './multiFactor';
+import { multiFactor, MultiFactorUser } from './multiFactor';
 
 const statics = {
   AppleAuthProvider,
@@ -413,6 +413,17 @@ class FirebaseAuthModule extends FirebaseModule {
     const port = parseInt(urlMatches[2], 10);
     this.native.useEmulator(host, port);
     return [host, port]; // undocumented return, useful for unit testing
+  }
+
+  getMultiFactorResolver(error) {
+    return getMultiFactorResolver(this, error);
+  }
+
+  multiFactor(user) {
+    if (user.userId !== this.currentUser.userId) {
+      throw new Error('firebase.auth().multiFactor() only operates on currentUser');
+    }
+    return new MultiFactorUser(this, user);
   }
 }
 

--- a/packages/auth/lib/multiFactor.js
+++ b/packages/auth/lib/multiFactor.js
@@ -2,14 +2,19 @@
  * Return a MultiFactorUser instance the gateway to multi-factor operations.
  */
 export function multiFactor(auth) {
+  // eslint-disable-next-line no-console
+  console.warn('This method is deprecated. Please use auth().multiFactor(user) instead');
   return new MultiFactorUser(auth);
 }
 
 export class MultiFactorUser {
-  constructor(auth) {
+  constructor(auth, user) {
     this._auth = auth;
-    this._user = auth.currentUser;
-    this.enrolledFactor = auth.currentUser.multiFactor.enrolledFactors;
+    if (user === undefined) {
+      user = auth.currentUser;
+    }
+    this._user = user;
+    this.enrolledFactor = user.multiFactor.enrolledFactors;
   }
 
   getSession() {

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1159,74 +1159,74 @@ PODS:
     - React-jsi (= 0.67.3)
     - React-logger (= 0.67.3)
     - React-perflogger (= 0.67.3)
-  - RNFBAnalytics (16.3.1):
+  - RNFBAnalytics (16.4.3):
     - Firebase/Analytics (= 10.1.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (16.3.1):
+  - RNFBApp (16.4.3):
     - Firebase/CoreOnly (= 10.1.0)
     - React-Core
-  - RNFBAppCheck (16.3.1):
+  - RNFBAppCheck (16.4.3):
     - Firebase/AppCheck (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (16.3.1):
+  - RNFBAppDistribution (16.4.3):
     - Firebase/AppDistribution (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (16.3.1):
+  - RNFBAuth (16.4.3):
     - Firebase/Auth (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (16.3.1):
+  - RNFBCrashlytics (16.4.3):
     - Firebase/Crashlytics (= 10.1.0)
     - FirebaseCoreExtension (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (16.3.1):
+  - RNFBDatabase (16.4.3):
     - Firebase/Database (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (16.3.1):
+  - RNFBDynamicLinks (16.4.3):
     - Firebase/DynamicLinks (= 10.1.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (16.3.1):
+  - RNFBFirestore (16.4.3):
     - Firebase/Firestore (= 10.1.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (16.3.1):
+  - RNFBFunctions (16.4.3):
     - Firebase/Functions (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (16.3.1):
+  - RNFBInAppMessaging (16.4.3):
     - Firebase/InAppMessaging (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (16.3.1):
+  - RNFBInstallations (16.4.3):
     - Firebase/Installations (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (16.3.1):
+  - RNFBMessaging (16.4.3):
     - Firebase/Messaging (= 10.1.0)
     - FirebaseCoreExtension (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBML (16.3.1):
+  - RNFBML (16.4.3):
     - React-Core
     - RNFBApp
-  - RNFBPerf (16.3.1):
+  - RNFBPerf (16.4.3):
     - Firebase/Performance (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (16.3.1):
+  - RNFBRemoteConfig (16.4.3):
     - Firebase/RemoteConfig (= 10.1.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (16.3.1):
+  - RNFBStorage (16.4.3):
     - Firebase/Storage (= 10.1.0)
     - React-Core
     - RNFBApp
@@ -1492,23 +1492,23 @@ SPEC CHECKSUMS:
   React-RCTVibration: d0361f15ea978958fab7ffb6960f475b5063d83f
   React-runtimeexecutor: af1946623656f9c5fd64ca6f36f3863516193446
   ReactCommon: 650e33cde4fb7d36781cd3143f5276da0abb2f96
-  RNFBAnalytics: 81429fa6c0569a16e91b9487c9a6ba56891ff72e
-  RNFBApp: 2eea718168efc2cc8c5993e4c51e9866baf55a9a
-  RNFBAppCheck: b562fad8b9435f5f4684927192d137885f900c97
-  RNFBAppDistribution: 423e27bc2828173123223349d8f007644ec49241
-  RNFBAuth: 4e27174df8c594d50c488115502b758875d30526
-  RNFBCrashlytics: db0d61b451a4bde94112f787381dc8e8bf596564
-  RNFBDatabase: 0043c006603b3b7d410d6b7da2371e1fea959d74
-  RNFBDynamicLinks: 7d95f1f6ae2abacb1e21cdce1ec242ba9f8bcd9b
-  RNFBFirestore: 35da9fdec881979d4155a161fd06e03a090b1d50
-  RNFBFunctions: ffbbeb361f88f3d54c38ab0ba0aac635f3d63968
-  RNFBInAppMessaging: 9208fd27e8a8317e00bfe14e2e980595d6adf3da
-  RNFBInstallations: 02a06897fc9ddd5e46c82cd7f48d8aaaf9cbfece
-  RNFBMessaging: 76445c5866517441c093b69b8d226170b52d4998
-  RNFBML: d9df4674c937c6727c1192221d83407d28ae91dc
-  RNFBPerf: 0a123624fa773a9f409076835ea8fa4b93b5209a
-  RNFBRemoteConfig: 9c39b75591748abdb5e5402b1020069ad5d47975
-  RNFBStorage: 4f956068208db65fda654562fe626810efbd144b
+  RNFBAnalytics: 1dbd03940c32e4da616a0f135baa633ae8be976d
+  RNFBApp: e2157f61e4769b53641df8948c534580630cb50a
+  RNFBAppCheck: 727f9be6729606b211391eface962737af5745c5
+  RNFBAppDistribution: 0b7f55adbfd5e238ae96d900abedfd3e2d765e11
+  RNFBAuth: 7d2d8b68ef2dbeed0844532e9b65df09af627bf9
+  RNFBCrashlytics: e0869743b4f57b0353605363a0a41fbff2500594
+  RNFBDatabase: d2f84c61c5899f64039151eda934d3cd94e99c2b
+  RNFBDynamicLinks: 5dbccab1f947e2a8a4d1c523f7b390501bedfc7b
+  RNFBFirestore: 10e53da935827fee199db750dbc3c5129c50a620
+  RNFBFunctions: a8b26554e652453a6c9d5cb8e399c9e4d6896030
+  RNFBInAppMessaging: 2206b4dc0a38da9f8caf14556e27b4b49bc6b93b
+  RNFBInstallations: af375a09ca33f051e06a36a77c058f6ebaa23521
+  RNFBMessaging: 00da9a5a7136caa61a7b75d87e1dd83864251136
+  RNFBML: e5e3faa3873f5abe724e237ccace8e4f93b72d2f
+  RNFBPerf: 17ab696f1fd684979d69aafbae216b792a168b47
+  RNFBRemoteConfig: ba95ab9f0034dae20b588ce625902a6fd3898319
+  RNFBStorage: 8addb089a67f88833e34f8ef8dde13a0a64c0050
   Yoga: 90dcd029e45d8a7c1ff059e8b3c6612ff409061a
 
 PODFILE CHECKSUM: cdac7095831bb39f8d76539f83a3580addb30d8b


### PR DESCRIPTION
### Description

The original implementation of multifactor auth worked beautifully, but during review I should have noticed the methods were statics when they should have been off the auth() module

Granted, firebase-js-sdk does not support MFA in it's v8/chained API, however this lines the API up with the rest of the APIs on modules such that they will transform v9/modular API

This also fills in a missing type as noticed + requested in #6672

### Related issues

Fixes #6672

### Release Summary

THERE IS ONLY CONVENTIONAL COMMITS :laughing: 

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

Dropping the deprecated version will be a semver major later though


### Test Plan

I checked it incrementally while making changes by using the fabulous e2e tests provided by @fzuellich - trivial changes really, it worked every time as I altered API surface

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
