### PR TITLE
docs(crashlytics, android): fix link for NDK configuration

### DIFF
--- a/docs/crashlytics/usage/index.md
+++ b/docs/crashlytics/usage/index.md
@@ -212,9 +212,12 @@ Because you have stack traces readily available while you're debugging your app,
 
 ## Crashlytics NDK
 
-React Native Firebase supports [Crashlytics NDK](https://docs.fabric.io/android/crashlytics/ndk.html#using-gradle) reporting
-which is enabled by default. This allows Crashlytics to capture crashes originating from the Yoga layout engine used by
-React Native. You can disable Crashlytics NDK in your `firebase.json` config.
+React Native Firebase supports [Crashlytics NDK](https://firebase.google.com/docs/crashlytics/ndk-reports) reporting
+which is enabled by default but will require a change as described in that link to enable symbol upload.
+
+This allows Crashlytics to capture crashes originating from the Yoga layout engine used by React Native.
+
+You can disable Crashlytics NDK in your `firebase.json` config.
 
 ```json
 // <project-root>/firebase.json


### PR DESCRIPTION
### Description

The NDK link was old, updating it and noting that symbol upload will likely need more config as described in link

### Related issues

Related #6747 

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Just a docs change but I'll check the vercel pre-publish to make sure it is correct (and CI will lint the thing)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
