### PR TITLE
docs(firestore): fixed pagination example.

### DIFF
--- a/docs/firestore/pagination.md
+++ b/docs/firestore/pagination.md
@@ -114,7 +114,7 @@ import firestore from '@react-native-firebase/firestore';
 const userCollection = firestore().collection('Users');
 
 const App: () => Node = () => {
-  const [lastDocument, setLastDocument] = useState();
+  const [lastDocument, setLastDocument] = useState<undefined | 'end'>();
   const [userData, setUserData] = useState([]);
 
   function LoadData() {
@@ -123,13 +123,19 @@ const App: () => Node = () => {
     if (lastDocument !== undefined) {
       query = query.startAfter(lastDocument); // fetch data following the last document accessed
     }
-    query.limit(3) // limit to your page size, 3 is just an example
+    if(lastDocument !== 'end'){ // if lastDocument is 'end', no more fetches 
+       query.limit(3) // limit to your page size, 3 is just an example
         .get()
         .then(querySnapshot => {
+          if(querySnapshot.empty){
+            setLastDocument('end'); // if there are no more docs setLastDocument with 'end' 
+          }
           setLastDocument(querySnapshot.docs[querySnapshot.docs.length - 1]);
           MakeUserData(querySnapshot.docs);
         });
     }
+    }
+   
   }
 
   function MakeUserData(docs) {


### PR DESCRIPTION
### Description
This example makes infinite data loading. ( after loading the last doc, it loads from the first doc again ) 
after loading the last docs of data, there should be no more loading. 

I added the 'end' state on lastBookDoc so when it is set to 'end', there would be no more loading.


### Related issues

no related issues

### Release Summary



### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e` -> just docs
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__` -> just docs
- [ ] I have updated TypeScript types that are affected by my change.  -> just docs 
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

just docs 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
