### PR TITLE
docs(messaging): fix how to inject a `isHeadless` prop into the app

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -289,14 +289,11 @@ To inject a `isHeadless` prop into your app, please update your `AppDelegate.m` 
 
 // in "(BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions" method
 // Use `addCustomPropsToUserProps` to pass in props for initialization of your app
-// Or pass in `nil` if you have none as per below example
-// For `withLaunchOptions` please pass in `launchOptions` object
-NSDictionary *appProperties = [RNFBMessagingModule addCustomPropsToUserProps:nil withLaunchOptions:launchOptions];
+NSDictionary *initProps = [self prepareInitialProps];
+NSDictionary *appProps = [RNFBMessagingModule addCustomPropsToUserProps:initProps withLaunchOptions:launchOptions];
 
-// Find the `RCTRootView` instance and update the `initialProperties` with your `appProperties` instance
-RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                             moduleName:@"nameOfYourApp"
-                                             initialProperties:appProperties];
+// Find the line which initialises the `rootView` and replace the param `initProps` with your `appProps` instance
+UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"nameOfYourApp", appProps);
 ```
 
 - For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `getIsHeadless` method (iOS only) from messaging like so:


### PR DESCRIPTION


### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This PR updates the Firebase Messaging doc to inject `isHeadless` prop into the app using the `AppDelegate.m` file. 
Since React Native has introduced New Architecture, code has changed in the `AppDelegate.m` file. 
This PR simply updates as per new code changes where `initProps` is already declared as passed to the initial UIView. 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- This is a breaking change;
  - [ ] Yes
  - [x] No


