### PR TITLE
docs(ios): note Xcode 13.3 / macOS 12 minimum requirement

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -102,6 +102,7 @@ launchProperties
 learnt
 Lerna
 lifecycle
+macOS
 MDX
 mlkit
 MLKit

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,8 @@ If you do not meet these prerequisites, follow the links below:
 - [React Native - Setting up the development environment](https://reactnative.dev/docs/environment-setup)
 - [Create a new Firebase project](https://console.firebase.google.com/)
 
+Additionally, current versions of firebase-ios-sdk have a minimum Xcode requirement of 13.3, which implies a minimum macOS version of 12 (macOS Monterey).
+
 ## Installation
 
 Installing React Native Firebase requires a few steps; installing the NPM module, adding the Firebase config files &


### PR DESCRIPTION
### Description

This has come up for a few people - that firebase-ios-sdk now requires Xcode 13.3+ / macOS 12+ - noting it in the pre-requisites just in case

### Related issues

Related #6490


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

It is a docs only change - I contemplated putting a test for Xcode version into our config shell script (or maybe in the podspec) but decided against it for complexity vs benefit reasons compared with a simple docs change

For future posterity, this appears to work on my machine though, and would just need some parsing and a comparison with the versions desired 

https://apple.stackexchange.com/a/384291/288316

```bash
# Xcode
if pkgutil --pkgs=com.apple.pkg.Xcode >/dev/null; then
    echo Xcode: $(pkgutil --pkg-info=com.apple.pkg.Xcode | awk '/version:/ {print $2}')
else
    echo Xcode: not installed
fi

# Command Line Tools for Xcode
if pkgutil --pkgs=com.apple.pkg.CLTools_Executables >/dev/null; then
    echo CommandLineTools: $(pkgutil --pkg-info=com.apple.pkg.CLTools_Executables | awk '/version:/ {print $2}')
else
    echo CommandLineTools: not installed
fi
```
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
