### PR TITLE
fix(firestore): fix an issue where using `FieldPath` in `orderBy` would lead to a native error being thrown

### DIFF
--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
@@ -129,7 +129,7 @@ public class ReactNativeFirebaseFirestoreQuery {
     for (Object o : ordersList) {
       Map<String, Object> order = (Map) o;
 
-      if (order.get("fieldPath").getClass().isArray()) {
+      if (order.get("fieldPath") instanceof List) {
         ArrayList fieldPathArray = (ArrayList) order.get("fieldPath");
         String[] segmentArray = (String[]) fieldPathArray.toArray(new String[0]);
         FieldPath fieldPath = FieldPath.of(segmentArray);

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
@@ -127,12 +127,21 @@ public class ReactNativeFirebaseFirestoreQuery {
     List<Object> ordersList = toArrayList(orders);
 
     for (Object o : ordersList) {
-      Map<String, String> order = (Map) o;
+      Map<String, Object> order = (Map) o;
 
-      String fieldPath = order.get("fieldPath");
-      String direction = order.get("direction");
+      if (order.get("fieldPath").getClass().isArray()) {
+        ArrayList fieldPathArray = (ArrayList) order.get("fieldPath");
+        String[] segmentArray = (String[]) fieldPathArray.toArray(new String[0]);
+        FieldPath fieldPath = FieldPath.of(segmentArray);
+        String direction = (String) order.get("direction");
 
-      query = query.orderBy(Objects.requireNonNull(fieldPath), Query.Direction.valueOf(direction));
+        query = query.orderBy(Objects.requireNonNull(fieldPath), Query.Direction.valueOf(direction));
+      } else {
+        String fieldPath = (String) order.get("fieldPath");
+        String direction = (String) order.get("direction");
+
+        query = query.orderBy(Objects.requireNonNull(fieldPath), Query.Direction.valueOf(direction));
+      }
     }
   }
 

--- a/packages/firestore/e2e/DocumentSnapshot/get.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/get.e2e.js
@@ -29,7 +29,7 @@ describe('firestore().doc() -> snapshot.get()', function () {
       snapshot.get(123);
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {
-      error.message.should.containEql("'fieldPath' expected type string or FieldPath");
+      error.message.should.containEql("'fieldPath' expected type string, array or FieldPath");
       return Promise.resolve();
     }
   });

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -294,7 +294,7 @@ describe('firestore().collection().where()', function () {
     });
   });
 
-  it('returns with when combining greather than and lesser than on the same nested field', async function () {
+  it.only('returns when combining greater than and lesser than on the same nested field', async function () {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greaterandless`);
 
     await Promise.all([
@@ -305,9 +305,12 @@ describe('firestore().collection().where()', function () {
     ]);
 
     const snapshot = await colRef
-      .where(new firestore.FieldPath('nested.field'), '>=', 1)
-      .where(new firestore.FieldPath('nested.field'), '<=', 2)
-      .orderBy(new firestore.FieldPath('nested.field'));
+      .where(new firebase.firestore.FieldPath('nested.field'), '>=', 1)
+      .where(new firebase.firestore.FieldPath('nested.field'), '<=', 2)
+      .orderBy(new firebase.firestore.FieldPath('nested.field'))
+      .get();
+
+    console.error(snapshot);
 
     snapshot.size.should.eql(2);
   });

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -312,7 +312,7 @@ describe('firestore().collection().where()', function () {
     snapshot.size.should.eql(1);
   });
 
-  it.only('returns when combining greater than and lesser than on the same nested field using FieldPath', async function () {
+  it('returns when combining greater than and lesser than on the same nested field using FieldPath', async function () {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greaterandless`);
 
     await Promise.all([
@@ -322,9 +322,9 @@ describe('firestore().collection().where()', function () {
     ]);
 
     const snapshot = await colRef
-      .where(new firebase.firestore.FieldPath('foo.bar'), '>', 1)
-      .where(new firebase.firestore.FieldPath('foo.bar'), '<', 3)
-      .orderBy(new firebase.firestore.FieldPath('foo.bar'))
+      .where(new firebase.firestore.FieldPath('foo', 'bar'), '>', 1)
+      .where(new firebase.firestore.FieldPath('foo', 'bar'), '<', 3)
+      .orderBy(new firebase.firestore.FieldPath('foo', 'bar'))
       .get();
 
     snapshot.size.should.eql(1);

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -298,19 +298,36 @@ describe('firestore().collection().where()', function () {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greaterandless`);
 
     await Promise.all([
-      colRef.add({ nested: { field: 0 } }),
-      colRef.add({ nested: { field: 1 } }),
-      colRef.add({ nested: { field: 2 } }),
-      colRef.add({ nested: { field: 3 } }),
+      colRef.doc('doc1').set({ foo: { bar: 1 } }),
+      colRef.doc('doc2').set({ foo: { bar: 2 } }),
+      colRef.doc('doc3').set({ foo: { bar: 3 } }),
     ]);
 
     const snapshot = await colRef
-      .where(new firebase.firestore.FieldPath('nested.field'), '>=', 1)
-      .where(new firebase.firestore.FieldPath('nested.field'), '<=', 2)
-      .orderBy(new firebase.firestore.FieldPath('nested.field'))
+      .where('foo.bar', '>', 1)
+      .where('foo.bar', '<', 3)
+      .orderBy('foo.bar')
       .get();
 
-    snapshot.size.should.eql(2);
+    snapshot.size.should.eql(1);
+  });
+
+  it.only('returns when combining greater than and lesser than on the same nested field using FieldPath', async function () {
+    const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greaterandless`);
+
+    await Promise.all([
+      colRef.doc('doc1').set({ foo: { bar: 1 } }),
+      colRef.doc('doc2').set({ foo: { bar: 2 } }),
+      colRef.doc('doc3').set({ foo: { bar: 3 } }),
+    ]);
+
+    const snapshot = await colRef
+      .where(new firebase.firestore.FieldPath('foo.bar'), '>', 1)
+      .where(new firebase.firestore.FieldPath('foo.bar'), '<', 3)
+      .orderBy(new firebase.firestore.FieldPath('foo.bar'))
+      .get();
+
+    snapshot.size.should.eql(1);
   });
 
   it('returns with where array-contains filter', async function () {

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -294,6 +294,24 @@ describe('firestore().collection().where()', function () {
     });
   });
 
+  it('returns with when combining greather than and lesser than on the same nested field', async function () {
+    const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greaterandless`);
+
+    await Promise.all([
+      colRef.add({ nested: { field: 0 } }),
+      colRef.add({ nested: { field: 1 } }),
+      colRef.add({ nested: { field: 2 } }),
+      colRef.add({ nested: { field: 3 } }),
+    ]);
+
+    const snapshot = await colRef
+      .where(new firestore.FieldPath('nested.field'), '>=', 1)
+      .where(new firestore.FieldPath('nested.field'), '<=', 2)
+      .orderBy(new firestore.FieldPath('nested.field'));
+
+    snapshot.size.should.eql(2);
+  });
+
   it('returns with where array-contains filter', async function () {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/array-contains`);
 

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -294,7 +294,7 @@ describe('firestore().collection().where()', function () {
     });
   });
 
-  it.only('returns when combining greater than and lesser than on the same nested field', async function () {
+  it('returns when combining greater than and lesser than on the same nested field', async function () {
     const colRef = firebase.firestore().collection(`${COLLECTION}/filter/greaterandless`);
 
     await Promise.all([
@@ -309,8 +309,6 @@ describe('firestore().collection().where()', function () {
       .where(new firebase.firestore.FieldPath('nested.field'), '<=', 2)
       .orderBy(new firebase.firestore.FieldPath('nested.field'))
       .get();
-
-    console.error(snapshot);
 
     snapshot.size.should.eql(2);
   });

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.m
@@ -82,13 +82,22 @@
 
 - (void)applyOrders {
   for (NSDictionary *order in _orders) {
-    NSArray *fieldPathArray  = order[@"fieldPath"];
-    NSString *direction = order[@"direction"];
-    bool isDescending = [direction isEqualToString:@"DESCENDING"];
-      
-    FIRFieldPath *fieldPath = [[FIRFieldPath alloc] initWithFields:fieldPathArray];
-      
-    _query = [_query queryOrderedByFieldPath:fieldPath descending:isDescending];
+    if ([order[@"fieldPath"] isKindOfClass:[NSArray class]]) {
+      NSArray *fieldPathArray = order[@"fieldPath"];
+      NSString *direction = order[@"direction"];
+      bool isDescending = [direction isEqualToString:@"DESCENDING"];
+
+      FIRFieldPath *fieldPath = [[FIRFieldPath alloc] initWithFields:fieldPathArray];
+
+      _query = [_query queryOrderedByFieldPath:fieldPath descending:isDescending];
+
+    } else {
+      NSString *fieldPath = order[@"fieldPath"];
+      NSString *direction = order[@"direction"];
+      bool isDescending = [direction isEqualToString:@"DESCENDING"];
+
+      _query = [_query queryOrderedByField:fieldPath descending:isDescending];
+    }
   }
 }
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.m
@@ -82,13 +82,13 @@
 
 - (void)applyOrders {
   for (NSDictionary *order in _orders) {
-    NSString *fieldPath = order[@"fieldPath"];
+    NSArray *fieldPathArray  = order[@"fieldPath"];
     NSString *direction = order[@"direction"];
     bool isDescending = [direction isEqualToString:@"DESCENDING"];
       
-    FIRFieldPath *fieldPathA = [[FIRFieldPath alloc] initWithFields:@[fieldPath]];
-
-    _query = [_query queryOrderedByFieldPath:fieldPathA descending:isDescending];
+    FIRFieldPath *fieldPath = [[FIRFieldPath alloc] initWithFields:fieldPathArray];
+      
+    _query = [_query queryOrderedByFieldPath:fieldPath descending:isDescending];
   }
 }
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.m
@@ -85,8 +85,10 @@
     NSString *fieldPath = order[@"fieldPath"];
     NSString *direction = order[@"direction"];
     bool isDescending = [direction isEqualToString:@"DESCENDING"];
+      
+    FIRFieldPath *fieldPathA = [[FIRFieldPath alloc] initWithFields:@[fieldPath]];
 
-    _query = [_query queryOrderedByField:fieldPath descending:isDescending];
+    _query = [_query queryOrderedByFieldPath:fieldPathA descending:isDescending];
   }
 }
 

--- a/packages/firestore/lib/FirestoreDocumentSnapshot.js
+++ b/packages/firestore/lib/FirestoreDocumentSnapshot.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { isString } from '@react-native-firebase/app/lib/common';
+import { isArray, isString } from '@react-native-firebase/app/lib/common';
 import FirestoreDocumentReference, {
   provideDocumentSnapshotClass,
 } from './FirestoreDocumentReference';
@@ -78,9 +78,13 @@ export default class FirestoreDocumentSnapshot {
   get(fieldPath) {
     // TODO: ehesp: How are SnapshotOptions handled?
 
-    if (!isString(fieldPath) && !(fieldPath instanceof FirestoreFieldPath)) {
+    if (
+      !isString(fieldPath) &&
+      !(fieldPath instanceof FirestoreFieldPath) &&
+      !Array.isArray(fieldPath)
+    ) {
       throw new Error(
-        "firebase.firestore() DocumentSnapshot.get(*) 'fieldPath' expected type string or FieldPath.",
+        "firebase.firestore() DocumentSnapshot.get(*) 'fieldPath' expected type string, array or FieldPath.",
       );
     }
 
@@ -92,6 +96,8 @@ export default class FirestoreDocumentSnapshot {
       } catch (e) {
         throw new Error(`firebase.firestore() DocumentSnapshot.get(*) 'fieldPath' ${e.message}.`);
       }
+    } else if (isArray(fieldPath)) {
+      path = new FirestoreFieldPath(...fieldPath);
     } else {
       // Is already field path
       path = fieldPath;

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -196,10 +196,6 @@ export default class FirestoreQuery {
 
     this._modifiers.validatelimitToLast();
 
-    console.error('coucou');
-    console.error(this._modifiers.filters);
-    console.error(this._modifiers.orders);
-
     return this._firestore.native
       .collectionGet(
         this._collectionPath.relativeName,

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -181,6 +181,8 @@ export default class FirestoreQuery {
       );
     }
 
+    console.error('get', this._modifiers.orders);
+
     if (!isUndefined(this._queryName)) {
       return this._firestore.native
         .namedQueryGet(
@@ -377,6 +379,8 @@ export default class FirestoreQuery {
       );
     }
 
+    console.log('path', path);
+
     const modifiers = this._modifiers._copy().orderBy(path, directionStr);
 
     try {
@@ -385,7 +389,10 @@ export default class FirestoreQuery {
       throw new Error(`firebase.firestore().collection().orderBy() ${e.message}`);
     }
 
-    return new FirestoreQuery(this._firestore, this._collectionPath, modifiers, this._queryName);
+    const a = new FirestoreQuery(this._firestore, this._collectionPath, modifiers, this._queryName);
+    console.error('a', a);
+    console.error('this', a._modifiers);
+    return a;
   }
 
   startAfter(docOrField, ...fields) {

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -23,10 +23,10 @@ import {
   isUndefined,
 } from '@react-native-firebase/app/lib/common';
 import NativeError from '@react-native-firebase/app/lib/internal/NativeFirebaseError';
+import { FirestoreAggregateQuery } from './FirestoreAggregate';
 import FirestoreDocumentSnapshot from './FirestoreDocumentSnapshot';
 import FirestoreFieldPath, { fromDotSeparatedString } from './FirestoreFieldPath';
 import FirestoreQuerySnapshot from './FirestoreQuerySnapshot';
-import { FirestoreAggregateQuery } from './FirestoreAggregate';
 import { parseSnapshotArgs } from './utils';
 
 let _id = 0;
@@ -195,6 +195,10 @@ export default class FirestoreQuery {
     }
 
     this._modifiers.validatelimitToLast();
+
+    console.error('coucou');
+    console.error(this._modifiers.filters);
+    console.error(this._modifiers.orders);
 
     return this._firestore.native
       .collectionGet(

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -79,11 +79,7 @@ export default class FirestoreQuery {
           continue;
         }
 
-        console.error('fieldpath', order.fieldPath);
-
         const value = documentSnapshot.get(order.fieldPath);
-
-        console.error('value', value);
 
         if (value === undefined) {
           throw new Error(

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -79,7 +79,11 @@ export default class FirestoreQuery {
           continue;
         }
 
+        console.error('fieldpath', order.fieldPath);
+
         const value = documentSnapshot.get(order.fieldPath);
+
+        console.error('value', value);
 
         if (value === undefined) {
           throw new Error(

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -181,8 +181,6 @@ export default class FirestoreQuery {
       );
     }
 
-    console.error('get', this._modifiers.orders);
-
     if (!isUndefined(this._queryName)) {
       return this._firestore.native
         .namedQueryGet(
@@ -379,8 +377,6 @@ export default class FirestoreQuery {
       );
     }
 
-    console.log('path', path);
-
     const modifiers = this._modifiers._copy().orderBy(path, directionStr);
 
     try {
@@ -389,10 +385,7 @@ export default class FirestoreQuery {
       throw new Error(`firebase.firestore().collection().orderBy() ${e.message}`);
     }
 
-    const a = new FirestoreQuery(this._firestore, this._collectionPath, modifiers, this._queryName);
-    console.error('a', a);
-    console.error('this', a._modifiers);
-    return a;
+    return new FirestoreQuery(this._firestore, this._collectionPath, modifiers, this._queryName);
   }
 
   startAfter(docOrField, ...fields) {

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -16,8 +16,8 @@
  */
 
 import { isNumber } from '@react-native-firebase/app/lib/common';
-import { buildNativeArray, generateNativeData } from './utils/serialize';
 import { DOCUMENT_ID } from './FirestoreFieldPath';
+import { buildNativeArray, generateNativeData } from './utils/serialize';
 
 const OPERATORS = {
   '==': 'EQUAL',
@@ -78,7 +78,7 @@ export default class FirestoreQueryModifiers {
   }
 
   get orders() {
-    return this._orders;
+    return this._orders.map(f => ({ ...f, fieldPath: f.fieldPath._toArray() }));
   }
 
   get options() {
@@ -337,7 +337,7 @@ export default class FirestoreQueryModifiers {
 
   orderBy(fieldPath, directionStr) {
     const order = {
-      fieldPath: fieldPath._toPath(),
+      fieldPath: fieldPath,
       direction: directionStr ? DIRECTIONS[directionStr.toLowerCase()] : DIRECTIONS.asc,
     };
 
@@ -386,7 +386,7 @@ export default class FirestoreQueryModifiers {
 
         if (INEQUALITY[filter.operator]) {
           // Initial orderBy() parameter has to match every where() fieldPath parameter when inequality operator is invoked
-          if (filterFieldPath !== this._orders[0].fieldPath) {
+          if (filterFieldPath !== this._orders[0].fieldPath._toPath()) {
             throw new Error(
               `Invalid query. Initial Query.orderBy() parameter: ${orderFieldPath} has to be the same as the Query.where() fieldPath parameter(s): ${filterFieldPath} when an inequality operator is invoked `,
             );

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -354,7 +354,7 @@ export default class FirestoreQueryModifiers {
   validateOrderBy() {
     // Ensure order hasn't been called on the same field
     if (this._orders.length > 1) {
-      const orders = this._orders.map($ => $.fieldPath);
+      const orders = this._orders.map($ => $.fieldPath._toPath());
       const set = new Set(orders);
 
       if (set.size !== orders.length) {
@@ -377,7 +377,7 @@ export default class FirestoreQueryModifiers {
         const orderFieldPath = order.fieldPath;
         if (filter.operator === OPERATORS['==']) {
           // Any where() fieldPath parameter cannot match any orderBy() parameter when '==' operand is invoked
-          if (filterFieldPath === orderFieldPath) {
+          if (filterFieldPath === orderFieldPath._toPath()) {
             throw new Error(
               `Invalid query. Query.orderBy() parameter: ${orderFieldPath} cannot be the same as your Query.where() fieldPath parameter: ${filterFieldPath}`,
             );

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -16,7 +16,7 @@
  */
 
 import { isNumber } from '@react-native-firebase/app/lib/common';
-import { DOCUMENT_ID } from './FirestoreFieldPath';
+import FirestoreFieldPath, { DOCUMENT_ID } from './FirestoreFieldPath';
 import { buildNativeArray, generateNativeData } from './utils/serialize';
 
 const OPERATORS = {
@@ -74,11 +74,17 @@ export default class FirestoreQueryModifiers {
   }
 
   get filters() {
-    return this._filters.map(f => ({ ...f, fieldPath: f.fieldPath._toArray() }));
+    return this._filters.map(f => ({
+      ...f,
+      fieldPath: f.fieldPath instanceof FirestoreFieldPath ? f.fieldPath._toArray() : f.fieldPath,
+    }));
   }
 
   get orders() {
-    return this._orders.map(f => ({ ...f, fieldPath: f.fieldPath._toArray() }));
+    return this._orders.map(f => ({
+      ...f,
+      fieldPath: f.fieldPath instanceof FirestoreFieldPath ? f.fieldPath._toArray() : f.fieldPath,
+    }));
   }
 
   get options() {

--- a/packages/firestore/lib/utils/index.js
+++ b/packages/firestore/lib/utils/index.js
@@ -26,18 +26,18 @@ import {
 } from '@react-native-firebase/app/lib/common';
 import FirestoreFieldPath, { fromDotSeparatedString } from '../FirestoreFieldPath';
 
-export function extractFieldPathData(data, segmenets) {
+export function extractFieldPathData(data, segments) {
   if (!isObject(data)) {
     return undefined;
   }
 
-  const pathValue = data[segmenets[0]];
+  const pathValue = data[segments[0]];
 
-  if (segmenets.length === 1) {
+  if (segments.length === 1) {
     return pathValue;
   }
 
-  return extractFieldPathData(pathValue, segmenets.slice(1));
+  return extractFieldPathData(pathValue, segments.slice(1));
 }
 
 export function parseUpdateArgs(args) {


### PR DESCRIPTION
### Description

Instead of always transforming the orderBy into a String, I allow the bridge to keep the reference to a FieldPath in order to be able to use FieldPath in native also.

### Related issues

closes #6602

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
