### PR TITLE
fix(app, ios): incorporate firebase-ios-sdk 10.12.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -233,7 +233,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '10.11.0'
+$FirebaseSDKVersion = '10.12.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.11.0",
+      "firebase": "10.12.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -325,13 +325,7 @@ class FirebaseConfigModule extends FirebaseModule {
       }
       subscription.remove();
       this._configUpdateListenerCount--;
-      // In firebase-ios-sdk, it appears listener removal fails, so our native listeners accumulate
-      // if we try to remove them. Temporarily allow iOS native listener to stay active forever after
-      // first subscription for an app, until issue #11458 in firebase-ios-sdk repo is resolved.
-      // react-native-firebase native subscribe code won't add multiple native listeners for same app,
-      // so this prevents listener accumulation but means the web socket on iOS will never close.
-      // TODO: Remove when firebase-ios-sdk 10.12.0 is adopted, the PR to fix it should be included
-      if (this._configUpdateListenerCount === 0 && Platform.OS !== 'ios') {
+      if (this._configUpdateListenerCount === 0) {
         this.native.removeConfigUpdateRegistration();
       }
     };

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -644,59 +644,59 @@ PODS:
     - React-Core (= 0.70.7)
     - React-jsi (= 0.70.7)
     - ReactCommon/turbomodule/core (= 0.70.7)
-  - Firebase/Analytics (10.11.0):
+  - Firebase/Analytics (10.12.0):
     - Firebase/Core
-  - Firebase/AppCheck (10.11.0):
+  - Firebase/AppCheck (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 10.11.0)
-  - Firebase/AppDistribution (10.11.0):
+    - FirebaseAppCheck (~> 10.12.0)
+  - Firebase/AppDistribution (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 10.11.0-beta)
-  - Firebase/Auth (10.11.0):
+    - FirebaseAppDistribution (~> 10.12.0-beta)
+  - Firebase/Auth (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.11.0)
-  - Firebase/Core (10.11.0):
+    - FirebaseAuth (~> 10.12.0)
+  - Firebase/Core (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.11.0)
-  - Firebase/CoreOnly (10.11.0):
-    - FirebaseCore (= 10.11.0)
-  - Firebase/Crashlytics (10.11.0):
+    - FirebaseAnalytics (~> 10.12.0)
+  - Firebase/CoreOnly (10.12.0):
+    - FirebaseCore (= 10.12.0)
+  - Firebase/Crashlytics (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.11.0)
-  - Firebase/Database (10.11.0):
+    - FirebaseCrashlytics (~> 10.12.0)
+  - Firebase/Database (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 10.11.0)
-  - Firebase/DynamicLinks (10.11.0):
+    - FirebaseDatabase (~> 10.12.0)
+  - Firebase/DynamicLinks (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.11.0)
-  - Firebase/Firestore (10.11.0):
+    - FirebaseDynamicLinks (~> 10.12.0)
+  - Firebase/Firestore (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.11.0)
-  - Firebase/Functions (10.11.0):
+    - FirebaseFirestore (~> 10.12.0)
+  - Firebase/Functions (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 10.11.0)
-  - Firebase/InAppMessaging (10.11.0):
+    - FirebaseFunctions (~> 10.12.0)
+  - Firebase/InAppMessaging (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 10.11.0-beta)
-  - Firebase/Installations (10.11.0):
+    - FirebaseInAppMessaging (~> 10.12.0-beta)
+  - Firebase/Installations (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 10.11.0)
-  - Firebase/Messaging (10.11.0):
+    - FirebaseInstallations (~> 10.12.0)
+  - Firebase/Messaging (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.11.0)
-  - Firebase/Performance (10.11.0):
+    - FirebaseMessaging (~> 10.12.0)
+  - Firebase/Performance (10.12.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 10.11.0)
-  - Firebase/RemoteConfig (10.11.0):
+    - FirebasePerformance (~> 10.12.0)
+  - Firebase/RemoteConfig (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 10.11.0)
-  - Firebase/Storage (10.11.0):
+    - FirebaseRemoteConfig (~> 10.12.0)
+  - Firebase/Storage (10.12.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.11.0)
-  - FirebaseABTesting (10.11.0):
+    - FirebaseStorage (~> 10.12.0)
+  - FirebaseABTesting (10.12.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseAnalytics (10.11.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.11.0)
+  - FirebaseAnalytics (10.12.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.12.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -704,41 +704,41 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.11.0):
+  - FirebaseAnalytics/AdIdSupport (10.12.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.11.0)
+    - GoogleAppMeasurement (= 10.12.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAppCheck (10.11.0):
+  - FirebaseAppCheck (10.12.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseAppCheckInterop (10.11.0)
-  - FirebaseAppDistribution (10.11.0-beta):
+  - FirebaseAppCheckInterop (10.12.0)
+  - FirebaseAppDistribution (10.12.0-beta):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-  - FirebaseAuth (10.11.0):
+  - FirebaseAuth (10.12.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseAuthInterop (10.11.0)
-  - FirebaseCore (10.11.0):
+  - FirebaseAuthInterop (10.12.0)
+  - FirebaseCore (10.12.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.11.0):
+  - FirebaseCoreExtension (10.12.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.11.0):
+  - FirebaseCoreInternal (10.12.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.11.0):
+  - FirebaseCrashlytics (10.12.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseSessions (~> 10.5)
@@ -746,12 +746,12 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (10.11.0):
+  - FirebaseDatabase (10.12.0):
     - FirebaseCore (~> 10.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (10.11.0):
+  - FirebaseDynamicLinks (10.12.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseFirestore (10.11.0):
+  - FirebaseFirestore (10.12.0):
     - abseil/algorithm (~> 1.20220623.0)
     - abseil/base (~> 1.20220623.0)
     - abseil/container/flat_hash_map (~> 1.20220623.0)
@@ -764,7 +764,7 @@ PODS:
     - "gRPC-C++ (~> 1.50.1)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseFunctions (10.11.0):
+  - FirebaseFunctions (10.12.0):
     - FirebaseAppCheckInterop (~> 10.10)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -772,18 +772,18 @@ PODS:
     - FirebaseMessagingInterop (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseInAppMessaging (10.11.0-beta):
+  - FirebaseInAppMessaging (10.12.0-beta):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (10.11.0):
+  - FirebaseInstallations (10.12.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.11.0):
+  - FirebaseMessaging (10.12.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.2)
@@ -792,8 +792,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseMessagingInterop (10.11.0)
-  - FirebasePerformance (10.11.0):
+  - FirebaseMessagingInterop (10.12.0)
+  - FirebasePerformance (10.12.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfig (~> 10.0)
@@ -803,13 +803,13 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (10.11.0):
+  - FirebaseRemoteConfig (10.12.0):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseSessions (10.11.0):
+  - FirebaseSessions (10.12.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -817,8 +817,8 @@ PODS:
     - GoogleUtilities/Environment (~> 7.10)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (10.11.0)
-  - FirebaseStorage (10.11.0):
+  - FirebaseSharedSwift (10.12.0)
+  - FirebaseStorage (10.12.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -826,27 +826,27 @@ PODS:
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (10.11.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.11.0)
+  - GoogleAppMeasurement (10.12.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.12.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.11.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.11.0)
+  - GoogleAppMeasurement/AdIdSupport (10.12.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.12.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.11.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.12.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurementOnDeviceConversion (10.11.0)
+  - GoogleAppMeasurementOnDeviceConversion (10.12.0)
   - GoogleDataTransport (9.2.3):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
@@ -1241,74 +1241,74 @@ PODS:
   - RNDeviceInfo (10.6.0):
     - React-Core
   - RNFBAnalytics (18.1.0):
-    - Firebase/Analytics (= 10.11.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 10.11.0)
+    - Firebase/Analytics (= 10.12.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBApp (18.1.0):
-    - Firebase/CoreOnly (= 10.11.0)
+    - Firebase/CoreOnly (= 10.12.0)
     - React-Core
   - RNFBAppCheck (18.1.0):
-    - Firebase/AppCheck (= 10.11.0)
+    - Firebase/AppCheck (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBAppDistribution (18.1.0):
-    - Firebase/AppDistribution (= 10.11.0)
+    - Firebase/AppDistribution (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBAuth (18.1.0):
-    - Firebase/Auth (= 10.11.0)
+    - Firebase/Auth (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBCrashlytics (18.1.0):
-    - Firebase/Crashlytics (= 10.11.0)
-    - FirebaseCoreExtension (= 10.11.0)
+    - Firebase/Crashlytics (= 10.12.0)
+    - FirebaseCoreExtension (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBDatabase (18.1.0):
-    - Firebase/Database (= 10.11.0)
+    - Firebase/Database (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBDynamicLinks (18.1.0):
-    - Firebase/DynamicLinks (= 10.11.0)
+    - Firebase/DynamicLinks (= 10.12.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
   - RNFBFirestore (18.1.0):
-    - Firebase/Firestore (= 10.11.0)
+    - Firebase/Firestore (= 10.12.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
   - RNFBFunctions (18.1.0):
-    - Firebase/Functions (= 10.11.0)
+    - Firebase/Functions (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBInAppMessaging (18.1.0):
-    - Firebase/InAppMessaging (= 10.11.0)
+    - Firebase/InAppMessaging (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBInstallations (18.1.0):
-    - Firebase/Installations (= 10.11.0)
+    - Firebase/Installations (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBMessaging (18.1.0):
-    - Firebase/Messaging (= 10.11.0)
-    - FirebaseCoreExtension (= 10.11.0)
+    - Firebase/Messaging (= 10.12.0)
+    - FirebaseCoreExtension (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBML (18.1.0):
     - React-Core
     - RNFBApp
   - RNFBPerf (18.1.0):
-    - Firebase/Performance (= 10.11.0)
+    - Firebase/Performance (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBRemoteConfig (18.1.0):
-    - Firebase/RemoteConfig (= 10.11.0)
+    - Firebase/RemoteConfig (= 10.12.0)
     - React-Core
     - RNFBApp
   - RNFBStorage (18.1.0):
-    - Firebase/Storage (= 10.11.0)
+    - Firebase/Storage (= 10.12.0)
     - React-Core
     - RNFBApp
   - Yoga (1.14.0)
@@ -1528,35 +1528,35 @@ SPEC CHECKSUMS:
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: a6454570f573a0f6f1d397e5a95c13e8e45d1700
   FBReactNativeSpec: 09e8dfba44487e5dc4882a9f5318cde67549549c
-  Firebase: 31d9575c124839fb5abc0db6d39511cc1dab1b85
-  FirebaseABTesting: 3f6b711718feb87346dc05f8c964601bc8fb2cf6
-  FirebaseAnalytics: 6c6bf99e8854475bf1fa342028841be8ecd236da
-  FirebaseAppCheck: fb7a0f680b941e9efd67b1ed9b1d700a2ed73ce5
-  FirebaseAppCheckInterop: 255b6c0292fe5da995c8b2df0c02f6a3ca7f61b4
-  FirebaseAppDistribution: 192195dfe33f95edad95ddc5d7a45ed39dfdf3c7
-  FirebaseAuth: 7aabcb00fbf330db49c207c0d645b8b1b62df0e9
-  FirebaseAuthInterop: 44e34efef7145776a107b9e7f79ed44beb4738fa
-  FirebaseCore: 62fd4d549f5e3f3bd52b7998721c5fa0557fb355
-  FirebaseCoreExtension: cacdad57fdb60e0b86dcbcac058ec78237946759
-  FirebaseCoreInternal: 9e46c82a14a3b3a25be4e1e151ce6d21536b89c0
-  FirebaseCrashlytics: 5927efd92f7fb052b0ab1e673d2f0d97274cd442
-  FirebaseDatabase: 4e1cb7f44ce6ffa553033913dd0d634b2310ce65
-  FirebaseDynamicLinks: 1217666a67daf61ea6107e9bc6d75311b519db67
-  FirebaseFirestore: 09be82b113fbcb225b9797d2c525ae8886abc7a3
-  FirebaseFunctions: 8a2c2328a422c796a331769c5f7f1838e41249a0
-  FirebaseInAppMessaging: ecdd797d89c19713cd9da2a2570fc1c056bd23cc
-  FirebaseInstallations: 2a2c6859354cbec0a228a863d4daf6de7c74ced4
-  FirebaseMessaging: 06253e9669434df0a40718fc82a90c78090f4704
-  FirebaseMessagingInterop: c78a2df8002e0b51fc446a687b5ba357b81e9e90
-  FirebasePerformance: 2e9aa0fb103d6c08403d20d135bf06b3adfb3454
-  FirebaseRemoteConfig: 5f907cd5cf6f64d026c8bfd196a1086cbe1e95e2
-  FirebaseSessions: a62ba5c45284adb7714f4126cfbdb32b17c260bd
-  FirebaseSharedSwift: c590d181c8b80ebf85f2606f4d366cf72f82f184
-  FirebaseStorage: 8d8f23ca3688c2edb1950bd38e44f82a325ceb6f
+  Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0
+  FirebaseABTesting: 09c328e6a86d562b4e1146c8a9073deadc566b77
+  FirebaseAnalytics: 0270389efbe3022b54ec4588862dabec3477ee98
+  FirebaseAppCheck: c5e49dadf9c9cbabf0066074af938e032a0cce48
+  FirebaseAppCheckInterop: f95a4feb9089867aff1a4bdc2ce309137e07736a
+  FirebaseAppDistribution: 3d681f4cfc51f7d1b3d922d9239781adbc33a958
+  FirebaseAuth: a66c1e14ec58f41d154a4b41ce1a23ea00ad4805
+  FirebaseAuthInterop: 047153f3c2928822032190aa5194e332670a0d66
+  FirebaseCore: f86a1394906b97ac445ae49c92552a9425831bed
+  FirebaseCoreExtension: 0ce5ac36042001cfa233ce7bfa28e5c313cf80f4
+  FirebaseCoreInternal: 950500ad8a08963657f6d8c67b579740c06d6aa1
+  FirebaseCrashlytics: c4d111b7430c49744c74bcc6346ea00868661ac8
+  FirebaseDatabase: 6d998d7ef2c1723b3e798a85e61a7dc0504b1ea0
+  FirebaseDynamicLinks: 1a387da899779e5ef34f4d6f8bdba882f90d0e67
+  FirebaseFirestore: f94c9541515fa4a49af52269bbc50349009424b4
+  FirebaseFunctions: d49c7920b289d85029882927e4056ad04a906e19
+  FirebaseInAppMessaging: dc24f50aebaf81a377f0b8abf360778f94208931
+  FirebaseInstallations: 7b99ef103f013624444c614397038219c45f8e63
+  FirebaseMessaging: bb2c4f6422a753038fe137d90ae7c1af57251316
+  FirebaseMessagingInterop: 9009d471dc63cb9e5a7d170e7c107fb78c469f19
+  FirebasePerformance: 1a63c51c9d14fc1190b0970d5aab96672cb0bce6
+  FirebaseRemoteConfig: bc7f260e6596956fafbb532443c19bd3c30f5258
+  FirebaseSessions: a4ee211eeb31a2224cd8d9d4e30a0fccde9aa00c
+  FirebaseSharedSwift: c4eb72d435973c77d6f155f05c963933dcba35a7
+  FirebaseStorage: 1d7ca8c8953fc61ccacaa7c612696b5402968a0d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  GoogleAppMeasurement: d3dabccdb336fc0ae44b633c8abaa26559893cd9
-  GoogleAppMeasurementOnDeviceConversion: 89cca2e1684af4e988a66d338788c3df9fd78086
+  GoogleAppMeasurement: 2d800fab85e7848b1e66a6f8ce5bca06c5aad892
+  GoogleAppMeasurementOnDeviceConversion: f65d325dcb9bfcae49ea75b36c4a552150bacca1
   GoogleDataTransport: f0308f5905a745f94fb91fea9c6cbaf3831cb1bd
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   "gRPC-C++": 0968bace703459fd3e5dcb0b2bed4c573dbff046
@@ -1597,23 +1597,23 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7cec9ed92ebde8309902530bb566819645c84ee5
   ReactCommon: 0253d197eaa7f6689dcd3e7d5360449ab93e10df
   RNDeviceInfo: 475a4c447168d0ad4c807e48ef5e0963a0f4eb1b
-  RNFBAnalytics: 3a376adb91a2f853b1c8174fc340cd2c518b97de
-  RNFBApp: fdbde65110240cd843e644270e974e9b455b0fc1
-  RNFBAppCheck: 00c7b85073266528bdc01051276139072cd9b751
-  RNFBAppDistribution: ecd651d791d502ff03213651850da935540722fa
-  RNFBAuth: 557866ac2a86d114034c0bcfd37b540a1f33d44a
-  RNFBCrashlytics: b69333e28f4c100dbbf69be885f80288b75c8f13
-  RNFBDatabase: 489b3dddcbde3551723f731685594a9ec6b071c4
-  RNFBDynamicLinks: 2060187623835ad6effb279e74503dceb0d9517d
-  RNFBFirestore: 76b44f22aef2629595bdc29fae03345224f185b3
-  RNFBFunctions: f8acac64c44f7f91f7ccb41cab47963424ee14e6
-  RNFBInAppMessaging: 7f45b28869036080123b342911fbb1b5a75175b3
-  RNFBInstallations: 3b2a614cdc7c185307f0784aa5dedbb7f53f304e
-  RNFBMessaging: 3aca7a5b3b1f79a9ee75026662ea57693436a338
+  RNFBAnalytics: 6eff9aec9a07227542f870839678ae33ca04f65d
+  RNFBApp: 80c408a4aedecf586590e8f4c8a5ab02fb34cdce
+  RNFBAppCheck: 1995af720556d3b10bae902d510f1baf7d20386b
+  RNFBAppDistribution: 4be35cc97f569ae076fb9bd20e8e450435ec0fcf
+  RNFBAuth: 209175cdce50e34b17007a1a7cffa21c41d596fe
+  RNFBCrashlytics: 89341ed22fde70dacd7ddd9b332fc470d650c71c
+  RNFBDatabase: 5daa39d00ca1cb377ffd99c4a2d5b18b112f1e6e
+  RNFBDynamicLinks: dc54ce3159ec088a01ae1bcbc60ad2f7ab45b546
+  RNFBFirestore: 57ab9b46d423e74c2c662df8d5c9a7a4d9cd87f2
+  RNFBFunctions: e711e9c17d1fd4421679c6a9055433f319afd470
+  RNFBInAppMessaging: dc54a18b06a3a35c82bd597ef92a1c18e8cca67b
+  RNFBInstallations: 0852d17481140387c1f72c628d8b8992ecb20765
+  RNFBMessaging: f954ddead7027e15c15947f546255528ea9084f8
   RNFBML: ba307c62ae38a4c79455f4511de4fe4f473c7966
-  RNFBPerf: 129977af7d47a2759e50a274b876d10afbf22cbb
-  RNFBRemoteConfig: 9619944a60253fc5998b9ad6e379562871f32149
-  RNFBStorage: 693965df29a3c4b67e3bd1f817dd21f6a7cf6df6
+  RNFBPerf: ea6a174cb7bc3b611f8ef40beef253422d955a81
+  RNFBRemoteConfig: b264f63244dfab6b9188ed9ef7f4a4524ad7e53f
+  RNFBStorage: 390c8acdee377155625015a16f9bf8dc1426c9e4
   Yoga: 92d086bb705a41cc588599b51db726ba7b1d341c
 
 PODFILE CHECKSUM: 99cabbfe87c312125518c3c570f54e7e137c4df7


### PR DESCRIPTION
### Description

New firebase-ios-sdk / remove remote-config realtime update workarounds

### Related issues

All the upstream + here stuff about realtime updates in remoteconfig needing a couple tweaks

### Release Summary

Conventional Commits: This Is The Way

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

CI should demonstrate them, the testing was a huge part of the whole process

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
