### PR TITLE
feat(messaging): Expose modular API that matches the Firebase web JS SDK v9 API

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -28,8 +28,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
-import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -240,18 +238,6 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
                 rejectPromiseWithExceptionMap(promise, task.getException());
               }
             });
-  }
-
-  @ReactMethod
-  public void isSupported(Promise promise) {
-    GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
-    int status = googleApiAvailability.isGooglePlayServicesAvailable(getReactApplicationContext());
-
-    if (status == ConnectionResult.SUCCESS) {
-      promise.resolve(true);
-    } else {
-      promise.resolve(false);
-    }
   }
 
   @Override

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -28,6 +28,8 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -238,6 +240,18 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
                 rejectPromiseWithExceptionMap(promise, task.getException());
               }
             });
+  }
+
+  @ReactMethod
+  public void isSupported(Promise promise) {
+    GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
+    int status = googleApiAvailability.isGooglePlayServicesAvailable(getReactApplicationContext());
+
+    if (status == ConnectionResult.SUCCESS) {
+      promise.resolve(true);
+    } else {
+      promise.resolve(false);
+    }
   }
 
   @Override

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -346,4 +346,12 @@ describe('messaging()', function () {
       should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
     });
   });
+
+  describe('isSupported()', function () {
+    it('should return "true" if the device or browser supports Firebase Messaging', async function () {
+      // For android, when the play services are available, it will return "true"
+      // iOS & web always return "true". Web can be fully implemented when the platform is supported
+      should.equal(await firebase.messaging().isSupported(), true);
+    });
+  });
 });

--- a/packages/messaging/e2e/messaging.modular.e2e.js
+++ b/packages/messaging/e2e/messaging.modular.e2e.js
@@ -347,6 +347,14 @@ describe('messaging() modular', function () {
         should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
       });
     });
+
+    describe('isSupported()', function () {
+      it('should return "true" if the device or browser supports Firebase Messaging', async function () {
+        // For android, when the play services are available, it will return "true"
+        // iOS & web always return "true". Web can be fully implemented when the platform is supported
+        should.equal(await firebase.messaging().isSupported(), true);
+      });
+    });
   });
 
   describe('modular', function () {
@@ -730,6 +738,15 @@ describe('messaging() modular', function () {
         // Set it back to the default value for future runs in re-use mode
         await setDeliveryMetricsExportToBigQuery(getMessaging(), false);
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
+      });
+
+      describe('isSupported()', function () {
+        const { isSupported, getMessaging } = messagingModular;
+        it('should return "true" if the device or browser supports Firebase Messaging', async function () {
+          // For android, when the play services are available, it will return "true"
+          // iOS & web always return "true". Web can be fully implemented when the platform is supported
+          should.equal(await isSupported(getMessaging()), true);
+        });
       });
     });
   });

