### PR TITLE
docs(functions): replace deprecated 'faker' with '@faker-js/faker'

### DIFF
--- a/docs/functions/writing-deploying-functions.md
+++ b/docs/functions/writing-deploying-functions.md
@@ -56,12 +56,12 @@ myproject
 
 The Firebase CLI has created a project structure and also installed a number of dependencies which will be used to build our Cloud Functions.
 
-To enable us to mock some fake data to use in the deployed functions, lets use the [`faker`](https://www.npmjs.com/package/faker)
+To enable us to mock some fake data to use in the deployed functions, lets use the [`@faker-js/faker`](https://www.npmjs.com/package/@faker-js/faker)
 library to create mock data.
 
 ```bash
 cd functions/
-npm install faker
+npm install @faker-js/faker
 ```
 
 Now it's time to write our Cloud Function. Open up the generated `functions/index.js` file in your chosen editor.
@@ -89,7 +89,7 @@ new data set being generated on each request:
 ```js
 // functions/index.js
 const functions = require('firebase-functions');
-const faker = require('faker');
+const { faker } = require('@faker-js/faker');
 
 // Initialize products array
 const products = [];


### PR DESCRIPTION
### Description

- 'faker' library was destroyed by the author ([link 🔗](https://stackoverflow.com/questions/21866285/cannot-find-module-faker-after-npm-install-save-dev))
- so I replaced it with `@faker-js/faker`.
- it works.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] N/A 
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] N/A 
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
