### PR TITLE
docs(messaging): document how to inject isHeadless prop into the app

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -294,6 +294,7 @@ To inject a `isHeadless` prop into your app, please update your `AppDelegate.m` 
 // and use it to set `self.initialProps` (available with react-native >= 0.71.1, older versions need a more difficult style, upgrading is recommended)
 
 self.initialProps = [RNFBMessagingModule addCustomPropsToUserProps:nil withLaunchOptions:launchOptions];
+```
 
 - For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `getIsHeadless` method (iOS only) from messaging like so:
 

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -291,13 +291,9 @@ To inject a `isHeadless` prop into your app, please update your `AppDelegate.m` 
 // Use `addCustomPropsToUserProps` to pass in props for initialization of your app
 // Or pass in `nil` if you have none as per below example
 // For `withLaunchOptions` please pass in `launchOptions` object
-NSDictionary *appProperties = [RNFBMessagingModule addCustomPropsToUserProps:nil withLaunchOptions:launchOptions];
+// and use it to set `self.initialProps`
 
-// Find the `RCTRootView` instance and update the `initialProperties` with your `appProperties` instance
-RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
-                                             moduleName:@"nameOfYourApp"
-                                             initialProperties:appProperties];
-```
+self.initialProps = [RNFBMessagingModule addCustomPropsToUserProps:nil withLaunchOptions:launchOptions];
 
 - For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `getIsHeadless` method (iOS only) from messaging like so:
 

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -291,7 +291,7 @@ To inject a `isHeadless` prop into your app, please update your `AppDelegate.m` 
 // Use `addCustomPropsToUserProps` to pass in props for initialization of your app
 // Or pass in `nil` if you have none as per below example
 // For `withLaunchOptions` please pass in `launchOptions` object
-// and use it to set `self.initialProps`
+// and use it to set `self.initialProps` (available with react-native >= 0.71.1, older versions need a more difficult style, upgrading is recommended)
 
 self.initialProps = [RNFBMessagingModule addCustomPropsToUserProps:nil withLaunchOptions:launchOptions];
 


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Since React Native updated to 0.71, code in the `AppDelegate.m` has evolved to rely more on the base implementation provided by the `RCTAppDelegate` class.

0.71.1 added an `initialProps` property to this base class to make it easy to pass initial properties to the initial UIView.

This PR updates the documentation of Firebase Messaging to show how to take advantage of this for injecting the `isHeadless` prop into the app

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
