### PR TITLE
fix(app, android): adopt firebase-android-sdk 31.2.2 w/crash fixes

### DIFF
--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -40,7 +40,7 @@ buildscript {
   // ..
   dependencies {
     // ..
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
   }
   // ..
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -218,7 +218,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "31.2.0"
+        bom           : "31.2.2"
       ],
     ],
   ])

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,8 +73,8 @@
       "minSdk": 19,
       "targetSdk": 33,
       "compileSdk": 33,
-      "firebase": "31.2.0",
-      "firebaseCrashlyticsGradle": "2.9.2",
+      "firebase": "31.2.2",
+      "firebaseCrashlyticsGradle": "2.9.4",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.15",
       "playServicesAuth": "20.3.0"

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION

Standard SDK update - app JSON version bump, docs, plugins (not always needed, this had one), plugin test fixture for expo plugin

Fixes #6930

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
