### PR TITLE
fix(auth, android): use a safe copy of auth provider info to avoid crash

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -70,6 +70,7 @@ import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
 import io.invertase.firebase.common.SharedUtils;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -2055,7 +2056,8 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   private WritableArray convertProviderData(
       List<? extends UserInfo> providerData, FirebaseUser user) {
     WritableArray output = Arguments.createArray();
-    for (UserInfo userInfo : providerData) {
+    ArrayList<? extends UserInfo> providerDataCopy = new ArrayList(providerData);
+    for (UserInfo userInfo : providerDataCopy) {
       // remove 'firebase' provider data - android fb sdk
       // should not be returning this as the ios/web ones don't
       if (!FirebaseAuthProvider.PROVIDER_ID.equals(userInfo.getProviderId())) {

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
@@ -135,12 +135,14 @@ public class ReactNativeFirebaseFirestoreQuery {
         FieldPath fieldPath = FieldPath.of(segmentArray);
         String direction = (String) order.get("direction");
 
-        query = query.orderBy(Objects.requireNonNull(fieldPath), Query.Direction.valueOf(direction));
+        query =
+            query.orderBy(Objects.requireNonNull(fieldPath), Query.Direction.valueOf(direction));
       } else {
         String fieldPath = (String) order.get("fieldPath");
         String direction = (String) order.get("direction");
 
-        query = query.orderBy(Objects.requireNonNull(fieldPath), Query.Direction.valueOf(direction));
+        query =
+            query.orderBy(Objects.requireNonNull(fieldPath), Query.Direction.valueOf(direction));
       }
     }
   }


### PR DESCRIPTION
### Description

It appears on android that we may crash due to non-threadsafe iteration on user provider data while
serializing the information for javascript listeners

This PR attempts to fix that by creating a shallow copy of the provider data prior to iteration, then working
against the shallow copy

### Related issues

Fixes #6798

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

E2e tests should exercise it reasonably well, and I'll call for testers on the patch

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
