### PR TITLE
fix(auth, types): add `OIDCProvider` to typescript declaration

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -118,12 +118,11 @@ export namespace FirebaseAuthTypes {
      */
     PROVIDER_ID: string;
     /**
-     * Creates a new `AuthCredential`.
+     * Creates a new `OIDCProvider`.
      *
      * @returns {@link auth.AuthCredential}.
      * @param oidcSuffix this is the "Provider ID" value from the firebase console fx `azure_test`.
      * @param token A provider token.
-     * @param secret A provider secret.
      */
     credential: (oidcSuffix: string, idToken: string) => AuthCredential;
   }

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -110,6 +110,25 @@ export namespace FirebaseAuthTypes {
   }
 
   /**
+   * Interface that represents an Open ID Connect auth provider. Implemented by other providers.
+   */
+  export interface OIDCProvider {
+    /**
+     * The provider ID of the provider.
+     */
+    PROVIDER_ID: string;
+    /**
+     * Creates a new `AuthCredential`.
+     *
+     * @returns {@link auth.AuthCredential}.
+     * @param oidcSuffix this is the "Provider ID" value from the firebase console fx `azure_test`.
+     * @param token A provider token.
+     * @param secret A provider secret.
+     */
+    credential: (oidcSuffix: string, idToken: string) => AuthCredential;
+  }
+
+  /**
    * Email and password auth provider implementation.
    */
   export interface EmailAuthProvider {
@@ -298,6 +317,16 @@ export namespace FirebaseAuthTypes {
      * ```
      */
     OAuthProvider: AuthProvider;
+    /**
+     * Custom Open ID connect auth provider implementation.
+     *
+     * #### Example
+     *
+     * ```js
+     * firebase.auth.OIDCAuthProvider;
+     * ```
+     */
+    OIDCAuthProvider: OIDCProvider;
     /**
      * A PhoneAuthState interface.
      *


### PR DESCRIPTION
### Description
https://github.com/invertase/react-native-firebase/pull/6574 added support for the `OIDCProvider` provider, but it was not added to the typescript declaration file.
cc: @Babsvik @mikehardy 

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

- auth: add missing `OIDCProvider` to typescript declaration

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
