### PR TITLE
docs(functions): replace deprecated 'useFunctionsEmulator' with 'useEmulator'

### DIFF
--- a/docs/functions/usage/index.md
+++ b/docs/functions/usage/index.md
@@ -47,6 +47,22 @@ about security or implementing a HTTP request library.
 Functions deployed to Firebase have unique names, allowing you to easily identify which endpoint you wish to send a request to.
 To learn more about deploying Functions to Firebase, view the [Writing & Deploying Functions](/functions/writing-deploying-functions) documentation.
 
+## Using an emulator
+
+Whilst developing your application with Cloud Functions, it is possible to run the functions inside of a local emulator.
+
+To call the emulated functions, call the `useEmulator` method exposed by the library:
+
+```js
+import functions from '@react-native-firebase/functions';
+
+// Use a local emulator in development
+if (__DEV__) {
+  // If you are running on a physical device, replace http://localhost with the local ip of your PC. (http://192.168.x.x)
+  firebase.functions().useEmulator('localhost', 5001);
+}
+```
+
 ## Calling an endpoint
 
 Assuming we have a deployed a callable endpoint named `listProducts`, to call the endpoint the library exposes a
@@ -85,21 +101,5 @@ function App() {
   }
 
   // ...
-}
-```
-
-## Using an emulator
-
-Whilst developing your application with Cloud Functions, it is possible to run the functions inside of a local emulator.
-
-To call the emulated functions, call the `useFunctionsEmulator` method exposed by the library:
-
-```js
-import functions from '@react-native-firebase/functions';
-
-// Use a local emulator in development
-if (__DEV__) {
-  // If you are running on a physical device, replace http://localhost with the local ip of your PC. (http://192.168.x.x)
-  functions().useFunctionsEmulator('http://localhost:5000');
 }
 ```


### PR DESCRIPTION
### Description

- The `useFunctionsEmulator` is deprecated ([link 🔗](https://firebase.google.com/docs/functions/local-emulator#web-version-9))
- I replaced it with an 'useEmulator`.
- The position of the paragraph "Using an emulator" has been moved to the front in the same article.
- Most people who practice following documents will do this in a test environment.
- The paragraph has been moved forward because the explanation section that sets this is at the end, causing confusion.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] N/A 
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] N/A 
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
