### PR TITLE
docs(app-check, android): note that Play Integrity requires Play Store distribution

### DIFF
--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -55,7 +55,7 @@ This App Check module has built-in support for using the following services as a
 
 - DeviceCheck on iOS
 - App Attest on iOS
-- Play Integrity on Android
+- Play Integrity on Android (requires distribution from Play Store to successfully fetch tokens)
 - SafetyNet on Android (deprecated)
 - Debug providers on both platforms
 


### PR DESCRIPTION

### Description


A user noted that Play Integrity works, but only with Play Store distribution

### Related issues

https://github.com/invertase/react-native-firebase/discussions/7007#discussioncomment-5466678

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
