### PR TITLE
fix(app-check, types): Correct ReactNativeFirebaseAppCheckProvider options type

### DIFF
--- a/packages/app-check/lib/index.d.ts
+++ b/packages/app-check/lib/index.d.ts
@@ -135,12 +135,12 @@ export namespace FirebaseAppCheckTypes {
      * so AppCheck has the same experience across all platforms, with the only difference being the native
      * providers you choose to use on each platform.
      */
-    configure(
+    configure(options: {
       web?: ReactNativeFirebaseAppCheckProviderWebOptions,
       android?: ReactNativeFirebaseAppCheckProviderAndroidOptions,
       apple?: ReactNativeFirebaseAppCheckProviderAppleOptions,
       isTokenAutoRefreshEnabled?: boolean,
-    ): Promise<void>;
+    }): Promise<void>;
   }
 
   /**

--- a/packages/app-check/lib/index.d.ts
+++ b/packages/app-check/lib/index.d.ts
@@ -136,10 +136,10 @@ export namespace FirebaseAppCheckTypes {
      * providers you choose to use on each platform.
      */
     configure(options: {
-      web?: ReactNativeFirebaseAppCheckProviderWebOptions,
-      android?: ReactNativeFirebaseAppCheckProviderAndroidOptions,
-      apple?: ReactNativeFirebaseAppCheckProviderAppleOptions,
-      isTokenAutoRefreshEnabled?: boolean,
+      web?: ReactNativeFirebaseAppCheckProviderWebOptions;
+      android?: ReactNativeFirebaseAppCheckProviderAndroidOptions;
+      apple?: ReactNativeFirebaseAppCheckProviderAppleOptions;
+      isTokenAutoRefreshEnabled?: boolean;
     }): Promise<void>;
   }
 


### PR DESCRIPTION
### Description

After the recent update to AppCheck types in 17.2.0, there is still an issue with configuring ReactNativeFirebaseAppCheckProvider when attempting to follow https://rnfirebase.io/app-check/usage:

![image](https://user-images.githubusercontent.com/1888212/218957572-a6881bd3-f869-412d-b85d-018e7b015f77.png)

The issue is due to a mismatch in the TypeScript declaration file.

`ReactNativeFirebaseAppCheckProvider` takes in a single options object:

https://github.com/invertase/react-native-firebase/blob/main/packages/app-check/lib/ReactNativeFirebaseAppCheckProvider.js#L6

while the type declaration indicates it takes in 4 separate objects for each platform:

https://github.com/invertase/react-native-firebase/blob/main/packages/app-check/lib/index.d.ts#L139-L142


### Related issues

Fixes #6886 

### Release Summary

- Update ReactNativeFirebaseAppCheckProvider options type

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- Tried using the new types and ensured they worked as expected

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
