### PR TITLE
docs(dynamic-links): Fix link to firebase docs

### DIFF
--- a/packages/dynamic-links/README.md
+++ b/packages/dynamic-links/README.md
@@ -23,7 +23,7 @@
 
 Dynamic Links are smart URLs that allow you to send existing and potential users to any location within your React Native app. They survive the app install process, so even new users can see the content they're looking for when they open the app for the first time.
 
-[> Learn More](https://firebase.google.com/products/dynamic-links/)
+[> Learn More](https://firebase.google.com/docs/dynamic-links)
 
 ## Installation
 


### PR DESCRIPTION
### Description

The README in the dynamic-links package pointed to an outdated firebase URL.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

:fire: