### PR TITLE
fix(firestore): support not equals null query

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ cd react-native-firebase
 yarn
 yarn tests:ios:pod:install
 brew tap wix/brew
-brew install applesimutils xbeautify
+brew install applesimutils xcbeautify
 ```
 
 > Note that this project is a mono-repo, so you only need to install NPM dependencies once at the root of the project with `yarn`.

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -88,6 +88,10 @@ describe('firestore().collection().where()', function () {
     firebase.firestore().collection(COLLECTION).where('foo.bar', '==', null);
   });
 
+  it('allows null to be used with not equal operator', function () {
+    firebase.firestore().collection(COLLECTION).where('foo.bar', '!=', null);
+  });
+
   it('throws if multiple inequalities on different paths is provided', function () {
     try {
       firebase.firestore().collection(COLLECTION).where('foo.bar', '>', 123).where('bar', '>', 123);

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -437,7 +437,11 @@ export default class FirestoreQuery {
       );
     }
 
-    if (isNull(value) && !this._modifiers.isEqualOperator(opStr)) {
+    if (
+      isNull(value) &&
+      !this._modifiers.isEqualOperator(opStr) &&
+      !this._modifiers.isNotEqualOperator(opStr)
+    ) {
       throw new Error(
         "firebase.firestore().collection().where(_, _, *) 'value' is invalid. You can only perform equals comparisons on null",
       );

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -198,6 +198,10 @@ export default class FirestoreQueryModifiers {
     return OPERATORS[operator] === 'EQUAL';
   }
 
+  isNotEqualOperator(operator) {
+    return OPERATORS[operator] === 'NOT_EQUAL';
+  }
+
   isInOperator(operator) {
     return (
       OPERATORS[operator] === 'IN' ||


### PR DESCRIPTION
### Description

Retrieving all documents with field not equal to null doesn't work. Example:
```
firestore().collection("USERS").where("address", "!=", null);
```
Returns
```
firebase.firestore().collection().where(_, _, *) 'value' is invalid. You can only perform equals comparisons on null
```
I've looked into  `FirestoreQuery.js` and only equality comparison is allowed. 
```
if (isNull(value) && !this._modifiers.isEqualOperator(opStr)){...}
```
Is there any specific reason for it? Is there anything else I need to change, that I'm not aware of ? 

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


### Test Plan

I've run tests locally and everything passes. I have not found a test related to this problem (maybe this is something that needs to be added).

🔥
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
