### PR TITLE
fix(firestore): Allow queries with combined in and array-contains-any

### DIFF
--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -245,24 +245,6 @@ describe(' firestore().collection().where(AND Filters)', function () {
     }
   });
 
-  it('throws if query has in & array-contains-any filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(
-          Filter.and(Filter('foo.bar', 'in', [1]), Filter('foo.bar', 'array-contains-any', [2])),
-        );
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'array-contains-any' filters with 'in' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
   it("should throw error when using 'not-in' operator twice", async function () {
     const ref = firebase.firestore().collection(COLLECTION);
 

--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -213,38 +213,6 @@ describe(' firestore().collection().where(AND Filters)', function () {
     }
   });
 
-  it('throws if query has array-contains-any & in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(
-          Filter.and(Filter('foo.bar', 'array-contains-any', [1]), Filter('foo.bar', 'in', [2])),
-        );
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'in' filters with 'array-contains-any' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
-  it('throws if query has multiple in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(Filter.and(Filter('foo.bar', 'in', [1]), Filter('foo.bar', 'in', [2])));
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql("You cannot use more than one 'in' filter");
-      return Promise.resolve();
-    }
-  });
-
   it("should throw error when using 'not-in' operator twice", async function () {
     const ref = firebase.firestore().collection(COLLECTION);
 

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -159,36 +159,6 @@ describe('firestore().collection().where()', function () {
     }
   });
 
-  it('throws if query has array-contains-any & in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where('foo.bar', 'array-contains-any', [1])
-        .where('foo.bar', 'in', [2]);
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'in' filters with 'array-contains-any' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
-  it('throws if query has multiple in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where('foo.bar', 'in', [1])
-        .where('foo.bar', 'in', [2]);
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql("You cannot use more than one 'in' filter");
-      return Promise.resolve();
-    }
-  });
-
   /* Queries */
 
   it('returns with where equal filter', async function () {

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -189,22 +189,6 @@ describe('firestore().collection().where()', function () {
     }
   });
 
-  it('throws if query has in & array-contains-any filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where('foo.bar', 'in', [1])
-        .where('foo.bar', 'array-contains-any', [2]);
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'array-contains-any' filters with 'in' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
   /* Queries */
 
   it('returns with where equal filter', async function () {

--- a/packages/firestore/e2e/Query/where.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.filter.e2e.js
@@ -171,38 +171,6 @@ describe('firestore().collection().where(Filters)', function () {
     }
   });
 
-  it('throws if query has array-contains-any & in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(Filter('foo.bar', 'array-contains-any', [1]))
-        .where(Filter('foo.bar', 'in', [2]));
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'in' filters with 'array-contains-any' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
-  it('throws if query has multiple in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(Filter('foo.bar', 'in', [1]))
-        .where(Filter('foo.bar', 'in', [2]));
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql("You cannot use more than one 'in' filter");
-      return Promise.resolve();
-    }
-  });
-
   it("should throw error when using 'not-in' operator twice", async function () {
     const ref = firebase.firestore().collection(COLLECTION);
 

--- a/packages/firestore/e2e/Query/where.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.filter.e2e.js
@@ -203,23 +203,6 @@ describe('firestore().collection().where(Filters)', function () {
     }
   });
 
-  it('throws if query has in & array-contains-any filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(Filter('foo.bar', 'in', [1]))
-        .where(Filter('foo.bar', 'array-contains-any', [2]));
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'array-contains-any' filters with 'in' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
   it("should throw error when using 'not-in' operator twice", async function () {
     const ref = firebase.firestore().collection(COLLECTION);
 

--- a/packages/firestore/e2e/Query/where.or.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.or.filter.e2e.js
@@ -318,46 +318,6 @@ describe('firestore().collection().where(OR Filters)', function () {
     }
   });
 
-  it('throws if query has array-contains-any & in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(
-          Filter.or(
-            Filter.and(Filter('foo.bar', 'array-contains-any', [1]), Filter('foo.bar', 'in', [2])),
-            Filter.and(Filter('foo.bar', 'array-contains-any', [1]), Filter('foo.bar', 'in', [2])),
-          ),
-        );
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'in' filters with 'array-contains-any' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
-  it('throws if query has multiple in filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(
-          Filter.or(
-            Filter.and(Filter('foo.bar', 'in', [1]), Filter('foo.bar', 'in', [2])),
-            Filter.and(Filter('foo.bar', 'in', [1]), Filter('foo.bar', 'in', [2])),
-          ),
-        );
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql("You cannot use more than one 'in' filter");
-      return Promise.resolve();
-    }
-  });
-
   it("should throw error when using 'not-in' operator twice", async function () {
     const ref = firebase.firestore().collection(COLLECTION);
 

--- a/packages/firestore/e2e/Query/where.or.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.or.filter.e2e.js
@@ -358,27 +358,6 @@ describe('firestore().collection().where(OR Filters)', function () {
     }
   });
 
-  it('throws if query has in & array-contains-any filter', function () {
-    try {
-      firebase
-        .firestore()
-        .collection(COLLECTION)
-        .where(
-          Filter.or(
-            Filter.and(Filter('foo.bar', 'in', [1]), Filter('foo.bar', 'array-contains-any', [2])),
-            Filter.and(Filter('foo.bar', 'in', [1]), Filter('foo.bar', 'array-contains-any', [2])),
-          ),
-        );
-
-      return Promise.reject(new Error('Did not throw an Error.'));
-    } catch (error) {
-      error.message.should.containEql(
-        "You cannot use 'array-contains-any' filters with 'in' filters",
-      );
-      return Promise.resolve();
-    }
-  });
-
   it("should throw error when using 'not-in' operator twice", async function () {
     const ref = firebase.firestore().collection(COLLECTION);
 

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -297,12 +297,6 @@ export default class FirestoreQueryModifiers {
           );
         }
 
-        if (this.hasIn) {
-          throw new Error(
-            "Invalid query. You cannot use 'array-contains-any' filters with 'in' filters.",
-          );
-        }
-
         if (this.hasNotIn) {
           throw new Error(
             "Invalid query. You cannot use 'array-contains-any' filters with 'not-in' filters.",
@@ -313,16 +307,6 @@ export default class FirestoreQueryModifiers {
       }
 
       if (filter.operator === OPERATORS.in) {
-        if (this.hasIn) {
-          throw new Error("Invalid query. You cannot use more than one 'in' filter.");
-        }
-
-        if (this.hasArrayContainsAny) {
-          throw new Error(
-            "Invalid query. You cannot use 'in' filters with 'array-contains-any' filters.",
-          );
-        }
-
         if (this.hasNotIn) {
           throw new Error("Invalid query. You cannot use 'in' filters with 'not-in' filters.");
         }


### PR DESCRIPTION
### Description

Since late april queries containing `in` and `array-contains-any` together are supported as queries with multiple `in` statements, given that the number of generated `or` queries in normal form is below 30. Since `@react-native-firebase/firestore` is currently blocking any of these queries, this PR aims at removing that block, leaving the check for the normal form limit to the underlying firestore engine.

This is the relevant firebase docs on these limitations: https://firebase.google.com/docs/firestore/query-data/queries#limitations_3

Please note: I do not have a history of the changes available, I know this change has been added with the `or` operator support.

### Related issues

None

### Release Summary

Allow the use of `in` and `array-contains-any` in the same query.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I ran the e2e tests, these are the results:

```
  1679 passing (3m)
  116 pending
```

Apart from running e2e tests I did use my fork in my own project using the aforementioned `in` and `array-contains-any` filters in some queries, and they work fine.

:fire: