### PR TITLE
feat(auth, revokeToken): sign in with apple revokeToken API

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -79,7 +79,7 @@ async function onAppleButtonPress() {
 Upon successful sign-in, any [`onAuthStateChanged`](/auth/usage#listening-to-authentication-state) listeners will trigger
 with the new authentication state of the user.
 
-Apple also requires that the app revoke the `Sign in with Apple` token when the user chooses to delete there account. This can be accomplished with the `revokeToken` API.
+Apple also requires that the app revoke the `Sign in with Apple` token when the user chooses to delete their account. This can be accomplished with the `revokeToken` API.
 
 ```js
 import auth from '@react-native-firebase/auth';

--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -79,6 +79,28 @@ async function onAppleButtonPress() {
 Upon successful sign-in, any [`onAuthStateChanged`](/auth/usage#listening-to-authentication-state) listeners will trigger
 with the new authentication state of the user.
 
+Apple also requires that the app revoke the `Sign in with Apple` token when the user chooses to delete there account. This can be accomplished with the `revokeToken` API.
+
+```js
+import auth from '@react-native-firebase/auth';
+import { appleAuth } from '@invertase/react-native-apple-authentication';
+
+async function revokeSignInWithAppleToken() {
+  // Get an authorizationCode from Apple
+  const { authorizationCode } = await appleAuth.performRequest({
+    requestedOperation: appleAuth.Operation.REFRESH,
+  });
+
+  // Ensure Apple returned an authorizationCode
+  if (!authorizationCode) {
+    throw new Error('Apple Revocation failed - no authorizationCode returned');
+  }
+
+  // Revoke the token
+  return auth().revokeToken(authorizationCode);
+}
+```
+
 ## Facebook
 
 There is a [community-supported React Native library](https://github.com/thebergamo/react-native-fbsdk-next) which wraps around

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -451,6 +451,22 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   /**
+   * revokeToken
+   *
+   * @param authorizationCode
+   * @param promise
+   */
+  @ReactMethod
+  public void revokeToken(
+      String appName, final String authorizationCode, final Promise promise) {
+    Log.d(TAG, "revokeToken");
+
+    // Revocation is not implemented on Android
+    Log.e(TAG, "revokeToken:failure:noCurrentUser");
+    promiseNoUser(promise, false);
+  }
+
+  /**
    * sendPasswordResetEmail
    *
    * @param email

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -457,8 +457,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
    * @param promise
    */
   @ReactMethod
-  public void revokeToken(
-      String appName, final String authorizationCode, final Promise promise) {
+  public void revokeToken(String appName, final String authorizationCode, final Promise promise) {
     Log.d(TAG, "revokeToken");
 
     // Revocation is not implemented on Android

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -669,13 +669,14 @@ RCT_EXPORT_METHOD(revokeToken
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   [[FIRAuth authWithApp:firebaseApp]
-   revokeTokenWithAuthorizationCode:authorizationCode completion:^(NSError * _Nullable error) {
-      if (error) {
-        [self promiseRejectAuthException:reject error:error];
-      } else {
-        [self promiseNoUser:resolve rejecter:reject isError:NO];
-      }
-    }];
+      revokeTokenWithAuthorizationCode:authorizationCode
+                            completion:^(NSError *_Nullable error) {
+                              if (error) {
+                                [self promiseRejectAuthException:reject error:error];
+                              } else {
+                                [self promiseNoUser:resolve rejecter:reject isError:NO];
+                              }
+                            }];
 }
 
 RCT_EXPORT_METHOD(sendPasswordResetEmail

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -663,6 +663,21 @@ RCT_EXPORT_METHOD(checkActionCode
            }];
 }
 
+RCT_EXPORT_METHOD(revokeToken
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)authorizationCode
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  [[FIRAuth authWithApp:firebaseApp]
+   revokeTokenWithAuthorizationCode:authorizationCode completion:^(NSError * _Nullable error) {
+      if (error) {
+        [self promiseRejectAuthException:reject error:error];
+      } else {
+        [self promiseNoUser:resolve rejecter:reject isError:NO];
+      }
+    }];
+}
+
 RCT_EXPORT_METHOD(sendPasswordResetEmail
                   : (FIRApp *)firebaseApp
                   : (NSString *)email

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1723,6 +1723,22 @@ export namespace FirebaseAuthTypes {
     signInWithCredential(credential: AuthCredential): Promise<UserCredential>;
 
     /**
+     * Revokes a user's Sign in with Apple token.
+     *
+     * #### Example
+     *
+     * ```js
+     * // Generate an Apple ID authorizationCode for the currently logged in user (ie, with @invertase/react-native-apple-authentication)
+     * const { authorizationCode } = await appleAuth.performRequest({ requestedOperation: appleAuth.Operation.REFRESH });
+     * // Revoke the token
+     * await firebase.auth().revokeToken(authorizationCode);
+     * ```
+     *
+     * @param authorizationCode A generated authorization code from Sign in with Apple.
+     */
+    revokeToken(authorizationCode: string): Promise<void>;
+
+    /**
      * Sends a password reset email to the given email address.
      * Unlike the web SDK, the email will contain a password reset link rather than a code.
      *

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -299,6 +299,10 @@ class FirebaseAuthModule extends FirebaseModule {
       .then(userCredential => this._setUserCredential(userCredential));
   }
 
+  revokeToken(authorizationCode) {
+    return this.native.revokeToken(authorizationCode);
+  }
+
   sendPasswordResetEmail(email, actionCodeSettings = null) {
     return this.native.sendPasswordResetEmail(email, actionCodeSettings);
   }


### PR DESCRIPTION
### Description

Apple requires apps support revocation of the Sign in with Apple token when a user wants to delete their account. Firebase added this support in the Firebase Auth iOS SDK. This PR adds the JS ReactNative bindings so that it can be called from JS.

### Related issues

N/A

### Release Summary

Added support for revoking a Sign in with Apple token

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

This is the same code that I patched into my own project to revoke Sign in with Apple tokens. I tested it extensively in that app. Unfortunately, I'm not allowed to provide screenshots or videos from that app because it is proprietary.

To make sure this works with your app, it's important to follow the steps outlined [here](https://firebase.google.com/docs/auth/ios/apple#configure_sign_in_with_apple), specifically creating a private key with Apple and filling out the `Services ID` and `OAuth code flow` portions on Firebase correctly.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire: 