### PR TITLE
fix(sdk): ios 10.7.0 / android 31.3.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -233,7 +233,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '10.6.0'
+$FirebaseSDKVersion = '10.7.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -218,7 +218,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "31.2.3"
+        bom           : "31.3.0"
       ],
     ],
   ])

--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -87,11 +87,11 @@ dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   // TODO remove the specific version once it is out of beta and participates in bom versioning
-  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta05'
+  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta06'
   // TODO demonstrate how to only include this in certain build variants
   // - perhaps have firebase.json name the variants to include, then roll through variants here and only
   //   add the dependency to variants that match? Or... (PRs welcome...)
-  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta05'
+  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta06'
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
       "minSdk": 19,
       "targetSdk": 33,
       "compileSdk": 33,
-      "firebase": "31.2.3",
+      "firebase": "31.3.0",
       "firebaseCrashlyticsGradle": "2.9.4",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.15",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -65,7 +65,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.6.0",
+      "firebase": "10.7.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -46,7 +46,7 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.4.2'
     classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
-    classpath 'com.google.firebase:firebase-appdistribution-gradle:3.2.0'
+    classpath 'com.google.firebase:firebase-appdistribution-gradle:4.0.0'
   }
 }
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -612,59 +612,59 @@ PODS:
     - React-Core (= 0.70.6)
     - React-jsi (= 0.70.6)
     - ReactCommon/turbomodule/core (= 0.70.6)
-  - Firebase/Analytics (10.6.0):
+  - Firebase/Analytics (10.7.0):
     - Firebase/Core
-  - Firebase/AppCheck (10.6.0):
+  - Firebase/AppCheck (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 10.6.0)
-  - Firebase/AppDistribution (10.6.0):
+    - FirebaseAppCheck (~> 10.7.0)
+  - Firebase/AppDistribution (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 10.6.0-beta)
-  - Firebase/Auth (10.6.0):
+    - FirebaseAppDistribution (~> 10.7.0-beta)
+  - Firebase/Auth (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.6.0)
-  - Firebase/Core (10.6.0):
+    - FirebaseAuth (~> 10.7.0)
+  - Firebase/Core (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.6.0)
-  - Firebase/CoreOnly (10.6.0):
-    - FirebaseCore (= 10.6.0)
-  - Firebase/Crashlytics (10.6.0):
+    - FirebaseAnalytics (~> 10.7.0)
+  - Firebase/CoreOnly (10.7.0):
+    - FirebaseCore (= 10.7.0)
+  - Firebase/Crashlytics (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.6.0)
-  - Firebase/Database (10.6.0):
+    - FirebaseCrashlytics (~> 10.7.0)
+  - Firebase/Database (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 10.6.0)
-  - Firebase/DynamicLinks (10.6.0):
+    - FirebaseDatabase (~> 10.7.0)
+  - Firebase/DynamicLinks (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.6.0)
-  - Firebase/Firestore (10.6.0):
+    - FirebaseDynamicLinks (~> 10.7.0)
+  - Firebase/Firestore (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.6.0)
-  - Firebase/Functions (10.6.0):
+    - FirebaseFirestore (~> 10.7.0)
+  - Firebase/Functions (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 10.6.0)
-  - Firebase/InAppMessaging (10.6.0):
+    - FirebaseFunctions (~> 10.7.0)
+  - Firebase/InAppMessaging (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 10.6.0-beta)
-  - Firebase/Installations (10.6.0):
+    - FirebaseInAppMessaging (~> 10.7.0-beta)
+  - Firebase/Installations (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 10.6.0)
-  - Firebase/Messaging (10.6.0):
+    - FirebaseInstallations (~> 10.7.0)
+  - Firebase/Messaging (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.6.0)
-  - Firebase/Performance (10.6.0):
+    - FirebaseMessaging (~> 10.7.0)
+  - Firebase/Performance (10.7.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 10.6.0)
-  - Firebase/RemoteConfig (10.6.0):
+    - FirebasePerformance (~> 10.7.0)
+  - Firebase/RemoteConfig (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 10.6.0)
-  - Firebase/Storage (10.6.0):
+    - FirebaseRemoteConfig (~> 10.7.0)
+  - Firebase/Storage (10.7.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.6.0)
-  - FirebaseABTesting (10.6.0):
+    - FirebaseStorage (~> 10.7.0)
+  - FirebaseABTesting (10.7.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseAnalytics (10.6.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.6.0)
+  - FirebaseAnalytics (10.7.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.7.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
@@ -672,40 +672,40 @@ PODS:
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.6.0):
+  - FirebaseAnalytics/AdIdSupport (10.7.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.6.0)
+    - GoogleAppMeasurement (= 10.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAppCheck (10.6.0):
+  - FirebaseAppCheck (10.7.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseAppCheckInterop (10.6.0)
-  - FirebaseAppDistribution (10.6.0-beta):
+  - FirebaseAppCheckInterop (10.7.0)
+  - FirebaseAppDistribution (10.7.0-beta):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-  - FirebaseAuth (10.6.0):
+  - FirebaseAuth (10.7.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseAuthInterop (10.6.0)
-  - FirebaseCore (10.6.0):
+  - FirebaseAuthInterop (10.7.0)
+  - FirebaseCore (10.7.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.6.0):
+  - FirebaseCoreExtension (10.7.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.6.0):
+  - FirebaseCoreInternal (10.7.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.6.0):
+  - FirebaseCrashlytics (10.7.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseSessions (~> 10.5)
@@ -713,12 +713,12 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (10.6.0):
+  - FirebaseDatabase (10.7.0):
     - FirebaseCore (~> 10.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (10.6.0):
+  - FirebaseDynamicLinks (10.7.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseFirestore (10.6.0):
+  - FirebaseFirestore (10.7.0):
     - abseil/algorithm (~> 1.20211102.0)
     - abseil/base (~> 1.20211102.0)
     - abseil/container/flat_hash_map (~> 1.20211102.0)
@@ -731,7 +731,7 @@ PODS:
     - "gRPC-C++ (~> 1.44.0)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseFunctions (10.6.0):
+  - FirebaseFunctions (10.7.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -739,18 +739,18 @@ PODS:
     - FirebaseMessagingInterop (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseInAppMessaging (10.6.0-beta):
+  - FirebaseInAppMessaging (10.7.0-beta):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (10.6.0):
+  - FirebaseInstallations (10.7.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.6.0):
+  - FirebaseMessaging (10.7.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.2)
@@ -759,8 +759,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseMessagingInterop (10.6.0)
-  - FirebasePerformance (10.6.0):
+  - FirebaseMessagingInterop (10.7.0)
+  - FirebasePerformance (10.7.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfig (~> 10.0)
@@ -770,13 +770,13 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (10.6.0):
+  - FirebaseRemoteConfig (10.7.0):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseSessions (10.6.0):
+  - FirebaseSessions (10.7.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -784,8 +784,8 @@ PODS:
     - GoogleUtilities/Environment (~> 7.10)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (10.6.0)
-  - FirebaseStorage (10.6.0):
+  - FirebaseSharedSwift (10.7.0)
+  - FirebaseStorage (10.7.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -793,27 +793,27 @@ PODS:
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (10.6.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.6.0)
+  - GoogleAppMeasurement (10.7.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.6.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.6.0)
+  - GoogleAppMeasurement/AdIdSupport (10.7.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.6.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.7.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - GoogleUtilities/Network (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurementOnDeviceConversion (10.6.0)
+  - GoogleAppMeasurementOnDeviceConversion (10.7.0)
   - GoogleDataTransport (9.2.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
@@ -1204,74 +1204,74 @@ PODS:
   - RNDeviceInfo (10.3.0):
     - React-Core
   - RNFBAnalytics (17.3.2):
-    - Firebase/Analytics (= 10.6.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 10.6.0)
+    - Firebase/Analytics (= 10.7.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBApp (17.3.2):
-    - Firebase/CoreOnly (= 10.6.0)
+    - Firebase/CoreOnly (= 10.7.0)
     - React-Core
   - RNFBAppCheck (17.3.2):
-    - Firebase/AppCheck (= 10.6.0)
+    - Firebase/AppCheck (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBAppDistribution (17.3.2):
-    - Firebase/AppDistribution (= 10.6.0)
+    - Firebase/AppDistribution (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBAuth (17.3.2):
-    - Firebase/Auth (= 10.6.0)
+    - Firebase/Auth (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBCrashlytics (17.3.2):
-    - Firebase/Crashlytics (= 10.6.0)
-    - FirebaseCoreExtension (= 10.6.0)
+    - Firebase/Crashlytics (= 10.7.0)
+    - FirebaseCoreExtension (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBDatabase (17.3.2):
-    - Firebase/Database (= 10.6.0)
+    - Firebase/Database (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBDynamicLinks (17.3.2):
-    - Firebase/DynamicLinks (= 10.6.0)
+    - Firebase/DynamicLinks (= 10.7.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
   - RNFBFirestore (17.3.2):
-    - Firebase/Firestore (= 10.6.0)
+    - Firebase/Firestore (= 10.7.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
   - RNFBFunctions (17.3.2):
-    - Firebase/Functions (= 10.6.0)
+    - Firebase/Functions (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBInAppMessaging (17.3.2):
-    - Firebase/InAppMessaging (= 10.6.0)
+    - Firebase/InAppMessaging (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBInstallations (17.3.2):
-    - Firebase/Installations (= 10.6.0)
+    - Firebase/Installations (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBMessaging (17.3.2):
-    - Firebase/Messaging (= 10.6.0)
-    - FirebaseCoreExtension (= 10.6.0)
+    - Firebase/Messaging (= 10.7.0)
+    - FirebaseCoreExtension (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBML (17.3.2):
     - React-Core
     - RNFBApp
   - RNFBPerf (17.3.2):
-    - Firebase/Performance (= 10.6.0)
+    - Firebase/Performance (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBRemoteConfig (17.3.2):
-    - Firebase/RemoteConfig (= 10.6.0)
+    - Firebase/RemoteConfig (= 10.7.0)
     - React-Core
     - RNFBApp
   - RNFBStorage (17.3.2):
-    - Firebase/Storage (= 10.6.0)
+    - Firebase/Storage (= 10.7.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -1492,35 +1492,35 @@ SPEC CHECKSUMS:
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 48289402952f4f7a4e235de70a9a590aa0b79ef4
   FBReactNativeSpec: dd1186fd05255e3457baa2f4ca65e94c2cd1e3ac
-  Firebase: f13680471b021937f2230ea8503c7809d8c29806
-  FirebaseABTesting: cec558d2e670053b1e862c98cfecae64aecfd629
-  FirebaseAnalytics: 9f382605c5ee412b039212f054bf7a403d9850c1
-  FirebaseAppCheck: 3977b20650f45cc5f67704044e5c5e925e933c20
-  FirebaseAppCheckInterop: 13e5394346a811e7158cc136c01f10e3302a3514
-  FirebaseAppDistribution: bf06552dd011b44b3170ecee9f50026535140467
-  FirebaseAuth: 743e5cd568af59d6d99a91ea9300843672515cf7
-  FirebaseAuthInterop: e407335bca1938d65c58db8f4ad14b3c1f862a82
-  FirebaseCore: fa80ad16a62d52f67274b5b88304c3a318bbf9a4
-  FirebaseCoreExtension: 318e5ee9ad4092b00423c2bddd51c3f5c3585973
-  FirebaseCoreInternal: c7cd505e2136811096b225ac388d6254a2622362
-  FirebaseCrashlytics: ede07e7f433a0a2270112baf2d156b111cfb422d
-  FirebaseDatabase: c3ab8f695e48d4c4431f8406b58ebe543be185d9
-  FirebaseDynamicLinks: 99c501143953e925681a37aade96bb2db34b30ca
-  FirebaseFirestore: f91b23a3c71448475d17163baf916d5d20d01609
-  FirebaseFunctions: 00d1f36edb73f589b7b22af06abc097d144644d9
-  FirebaseInAppMessaging: 1ba33ed4c88ba8384a2c239f722d8810c479ad70
-  FirebaseInstallations: 13dde135fa0524e15bddb133ccc8465c53a1b3f3
-  FirebaseMessaging: fd93783258c53ae5cdb9b41bf0c51606a677f2d5
-  FirebaseMessagingInterop: 9607c116534fc11e11925a312da989a5dd8e6827
-  FirebasePerformance: 015ec3614f742150244171522bdb75995dbf98b7
-  FirebaseRemoteConfig: 7ef4dd164f3066c64ca1efab0f990152a6b94fc0
-  FirebaseSessions: 60e877d5159eb571a3d82df68947a7941b475a20
-  FirebaseSharedSwift: 103ae5bacb5468cd7727ae141f338fa94d7ee1f2
-  FirebaseStorage: 10d4f43a4ef98e7554da72197ad52216686ea990
+  Firebase: 0219acf760880eeec8ce479895bd7767466d9f81
+  FirebaseABTesting: 76c8297fd026074e0366dc941d265d1be80a56d5
+  FirebaseAnalytics: f8133442ee6f8512e28ff19e62ce15398bfaeace
+  FirebaseAppCheck: 81143f6f973d277962b71e16c63068a8f4a755dc
+  FirebaseAppCheckInterop: 8e907eea79958960a8bd2058e067f31e03a7914b
+  FirebaseAppDistribution: f990e8a748106da0f1a67960b13f3c4a7bba21f7
+  FirebaseAuth: dd64c01631df724b09f33e584625775c52f7d71f
+  FirebaseAuthInterop: 46201190fe90ef1f581513eb0f9fa3d7820e7d6d
+  FirebaseCore: e317665b9d744727a97e623edbbed009320afdd7
+  FirebaseCoreExtension: f17247ba8c61e4d3c8d136b5e2de3cb4ac6a85b6
+  FirebaseCoreInternal: 8845798510aae74703467480f71ac613788d0696
+  FirebaseCrashlytics: 35fdd1a433b31e28adcf5c8933f4c526691a1e0b
+  FirebaseDatabase: 06195bac336b5e4c893ec04a111631a4cdb00178
+  FirebaseDynamicLinks: 16a8fae3697fba66fed7a1d646fe59f30d42aa31
+  FirebaseFirestore: 3963a6edd1c84b4748dab3e2c62624a29d03eca1
+  FirebaseFunctions: 6cede311274dd1e13ea4950fc9e57221d3538386
+  FirebaseInAppMessaging: d04732fe9c37c3d026d66435abba60120087a7f5
+  FirebaseInstallations: 59c0e4c7a816a0f76710d83f77e5369b3e45eb96
+  FirebaseMessaging: ac9062bcc35ed56e15a0241d8fd317022499baf8
+  FirebaseMessagingInterop: c49e2766f4059ea4ef9e7c7764ed741a14aaeded
+  FirebasePerformance: 8281bbaf08aad194001018b932115b7d58a6f00b
+  FirebaseRemoteConfig: d5de62211e2eaa2152d8ee85a23c301b70887a74
+  FirebaseSessions: 34e5c084da010ef3802cbc062b822e513c9e6318
+  FirebaseSharedSwift: 993e46657e34f14fe497c4a43c1f9608dabfb2e5
+  FirebaseStorage: 4841efa304543e1f9e4ca116c559c7a1ea2a9d0f
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  GoogleAppMeasurement: 686b48c3c895f3c55c70719041913d5d150b74f6
-  GoogleAppMeasurementOnDeviceConversion: 89f6c920a28524932cc00b5397ec48cb0450214f
+  GoogleAppMeasurement: fe17c92a32207dd5cdd4e8d742767f2da74857f6
+  GoogleAppMeasurementOnDeviceConversion: 22e46334a29666388df619958609fc76a8458b3c
   GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
   GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
   "gRPC-C++": 9675f953ace2b3de7c506039d77be1f2e77a8db2
@@ -1562,23 +1562,23 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 15437b576139df27635400de0599d9844f1ab817
   ReactCommon: 349be31adeecffc7986a0de875d7fb0dcf4e251c
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
-  RNFBAnalytics: fcf48679ae8ec2b767695d9ca7b40a94a2d613c9
-  RNFBApp: dd22a306a31189e99126a35962498c83b06520ab
-  RNFBAppCheck: 888fa983b855bbbec5ca55d2e8b59f89150e8729
-  RNFBAppDistribution: 7e19d235f6771d65a2b475efc16b52eec75426e2
-  RNFBAuth: c0dbc7680a3181e460fdc2b4ba80851363c6946d
-  RNFBCrashlytics: d377d4bbe23f6054340224033c2b5681bfb46975
-  RNFBDatabase: 092d98672c640241688cc9f30e80576b075e2ff6
-  RNFBDynamicLinks: 31246d22f0bcda1b3022b89c97483fc079cc3025
-  RNFBFirestore: 8530d924a54b8e52dd89d0335bb161c41d36a252
-  RNFBFunctions: 00024bff9ad1b7fb90b7616f78bfcd7019968df0
-  RNFBInAppMessaging: cf309752c6ce459575a825775f0a6d5401fa908a
-  RNFBInstallations: 610d5d29b957939c7d53aaf0a2577b98745421c9
-  RNFBMessaging: 8c6192acc48b9daacbfe9da9cacca8bee740ce46
+  RNFBAnalytics: cc47d7b6690f94c7881664f5a8c08892914587ab
+  RNFBApp: ac84fed5b4aec083f6119be2e5708fcc180e6ec4
+  RNFBAppCheck: 498d25fc67cb81cf126dbaeb5159c31fff75cdfe
+  RNFBAppDistribution: b86a5021b568c689231469f8a57360f37be6bead
+  RNFBAuth: e419624703bae531c48c9b0a3ced2c198099ed71
+  RNFBCrashlytics: e5b22746a343595f42e8b46dbd5cce06da9636f7
+  RNFBDatabase: c16973344d93e73109a6780ace83d578a82677f0
+  RNFBDynamicLinks: 822b49584b50baa048317984c0fda852ffafc20b
+  RNFBFirestore: d9e0512e5d62f0a4c5ac13f7cdcf34b2a530ea4d
+  RNFBFunctions: 087d687aa2dfcf100d2d9af3c608534ab6b15878
+  RNFBInAppMessaging: 0570b28f4b417ce067c72cfc5b30cc735715d7b6
+  RNFBInstallations: 4a3304f1d67a41634a0b8012a00a56fdef3812d9
+  RNFBMessaging: 3cb6638f013123712e490c2e3685b4bd4e4dbf58
   RNFBML: 152d4a41ba31530fef895df150d593dfcfba4c2d
-  RNFBPerf: 6141204b1666b966d8170037e7c9d227c9700969
-  RNFBRemoteConfig: 1a0fc7fbd6ae83cc73e49daca65a81038fcdab70
-  RNFBStorage: 83ac3f2b388cdba567f7a39f59b5a895de8e38e4
+  RNFBPerf: c208696ad2fd663a1bfde2e3f27fa5d8fc25cc33
+  RNFBRemoteConfig: 50ebce2784d03021610f1ab6f7bab637a6cab5dc
+  RNFBStorage: a09ea73cb1d4e11f9bcb297d0a6e94af04e03652
   Yoga: 99caf8d5ab45e9d637ee6e0174ec16fbbb01bcfc
 
 PODFILE CHECKSUM: 32a969fd7f3b6c33961f117a754db51a2771db9a

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1203,74 +1203,74 @@ PODS:
     - React-perflogger (= 0.70.6)
   - RNDeviceInfo (10.3.0):
     - React-Core
-  - RNFBAnalytics (17.3.1):
+  - RNFBAnalytics (17.3.2):
     - Firebase/Analytics (= 10.6.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (17.3.1):
+  - RNFBApp (17.3.2):
     - Firebase/CoreOnly (= 10.6.0)
     - React-Core
-  - RNFBAppCheck (17.3.1):
+  - RNFBAppCheck (17.3.2):
     - Firebase/AppCheck (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (17.3.1):
+  - RNFBAppDistribution (17.3.2):
     - Firebase/AppDistribution (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (17.3.1):
+  - RNFBAuth (17.3.2):
     - Firebase/Auth (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (17.3.1):
+  - RNFBCrashlytics (17.3.2):
     - Firebase/Crashlytics (= 10.6.0)
     - FirebaseCoreExtension (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (17.3.1):
+  - RNFBDatabase (17.3.2):
     - Firebase/Database (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (17.3.1):
+  - RNFBDynamicLinks (17.3.2):
     - Firebase/DynamicLinks (= 10.6.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (17.3.1):
+  - RNFBFirestore (17.3.2):
     - Firebase/Firestore (= 10.6.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (17.3.1):
+  - RNFBFunctions (17.3.2):
     - Firebase/Functions (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (17.3.1):
+  - RNFBInAppMessaging (17.3.2):
     - Firebase/InAppMessaging (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (17.3.1):
+  - RNFBInstallations (17.3.2):
     - Firebase/Installations (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (17.3.1):
+  - RNFBMessaging (17.3.2):
     - Firebase/Messaging (= 10.6.0)
     - FirebaseCoreExtension (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBML (17.3.1):
+  - RNFBML (17.3.2):
     - React-Core
     - RNFBApp
-  - RNFBPerf (17.3.1):
+  - RNFBPerf (17.3.2):
     - Firebase/Performance (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (17.3.1):
+  - RNFBRemoteConfig (17.3.2):
     - Firebase/RemoteConfig (= 10.6.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (17.3.1):
+  - RNFBStorage (17.3.2):
     - Firebase/Storage (= 10.6.0)
     - React-Core
     - RNFBApp
@@ -1562,23 +1562,23 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 15437b576139df27635400de0599d9844f1ab817
   ReactCommon: 349be31adeecffc7986a0de875d7fb0dcf4e251c
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
-  RNFBAnalytics: dddcf6c6917c535e3dd956265a4928da12c09629
-  RNFBApp: 6648d604240925bc43480c4c68d393baf39859fa
-  RNFBAppCheck: 46335cbee73cb8716788a0d886f76bf16a90e597
-  RNFBAppDistribution: 9fa9b2cb2afe2652059a4956535b8c1bd24c12c0
-  RNFBAuth: 08e36332c7987646bea1ebb5c58f8c2055cb832d
-  RNFBCrashlytics: a22383f36cf700ad2909f531fd62e79c2d372c7a
-  RNFBDatabase: 04861245173a38c2b099d5a93238c1bb008305ac
-  RNFBDynamicLinks: b1f94712eed98459981b6a6d3a7330c0871c830c
-  RNFBFirestore: 1cef7fc2fceb20305096e69a3e3c4807bfa6d16a
-  RNFBFunctions: 9e6ec443eb0bffb761c73d4bd528d48be267067b
-  RNFBInAppMessaging: a10e2587ec38825b03edf3ad90d30a57e49afde6
-  RNFBInstallations: 30bc0f13699c2070b9a5c6d593bf7910cea6d296
-  RNFBMessaging: 777dc568f1f35a4eaa8c8a2ec7f770751cc5da92
-  RNFBML: c851993f2339a455a65b68d46c5ec5a340756f67
-  RNFBPerf: c4d1db8432e5a6ba8bbc7228c24fd0c9ba30b821
-  RNFBRemoteConfig: 0412c351ccfc668d7410e2ef189669b4bf6956a0
-  RNFBStorage: 12a5cc82598ba384600b2ff3798f99d834d36969
+  RNFBAnalytics: fcf48679ae8ec2b767695d9ca7b40a94a2d613c9
+  RNFBApp: dd22a306a31189e99126a35962498c83b06520ab
+  RNFBAppCheck: 888fa983b855bbbec5ca55d2e8b59f89150e8729
+  RNFBAppDistribution: 7e19d235f6771d65a2b475efc16b52eec75426e2
+  RNFBAuth: c0dbc7680a3181e460fdc2b4ba80851363c6946d
+  RNFBCrashlytics: d377d4bbe23f6054340224033c2b5681bfb46975
+  RNFBDatabase: 092d98672c640241688cc9f30e80576b075e2ff6
+  RNFBDynamicLinks: 31246d22f0bcda1b3022b89c97483fc079cc3025
+  RNFBFirestore: 8530d924a54b8e52dd89d0335bb161c41d36a252
+  RNFBFunctions: 00024bff9ad1b7fb90b7616f78bfcd7019968df0
+  RNFBInAppMessaging: cf309752c6ce459575a825775f0a6d5401fa908a
+  RNFBInstallations: 610d5d29b957939c7d53aaf0a2577b98745421c9
+  RNFBMessaging: 8c6192acc48b9daacbfe9da9cacca8bee740ce46
+  RNFBML: 152d4a41ba31530fef895df150d593dfcfba4c2d
+  RNFBPerf: 6141204b1666b966d8170037e7c9d227c9700969
+  RNFBRemoteConfig: 1a0fc7fbd6ae83cc73e49daca65a81038fcdab70
+  RNFBStorage: 83ac3f2b388cdba567f7a39f59b5a895de8e38e4
   Yoga: 99caf8d5ab45e9d637ee6e0174ec16fbbb01bcfc
 
 PODFILE CHECKSUM: 32a969fd7f3b6c33961f117a754db51a2771db9a


### PR DESCRIPTION
Also includes remnants from prior firebase-android-sdk 31.2.3 release - specifically the app-distribution plugin bump was missed before (apologies)

There does not appear to be anything remarkable about this SDK version bump for us at all (excellent!) so just going to leave it pending on CI