### PR TITLE
test(ios): increase ccache from 1024M to 1500M

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -80,7 +80,7 @@ jobs:
         name: Xcode Compile Cache
         with:
           key: ${{ runner.os }}-v2 # makes a unique key w/related restore key internally
-          max-size: 1G
+          max-size: 1500M
 
       - name: Yarn Install
         uses: nick-invision/retry@v2


### PR DESCRIPTION
### Description

There were some cleanups during the build and some cache misses on what should have been a clean run, so we are bumping up against size constraints again.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan


Check the last part of the build iOS app phase of iOS e2e tests and the statistics will show if we have cleanups + misses. There should not be any misses and zero cleanups is best

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
