### PR TITLE
docs(messaging, android): add note about permissions on API33+

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -68,7 +68,7 @@ async function requestUserPermission() {
 The permissions API for iOS provides much more fine-grain control over permissions and how they're handled within your
 application. To learn more, view the advanced [iOS Permissions](/messaging/ios-permissions) documentation.
 
-On Android pre api level 33 you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For api level 33+ you will need to request the permission manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
+On Android api level 32 and below, you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For api level 33+ you will need to request the permission manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
 
 ```
   import {PermissionsAndroid} from 'react-native'}

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -68,7 +68,12 @@ async function requestUserPermission() {
 The permissions API for iOS provides much more fine-grain control over permissions and how they're handled within your
 application. To learn more, view the advanced [iOS Permissions](/messaging/ios-permissions) documentation.
 
-On Android, you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully.
+On Android pre api level 33 you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For api level 33+ you will need to request the permission manually.
+
+```
+  import {PermissionsAndroid} from 'react-native'}
+  PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
+```
 
 ## Receiving messages
 

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -68,7 +68,7 @@ async function requestUserPermission() {
 The permissions API for iOS provides much more fine-grain control over permissions and how they're handled within your
 application. To learn more, view the advanced [iOS Permissions](/messaging/ios-permissions) documentation.
 
-On Android api level 32 and below, you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For api level 33+ you will need to request the permission manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
+On Android API level 32 and below, you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For API level 33+ you will need to request the permission manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
 
 ```
   import {PermissionsAndroid} from 'react-native'}

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -68,7 +68,7 @@ async function requestUserPermission() {
 The permissions API for iOS provides much more fine-grain control over permissions and how they're handled within your
 application. To learn more, view the advanced [iOS Permissions](/messaging/ios-permissions) documentation.
 
-On Android pre api level 33 you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For api level 33+ you will need to request the permission manually.
+On Android pre api level 33 you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For api level 33+ you will need to request the permission manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
 
 ```
   import {PermissionsAndroid} from 'react-native'}


### PR DESCRIPTION
### Description

Fix note about android permissions always being TRUE. Is now conditional on being pre api level 33

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- This is a breaking change;
  - [ ] Yes
  - [x] No
