### PR TITLE
fix(expo): extend expo config plugin regex to match latest version of AppDelegate

### DIFF
--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 const methodInvocationBlock = `[FIRApp configure];`;
 // https://regex101.com/r/mPgaq6/1
 const methodInvocationLineMatcher =
-  /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))/g;
+  /(?:self\.moduleName\s*=\s*@\"([^"]*)\";)|(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))/g;
 
 // https://regex101.com/r/nHrTa9/1/
 // if the above regex fails, we can use this one as a fallback:

--- a/packages/dynamic-links/plugin/src/ios/appDelegate.ts
+++ b/packages/dynamic-links/plugin/src/ios/appDelegate.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 const methodInvocationBlock = `[RNFBDynamicLinksAppDelegateInterceptor sharedInstance];`;
 // https://regex101.com/r/mPgaq6/1
 const methodInvocationLineMatcher =
-  /(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))/g;
+  /(?:self\.moduleName\s*=\s*@\"([^"]*)\";)|(?:(self\.|_)(\w+)\s?=\s?\[\[UMModuleRegistryAdapter alloc\])|(?:RCTBridge\s?\*\s?(\w+)\s?=\s?\[(\[RCTBridge alloc\]|self\.reactDelegate))/g;
 
 // https://regex101.com/r/nHrTa9/1/
 // if the above regex fails, we can use this one as a fallback:


### PR DESCRIPTION
### Description

The AppDelegate file has changed in the latest React Native release. Native code must be manually added to the AppDelegate file for React Native Firebase to work. In the case of Expo, this is done using config plugins that use a regex to find the right place in the AppDelegate file and add the required code. With the latest changes in React Native, the regex does not find a match, so no code is added to the AppDelegate file. This pull request updated the regex to find a match in the latest version of the AppDelegate.

https://react-native-community.github.io/upgrade-helper/?from=0.70.5&to=0.71.3 -> see AppDelegate.mm

The regex was extended to find this line: self.moduleName = @"RnDiffApp"; where any string can be the moduleName

Without this change react native firebase will not initailize properly and will not work correctly.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
