### PR TITLE
docs(app-check): Added context for registering app

### DIFF
--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -67,6 +67,16 @@ The [official Firebase App Check documentation](https://firebase.google.com/docs
 
 # Usage
 
+## Register Firebase Apps
+
+Before the App Check package can be used on iOS or Android the corresponding App must be registered in the firebase console. 
+
+For instructions on how to generate required keys and register an app for App Check with iOS Device Check and Android SafetyNet follow **Step 1** in these firebase guides:
+- [Get started using App Check with DeviceCheck on Apple platforms](https://firebase.google.com/docs/app-check/ios/devicecheck-provider?hl=en&authuser=1#project-setup) 
+- [Get started using App Check with SafetyNet on Android](https://firebase.google.com/docs/app-check/android/safetynet-provider?hl=en&authuser=1#project-setup)
+
+> Additionally, You can reference the iOS private key creation and registrations steps outlined in the [Cloud Messaging iOS Setup](/messaging/usage/ios-setup#linking-apns-with-fcm-ios).
+
 ## Activate
 
 On iOS if you include the App Check package, it is activated by default. The only configuration possible is the token auto refresh. When you call activate, the provider (DeviceCheck by default) stays the same but the token auto refresh setting will be changed based on the argument provided.

--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -69,9 +69,9 @@ The [official Firebase App Check documentation](https://firebase.google.com/docs
 
 ## Register Firebase Apps
 
-Before the App Check package can be used on iOS or Android the corresponding App must be registered in the firebase console. 
+Before the App Check package can be used on iOS or Android, the corresponding App must be registered in the firebase console. 
 
-For instructions on how to generate required keys and register an app for App Check with iOS Device Check and Android SafetyNet follow **Step 1** in these firebase guides:
+For instructions on how to generate required keys and register an app for App Check with iOS Device Check and Android SafetyNet, follow **Step 1** in these firebase guides:
 - [Get started using App Check with DeviceCheck on Apple platforms](https://firebase.google.com/docs/app-check/ios/devicecheck-provider?hl=en&authuser=1#project-setup) 
 - [Get started using App Check with SafetyNet on Android](https://firebase.google.com/docs/app-check/android/safetynet-provider?hl=en&authuser=1#project-setup)
 

--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -69,10 +69,11 @@ The [official Firebase App Check documentation](https://firebase.google.com/docs
 
 ## Register Firebase Apps
 
-Before the App Check package can be used on iOS or Android, the corresponding App must be registered in the firebase console. 
+Before the App Check package can be used on iOS or Android, the corresponding App must be registered in the firebase console.
 
 For instructions on how to generate required keys and register an app for App Check with iOS Device Check and Android SafetyNet, follow **Step 1** in these firebase guides:
-- [Get started using App Check with DeviceCheck on Apple platforms](https://firebase.google.com/docs/app-check/ios/devicecheck-provider?hl=en&authuser=1#project-setup) 
+
+- [Get started using App Check with DeviceCheck on Apple platforms](https://firebase.google.com/docs/app-check/ios/devicecheck-provider?hl=en&authuser=1#project-setup)
 - [Get started using App Check with SafetyNet on Android](https://firebase.google.com/docs/app-check/android/safetynet-provider?hl=en&authuser=1#project-setup)
 
 > Additionally, You can reference the iOS private key creation and registrations steps outlined in the [Cloud Messaging iOS Setup](/messaging/usage/ios-setup#linking-apns-with-fcm-ios).


### PR DESCRIPTION
docs(app-check): Added context for registering app. Added Additional references and context for registering App Check with iOS apps. This step was not previously called out and could cause confusion.

### Description

Existing documentation skipped over steps for creating keys and registering with app check apps. 

### Related issues

N/A

### Release Summary

docs(app-check): Added context for registering app

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

N/A
---

:fire: