### PR TITLE
feat(firestore): make nested collection as generic

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -237,7 +237,9 @@ export namespace FirebaseFirestoreTypes {
      *
      * @param collectionPath A slash-separated path to a collection.
      */
-    collection(collectionPath: string): CollectionReference;
+    collection<T extends DocumentData = DocumentData>(
+      collectionPath: string,
+    ): CollectionReference<T>;
 
     /**
      * Deletes the document referred to by this DocumentReference.
@@ -2084,7 +2086,7 @@ export namespace FirebaseFirestoreTypes {
      *
      * #### Example
      *
-     * ```js
+     * ```jsc
      * const collectionGroup = firebase.firestore().collectionGroup('orders');
      * ```
      *


### PR DESCRIPTION
…nts.

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Currently, top level `collection` is generic so you can type its documents by `firestore().collection<User>()`.
However, nested collection that looks like `firestore().collection<User>().doc(userId).collection()` is not generic.
Then it gives its document data naive `DocumentData` type which helps developers little.
I made a very small change that changed nested `collection` into generic also, not only top level one.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