--- a/packages/messaging/e2e/messaging.modular.e2e.js
+++ b/packages/messaging/e2e/messaging.modular.e2e.js
@@ -746,14 +746,16 @@ describe('messaging() modular', function () {
 
     describe('setDeliveryMetricsExportToBigQuery()', function () {
       afterEach(async function () {
-        const { getMessaging, setDeliveryMetricsExportToBigQuery } = messagingModular;
-        await setDeliveryMetricsExportToBigQuery(getMessaging(), false);
+        const { getMessaging, experimentalSetDeliveryMetricsExportedToBigQueryEnabled } =
+          messagingModular;
+        await experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), false);
       });
 
       it('throws if enabled is not a boolean', function () {
-        const { getMessaging, setDeliveryMetricsExportToBigQuery } = messagingModular;
+        const { getMessaging, experimentalSetDeliveryMetricsExportedToBigQueryEnabled } =
+          messagingModular;
         try {
-          setDeliveryMetricsExportToBigQuery(getMessaging(), 123);
+          experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), 123);
           return Promise.reject(new Error('Did not throw Error.'));
         } catch (e) {
           e.message.should.containEql("'enabled' expected a boolean value");

--- a/packages/messaging/e2e/messaging.modular.e2e.js
+++ b/packages/messaging/e2e/messaging.modular.e2e.js
@@ -450,7 +450,7 @@ describe('messaging() modular', function () {
         } = messagingModular;
 
         if (device.getPlatform() === 'ios') {
-          should.equal(is, true);
+          should.equal(isDeviceRegisteredForRemoteMessages(getMessaging()), true);
           await unregisterDeviceForRemoteMessages(getMessaging());
           should.equal(isDeviceRegisteredForRemoteMessages(getMessaging()), false);
         } else {

--- a/packages/messaging/e2e/messaging.modular.e2e.js
+++ b/packages/messaging/e2e/messaging.modular.e2e.js
@@ -1,0 +1,371 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+describe('messaging() modular', function () {
+  describe('firebase v8 compatibility', function () {
+    describe('namespace', function () {
+      it('accessible from firebase.app()', function () {
+        const app = firebase.app();
+        should.exist(app.messaging);
+        app.messaging().app.should.equal(app);
+      });
+    });
+
+    describe('setAutoInitEnabled()', function () {
+      // These depend on `tests/firebase.json` having `messaging_auto_init_enabled` set to false the first time
+      // The setting is persisted across restarts, reset to false after for local runs where prefs are sticky
+      afterEach(async function () {
+        await firebase.messaging().setAutoInitEnabled(false);
+      });
+
+      it('throws if enabled is not a boolean', function () {
+        try {
+          firebase.messaging().setAutoInitEnabled(123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'enabled' expected a boolean value");
+          return Promise.resolve();
+        }
+      });
+
+      it('sets the value', async function () {
+        should.equal(firebase.messaging().isAutoInitEnabled, false);
+        await firebase.messaging().setAutoInitEnabled(true);
+        should.equal(firebase.messaging().isAutoInitEnabled, true);
+
+        // Set it back to the default value for future runs in re-use mode
+        await firebase.messaging().setAutoInitEnabled(false);
+        should.equal(firebase.messaging().isAutoInitEnabled, false);
+      });
+    });
+
+    describe('isDeviceRegisteredForRemoteMessages', function () {
+      it('returns true on android', function () {
+        if (device.getPlatform() === 'android') {
+          should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, true);
+        } else {
+          this.skip();
+        }
+      });
+      it('defaults to false on ios before registering', async function () {
+        if (device.getPlatform() === 'ios') {
+          should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, false);
+          await firebase.messaging().registerDeviceForRemoteMessages();
+          should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, true);
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('unregisterDeviceForRemoteMessages', function () {
+      it('resolves on android, remains registered', async function () {
+        if (device.getPlatform() === 'android') {
+          await firebase.messaging().unregisterDeviceForRemoteMessages();
+          should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, true);
+        } else {
+          this.skip();
+        }
+      });
+      it('successfully unregisters on ios', async function () {
+        if (device.getPlatform() === 'ios') {
+          should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, true);
+          await firebase.messaging().unregisterDeviceForRemoteMessages();
+          should.equal(firebase.messaging().isDeviceRegisteredForRemoteMessages, false);
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('hasPermission', function () {
+      it('returns true android (default)', async function () {
+        if (device.getPlatform() === 'android') {
+          should.equal(await firebase.messaging().hasPermission(), true);
+        } else {
+          this.skip();
+        }
+      });
+      it('returns -1 on ios (default)', async function () {
+        if (device.getPlatform() === 'ios') {
+          should.equal(await firebase.messaging().hasPermission(), -1);
+        }
+      });
+    });
+
+    describe('requestPermission', function () {
+      it('resolves 1 on android', async function () {
+        if (device.getPlatform() === 'android') {
+          should.equal(await firebase.messaging().requestPermission(), 1);
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('getAPNSToken', function () {
+      it('resolves null on android', async function () {
+        if (device.getPlatform() === 'android') {
+          should.equal(await firebase.messaging().getAPNSToken(), null);
+        } else {
+          this.skip();
+        }
+      });
+      it('resolves null on ios if using simulator', async function () {
+        if (device.getPlatform() === 'ios') {
+          should.equal(await firebase.messaging().getAPNSToken(), null);
+        }
+      });
+    });
+
+    describe('unsupported web sdk methods', function () {
+      it('useServiceWorker should not error when called', function () {
+        firebase.messaging().useServiceWorker();
+      });
+      it('usePublicVapidKey should not error when called', function () {
+        firebase.messaging().usePublicVapidKey();
+      });
+    });
+
+    describe('getInitialNotification', function () {
+      it('returns null when no initial notification', async function () {
+        should.strictEqual(await firebase.messaging().getInitialNotification(), null);
+      });
+    });
+
+    describe('deleteToken()', function () {
+      it('generate a new token after deleting', async function () {
+        const token1 = await firebase.messaging().getToken();
+        should.exist(token1);
+        await firebase.messaging().deleteToken();
+        const token2 = await firebase.messaging().getToken();
+        should.exist(token2);
+        token1.should.not.eql(token2);
+      });
+    });
+
+    describe('onMessage()', function () {
+      it('throws if listener is not a function', function () {
+        try {
+          firebase.messaging().onMessage({});
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      xit('receives messages when the app is in the foreground', async function () {
+        const spy = sinon.spy();
+        const unsubscribe = firebase.messaging().onMessage(spy);
+        if (device.getPlatform() === 'ios') {
+          await firebase.messaging().registerDeviceForRemoteMessages();
+        }
+        const token = await firebase.messaging().getToken();
+        await TestsAPI.messaging().sendToDevice(token, {
+          data: {
+            foo: 'bar',
+            doop: 'boop',
+          },
+        });
+        await Utils.spyToBeCalledOnceAsync(spy);
+        unsubscribe();
+        spy.firstCall.args[0].should.be.an.Object();
+        spy.firstCall.args[0].data.should.be.an.Object();
+        spy.firstCall.args[0].data.foo.should.eql('bar');
+      });
+    });
+
+    describe('onTokenRefresh()', function () {
+      it('throws if listener is not a function', function () {
+        try {
+          firebase.messaging().onTokenRefresh({});
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('onDeletedMessages()', function () {
+      it('throws if listener is not a function', function () {
+        try {
+          firebase.messaging().onDeletedMessages(123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('onMessageSent()', function () {
+      it('throws if listener is not a function', function () {
+        try {
+          firebase.messaging().onMessageSent(123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('onSendError()', function () {
+      it('throws if listener is not a function', function () {
+        try {
+          firebase.messaging().onSendError('123');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('setBackgroundMessageHandler()', function () {
+      it('throws if handler is not a function', function () {
+        try {
+          firebase.messaging().setBackgroundMessageHandler('123');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'handler' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      // FIXME unfortunately this has started to fake locally as well. Disabling for now.
+      xit('receives messages when the app is in the background', async function () {
+        // This is slow and thus flaky in CI. It runs locally on android though.
+        if (device.getPlatform() === 'android' && !global.isCI) {
+          const spy = sinon.spy();
+          const token = await firebase.messaging().getToken();
+          firebase.messaging().setBackgroundMessageHandler(remoteMessage => {
+            spy(remoteMessage);
+            return Promise.resolve();
+          });
+
+          await device.sendToHome();
+          await TestsAPI.messaging().sendToDevice(token, {
+            data: {
+              foo: 'bar',
+              doop: 'boop',
+            },
+          });
+          await Utils.spyToBeCalledOnceAsync(spy);
+          await device.launchApp({ newInstance: false });
+          spy.firstCall.args[0].should.be.an.Object();
+          spy.firstCall.args[0].data.should.be.an.Object();
+          spy.firstCall.args[0].data.foo.should.eql('bar');
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('subscribeToTopic()', function () {
+      it('throws if topic is not a string', function () {
+        try {
+          firebase.messaging().subscribeToTopic(123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'topic' expected a string value");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if topic contains a /', function () {
+        try {
+          firebase.messaging().subscribeToTopic('foo/bar');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql('\'topic\' must not include "/"');
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('unsubscribeFromTopic()', function () {
+      it('throws if topic is not a string', function () {
+        try {
+          firebase.messaging().unsubscribeFromTopic(123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'topic' expected a string value");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if topic contains a /', function () {
+        try {
+          firebase.messaging().unsubscribeFromTopic('foo/bar');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql('\'topic\' must not include "/"');
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('setDeliveryMetricsExportToBigQuery()', function () {
+      afterEach(async function () {
+        await firebase.messaging().setDeliveryMetricsExportToBigQuery(false);
+      });
+
+      it('throws if enabled is not a boolean', function () {
+        try {
+          firebase.messaging().setDeliveryMetricsExportToBigQuery(123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'enabled' expected a boolean value");
+          return Promise.resolve();
+        }
+      });
+
+      it('sets the value', async function () {
+        should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
+        await firebase.messaging().setDeliveryMetricsExportToBigQuery(true);
+        should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, true);
+
+        // Set it back to the default value for future runs in re-use mode
+        await firebase.messaging().setDeliveryMetricsExportToBigQuery(false);
+        should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
+      });
+    });
+  });
+
+  describe('modular', function () {
+    describe('getMessaging', function () {
+      it('pass app as argument', function () {
+        const { getPerformance } = perfModular;
+
+        const perf = getPerformance(firebase.app());
+
+        perf.constructor.name.should.be.equal('FirebasePerfModule');
+      });
+
+      it('no app as argument', function () {
+        const { getPerformance } = perfModular;
+
+        const perf = getPerformance();
+
+        perf.constructor.name.should.be.equal('FirebasePerfModule');
+      });
+    });
+  });
+});

--- a/packages/messaging/e2e/messaging.modular.e2e.js
+++ b/packages/messaging/e2e/messaging.modular.e2e.js
@@ -352,19 +352,384 @@ describe('messaging() modular', function () {
   describe('modular', function () {
     describe('getMessaging', function () {
       it('pass app as argument', function () {
-        const { getPerformance } = perfModular;
+        const { getMessaging } = messagingModular;
 
-        const perf = getPerformance(firebase.app());
+        const messaging = getMessaging(firebase.app());
 
-        perf.constructor.name.should.be.equal('FirebasePerfModule');
+        messaging.constructor.name.should.be.equal('FirebaseMessagingModule');
       });
 
       it('no app as argument', function () {
-        const { getPerformance } = perfModular;
+        const { getMessaging } = messagingModular;
 
-        const perf = getPerformance();
+        const messaging = getMessaging();
 
-        perf.constructor.name.should.be.equal('FirebasePerfModule');
+        messaging.constructor.name.should.be.equal('FirebaseMessagingModule');
+      });
+    });
+
+    describe('setAutoInitEnabled()', function () {
+      // These depend on `tests/firebase.json` having `messaging_auto_init_enabled` set to false the first time
+      // The setting is persisted across restarts, reset to false after for local runs where prefs are sticky
+      afterEach(async function () {
+        const { getMessaging, setAutoInitEnabled } = messagingModular;
+        await setAutoInitEnabled(getMessaging(), false);
+      });
+
+      it('throws if enabled is not a boolean', async function () {
+        const { getMessaging, setAutoInitEnabled } = messagingModular;
+        try {
+          await setAutoInitEnabled(getMessaging(), 123);
+
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'enabled' expected a boolean value");
+          return Promise.resolve();
+        }
+      });
+
+      it('sets the value', async function () {
+        const { getMessaging, isAutoInitEnabled, setAutoInitEnabled } = messagingModular;
+        should.equal(isAutoInitEnabled(getMessaging()), false);
+        await firebase.messaging().setAutoInitEnabled(true);
+        should.equal(isAutoInitEnabled(getMessaging()), true);
+
+        // Set it back to the default value for future runs in re-use mode
+        await setAutoInitEnabled(getMessaging(), false);
+        should.equal(firebase.messaging().isAutoInitEnabled, false);
+      });
+    });
+
+    describe('isDeviceRegisteredForRemoteMessages', function () {
+      it('returns true on android', function () {
+        const { getMessaging, isDeviceRegisteredForRemoteMessages } = messagingModular;
+
+        if (device.getPlatform() === 'android') {
+          should.equal(isDeviceRegisteredForRemoteMessages(getMessaging()), true);
+        } else {
+          this.skip();
+        }
+      });
+      it('defaults to false on ios before registering', async function () {
+        const {
+          getMessaging,
+          isDeviceRegisteredForRemoteMessages,
+          registerDeviceForRemoteMessages,
+        } = messagingModular;
+
+        if (device.getPlatform() === 'ios') {
+          should.equal(isDeviceRegisteredForRemoteMessages(getMessaging()), false);
+          await registerDeviceForRemoteMessages(getMessaging());
+          should.equal(isDeviceRegisteredForRemoteMessages(getMessaging()), true);
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('unregisterDeviceForRemoteMessages', function () {
+      it('resolves on android, remains registered', async function () {
+        const {
+          getMessaging,
+          unregisterDeviceForRemoteMessages,
+          isDeviceRegisteredForRemoteMessages,
+        } = messagingModular;
+
+        if (device.getPlatform() === 'android') {
+          await unregisterDeviceForRemoteMessages(getMessaging());
+          should.equal(isDeviceRegisteredForRemoteMessages(getMessaging()), true);
+        } else {
+          this.skip();
+        }
+      });
+      it('successfully unregisters on ios', async function () {
+        const {
+          getMessaging,
+          unregisterDeviceForRemoteMessages,
+          isDeviceRegisteredForRemoteMessages,
+        } = messagingModular;
+
+        if (device.getPlatform() === 'ios') {
+          should.equal(is, true);
+          await unregisterDeviceForRemoteMessages(getMessaging());
+          should.equal(isDeviceRegisteredForRemoteMessages(getMessaging()), false);
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('hasPermission', function () {
+      it('returns true android (default)', async function () {
+        const { getMessaging, hasPermission } = messagingModular;
+        if (device.getPlatform() === 'android') {
+          should.equal(await hasPermission(getMessaging()), true);
+        } else {
+          this.skip();
+        }
+      });
+      it('returns -1 on ios (default)', async function () {
+        const { getMessaging, hasPermission } = messagingModular;
+        if (device.getPlatform() === 'ios') {
+          should.equal(await hasPermission(getMessaging()), -1);
+        }
+      });
+    });
+
+    describe('requestPermission', function () {
+      it('resolves 1 on android', async function () {
+        const { getMessaging, requestPermission } = messagingModular;
+        if (device.getPlatform() === 'android') {
+          should.equal(await requestPermission(getMessaging()), 1);
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('getAPNSToken', function () {
+      it('resolves null on android', async function () {
+        const { getMessaging, getAPNSToken } = messagingModular;
+        if (device.getPlatform() === 'android') {
+          should.equal(await getAPNSToken(getMessaging()), null);
+        } else {
+          this.skip();
+        }
+      });
+      it('resolves null on ios if using simulator', async function () {
+        const { getMessaging, getAPNSToken } = messagingModular;
+        if (device.getPlatform() === 'ios') {
+          should.equal(await getAPNSToken(getMessaging()), null);
+        }
+      });
+    });
+
+    describe('getInitialNotification', function () {
+      it('returns null when no initial notification', async function () {
+        const { getMessaging, getInitialNotification } = messagingModular;
+        should.strictEqual(await getInitialNotification(getMessaging()), null);
+      });
+    });
+
+    describe('deleteToken()', function () {
+      it('generate a new token after deleting', async function () {
+        const { getMessaging, getToken, deleteToken } = messagingModular;
+        const token1 = await getToken(getMessaging());
+        should.exist(token1);
+        await deleteToken(getMessaging());
+        const token2 = await getToken(getMessaging());
+        should.exist(token2);
+        token1.should.not.eql(token2);
+      });
+    });
+
+    describe('onMessage()', function () {
+      it('throws if listener is not a function', function () {
+        const { getMessaging, onMessage } = messagingModular;
+        try {
+          onMessage(getMessaging(), {});
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      xit('receives messages when the app is in the foreground', async function () {
+        const { getMessaging, onMessage, registerDeviceForRemoteMessages, getToken } =
+          messagingModular;
+        const spy = sinon.spy();
+        const unsubscribe = onMessage(getMessaging(), spy);
+        if (device.getPlatform() === 'ios') {
+          await registerDeviceForRemoteMessages(getMessaging());
+        }
+        const token = await getToken(getMessaging());
+        await TestsAPI.messaging().sendToDevice(token, {
+          data: {
+            foo: 'bar',
+            doop: 'boop',
+          },
+        });
+        await Utils.spyToBeCalledOnceAsync(spy);
+        unsubscribe();
+        spy.firstCall.args[0].should.be.an.Object();
+        spy.firstCall.args[0].data.should.be.an.Object();
+        spy.firstCall.args[0].data.foo.should.eql('bar');
+      });
+    });
+
+    describe('onTokenRefresh()', function () {
+      it('throws if listener is not a function', function () {
+        const { getMessaging, onTokenRefresh } = messagingModular;
+        try {
+          onTokenRefresh(getMessaging(), {});
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('onDeletedMessages()', function () {
+      it('throws if listener is not a function', function () {
+        const { getMessaging, onDeletedMessages } = messagingModular;
+        try {
+          onDeletedMessages(getMessaging(), 123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('onMessageSent()', function () {
+      it('throws if listener is not a function', function () {
+        const { getMessaging, onMessageSent } = messagingModular;
+        try {
+          onMessageSent(getMessaging(), 123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('onSendError()', function () {
+      it('throws if listener is not a function', function () {
+        const { getMessaging, onSendError } = messagingModular;
+        try {
+          onSendError(getMessaging(), '123');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'listener' expected a function");
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('setBackgroundMessageHandler()', function () {
+      it('throws if handler is not a function', function () {
+        const { getMessaging, setBackgroundMessageHandler } = messagingModular;
+        try {
+          setBackgroundMessageHandler(getMessaging(), '123');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'handler' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      // FIXME unfortunately this has started to fake locally as well. Disabling for now.
+      xit('receives messages when the app is in the background', async function () {
+        const { getMessaging, getToken, setBackgroundMessageHandler } = messagingModular;
+        // This is slow and thus flaky in CI. It runs locally on android though.
+        if (device.getPlatform() === 'android' && !global.isCI) {
+          const spy = sinon.spy();
+          const token = await getToken(getMessaging());
+          setBackgroundMessageHandler(getMessaging(), remoteMessage => {
+            spy(remoteMessage);
+            return Promise.resolve();
+          });
+
+          await device.sendToHome();
+          await TestsAPI.messaging().sendToDevice(token, {
+            data: {
+              foo: 'bar',
+              doop: 'boop',
+            },
+          });
+          await Utils.spyToBeCalledOnceAsync(spy);
+          await device.launchApp({ newInstance: false });
+          spy.firstCall.args[0].should.be.an.Object();
+          spy.firstCall.args[0].data.should.be.an.Object();
+          spy.firstCall.args[0].data.foo.should.eql('bar');
+        } else {
+          this.skip();
+        }
+      });
+    });
+
+    describe('subscribeToTopic()', function () {
+      it('throws if topic is not a string', function () {
+        const { getMessaging, subscribeToTopic } = messagingModular;
+        try {
+          subscribeToTopic(getMessaging(), 123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'topic' expected a string value");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if topic contains a /', function () {
+        const { getMessaging, subscribeToTopic } = messagingModular;
+        try {
+          subscribeToTopic(getMessaging(), 'foo/bar');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql('\'topic\' must not include "/"');
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('unsubscribeFromTopic()', function () {
+      it('throws if topic is not a string', function () {
+        const { getMessaging, unsubscribeFromTopic } = messagingModular;
+        try {
+          unsubscribeFromTopic(getMessaging(), 123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'topic' expected a string value");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if topic contains a /', function () {
+        const { getMessaging, unsubscribeFromTopic } = messagingModular;
+        try {
+          unsubscribeFromTopic(getMessaging(), 'foo/bar');
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql('\'topic\' must not include "/"');
+          return Promise.resolve();
+        }
+      });
+    });
+
+    describe('setDeliveryMetricsExportToBigQuery()', function () {
+      afterEach(async function () {
+        const { getMessaging, setDeliveryMetricsExportToBigQuery } = messagingModular;
+        await setDeliveryMetricsExportToBigQuery(getMessaging(), false);
+      });
+
+      it('throws if enabled is not a boolean', function () {
+        const { getMessaging, setDeliveryMetricsExportToBigQuery } = messagingModular;
+        try {
+          setDeliveryMetricsExportToBigQuery(getMessaging(), 123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'enabled' expected a boolean value");
+          return Promise.resolve();
+        }
+      });
+
+      it('sets the value', async function () {
+        const {
+          getMessaging,
+          setDeliveryMetricsExportToBigQuery,
+          isDeliveryMetricsExportToBigQueryEnabled,
+        } = messagingModular;
+        should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
+        await setDeliveryMetricsExportToBigQuery(getMessaging(), true);
+        should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), true);
+
+        // Set it back to the default value for future runs in re-use mode
+        await setDeliveryMetricsExportToBigQuery(getMessaging(), false);
+        should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
       });
     });
   });

--- a/packages/messaging/e2e/messaging.modular.e2e.js
+++ b/packages/messaging/e2e/messaging.modular.e2e.js
@@ -741,8 +741,8 @@ describe('messaging() modular', function () {
       });
 
       describe('isSupported()', function () {
-        const { isSupported, getMessaging } = messagingModular;
         it('should return "true" if the device or browser supports Firebase Messaging', async function () {
+          const { isSupported, getMessaging } = messagingModular;
           // For android, when the play services are available, it will return "true"
           // iOS & web always return "true". Web can be fully implemented when the platform is supported
           should.equal(await isSupported(getMessaging()), true);

--- a/packages/messaging/e2e/messaging.modular.e2e.js
+++ b/packages/messaging/e2e/messaging.modular.e2e.js
@@ -158,6 +158,25 @@ describe('messaging() modular', function () {
       });
     });
 
+    describe('getToken()', function () {
+      it('should throw Error with wrong parameters types', async function () {
+        try {
+          await firebase.messaging().getToken({ appName: 33 });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'appName' expected a string");
+        }
+
+        try {
+          await firebase.messaging().getToken({ senderId: 33 });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'senderId' expected a string.");
+          return Promise.resolve();
+        }
+      });
+    });
+
     describe('onMessage()', function () {
       it('throws if listener is not a function', function () {
         try {
@@ -529,6 +548,23 @@ describe('messaging() modular', function () {
         should.exist(token2);
         token1.should.not.eql(token2);
       });
+
+      it('should throw Error with wrong parameter types', async function () {
+        try {
+          await firebase.messaging().deleteToken({ appName: 33 });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'appName' expected a string");
+        }
+
+        try {
+          await firebase.messaging().getToken({ senderId: 33 });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'senderId' expected a string.");
+          return Promise.resolve();
+        }
+      });
     });
 
     describe('onMessage()', function () {
@@ -728,15 +764,16 @@ describe('messaging() modular', function () {
       it('sets the value', async function () {
         const {
           getMessaging,
-          setDeliveryMetricsExportToBigQuery,
+          experimentalSetDeliveryMetricsExportedToBigQueryEnabled,
           isDeliveryMetricsExportToBigQueryEnabled,
         } = messagingModular;
+
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
-        await setDeliveryMetricsExportToBigQuery(getMessaging(), true);
+        await experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), true);
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), true);
 
         // Set it back to the default value for future runs in re-use mode
-        await setDeliveryMetricsExportToBigQuery(getMessaging(), false);
+        await experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), false);
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
       });
 

--- a/packages/messaging/e2e/remoteMesssage.modular.e2e.js
+++ b/packages/messaging/e2e/remoteMesssage.modular.e2e.js
@@ -17,231 +17,231 @@
 
 describe('remoteMessage modular', function () {
   describe('firebase v8 compatibility', function () {
-    // describe('messaging().sendMessage(*)', function () {
-    //   it('throws if used on ios', function () {
-    //     if (device.getPlatform() === 'ios') {
-    //       try {
-    //         firebase.messaging().sendMessage(123);
-    //         return Promise.reject(new Error('Did not throw Error.'));
-    //       } catch (e) {
-    //         e.message.should.containEql(
-    //           'firebase.messaging().sendMessage() is only supported on Android devices.',
-    //         );
-    //         return Promise.resolve();
-    //       }
-    //     } else {
-    //       Promise.resolve();
-    //     }
-    //   });
-    //   it('throws if no object provided', function () {
-    //     if (device.getPlatform() === 'android') {
-    //       try {
-    //         firebase.messaging().sendMessage(123);
-    //         return Promise.reject(new Error('Did not throw Error.'));
-    //       } catch (e) {
-    //         e.message.should.containEql("'remoteMessage' expected an object value");
-    //         return Promise.resolve();
-    //       }
-    //     } else {
-    //       this.skip();
-    //     }
-    //   });
-    //   it('uses default values', async function () {
-    //     if (device.getPlatform() === 'android') {
-    //       firebase.messaging().sendMessage({});
-    //     } else {
-    //       this.skip();
-    //     }
-    //   });
-    //   describe('to', function () {
-    //     it('throws if to is not a string', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             to: 123,
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("'remoteMessage.to' expected a string value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('accepts custom to value', async function () {
-    //       if (device.getPlatform() === 'android') {
-    //         await firebase.messaging().sendMessage({
-    //           to: 'foobar',
-    //         });
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //   });
-    //   describe('messageId', function () {
-    //     it('throws if messageId is not a string', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             messageId: 123,
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("'remoteMessage.messageId' expected a string value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('accepts custom messageId value', async function () {
-    //       if (device.getPlatform() === 'android') {
-    //         await firebase.messaging().sendMessage({
-    //           messageId: 'foobar',
-    //         });
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //   });
-    //   describe('ttl', function () {
-    //     it('throws if not a number', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             ttl: '123',
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("remoteMessage.ttl' expected a number value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('throws if negative number', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             ttl: -2,
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('throws if float number', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             ttl: 123.4,
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('accepts custom ttl value', async function () {
-    //       if (device.getPlatform() === 'android') {
-    //         await firebase.messaging().sendMessage({
-    //           ttl: 123,
-    //         });
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //   });
-    //   describe('data', function () {
-    //     it('throws if data not an object', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             data: 123,
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("'remoteMessage.data' expected an object value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('accepts custom data value', async function () {
-    //       if (device.getPlatform() === 'android') {
-    //         await firebase.messaging().sendMessage({
-    //           data: {
-    //             foo: 'bar',
-    //           },
-    //         });
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //   });
-    //   describe('collapseKey', function () {
-    //     it('throws if collapseKey is not a string', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             collapseKey: 123,
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("'remoteMessage.collapseKey' expected a string value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('accepts custom collapseKey value', async function () {
-    //       if (device.getPlatform() === 'android') {
-    //         await firebase.messaging().sendMessage({
-    //           collapseKey: 'foobar',
-    //         });
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //   });
-    //   describe('messageType', function () {
-    //     it('throws if messageType is not a string', function () {
-    //       if (device.getPlatform() === 'android') {
-    //         try {
-    //           firebase.messaging().sendMessage({
-    //             messageType: 123,
-    //           });
-    //           return Promise.reject(new Error('Did not throw Error.'));
-    //         } catch (e) {
-    //           e.message.should.containEql("'remoteMessage.messageType' expected a string value");
-    //           return Promise.resolve();
-    //         }
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //     it('accepts custom messageType value', async function () {
-    //       if (device.getPlatform() === 'android') {
-    //         await firebase.messaging().sendMessage({
-    //           messageType: 'foobar',
-    //         });
-    //       } else {
-    //         this.skip();
-    //       }
-    //     });
-    //   });
-    // });
+    describe('messaging().sendMessage(*)', function () {
+      it('throws if used on ios', function () {
+        if (device.getPlatform() === 'ios') {
+          try {
+            firebase.messaging().sendMessage(123);
+            return Promise.reject(new Error('Did not throw Error.'));
+          } catch (e) {
+            e.message.should.containEql(
+              'firebase.messaging().sendMessage() is only supported on Android devices.',
+            );
+            return Promise.resolve();
+          }
+        } else {
+          Promise.resolve();
+        }
+      });
+      it('throws if no object provided', function () {
+        if (device.getPlatform() === 'android') {
+          try {
+            firebase.messaging().sendMessage(123);
+            return Promise.reject(new Error('Did not throw Error.'));
+          } catch (e) {
+            e.message.should.containEql("'remoteMessage' expected an object value");
+            return Promise.resolve();
+          }
+        } else {
+          this.skip();
+        }
+      });
+      it('uses default values', async function () {
+        if (device.getPlatform() === 'android') {
+          firebase.messaging().sendMessage({});
+        } else {
+          this.skip();
+        }
+      });
+      describe('to', function () {
+        it('throws if to is not a string', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                to: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.to' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom to value', async function () {
+          if (device.getPlatform() === 'android') {
+            await firebase.messaging().sendMessage({
+              to: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('messageId', function () {
+        it('throws if messageId is not a string', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                messageId: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.messageId' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom messageId value', async function () {
+          if (device.getPlatform() === 'android') {
+            await firebase.messaging().sendMessage({
+              messageId: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('ttl', function () {
+        it('throws if not a number', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                ttl: '123',
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("remoteMessage.ttl' expected a number value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('throws if negative number', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                ttl: -2,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('throws if float number', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                ttl: 123.4,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom ttl value', async function () {
+          if (device.getPlatform() === 'android') {
+            await firebase.messaging().sendMessage({
+              ttl: 123,
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('data', function () {
+        it('throws if data not an object', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                data: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.data' expected an object value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom data value', async function () {
+          if (device.getPlatform() === 'android') {
+            await firebase.messaging().sendMessage({
+              data: {
+                foo: 'bar',
+              },
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('collapseKey', function () {
+        it('throws if collapseKey is not a string', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                collapseKey: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.collapseKey' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom collapseKey value', async function () {
+          if (device.getPlatform() === 'android') {
+            await firebase.messaging().sendMessage({
+              collapseKey: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('messageType', function () {
+        it('throws if messageType is not a string', function () {
+          if (device.getPlatform() === 'android') {
+            try {
+              firebase.messaging().sendMessage({
+                messageType: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.messageType' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom messageType value', async function () {
+          if (device.getPlatform() === 'android') {
+            await firebase.messaging().sendMessage({
+              messageType: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+    });
   });
 
   describe('modular', function () {

--- a/packages/messaging/e2e/remoteMesssage.modular.e2e.js
+++ b/packages/messaging/e2e/remoteMesssage.modular.e2e.js
@@ -1,0 +1,491 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+describe('remoteMessage modular', function () {
+  describe('firebase v8 compatibility', function () {
+    // describe('messaging().sendMessage(*)', function () {
+    //   it('throws if used on ios', function () {
+    //     if (device.getPlatform() === 'ios') {
+    //       try {
+    //         firebase.messaging().sendMessage(123);
+    //         return Promise.reject(new Error('Did not throw Error.'));
+    //       } catch (e) {
+    //         e.message.should.containEql(
+    //           'firebase.messaging().sendMessage() is only supported on Android devices.',
+    //         );
+    //         return Promise.resolve();
+    //       }
+    //     } else {
+    //       Promise.resolve();
+    //     }
+    //   });
+    //   it('throws if no object provided', function () {
+    //     if (device.getPlatform() === 'android') {
+    //       try {
+    //         firebase.messaging().sendMessage(123);
+    //         return Promise.reject(new Error('Did not throw Error.'));
+    //       } catch (e) {
+    //         e.message.should.containEql("'remoteMessage' expected an object value");
+    //         return Promise.resolve();
+    //       }
+    //     } else {
+    //       this.skip();
+    //     }
+    //   });
+    //   it('uses default values', async function () {
+    //     if (device.getPlatform() === 'android') {
+    //       firebase.messaging().sendMessage({});
+    //     } else {
+    //       this.skip();
+    //     }
+    //   });
+    //   describe('to', function () {
+    //     it('throws if to is not a string', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             to: 123,
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("'remoteMessage.to' expected a string value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('accepts custom to value', async function () {
+    //       if (device.getPlatform() === 'android') {
+    //         await firebase.messaging().sendMessage({
+    //           to: 'foobar',
+    //         });
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //   });
+    //   describe('messageId', function () {
+    //     it('throws if messageId is not a string', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             messageId: 123,
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("'remoteMessage.messageId' expected a string value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('accepts custom messageId value', async function () {
+    //       if (device.getPlatform() === 'android') {
+    //         await firebase.messaging().sendMessage({
+    //           messageId: 'foobar',
+    //         });
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //   });
+    //   describe('ttl', function () {
+    //     it('throws if not a number', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             ttl: '123',
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("remoteMessage.ttl' expected a number value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('throws if negative number', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             ttl: -2,
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('throws if float number', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             ttl: 123.4,
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('accepts custom ttl value', async function () {
+    //       if (device.getPlatform() === 'android') {
+    //         await firebase.messaging().sendMessage({
+    //           ttl: 123,
+    //         });
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //   });
+    //   describe('data', function () {
+    //     it('throws if data not an object', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             data: 123,
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("'remoteMessage.data' expected an object value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('accepts custom data value', async function () {
+    //       if (device.getPlatform() === 'android') {
+    //         await firebase.messaging().sendMessage({
+    //           data: {
+    //             foo: 'bar',
+    //           },
+    //         });
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //   });
+    //   describe('collapseKey', function () {
+    //     it('throws if collapseKey is not a string', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             collapseKey: 123,
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("'remoteMessage.collapseKey' expected a string value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('accepts custom collapseKey value', async function () {
+    //       if (device.getPlatform() === 'android') {
+    //         await firebase.messaging().sendMessage({
+    //           collapseKey: 'foobar',
+    //         });
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //   });
+    //   describe('messageType', function () {
+    //     it('throws if messageType is not a string', function () {
+    //       if (device.getPlatform() === 'android') {
+    //         try {
+    //           firebase.messaging().sendMessage({
+    //             messageType: 123,
+    //           });
+    //           return Promise.reject(new Error('Did not throw Error.'));
+    //         } catch (e) {
+    //           e.message.should.containEql("'remoteMessage.messageType' expected a string value");
+    //           return Promise.resolve();
+    //         }
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //     it('accepts custom messageType value', async function () {
+    //       if (device.getPlatform() === 'android') {
+    //         await firebase.messaging().sendMessage({
+    //           messageType: 'foobar',
+    //         });
+    //       } else {
+    //         this.skip();
+    //       }
+    //     });
+    //   });
+    // });
+  });
+
+  describe('modular', function () {
+    describe('messaging().sendMessage(*)', function () {
+      it('throws if used on ios', function () {
+        const { getMessaging, sendMessage } = messagingModular;
+        if (device.getPlatform() === 'ios') {
+          try {
+            sendMessage(getMessaging(), 123);
+            return Promise.reject(new Error('Did not throw Error.'));
+          } catch (e) {
+            e.message.should.containEql(
+              'firebase.messaging().sendMessage() is only supported on Android devices.',
+            );
+            return Promise.resolve();
+          }
+        } else {
+          Promise.resolve();
+        }
+      });
+      it('throws if no object provided', function () {
+        const { getMessaging, sendMessage } = messagingModular;
+        if (device.getPlatform() === 'android') {
+          try {
+            sendMessage(getMessaging(), 123);
+            return Promise.reject(new Error('Did not throw Error.'));
+          } catch (e) {
+            e.message.should.containEql("'remoteMessage' expected an object value");
+            return Promise.resolve();
+          }
+        } else {
+          this.skip();
+        }
+      });
+      it('uses default values', async function () {
+        const { getMessaging, sendMessage } = messagingModular;
+        if (device.getPlatform() === 'android') {
+          sendMessage(getMessaging(), {});
+        } else {
+          this.skip();
+        }
+      });
+      describe('to', function () {
+        it('throws if to is not a string', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                to: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.to' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom to value', async function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            await sendMessage(getMessaging(), {
+              to: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('messageId', function () {
+        it('throws if messageId is not a string', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                messageId: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.messageId' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom messageId value', async function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            await sendMessage(getMessaging(), {
+              messageId: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('ttl', function () {
+        it('throws if not a number', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                ttl: '123',
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("remoteMessage.ttl' expected a number value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('throws if negative number', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                ttl: -2,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('throws if float number', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                ttl: 123.4,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.ttl' expected a positive integer value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom ttl value', async function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            await sendMessage(getMessaging(), {
+              ttl: 123,
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('data', function () {
+        it('throws if data not an object', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                data: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.data' expected an object value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom data value', async function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            await sendMessage(getMessaging(), {
+              data: {
+                foo: 'bar',
+              },
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('collapseKey', function () {
+        it('throws if collapseKey is not a string', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                collapseKey: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.collapseKey' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom collapseKey value', async function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            await sendMessage(getMessaging(), {
+              collapseKey: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+      describe('messageType', function () {
+        it('throws if messageType is not a string', function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            try {
+              sendMessage(getMessaging(), {
+                messageType: 123,
+              });
+              return Promise.reject(new Error('Did not throw Error.'));
+            } catch (e) {
+              e.message.should.containEql("'remoteMessage.messageType' expected a string value");
+              return Promise.resolve();
+            }
+          } else {
+            this.skip();
+          }
+        });
+        it('accepts custom messageType value', async function () {
+          const { getMessaging, sendMessage } = messagingModular;
+          if (device.getPlatform() === 'android') {
+            await sendMessage(getMessaging(), {
+              messageType: 'foobar',
+            });
+          } else {
+            this.skip();
+          }
+        });
+      });
+    });
+  });
+});

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -139,14 +139,35 @@ export namespace FirebaseMessagingTypes {
 
     /**
      * An iOS app specific identifier used for notification grouping.
-     */
     threadId?: string;
+    */
+    threadId?: string;
+
+    /**
+     * Options for features provided by the FCM SDK for Web.
+     */
+    fcmOptions: FcmOptions;
   }
 
   /**
-   * Options for `getToken()`, `deleteToken()`
+   * Options for features provided by the FCM SDK for Web.
    */
-  export interface TokenOptions {
+  export interface FcmOptions {
+    /**
+     * The link to open when the user clicks on the notification.
+     */
+    link?: string;
+
+    /**
+     * The label associated with the message's analytics data.
+     */
+    analyticsLabel?: string;
+  }
+
+  /**
+   * Options for `getToken()`
+   */
+  export interface GetTokenOptions {
     /**
      * The app name of the FirebaseApp instance.
      *
@@ -160,6 +181,45 @@ export namespace FirebaseMessagingTypes {
      * @platform ios iOS
      */
     senderId?: string;
+  }
+
+  /**
+   * Options for `deleteToken()`
+   */
+  export interface DeleteTokenOptions {
+    /**
+     * The app name of the FirebaseApp instance.
+     *
+     * @platform android Android
+     */
+    appName?: string;
+
+    /**
+     * The senderID for a particular Firebase project.
+     *
+     * @platform ios iOS
+     */
+    senderId?: string;
+
+    /**
+     * The VAPID key used to authenticate the push subscribers
+     *  to receive push messages only from sending servers
+     * that hold the corresponding private key.
+     *
+     * @platform web
+     */
+    vapidKey?: string;
+
+    /**
+     * The service worker registration for receiving push messaging.
+     * If the registration is not provided explicitly, you need to
+     * have a firebase-messaging-sw.js at your root location.
+     *
+     * @platform web
+     */
+
+    // TODO - A typed service worker. Could use this https://www.npmjs.com/package/@types/serviceworker ??
+    serviceWorkerRegistration;
   }
 
   export interface Notification {
@@ -182,6 +242,22 @@ export namespace FirebaseMessagingTypes {
      * The notification body content.
      */
     body?: string;
+
+    /**
+     * Web only. The URL to use for the notification's icon. If you don't send this key in the request,
+     * FCM displays the launcher icon specified in your app manifest.
+     */
+    icon?: string;
+
+    /**
+     * Web only. The URL of an image that is downloaded on the device and displayed in the notification.
+     */
+    image?: string;
+
+    /**
+     * Web only. The notification's title.
+     */
+    title?: string;
 
     /**
      * The native localization key for the notification body content.
@@ -630,7 +706,7 @@ export namespace FirebaseMessagingTypes {
      *
      * @param options Options to override senderId (iOS) and projectId (Android).
      */
-    getToken(options?: TokenOptions): Promise<string>;
+    getToken(options?: GetTokenOptions): Promise<string>;
 
     /**
      * Returns whether the root view is headless or not
@@ -653,7 +729,7 @@ export namespace FirebaseMessagingTypes {
      *
      * @param options Options to override senderId (iOS) and projectId (Android).
      */
-    deleteToken(options?: TokenOptions): Promise<void>;
+    deleteToken(options?: DeleteTokenOptions): Promise<void>;
 
     /**
      * When any FCM payload is received, the listener callback is called with a `RemoteMessage`.
@@ -1012,6 +1088,12 @@ export namespace FirebaseMessagingTypes {
      * @param enabled A boolean value to enable or disable exporting of message delivery metrics to BigQuery.
      */
     setDeliveryMetricsExportToBigQuery(enabled: boolean): Promise<void>;
+    /**
+     * Checks if all required APIs exist in the browser.
+     *
+     * @web
+     */
+    isSupported(): Promise<boolean>;
   }
 }
 

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -111,9 +111,9 @@ export namespace FirebaseMessagingTypes {
     data?: { [key: string]: string };
 
     /**
-     * Additional Notification data sent with the message
+     * Additional NotificationPayload data sent with the message
      */
-    notification?: Notification;
+    notification?: NotificationPayload;
 
     /**
      * Whether the iOS APNs message was configured as a background update notification.
@@ -165,9 +165,9 @@ export namespace FirebaseMessagingTypes {
   }
 
   /**
-   * Options for `getToken()`
+   * Options for `getToken()` and `deleteToken()`
    */
-  export interface GetTokenOptions {
+  export interface NativeTokenOptions {
     /**
      * The app name of the FirebaseApp instance.
      *
@@ -184,23 +184,9 @@ export namespace FirebaseMessagingTypes {
   }
 
   /**
-   * Options for `deleteToken()`
+   * Options for `getToken()`
    */
-  export interface DeleteTokenOptions {
-    /**
-     * The app name of the FirebaseApp instance.
-     *
-     * @platform android Android
-     */
-    appName?: string;
-
-    /**
-     * The senderID for a particular Firebase project.
-     *
-     * @platform ios iOS
-     */
-    senderId?: string;
-
+  export interface GetTokenOptions {
     /**
      * The VAPID key used to authenticate the push subscribers
      *  to receive push messages only from sending servers
@@ -217,10 +203,14 @@ export namespace FirebaseMessagingTypes {
      *
      * @platform web
      */
-
-    // TODO - A typed service worker. Could use this https://www.npmjs.com/package/@types/serviceworker ??
-    serviceWorkerRegistration;
+    serviceWorkerRegistration?: ServiceWorker;
   }
+
+  /**
+   * NotificationPayload is an alias for Notification. This is to keep it the same as
+   * Firebase Web JS SDK v9 and to make it backwards compatible.
+   */
+  type NotificationPayload = Notification;
 
   export interface Notification {
     /**
@@ -704,9 +694,9 @@ export namespace FirebaseMessagingTypes {
      *   });
      * ```
      *
-     * @param options Options to override senderId (iOS) and projectId (Android).
+     * @param options Options can be either `GetTokenOptions` or `NativeTokenOptions`
      */
-    getToken(options?: GetTokenOptions): Promise<string>;
+    getToken(options?: GetTokenOptions | NativeTokenOptions): Promise<string>;
 
     /**
      * Returns whether the root view is headless or not
@@ -727,9 +717,9 @@ export namespace FirebaseMessagingTypes {
      * await firebase.messaging().deleteToken();
      * ```
      *
-     * @param options Options to override senderId (iOS) and projectId (Android).
+     * @param options Options to override senderId (iOS) and appName (android)
      */
-    deleteToken(options?: DeleteTokenOptions): Promise<void>;
+    deleteToken(options?: NativeTokenOptions): Promise<void>;
 
     /**
      * When any FCM payload is received, the listener callback is called with a `RemoteMessage`.
@@ -1094,6 +1084,15 @@ export namespace FirebaseMessagingTypes {
      * @web
      */
     isSupported(): Promise<boolean>;
+
+    /**
+     * Enables or disables Firebase Cloud Messaging message delivery metrics export to BigQuery. By
+     * default, message delivery metrics are not exported to BigQuery. Use this method to enable or
+     * disable the export at runtime.
+     *
+     * @web
+     */
+    experimentalSetDeliveryMetricsExportedToBigQueryEnabled(): void;
   }
 }
 

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -203,7 +203,7 @@ export namespace FirebaseMessagingTypes {
      *
      * @platform web
      */
-    serviceWorkerRegistration?: ServiceWorker;
+    serviceWorkerRegistration?: ServiceWorkerRegistration;
   }
 
   /**
@@ -693,10 +693,9 @@ export namespace FirebaseMessagingTypes {
      *     fcmTokens: firebase.firestore.FieldValues.arrayUnion(fcmToken),
      *   });
      * ```
-     *
-     * @param options Options can be either `GetTokenOptions` or `NativeTokenOptions`
+     * @param options Options composite type with all members of `GetTokenOptions` and `NativeTokenOptions`
      */
-    getToken(options?: GetTokenOptions | NativeTokenOptions): Promise<string>;
+    getToken(options?: GetTokenOptions & NativeTokenOptions): Promise<string>;
 
     /**
      * Returns whether the root view is headless or not

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -482,7 +482,8 @@ class FirebaseMessagingModule extends FirebaseModule {
 
   async isSupported() {
     if (Platform.isAndroid) {
-      return this.native.isSupported();
+      playServicesAvailability = firebase.utils().playServicesAvailability;
+      return playServicesAvailability.isAvailable;
     }
     // Always return "true" for iOS. Web will be implemented when it is supported
     return true;

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -30,7 +30,7 @@ import {
   FirebaseModule,
   getFirebaseRoot,
 } from '@react-native-firebase/app/lib/internal';
-import { AppRegistry } from 'react-native';
+import { AppRegistry, Platform } from 'react-native';
 import remoteMessageOptions from './remoteMessageOptions';
 import version from './version';
 
@@ -62,6 +62,7 @@ export {
   unsubscribeFromTopic,
   setDeliveryMetricsExportToBigQuery,
   isDeliveryMetricsExportToBigQueryEnabled,
+  isSupported,
 } from '../modular/index';
 
 const statics = {
@@ -480,7 +481,10 @@ class FirebaseMessagingModule extends FirebaseModule {
   }
 
   async isSupported() {
-    // No-op as web platform isn't implemented
+    if (Platform.isAndroid) {
+      return this.native.isSupported();
+    }
+    // Always return "true" for iOS. Web will be implemented when it is supported
     return true;
   }
 

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -196,7 +196,7 @@ class FirebaseMessagingModule extends FirebaseModule {
 
   getToken({ appName, senderId } = {}) {
     if (!isUndefined(appName) && !isString(appName)) {
-      throw new Error("firebase.messaging().getToken(*) 'projectId' expected a string.");
+      throw new Error("firebase.messaging().getToken(*) 'appName' expected a string.");
     }
 
     if (!isUndefined(senderId) && !isString(senderId)) {
@@ -211,7 +211,7 @@ class FirebaseMessagingModule extends FirebaseModule {
 
   deleteToken({ appName, senderId } = {}) {
     if (!isUndefined(appName) && !isString(appName)) {
-      throw new Error("firebase.messaging().deleteToken(*) 'projectId' expected a string.");
+      throw new Error("firebase.messaging().deleteToken(*) 'appName' expected a string.");
     }
 
     if (!isUndefined(senderId) && !isString(senderId)) {
@@ -477,6 +477,11 @@ class FirebaseMessagingModule extends FirebaseModule {
 
     this._isDeliveryMetricsExportToBigQueryEnabled = enabled;
     return this.native.setDeliveryMetricsExportToBigQuery(enabled);
+  }
+
+  async isSupported() {
+    // No-op as web platform isn't implemented
+    return true;
   }
 }
 

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -61,7 +61,8 @@ export {
   subscribeToTopic,
   unsubscribeFromTopic,
   setDeliveryMetricsExportToBigQuery,
-} from './modular/index';
+  isDeliveryMetricsExportToBigQueryEnabled,
+} from '../modular/index';
 
 const statics = {
   AuthorizationStatus: {

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -483,6 +483,10 @@ class FirebaseMessagingModule extends FirebaseModule {
     // No-op as web platform isn't implemented
     return true;
   }
+
+  experimentalSetDeliveryMetricsExportedToBigQueryEnabled(enable) {
+    // No-op as web platform isn't implemented
+  }
 }
 
 // import { SDK_VERSION } from '@react-native-firebase/messaging';

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -34,6 +34,35 @@ import { AppRegistry } from 'react-native';
 import remoteMessageOptions from './remoteMessageOptions';
 import version from './version';
 
+export {
+  getMessaging,
+  deleteToken,
+  getToken,
+  onMessage,
+  onNotificationOpenedApp,
+  onTokenRefresh,
+  requestPermission,
+  isAutoInitEnabled,
+  setAutoInitEnabled,
+  getInitialNotification,
+  getDidOpenSettingsForNotification,
+  getIsHeadless,
+  registerDeviceForRemoteMessages,
+  isDeviceRegisteredForRemoteMessages,
+  unregisterDeviceForRemoteMessages,
+  getAPNSToken,
+  hasPermission,
+  onDeletedMessages,
+  onMessageSent,
+  onSendError,
+  setBackgroundMessageHandler,
+  setOpenSettingsForNotificationsHandler,
+  sendMessage,
+  subscribeToTopic,
+  unsubscribeFromTopic,
+  setDeliveryMetricsExportToBigQuery,
+} from './modular/index';
+
 const statics = {
   AuthorizationStatus: {
     NOT_DETERMINED: -1,

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -488,8 +488,8 @@ class FirebaseMessagingModule extends FirebaseModule {
     return true;
   }
 
-  experimentalSetDeliveryMetricsExportedToBigQueryEnabled(enable) {
-    // No-op as web platform isn't implemented
+  experimentalSetDeliveryMetricsExportedToBigQueryEnabled(enabled) {
+    return this.setDeliveryMetricsExportToBigQuery(enabled);
   }
 }
 

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -60,7 +60,7 @@ export {
   sendMessage,
   subscribeToTopic,
   unsubscribeFromTopic,
-  setDeliveryMetricsExportToBigQuery,
+  experimentalSetDeliveryMetricsExportedToBigQueryEnabled,
   isDeliveryMetricsExportToBigQueryEnabled,
   isSupported,
 } from '../modular/index';

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -488,10 +488,6 @@ class FirebaseMessagingModule extends FirebaseModule {
     // Always return "true" for iOS. Web will be implemented when it is supported
     return true;
   }
-
-  experimentalSetDeliveryMetricsExportedToBigQueryEnabled(enabled) {
-    return this.setDeliveryMetricsExportToBigQuery(enabled);
-  }
 }
 
 // import { SDK_VERSION } from '@react-native-firebase/messaging';

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -16,9 +16,9 @@ export function getMessaging(app) {
 /**
  * Removes access to an FCM token previously authorized by it's scope. 
  * Messages sent by the server to this token will fail.
- * @param messaging Messaging instance
+ * @param messaging Messaging instance.
  * @param tokenOptions Options to override senderId (iOS) and projectId (Android).
- * @returns {Void}
+ * @returns {Promise<void>}
  */
 export function deleteToken(messaging, tokenOptions) {
   if (tokenOptions != null) {
@@ -30,9 +30,9 @@ export function deleteToken(messaging, tokenOptions) {
 
 /**
  * Returns an FCM token for this device. Optionally you can specify a custom options to your own use-case.
- * @param messaging Messaging instance
+ * @param messaging Messaging instance.
  * @param options Options to override senderId (iOS) and projectId (Android).
- * @returns {String}
+ * @returns {Promise<string>}
  */
 export function getToken(messaging, options) {
   if (options != null) {
@@ -45,7 +45,7 @@ export function getToken(messaging, options) {
 /**
  * When any FCM payload is received, the listener callback is called with a `RemoteMessage`.
  * > This subscriber method is only called when the app is active (in the foreground).
- * @param messaging Messaging instance
+ * @param messaging Messaging instance.
  * @param listener Called with a `RemoteMessage` when a new FCM payload is received from the server.
  * @returns {Function}
  */
@@ -54,12 +54,228 @@ export function onMessage(messaging, nextOrObserver) {
 }
 
 /**
- * When any FCM payload is received, the listener callback is called with a `RemoteMessage`.
- * > This subscriber method is only called when the app is active (in the foreground).
- * @param messaging Messaging instance
- * @param listener Called with a `RemoteMessage` when a new FCM payload is received from the server.
+ * When the user presses a notification displayed via FCM, this listener will be called if the app
+ * has opened from a background state.
+ * @param messaging Messaging instance.
+ * @param listener Called with a `RemoteMessage` when a notification press opens the application.
  * @returns {Function}
  */
-export function isSupported(messaging, nextOrObserver) {
-  return messaging.isSupported(nextOrObserver);
+export function onNotificationOpenedApp(messaging, listener) {
+  return messaging.onNotificationOpenedApp(listener);
+}
+
+/**
+ * Called when a new registration token is generated for the device. For example, this event can happen when a
+ * token expires or when the server invalidates the token.
+ * > This subscriber method is only called when the app is active (in the foreground).
+ * @param messaging Messaging instance.
+ * @param listener Called with a FCM token when the token is refreshed.
+ * @returns {Function}
+ */
+export function onTokenRefresh(messaging, listener) {
+  return messaging.onTokenRefresh(listener);
+}
+
+/**
+ * On iOS, messaging permission must be requested by the current application before messages can
+ * be received or sent.
+ * @param messaging Messaging instance.
+ * @param iosPermissions All the available permissions for iOS that can be requested
+ * @returns {Promise<AuthorizationStatus>}
+ */
+export function requestPermission(messaging, iosPermissions) {
+  return messaging.requestPermission(iosPermissions);
+}
+
+/**
+ * Returns whether messaging auto initialization is enabled or disabled for the device.
+ * @param messaging Messaging instance.
+ * @returns {boolean}
+ */
+export function isAutoInitEnabled(messaging) {
+  return messaging.isAutoInitEnabled();
+}
+
+/**
+ * Returns whether messaging auto initialization is enabled or disabled for the device.
+ * @param messaging Messaging instance.
+ * @param enabled A boolean value to enable or disable auto initialization.
+ * @returns {Promise<boolean>}
+ */
+export function setAutoInitEnabled(messaging, enabled) {
+  return messaging.setAutoInitEnabled(enabled);
+}
+
+/**
+ * When a notification from FCM has triggered the application to open from a quit state,
+ * this method will return a `RemoteMessage` containing the notification data, or `null` if
+ * the app was opened via another method.
+ * @param messaging Messaging instance.
+ * @returns {Promise<RemoteMessage | null>}
+ */
+export function getInitialNotification(messaging) {
+  return messaging.getInitialNotification();
+}
+
+/**
+ * When the app is opened from iOS notifications settings from a quit state,
+ * this method will return `true` or `false` if the app was opened via another method.
+ * @param messaging Messaging instance.
+ * @returns {Promise<boolean>}
+ */
+export function getDidOpenSettingsForNotification(messaging) {
+  return messaging.getDidOpenSettingsForNotification();
+}
+
+/**
+ * Returns whether the root view is headless or not
+ * i.e true if the app was launched in the background (for example, by data-only cloud message)
+ * @param messaging Messaging instance.
+ * @returns {Promise<boolean>}
+ */
+export function getIsHeadless(messaging) {
+  return messaging.getIsHeadless();
+}
+
+/**
+ * On iOS, if your app wants to receive remote messages from FCM (via APNs), you must explicitly register
+ * with APNs if auto-registration has been disabled.
+ * @param messaging Messaging instance.
+ * @returns {Promise<void>}
+ */
+export function registerDeviceForRemoteMessages(messaging) {
+  return messaging.registerDeviceForRemoteMessages();
+}
+
+/**
+ * Returns a boolean value whether the user has registered for remote notifications via
+ * `registerDeviceForRemoteMessages()`. For iOS. Android always returns `true`
+ * @param messaging Messaging instance.
+ * @returns {boolean}
+ */
+export function isDeviceRegisteredForRemoteMessages(messaging) {
+  return messaging.isDeviceRegisteredForRemoteMessages();
+}
+
+/**
+ * Unregisters the app from receiving remote notifications.
+ * @param messaging Messaging instance.
+ * @returns {Promise<void>}
+ */
+export function unregisterDeviceForRemoteMessages(messaging) {
+  return messaging.unregisterDeviceForRemoteMessages();
+}
+
+/**
+ * On iOS, it is possible to get the users APNs token. This may be required if you want to send messages to your
+ * iOS devices without using the FCM service.
+ * @param messaging Messaging instance.
+ * @returns {Promise<string | null>}
+ */
+export function getAPNSToken(messaging) {
+  return messaging.getAPNSToken();
+}
+
+/**
+ * Returns a `AuthorizationStatus` as to whether the user has messaging permission for this app.
+ * @param messaging Messaging instance.
+ * @returns {Promise<AuthorizationStatus>}
+ */
+export function hasPermission(messaging) {
+  return messaging.hasPermission();
+}
+
+/**
+ * Called when the FCM server deletes pending messages.
+ * @param messaging Messaging instance.
+ * @param listener Called when the FCM deletes pending messages.
+ * @returns {Function}
+ */
+export function onDeletedMessages(messaging, listener) {
+  return messaging.onDeletedMessages(listener);
+}
+
+/**
+ * When sending a `RemoteMessage`, this listener is called when the message has been sent to FCM.
+ * @param messaging Messaging instance.
+ * @param listener Called when the FCM sends the remote message to FCM.
+ * @returns {Function}
+ */
+export function onMessageSent(messaging, listener) {
+  return messaging.onMessageSent(listener);
+}
+
+/**
+ * When sending a `RemoteMessage`, this listener is called when the message has been sent to FCM.
+ * @param messaging Messaging instance.
+ * @param listener Called when the FCM sends the remote message to FCM.
+ * @returns {Function}
+ */
+export function onSendError(messaging, listener) {
+  return messaging.onSendError(listener);
+}
+
+/**
+ * Set a message handler function which is called when the app is in the background
+ * or terminated. In Android, a headless task is created, allowing you to access the React Native environment
+ * to perform tasks such as updating local storage, or sending a network request.
+ * @param messaging Messaging instance.
+ * @param handler Called when a message is sent and the application is in a background or terminated state.
+ * @returns {void}
+ */
+export function setBackgroundMessageHandler(messaging, handler) {
+  return messaging.setBackgroundMessageHandler(handler);
+}
+
+/**
+ * Set a handler function which is called when the `${App Name} notifications settings`
+ * link in iOS settings is clicked.
+ * @param messaging Messaging instance.
+ * @param handler Called when link in iOS settings is clicked
+ * @returns {void}
+ */
+export function setOpenSettingsForNotificationsHandler(messaging, handler) {
+  return messaging.setOpenSettingsForNotificationsHandler(handler);
+}
+
+/**
+ * Send a new `RemoteMessage` to the FCM server.
+ * @param messaging Messaging instance.
+ * @param message A `RemoteMessage` interface.
+ * @returns {Promise<void>}
+ */
+export function sendMessage(messaging, message) {
+  return messaging.sendMessage(message);
+}
+
+/**
+ * Apps can subscribe to a topic, which allows the FCM server to send targeted messages to only those
+ * devices subscribed to that topic.
+ * @param messaging Messaging instance.
+ * @param topic The topic name.
+ * @returns {Promise<void>}
+ */
+export function subscribeToTopic(messaging, topic) {
+  return messaging.subscribeToTopic(topic);
+}
+
+/**
+ * Unsubscribe the device from a topic.
+ * @param messaging Messaging instance.
+ * @param topic The topic name.
+ * @returns {Promise<void>}
+ */
+export function unsubscribeFromTopic(messaging, topic) {
+  return messaging.unsubscribeFromTopic(topic);
+}
+
+/**
+ * Sets whether message delivery metrics are exported to BigQuery is enabled or disabled.
+ * The value is false by default. Set this to true to allow exporting of message delivery metrics to BigQuery.
+ * @param messaging Messaging instance.
+ * @param enabled A boolean value to enable or disable exporting of message delivery metrics to BigQuery.
+ * @returns {Promise<void>}
+ */
+export function setDeliveryMetricsExportToBigQuery(messaging, enabled) {
+  return messaging.setDeliveryMetricsExportToBigQuery(enabled);
 }

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -293,3 +293,8 @@ export function isSupported(messaging) {
   // No-op as web platform isn't implemented
   return messaging.isSupported();
 }
+
+export function experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enable) {
+  // No-op as web platform isn't implemented
+  return messaging.experimentalSetDeliveryMetricsExportedToBigQueryEnabled(enable);
+}

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -270,17 +270,6 @@ export function unsubscribeFromTopic(messaging, topic) {
 }
 
 /**
- * Sets whether message delivery metrics are exported to BigQuery is enabled or disabled.
- * The value is false by default. Set this to true to allow exporting of message delivery metrics to BigQuery.
- * @param messaging Messaging instance.
- * @param enabled A boolean value to enable or disable exporting of message delivery metrics to BigQuery.
- * @returns {Promise<void>}
- */
-export function setDeliveryMetricsExportToBigQuery(messaging, enabled) {
-  return messaging.setDeliveryMetricsExportToBigQuery(enabled);
-}
-
-/**
  * Returns a boolean whether message delivery metrics are exported to BigQuery.
  * @param messaging Messaging instance.
  * @returns {boolean}
@@ -289,11 +278,22 @@ export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
   return messaging.isDeliveryMetricsExportToBigQueryEnabled;
 }
 
+/**
+ * Checks if all required APIs exist in the browser.
+ * @param messaging Messaging instance.
+ * @returns {boolean}
+ */
 export function isSupported(messaging) {
   return messaging.isSupported();
 }
 
+/**
+ * Sets whether message delivery metrics are exported to BigQuery is enabled or disabled.
+ * The value is false by default. Set this to true to allow exporting of message delivery metrics to BigQuery.
+ * @param messaging Messaging instance.
+ * @param enabled A boolean value to enable or disable exporting of message delivery metrics to BigQuery.
+ * @returns {Promise<void>}
+ */
 export function experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enable) {
-  // No-op as web platform isn't implemented
-  return messaging.experimentalSetDeliveryMetricsExportedToBigQueryEnabled(enable);
+  return messaging.setDeliveryMetricsExportToBigQuery(enable);
 }

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -93,7 +93,7 @@ export function requestPermission(messaging, iosPermissions) {
  * @returns {boolean}
  */
 export function isAutoInitEnabled(messaging) {
-  return messaging.isAutoInitEnabled();
+  return messaging.isAutoInitEnabled;
 }
 
 /**
@@ -154,7 +154,7 @@ export function registerDeviceForRemoteMessages(messaging) {
  * @returns {boolean}
  */
 export function isDeviceRegisteredForRemoteMessages(messaging) {
-  return messaging.isDeviceRegisteredForRemoteMessages();
+  return messaging.isDeviceRegisteredForRemoteMessages;
 }
 
 /**
@@ -278,4 +278,13 @@ export function unsubscribeFromTopic(messaging, topic) {
  */
 export function setDeliveryMetricsExportToBigQuery(messaging, enabled) {
   return messaging.setDeliveryMetricsExportToBigQuery(enabled);
+}
+
+/**
+ * Returns a boolean whether message delivery metrics are exported to BigQuery.
+ * @param messaging Messaging instance.
+ * @returns {boolean}
+ */
+export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
+  return messaging.isDeliveryMetricsExportToBigQueryEnabled;
 }

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -14,7 +14,7 @@ export function getMessaging(app) {
 }
 
 /**
- * Removes access to an FCM token previously authorized by it's scope. 
+ * Removes access to an FCM token previously authorized by it's scope.
  * Messages sent by the server to this token will fail.
  * @param messaging Messaging instance.
  * @param tokenOptions Options to override senderId (iOS) and projectId (Android).

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -31,7 +31,7 @@ export function deleteToken(messaging, tokenOptions) {
 /**
  * Returns an FCM token for this device. Optionally you can specify a custom options to your own use-case.
  * @param messaging Messaging instance.
- * @param options Options to override senderId (iOS) and projectId (Android).
+ * @param options Options to override senderId (iOS) and appName
  * @returns {Promise<string>}
  */
 export function getToken(messaging, options) {
@@ -287,4 +287,9 @@ export function setDeliveryMetricsExportToBigQuery(messaging, enabled) {
  */
 export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
   return messaging.isDeliveryMetricsExportToBigQueryEnabled;
+}
+
+export function isSupported(messaging) {
+  // No-op as web platform isn't implemented
+  return messaging.isSupported();
 }

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -290,7 +290,6 @@ export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
 }
 
 export function isSupported(messaging) {
-  // No-op as web platform isn't implemented
   return messaging.isSupported();
 }
 

--- a/packages/messaging/modular/index.js
+++ b/packages/messaging/modular/index.js
@@ -1,0 +1,65 @@
+import { firebase } from '..';
+
+/**
+ * Returns a Messaging instance for the given app.
+ * @param app - FirebaseApp. Optional.
+ * @returns {Messaging}
+ */
+export function getMessaging(app) {
+  if (app) {
+    return firebase.app(app.name).messaging();
+  }
+
+  return firebase.app().messaging();
+}
+
+/**
+ * Removes access to an FCM token previously authorized by it's scope. 
+ * Messages sent by the server to this token will fail.
+ * @param messaging Messaging instance
+ * @param tokenOptions Options to override senderId (iOS) and projectId (Android).
+ * @returns {Void}
+ */
+export function deleteToken(messaging, tokenOptions) {
+  if (tokenOptions != null) {
+    return messaging.deleteToken();
+  }
+
+  return messaging.deleteToken(tokenOptions);
+}
+
+/**
+ * Returns an FCM token for this device. Optionally you can specify a custom options to your own use-case.
+ * @param messaging Messaging instance
+ * @param options Options to override senderId (iOS) and projectId (Android).
+ * @returns {String}
+ */
+export function getToken(messaging, options) {
+  if (options != null) {
+    return messaging.getToken();
+  }
+
+  return messaging.getToken(options);
+}
+
+/**
+ * When any FCM payload is received, the listener callback is called with a `RemoteMessage`.
+ * > This subscriber method is only called when the app is active (in the foreground).
+ * @param messaging Messaging instance
+ * @param listener Called with a `RemoteMessage` when a new FCM payload is received from the server.
+ * @returns {Function}
+ */
+export function onMessage(messaging, nextOrObserver) {
+  return messaging.onMessage(nextOrObserver);
+}
+
+/**
+ * When any FCM payload is received, the listener callback is called with a `RemoteMessage`.
+ * > This subscriber method is only called when the app is active (in the foreground).
+ * @param messaging Messaging instance
+ * @param listener Called with a `RemoteMessage` when a new FCM payload is received from the server.
+ * @returns {Function}
+ */
+export function isSupported(messaging, nextOrObserver) {
+  return messaging.isSupported(nextOrObserver);
+}

--- a/tests/app.js
+++ b/tests/app.js
@@ -27,6 +27,7 @@ import '@react-native-firebase/database';
 import '@react-native-firebase/dynamic-links';
 import '@react-native-firebase/firestore';
 import * as functionsModular from '@react-native-firebase/functions';
+import * as messagingModular from '@react-native-firebase/messaging';
 import '@react-native-firebase/in-app-messaging';
 import '@react-native-firebase/installations';
 import '@react-native-firebase/messaging';
@@ -43,6 +44,7 @@ jet.exposeContextProperty('NativeEventEmitter', NativeEventEmitter);
 jet.exposeContextProperty('module', firebase);
 jet.exposeContextProperty('modular', modular);
 jet.exposeContextProperty('functionsModular', functionsModular);
+jet.exposeContextProperty('messagingModular', messagingModular);
 
 firebase.database().useEmulator('localhost', 9000);
 firebase.auth().useEmulator('http://localhost:9099');

--- a/tests/e2e/globals.js
+++ b/tests/e2e/globals.js
@@ -71,4 +71,10 @@ Object.defineProperty(global, 'functionsModular', {
   },
 });
 
+Object.defineProperty(global, 'messagingModular', {
+  get() {
+    return jet.messagingModular;
+  },
+});
+
 global.isCI = !!process.env.CI;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
-    "lib": ["es2015", "es2016", "esnext"]
+    "lib": ["es2015", "es2016", "esnext", "DOM"]
   },
   "exclude": ["node_modules", "**/*.spec.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
-    "lib": ["es2015", "es2016", "esnext", "DOM"]
+    "lib": ["es2015", "es2016", "esnext", "dom"]
   },
   "exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
### Description

## Action Items summary (details under the "API review" header)
1. What to do about the `GetTokenOptions.serviceWorkerRegistration` value. We could pull in this Type: https://www.npmjs.com/package/@types/serviceworker and implement in the `index.d.ts` file?
2. What to do about the `isSupported()` API? I created a new function in existing code but it perhaps it shouldn't be there?
	1. If it is supposed to be there, we have to pass in `messaging` as the first argument which isn't the same as the Firebase Web JS SDK v9. 
3. Should we put `icon`, `image` & `title` on their own separate `web` object like `android` & `ios` for `Notification` payload?
4. I've also modularised a bunch of API that have no corresponding API on the Firebase Web JS SDK v9. I assume they are fine as they simply wrap around existing.

## API review


## getMessaging()


### Firebase Web JS SDK v9
```js
export declare function getMessagingInWindow(app?: FirebaseApp): Messaging;
```

### RNFB modular v9

```dart
export function getMessaging(app) {
if (app) {
  return firebase.app(app.name).messaging();
}

return firebase.app().messaging();
}
```

### Compare API
The same.


## ## deleteToken()


### Firebase Web JS SDK v9
```js
export declare function deleteToken(messaging: Messaging): Promise<boolean>;
```

### RNFB modular v9

```js
export function deleteToken(messaging, tokenOptions) {
  if (tokenOptions != null) {
    return messaging.deleteToken();
  }

  return messaging.deleteToken(tokenOptions);
}
```

### Existing API

```js
deleteToken({ appName, senderId } = {}) {
    if (!isUndefined(appName) && !isString(appName)) {
      throw new Error("firebase.messaging().deleteToken(*) 'appName' expected a string.");
    }

    if (!isUndefined(senderId) && !isString(senderId)) {
      throw new Error("firebase.messaging().deleteToken(*) 'senderId' expected a string.");
    }

    return this.native.deleteToken(
      appName || this.app.name,
      senderId || this.app.options.messagingSenderId,
    );
  }
```

### Compare API
1. We allow passing `tokenOptions` as a second argument as it is needed for native SDKs. 
2. I have updated `projectId` to `appName` string in `Error()` thrown.


## ## getToken()


### Firebase Web JS SDK v9
```js
export declare function getToken(messaging: Messaging, options?: GetTokenOptions): Promise<string>;
```

### RNFB modular v9

```js
export function getToken(messaging, options) {
  if (options != null) {
    return messaging.getToken();
  }

  return messaging.getToken(options);
}
```

### Existing API

```js
  getToken({ appName, senderId } = {}) {
    if (!isUndefined(appName) && !isString(appName)) {
      throw new Error("firebase.messaging().getToken(*) 'appName' expected a string.");
    }

    if (!isUndefined(senderId) && !isString(senderId)) {
      throw new Error("firebase.messaging().getToken(*) 'senderId' expected a string.");
    }

    return this.native.getToken(
      appName || this.app.name,
      senderId || this.app.options.messagingSenderId,
    );
  }
```

### Compare API
1. I have updated `projectId` to `appName` string in `Error()` thrown.
2. I've removed the type `TokenOptions` in RNFB. Introducing `GetTokenOptions` & `DeleteTokenOptions`. 
3. `GetTokenOptions` is the same as there is no corresponding object in the Firebase Web JS SDK
5. [[Action item]] What to do about `serviceWorkerRegistration` type?

`GetTokenOptions`

```ts
  /**
   * Options for `getToken()`
   */
  export interface GetTokenOptions {
    /**
     * The app name of the FirebaseApp instance.
     *
     * @platform android Android
     */
    appName?: string;

    /**
     * The senderID for a particular Firebase project.
     *
     * @platform ios iOS
     */
    senderId?: string;
  }
```


`DeleteTokenOptions`

```ts
/**
   * Options for `deleteToken()`
   */
  export interface DeleteTokenOptions {
    /**
     * The app name of the FirebaseApp instance.
     *
     * @platform android Android
     */
    appName?: string;

    /**
     * The senderID for a particular Firebase project.
     *
     * @platform ios iOS
     */
    senderId?: string;

    /**
     * The VAPID key used to authenticate the push subscribers
     *  to receive push messages only from sending servers
     * that hold the corresponding private key.
     *
     * @platform web
     */
    vapidKey?: string;

    /**
     * The VAPID key used to authenticate the push subscribers
     * to receive push messages only from sending servers
     * that hold the corresponding private key.
     *
     * @platform web
     */

    // TODO - A typed service worker. Could use this https://www.npmjs.com/package/@types/serviceworker ??
    serviceWorkerRegistration;
  }
```


## onMessage()


### Firebase Web JS SDK v9
```js
export declare function onMessage(messaging: Messaging, nextOrObserver: NextFn<MessagePayload> | Observer<MessagePayload>): Unsubscribe;
```

### RNFB modular v9

```js
export function onMessage(messaging, nextOrObserver) {
  return messaging.onMessage(nextOrObserver);
}
```

### Existing API

```js
 onMessage(listener) {
    if (!isFunction(listener)) {
      throw new Error("firebase.messaging().onMessage(*) 'listener' expected a function.");
    }

    const subscription = this.emitter.addListener('messaging_message_received', listener);
    return () => subscription.remove();
  }
```

### Compare API
The same.


## isSupported()


### Firebase Web JS SDK v9
```js
export declare function isWindowSupported(): Promise<boolean>;
```

### RNFB modular v9

```js
export function isSupported(messaging) {
  // No-op as web platform isn't implemented
  return messaging.isSupported();
}
```

### New API

```js
  async isSupported() {
    // No-op as web platform isn't implemented
    return true;
  }
```

### Compare API
1. We have to pass in `messaging` but it isn't necessary for the Firebase Web JS SDK v9. [[Action item]].


## MessagePayload

### Firebase Web JS SDK v9
```js
export interface MessagePayload {
  /**
   * {@inheritdoc NotificationPayload}
   */
  notification?: NotificationPayload;

  /**
   * Arbitrary key/value payload.
   */
  data?: { [key: string]: string };

  /**
   * {@inheritdoc FcmOptions}
   */
  fcmOptions?: FcmOptions;

  /**
   * The sender of this message.
   */
  from: string;

  /**
   * The collapse key of the message. See
   * {@link https://firebase.google.com/docs/cloud-messaging/concept-options#collapsible_and_non-collapsible_messages | Non-collapsible and collapsible messages}
   */
  collapseKey: string;

  /**
   * The message id of a message.
   */
  messageId: string;
}
```

### New API

```js
/**
   * The `RemoteMessage` interface describes an outgoing & incoming message from the remote FCM server.
   */
  export interface RemoteMessage {
    /**
     * The collapse key a message was sent with. Used to override existing messages with the same
     * key.
     */
    collapseKey?: string;

    /**
     * A unique ID assigned to every message.
     *
     * If not provided, a random unique ID is generated.
     */
    messageId?: string;

    /**
     * The message type of the message.
     */
    messageType?: string;
    /**
     * The topic name or message identifier.
     */
    from?: string;
    /**
     * The address for the message.
     */
    to?: string;

    /**
     * The time to live for the message in seconds.
     *
     * Defaults to 3600.
     */
    ttl?: number;

    /**
     * The time the message was sent, in milliseconds since the start of unix epoch
     */
    sentTime?: number;

    /**
     * Any additional data sent with the message.
     */
    data?: { [key: string]: string };

    /**
     * Additional Notification data sent with the message
     */
    notification?: Notification;

    /**
     * Whether the iOS APNs message was configured as a background update notification.
     *
     * @platform ios iOS
     */
    contentAvailable?: boolean;

    /**
     * Whether the iOS APNs `mutable-content` property on the message was set
     * allowing the app to modify the notification via app extensions.
     *
     * @platform ios iOS
     */
    mutableContent?: boolean;

    /**
     * The iOS category this notification is assigned to.
     *
     * @platform ios iOS
     */
    category?: string;

    /**
     * An iOS app specific identifier used for notification grouping.
     */
    threadId?: string;
	/**
     * Options for features provided by the FCM SDK for Web.
     */
	fcmOptions: FcmOptions;
  }

export interface FcmOptions {
  /**
   * The link to open when the user clicks on the notification.
   */
  link?: string;

  /**
   * The label associated with the message's analytics data.
   */
  analyticsLabel?: string;
}
```

### Compare API
1. I've added the missing property `fcmOptions` in the `RemoteMessage` in the "index.d.ts" file.


## Notification

### Firebase Web JS SDK v9
```js
export interface Notification {
    /**
     * The notification title.
     */
    title?: string;

    /**
     * The native localization key for the notification title.
     */
    titleLocKey?: string;

    /**
     * Any arguments that should be formatted into the resource specified by titleLocKey.
     */
    titleLocArgs?: string[];

    /**
     * The notification body content.
     */
    body?: string;

    /**
     * Web only. The URL to use for the notification's icon. If you don't send this key in the request,
     * FCM displays the launcher icon specified in your app manifest.
     */
    icon?: string;

    /**
     * Web only. The URL of an image that is downloaded on the device and displayed in the notification.
     */
    image?: string;

    /**
     * Web only. The notification's title.
     */
    title?: string;

    /**
     * The native localization key for the notification body content.
     */
    bodyLocKey?: string;

    /**
     * Any arguments that should be formatted into the resource specified by bodyLocKey.
     */
    bodyLocArgs?: string[];

    ios?: {
      /**
       * The notification's subtitle.
       */
      subtitle?: string;

      /**
       * The native localization key for the notification's subtitle.
       */
      subtitleLocKey?: string;

      /**
       * Any arguments that should be formatted into the resource specified by subtitleLocKey.
       */
      subtitleLocArgs?: string[];

      /**
       * The value of the badge on the home screen app icon.
       * If not specified, the badge is not changed.
       * If set to 0, the badge has been removed.
       */
      badge?: string;

      /**
       * The sound played when the notification was delivered on the device (if permissions permit).
       */
      sound?: string | NotificationIOSCriticalSound;
    };

    /**
     * Additional Android specific properties set on the notification.
     */
    android?: {
      /**
       * The sound played when the notification was delivered on the device (channel settings permitted).
       *
       * Set as "default" if the default device notification sound was used.
       */
      sound?: string;

      /**
       * The channel ID set on the notification. If not set, the notification uses the default
       * "Miscellaneous" channel set by FCM.
       */
      channelId?: string;

      /**
       * The custom color used to tint the notification content.
       */
      color?: string;

      /**
       * The custom small icon used to display on the notification. If not set, uses the default
       * application icon defined in the AndroidManifest file.
       */
      smallIcon?: string;

      /**
       * The custom image was provided and displayed in the notification body.
       */
      imageUrl?: string;

      /**
       * Deep link URL provided to the notification.
       */
      link?: string;

      /**
       * The current unread notification count for this application, managed by the device.
       */
      count?: number;

      /**
       * Name of the click action set on the notification.
       */
      clickAction?: string;

      /**
       * The notification priority.
       *
       * Note; on devices which have channel support (Android 8.0 (API level 26) +),
       * this value will be ignored. Instead, the channel "importance" level is used.
       */
      priority?:
        | NotificationAndroidPriority.PRIORITY_MIN
        | NotificationAndroidPriority.PRIORITY_LOW
        | NotificationAndroidPriority.PRIORITY_DEFAULT
        | NotificationAndroidPriority.PRIORITY_HIGH
        | NotificationAndroidPriority.PRIORITY_MAX;

      /**
       * Ticker text set on the notification.
       *
       * Ticker text is used for devices with accessibility enabled (e.g. to read out the message).
       */
      ticker?: string;

      /**
       * The visibility of a notification. This value determines how the notification is shown on the users
       * devices (e.g. on the lock-screen).
       */
      visibility?:
        | NotificationAndroidVisibility.VISIBILITY_SECRET
        | NotificationAndroidVisibility.VISIBILITY_PRIVATE
        | NotificationAndroidVisibility.VISIBILITY_PUBLIC;
    };
  }
```

### New API

```js
export interface Notification {
    /**
     * The notification title.
     */
    title?: string;

    /**
     * The native localization key for the notification title.
     */
    titleLocKey?: string;

    /**
     * Any arguments that should be formatted into the resource specified by titleLocKey.
     */
    titleLocArgs?: string[];

    /**
     * The notification body content.
     */
    body?: string;

    /**
     * Web only. The URL to use for the notification's icon. If you don't send this key in the request,
     * FCM displays the launcher icon specified in your app manifest.
     */
    icon?: string;

    /**
     * Web only. The URL of an image that is downloaded on the device and displayed in the notification.
     */
    image?: string;

    /**
     * Web only. The notification's title.
     */
    title?: string;

    /**
     * The native localization key for the notification body content.
     */
    bodyLocKey?: string;

    /**
     * Any arguments that should be formatted into the resource specified by bodyLocKey.
     */
    bodyLocArgs?: string[];

    ios?: {
      /**
       * The notification's subtitle.
       */
      subtitle?: string;

      /**
       * The native localization key for the notification's subtitle.
       */
      subtitleLocKey?: string;

      /**
       * Any arguments that should be formatted into the resource specified by subtitleLocKey.
       */
      subtitleLocArgs?: string[];

      /**
       * The value of the badge on the home screen app icon.
       * If not specified, the badge is not changed.
       * If set to 0, the badge has been removed.
       */
      badge?: string;

      /**
       * The sound played when the notification was delivered on the device (if permissions permit).
       */
      sound?: string | NotificationIOSCriticalSound;
    };

    /**
     * Additional Android specific properties set on the notification.
     */
    android?: {
      /**
       * The sound played when the notification was delivered on the device (channel settings permitted).
       *
       * Set as "default" if the default device notification sound was used.
       */
      sound?: string;

      /**
       * The channel ID set on the notification. If not set, the notification uses the default
       * "Miscellaneous" channel set by FCM.
       */
      channelId?: string;

      /**
       * The custom color used to tint the notification content.
       */
      color?: string;

      /**
       * The custom small icon used to display on the notification. If not set, uses the default
       * application icon defined in the AndroidManifest file.
       */
      smallIcon?: string;

      /**
       * The custom image was provided and displayed in the notification body.
       */
      imageUrl?: string;

      /**
       * Deep link URL provided to the notification.
       */
      link?: string;

      /**
       * The current unread notification count for this application, managed by the device.
       */
      count?: number;

      /**
       * Name of the click action set on the notification.
       */
      clickAction?: string;

      /**
       * The notification priority.
       *
       * Note; on devices which have channel support (Android 8.0 (API level 26) +),
       * this value will be ignored. Instead, the channel "importance" level is used.
       */
      priority?:
        | NotificationAndroidPriority.PRIORITY_MIN
        | NotificationAndroidPriority.PRIORITY_LOW
        | NotificationAndroidPriority.PRIORITY_DEFAULT
        | NotificationAndroidPriority.PRIORITY_HIGH
        | NotificationAndroidPriority.PRIORITY_MAX;

      /**
       * Ticker text set on the notification.
       *
       * Ticker text is used for devices with accessibility enabled (e.g. to read out the message).
       */
      ticker?: string;

      /**
       * The visibility of a notification. This value determines how the notification is shown on the users
       * devices (e.g. on the lock-screen).
       */
      visibility?:
        | NotificationAndroidVisibility.VISIBILITY_SECRET
        | NotificationAndroidVisibility.VISIBILITY_PRIVATE
        | NotificationAndroidVisibility.VISIBILITY_PUBLIC;
    };
  }
```

### Compare API
1. I've added the missing properties to `Notification` found on the Firebase Web JS SDK v9. They are `icon`, `image` & `title`. Maybe we should create our own `web` object like `android` & `iOS`? [[Action item]]


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
