### PR TITLE
docs(messaging): Made corrections to notification color example.

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -474,7 +474,7 @@ Note that only predefined colors can be used in `firebase.json`. If you want to 
 ```xml
 <!-- <projectRoot>/android/app/src/main/res/values/colors.xml -->
 <resources>
-  <color name="my-custom-color">#123456</color>
+  <color name="my_custom_color">#123456</color>
 </resources>
 
 <!-- <projectRoot>/android/app/src/main/AndroidManifest.xml -->
@@ -486,7 +486,7 @@ Note that only predefined colors can be used in `firebase.json`. If you want to 
 
       <meta-data
             android:name="com.google.firebase.messaging.default_notification_color"
-            android:resource="@color/my-custom-color"
+            android:resource="@color/my_custom_color"
             tools:replace="android:resource" />
   </application>
 </manifest>


### PR DESCRIPTION
### Description
In the original notification color example the name provided `my-custom-color` will result in an error because '-' is not a valid resource name character. I have updated the example color name to use underscores `my_custom_color` to resolve this.

Error resulting from using an underscore:
`Resource and asset merger: '-' is not a valid resource name character`

### Release Summary

Made corrections to cloud messaging notification color documentation.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


:fire: