### PR TITLE
fix(crashlytics, android): use v2.9.2 of crashlytics android plugin

### DIFF
--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -40,7 +40,8 @@ buildscript {
   // ..
   dependencies {
     // ..
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
+    // NOTE: 2.9.4 has issues: https://github.com/invertase/react-native-firebase/issues/6983
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
   }
   // ..
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -74,7 +74,7 @@
       "targetSdk": 33,
       "compileSdk": 33,
       "firebase": "31.3.0",
-      "firebaseCrashlyticsGradle": "2.9.4",
+      "firebaseCrashlyticsGradle": "2.9.2",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.15",
       "playServicesAuth": "20.3.0"

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.4'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1203,74 +1203,74 @@ PODS:
     - React-perflogger (= 0.70.6)
   - RNDeviceInfo (10.3.0):
     - React-Core
-  - RNFBAnalytics (17.3.2):
+  - RNFBAnalytics (17.4.0):
     - Firebase/Analytics (= 10.7.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (17.3.2):
+  - RNFBApp (17.4.0):
     - Firebase/CoreOnly (= 10.7.0)
     - React-Core
-  - RNFBAppCheck (17.3.2):
+  - RNFBAppCheck (17.4.0):
     - Firebase/AppCheck (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (17.3.2):
+  - RNFBAppDistribution (17.4.0):
     - Firebase/AppDistribution (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (17.3.2):
+  - RNFBAuth (17.4.0):
     - Firebase/Auth (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (17.3.2):
+  - RNFBCrashlytics (17.4.0):
     - Firebase/Crashlytics (= 10.7.0)
     - FirebaseCoreExtension (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (17.3.2):
+  - RNFBDatabase (17.4.0):
     - Firebase/Database (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (17.3.2):
+  - RNFBDynamicLinks (17.4.0):
     - Firebase/DynamicLinks (= 10.7.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (17.3.2):
+  - RNFBFirestore (17.4.0):
     - Firebase/Firestore (= 10.7.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (17.3.2):
+  - RNFBFunctions (17.4.0):
     - Firebase/Functions (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (17.3.2):
+  - RNFBInAppMessaging (17.4.0):
     - Firebase/InAppMessaging (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (17.3.2):
+  - RNFBInstallations (17.4.0):
     - Firebase/Installations (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (17.3.2):
+  - RNFBMessaging (17.4.0):
     - Firebase/Messaging (= 10.7.0)
     - FirebaseCoreExtension (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBML (17.3.2):
+  - RNFBML (17.4.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (17.3.2):
+  - RNFBPerf (17.4.0):
     - Firebase/Performance (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (17.3.2):
+  - RNFBRemoteConfig (17.4.0):
     - Firebase/RemoteConfig (= 10.7.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (17.3.2):
+  - RNFBStorage (17.4.0):
     - Firebase/Storage (= 10.7.0)
     - React-Core
     - RNFBApp
@@ -1562,23 +1562,23 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 15437b576139df27635400de0599d9844f1ab817
   ReactCommon: 349be31adeecffc7986a0de875d7fb0dcf4e251c
   RNDeviceInfo: 4701f0bf2a06b34654745053db0ce4cb0c53ada7
-  RNFBAnalytics: cc47d7b6690f94c7881664f5a8c08892914587ab
-  RNFBApp: ac84fed5b4aec083f6119be2e5708fcc180e6ec4
-  RNFBAppCheck: 498d25fc67cb81cf126dbaeb5159c31fff75cdfe
-  RNFBAppDistribution: b86a5021b568c689231469f8a57360f37be6bead
-  RNFBAuth: e419624703bae531c48c9b0a3ced2c198099ed71
-  RNFBCrashlytics: e5b22746a343595f42e8b46dbd5cce06da9636f7
-  RNFBDatabase: c16973344d93e73109a6780ace83d578a82677f0
-  RNFBDynamicLinks: 822b49584b50baa048317984c0fda852ffafc20b
-  RNFBFirestore: d9e0512e5d62f0a4c5ac13f7cdcf34b2a530ea4d
-  RNFBFunctions: 087d687aa2dfcf100d2d9af3c608534ab6b15878
-  RNFBInAppMessaging: 0570b28f4b417ce067c72cfc5b30cc735715d7b6
-  RNFBInstallations: 4a3304f1d67a41634a0b8012a00a56fdef3812d9
-  RNFBMessaging: 3cb6638f013123712e490c2e3685b4bd4e4dbf58
-  RNFBML: 152d4a41ba31530fef895df150d593dfcfba4c2d
-  RNFBPerf: c208696ad2fd663a1bfde2e3f27fa5d8fc25cc33
-  RNFBRemoteConfig: 50ebce2784d03021610f1ab6f7bab637a6cab5dc
-  RNFBStorage: a09ea73cb1d4e11f9bcb297d0a6e94af04e03652
+  RNFBAnalytics: bf81020182848cc442aca85a1b05c6c3bdb61f6e
+  RNFBApp: b0f0c53ed8a00395ceb4863910a2c1ff6e24d9f6
+  RNFBAppCheck: 6323b6056a2128045cde72e2a367ea393204fa2c
+  RNFBAppDistribution: e6253fc47e2091b3182549f842d756505251cf6f
+  RNFBAuth: 6cdbfd3633030da325c011853a4b312aa40cb6ad
+  RNFBCrashlytics: 43358406044e9fa98f949b3fd7129df33bd6a9a8
+  RNFBDatabase: 680e6477a552a7af87cc49df1e24f4b6bbb2c8ee
+  RNFBDynamicLinks: 55245367dd76723ab59f1d257c653e765a65cff1
+  RNFBFirestore: 16d774335ee79cfc33106d5e124dca73af4e47bb
+  RNFBFunctions: 8748ffd01c62b4f7d483efbb82e83311a7ff8f65
+  RNFBInAppMessaging: d1fe00eb7f40911e3ef7b6974e97d850ad72e5f6
+  RNFBInstallations: c4aa6a4ee5a7d08a391cf716815f16532bf0b8a2
+  RNFBMessaging: e683adf735d2afb847bce161dce0e4006e88a3a2
+  RNFBML: 2fdebccf20764feb9cdb37a7510bf670e03d771f
+  RNFBPerf: 6656d4787d7f19e0acc8c7e7e165f06f3b843524
+  RNFBRemoteConfig: 8d4731e0e39fc0d10cfec2f2a451def50f65a426
+  RNFBStorage: dbb6ce9ec899f3e8b3e5607b3461f7630a8ef21e
   Yoga: 99caf8d5ab45e9d637ee6e0174ec16fbbb01bcfc
 
 PODFILE CHECKSUM: 32a969fd7f3b6c33961f117a754db51a2771db9a


### PR DESCRIPTION
### Description

There have been multiple reports of problems with android release builds recently, looks like root cause is upstream

Recommending people use the 2.9.2 version of the crashlytics gradle plugin until upstream issue is resolved

### Related issues

Related #6983 / #7000 

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I used my make-demo script to reproduce the failure and the success after backing plugin version down to 2.9.2 https://github.com/mikehardy/rnfbdemo/blob/main/make-demo.sh

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
