### PR TITLE
fix(firestore, types): add types for Filter constraints on Queries

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1395,6 +1395,24 @@ export namespace FirebaseFirestoreTypes {
      * @param value The comparison value.
      */
     where(fieldPath: keyof T | FieldPath, opStr: WhereFilterOp, value: any): Query<T>;
+
+    /**
+     * Creates and returns a new Query with the additional filter that documents must contain the specified field and
+     * the value should satisfy the relation constraint provided.
+     *
+     * #### Example
+     *
+     * ```js
+     * // Get all users who's age is 30 or above
+     * const querySnapshot = await firebase.firestore()
+     *   .collection('users')
+     *   .where(Filter('age', '>=', 30));
+     *   .get();
+     * ```
+     *
+     * @param filter The filter to apply to the query.
+     */
+    where(filter: FilterFunction): Query<T>;
   }
 
   /**

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1412,7 +1412,7 @@ export namespace FirebaseFirestoreTypes {
      *
      * @param filter The filter to apply to the query.
      */
-    where(filter: FilterFunction): Query<T>;
+    where(filter: QueryFilterConstraint | QueryCompositeFilterConstraint): Query<T>;
   }
 
   /**

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -2066,6 +2066,11 @@ export namespace FirebaseFirestoreTypes {
     Timestamp: typeof Timestamp;
 
     /**
+     * Returns the `Filter` function.
+     */
+    Filter: typeof Filter;
+
+    /**
      * Used to set the cache size to unlimited when passing to `cacheSizeBytes` in
      * `firebase.firestore().settings()`.
      */

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -2335,6 +2335,8 @@ export const firebase: ReactNativeFirebase.Module & {
   ): ReactNativeFirebase.FirebaseApp & { firestore(): FirebaseFirestoreTypes.Module };
 };
 
+export const Filter: FilterFunction;
+
 export default defaultExport;
 
 /**

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -33,7 +33,6 @@ import FirestoreCollectionReference from './FirestoreCollectionReference';
 import FirestoreDocumentReference from './FirestoreDocumentReference';
 import FirestorePath from './FirestorePath';
 import FirestoreQuery from './FirestoreQuery';
-export { Filter } from './FirestoreFilter';
 import FirestoreQueryModifiers from './FirestoreQueryModifiers';
 import FirestoreStatics from './FirestoreStatics';
 import FirestoreTransactionHandler from './FirestoreTransactionHandler';

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -33,6 +33,7 @@ import FirestoreCollectionReference from './FirestoreCollectionReference';
 import FirestoreDocumentReference from './FirestoreDocumentReference';
 import FirestorePath from './FirestorePath';
 import FirestoreQuery from './FirestoreQuery';
+export { Filter } from './FirestoreFilter';
 import FirestoreQueryModifiers from './FirestoreQueryModifiers';
 import FirestoreStatics from './FirestoreStatics';
 import FirestoreTransactionHandler from './FirestoreTransactionHandler';


### PR DESCRIPTION
### Description

When using the firestore document queries, typescript types seem to ignore the Filter object. Filter is already supported and well documented at https://rnfirebase.io/firestore/usage#filtering.

The documentation example does not compile when using typescript:

```ts
const snapshot = await firestore()
  .collection('Users')
  .where(Filter('user', '==', 'Tim'))
  .where('email', '==', 'tim@example.com')
  .get();
```

### Release Summary

Adding type support for Filter constraints on document queries.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No