### PR TITLE
fix(app, sdks): adopt android-sdk 32.2.2 / ios-sdk 10.13.0

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -29,7 +29,7 @@ jobs:
     name: iOS
     runs-on: macos-13
     # TODO matrix across APIs, at least 11 and 15 (lowest to highest)
-    timeout-minutes: 80
+    timeout-minutes: 100
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
@@ -179,7 +179,7 @@ jobs:
         run: nohup sh -c "sleep 30 && xcrun simctl spawn booted log stream --level debug --style compact > simulator.log 2>&1 &"
 
       - name: Detox Test
-        timeout-minutes: 30
+        timeout-minutes: 50
         run: yarn tests:ios:test-cover
 
       - name: Compress Simulator Log

--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -40,8 +40,7 @@ buildscript {
   // ..
   dependencies {
     // ..
-    // NOTE: 2.9.4 has issues: https://github.com/invertase/react-native-firebase/issues/6983
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.8'
   }
   // ..
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -218,7 +218,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "32.1.0"
+        bom           : "32.2.2"
       ],
     ],
   ])
@@ -233,7 +233,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '10.12.0'
+$FirebaseSDKVersion = '10.13.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -87,11 +87,11 @@ dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   // TODO remove the specific version once it is out of beta and participates in bom versioning
-  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta08'
+  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta10'
   // TODO demonstrate how to only include this in certain build variants
   // - perhaps have firebase.json name the variants to include, then roll through variants here and only
   //   add the dependency to variants that match? Or... (PRs welcome...)
-  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta08'
+  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta10'
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -85,7 +85,7 @@
       "firebaseCrashlyticsGradle": "2.9.8",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.15",
-      "playServicesAuth": "20.5.0"
+      "playServicesAuth": "20.6.0"
     }
   }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.12.0",
+      "firebase": "10.13.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },
@@ -81,8 +81,8 @@
       "minSdk": 19,
       "targetSdk": 33,
       "compileSdk": 33,
-      "firebase": "32.1.0",
-      "firebaseCrashlyticsGradle": "2.9.2",
+      "firebase": "32.2.2",
+      "firebaseCrashlyticsGradle": "2.9.8",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.15",
       "playServicesAuth": "20.5.0"

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.8'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -39,7 +39,7 @@ buildscript {
     classpath("com.facebook.react:react-native-gradle-plugin")
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.4.2'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.2'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.8'
     classpath 'com.google.firebase:firebase-appdistribution-gradle:4.0.0'
   }
 }

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -17,9 +17,9 @@ buildscript {
   ext.fragmentVersion = '1.4.0' // https://developer.android.com/jetpack/androidx/releases/fragment
   ext.vectordrawableVersion = '1.1.0' // https://developer.android.com/jetpack/androidx/releases/vectordrawable
   ext.androidxAnnotationVersion = '1.3.0' // https://developer.android.com/jetpack/androidx/releases/annotation
-  ext.googlePlayServicesLocationVersion = '19.0.1' // https://developers.google.com/android/guides/setup
-  ext.googlePlayServicesVersion = '18.0.1' // play-services-base
-  ext.googlePlayServicesAuthVersion = '20.2.0' // play-services-auth
+  ext.googlePlayServicesLocationVersion = '21.0.1' // https://developers.google.com/android/guides/setup
+  ext.googlePlayServicesVersion = '18.2.0' // play-services-base
+  ext.googlePlayServicesAuthVersion = '20.6.0' // play-services-auth
   ext.googlePlayServicesVisionVersion = '20.1.3' // play-services-vision
   ext.googlePlayServicesIidVersion = '17.0.0' // play-services-iid - deprecated, device-info only
   ext.mediaCompatVersion = '1.4.3' // https://developer.android.com/jetpack/androidx/releases/media

--- a/tests/e2e/.mocharc.js
+++ b/tests/e2e/.mocharc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   recursive: true,
-  timeout: 720000,
+  timeout: 1000000,
   reporter: 'spec',
   slow: 2000,
   retries: 4,

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -644,59 +644,59 @@ PODS:
     - React-Core (= 0.72.3)
     - React-jsi (= 0.72.3)
     - ReactCommon/turbomodule/core (= 0.72.3)
-  - Firebase/Analytics (10.12.0):
+  - Firebase/Analytics (10.13.0):
     - Firebase/Core
-  - Firebase/AppCheck (10.12.0):
+  - Firebase/AppCheck (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 10.12.0)
-  - Firebase/AppDistribution (10.12.0):
+    - FirebaseAppCheck (~> 10.13.0)
+  - Firebase/AppDistribution (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 10.12.0-beta)
-  - Firebase/Auth (10.12.0):
+    - FirebaseAppDistribution (~> 10.13.0-beta)
+  - Firebase/Auth (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.12.0)
-  - Firebase/Core (10.12.0):
+    - FirebaseAuth (~> 10.13.0)
+  - Firebase/Core (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.12.0)
-  - Firebase/CoreOnly (10.12.0):
-    - FirebaseCore (= 10.12.0)
-  - Firebase/Crashlytics (10.12.0):
+    - FirebaseAnalytics (~> 10.13.0)
+  - Firebase/CoreOnly (10.13.0):
+    - FirebaseCore (= 10.13.0)
+  - Firebase/Crashlytics (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.12.0)
-  - Firebase/Database (10.12.0):
+    - FirebaseCrashlytics (~> 10.13.0)
+  - Firebase/Database (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 10.12.0)
-  - Firebase/DynamicLinks (10.12.0):
+    - FirebaseDatabase (~> 10.13.0)
+  - Firebase/DynamicLinks (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.12.0)
-  - Firebase/Firestore (10.12.0):
+    - FirebaseDynamicLinks (~> 10.13.0)
+  - Firebase/Firestore (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.12.0)
-  - Firebase/Functions (10.12.0):
+    - FirebaseFirestore (~> 10.13.0)
+  - Firebase/Functions (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 10.12.0)
-  - Firebase/InAppMessaging (10.12.0):
+    - FirebaseFunctions (~> 10.13.0)
+  - Firebase/InAppMessaging (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 10.12.0-beta)
-  - Firebase/Installations (10.12.0):
+    - FirebaseInAppMessaging (~> 10.13.0-beta)
+  - Firebase/Installations (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 10.12.0)
-  - Firebase/Messaging (10.12.0):
+    - FirebaseInstallations (~> 10.13.0)
+  - Firebase/Messaging (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.12.0)
-  - Firebase/Performance (10.12.0):
+    - FirebaseMessaging (~> 10.13.0)
+  - Firebase/Performance (10.13.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 10.12.0)
-  - Firebase/RemoteConfig (10.12.0):
+    - FirebasePerformance (~> 10.13.0)
+  - Firebase/RemoteConfig (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 10.12.0)
-  - Firebase/Storage (10.12.0):
+    - FirebaseRemoteConfig (~> 10.13.0)
+  - Firebase/Storage (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.12.0)
-  - FirebaseABTesting (10.12.0):
+    - FirebaseStorage (~> 10.13.0)
+  - FirebaseABTesting (10.13.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseAnalytics (10.12.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.12.0)
+  - FirebaseAnalytics (10.13.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.13.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -704,41 +704,41 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.12.0):
+  - FirebaseAnalytics/AdIdSupport (10.13.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.12.0)
+    - GoogleAppMeasurement (= 10.13.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAppCheck (10.12.0):
+  - FirebaseAppCheck (10.13.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseAppCheckInterop (10.12.0)
-  - FirebaseAppDistribution (10.12.0-beta):
+  - FirebaseAppCheckInterop (10.13.0)
+  - FirebaseAppDistribution (10.13.0-beta):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-  - FirebaseAuth (10.12.0):
+  - FirebaseAuth (10.13.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseAuthInterop (10.12.0)
-  - FirebaseCore (10.12.0):
+  - FirebaseAuthInterop (10.13.0)
+  - FirebaseCore (10.13.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.12.0):
+  - FirebaseCoreExtension (10.13.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.12.0):
+  - FirebaseCoreInternal (10.13.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.12.0):
+  - FirebaseCrashlytics (10.13.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseSessions (~> 10.5)
@@ -746,12 +746,12 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (10.12.0):
+  - FirebaseDatabase (10.13.0):
     - FirebaseCore (~> 10.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (10.12.0):
+  - FirebaseDynamicLinks (10.13.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseFirestore (10.12.0):
+  - FirebaseFirestore (10.13.0):
     - abseil/algorithm (~> 1.20220623.0)
     - abseil/base (~> 1.20220623.0)
     - abseil/container/flat_hash_map (~> 1.20220623.0)
@@ -764,7 +764,7 @@ PODS:
     - "gRPC-C++ (~> 1.50.1)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseFunctions (10.12.0):
+  - FirebaseFunctions (10.13.0):
     - FirebaseAppCheckInterop (~> 10.10)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -772,18 +772,18 @@ PODS:
     - FirebaseMessagingInterop (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseInAppMessaging (10.12.0-beta):
+  - FirebaseInAppMessaging (10.13.0-beta):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (10.12.0):
+  - FirebaseInstallations (10.13.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.12.0):
+  - FirebaseMessaging (10.13.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.2)
@@ -792,8 +792,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseMessagingInterop (10.12.0)
-  - FirebasePerformance (10.12.0):
+  - FirebaseMessagingInterop (10.13.0)
+  - FirebasePerformance (10.13.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfig (~> 10.0)
@@ -803,13 +803,13 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (10.12.0):
+  - FirebaseRemoteConfig (10.13.0):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseSessions (10.12.0):
+  - FirebaseSessions (10.13.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -817,8 +817,8 @@ PODS:
     - GoogleUtilities/Environment (~> 7.10)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (10.12.0)
-  - FirebaseStorage (10.12.0):
+  - FirebaseSharedSwift (10.13.0)
+  - FirebaseStorage (10.13.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -826,50 +826,50 @@ PODS:
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (10.12.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.12.0)
+  - GoogleAppMeasurement (10.13.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.13.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.12.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.12.0)
+  - GoogleAppMeasurement/AdIdSupport (10.13.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.13.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.12.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.13.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurementOnDeviceConversion (10.12.0)
-  - GoogleDataTransport (9.2.3):
+  - GoogleAppMeasurementOnDeviceConversion (10.13.0)
+  - GoogleDataTransport (9.2.5):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/AppDelegateSwizzler (7.11.1):
+  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (7.11.1):
+  - GoogleUtilities/Environment (7.11.5):
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/ISASwizzler (7.11.1)
-  - GoogleUtilities/Logger (7.11.1):
+  - GoogleUtilities/ISASwizzler (7.11.5)
+  - GoogleUtilities/Logger (7.11.5):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (7.11.1):
+  - GoogleUtilities/MethodSwizzler (7.11.5):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (7.11.1):
+  - GoogleUtilities/Network (7.11.5):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.11.1)"
-  - GoogleUtilities/Reachability (7.11.1):
+  - "GoogleUtilities/NSData+zlib (7.11.5)"
+  - GoogleUtilities/Reachability (7.11.5):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (7.11.1):
+  - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
   - "gRPC-C++ (1.50.1)":
     - "gRPC-C++/Implementation (= 1.50.1)"
@@ -945,9 +945,9 @@ PODS:
     - nanopb/encode (= 2.30909.0)
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
-  - PromisesObjC (2.2.0)
-  - PromisesSwift (2.2.0):
-    - PromisesObjC (= 2.2.0)
+  - PromisesObjC (2.3.1)
+  - PromisesSwift (2.3.1):
+    - PromisesObjC (= 2.3.1)
   - RCT-Folly (2021.07.22.00):
     - boost
     - DoubleConversion
@@ -1360,75 +1360,75 @@ PODS:
     - React-perflogger (= 0.72.3)
   - RNDeviceInfo (10.6.0):
     - React-Core
-  - RNFBAnalytics (18.2.0):
-    - Firebase/Analytics (= 10.12.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 10.12.0)
+  - RNFBAnalytics (18.3.0):
+    - Firebase/Analytics (= 10.13.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (18.2.0):
-    - Firebase/CoreOnly (= 10.12.0)
+  - RNFBApp (18.3.0):
+    - Firebase/CoreOnly (= 10.13.0)
     - React-Core
-  - RNFBAppCheck (18.2.0):
-    - Firebase/AppCheck (= 10.12.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (18.2.0):
-    - Firebase/AppDistribution (= 10.12.0)
+  - RNFBAppCheck (18.3.0):
+    - Firebase/AppCheck (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (18.2.0):
-    - Firebase/Auth (= 10.12.0)
+  - RNFBAppDistribution (18.3.0):
+    - Firebase/AppDistribution (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (18.2.0):
-    - Firebase/Crashlytics (= 10.12.0)
-    - FirebaseCoreExtension (= 10.12.0)
+  - RNFBAuth (18.3.0):
+    - Firebase/Auth (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (18.2.0):
-    - Firebase/Database (= 10.12.0)
+  - RNFBCrashlytics (18.3.0):
+    - Firebase/Crashlytics (= 10.13.0)
+    - FirebaseCoreExtension (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (18.2.0):
-    - Firebase/DynamicLinks (= 10.12.0)
+  - RNFBDatabase (18.3.0):
+    - Firebase/Database (= 10.13.0)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (18.3.0):
+    - Firebase/DynamicLinks (= 10.13.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (18.2.0):
-    - Firebase/Firestore (= 10.12.0)
+  - RNFBFirestore (18.3.0):
+    - Firebase/Firestore (= 10.13.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (18.2.0):
-    - Firebase/Functions (= 10.12.0)
+  - RNFBFunctions (18.3.0):
+    - Firebase/Functions (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (18.2.0):
-    - Firebase/InAppMessaging (= 10.12.0)
+  - RNFBInAppMessaging (18.3.0):
+    - Firebase/InAppMessaging (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (18.2.0):
-    - Firebase/Installations (= 10.12.0)
+  - RNFBInstallations (18.3.0):
+    - Firebase/Installations (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (18.2.0):
-    - Firebase/Messaging (= 10.12.0)
-    - FirebaseCoreExtension (= 10.12.0)
+  - RNFBMessaging (18.3.0):
+    - Firebase/Messaging (= 10.13.0)
+    - FirebaseCoreExtension (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBML (18.2.0):
+  - RNFBML (18.3.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (18.2.0):
-    - Firebase/Performance (= 10.12.0)
+  - RNFBPerf (18.3.0):
+    - Firebase/Performance (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (18.2.0):
-    - Firebase/RemoteConfig (= 10.12.0)
+  - RNFBRemoteConfig (18.3.0):
+    - Firebase/RemoteConfig (= 10.13.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (18.2.0):
-    - Firebase/Storage (= 10.12.0)
+  - RNFBStorage (18.3.0):
+    - Firebase/Storage (= 10.13.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.6.1)
@@ -1661,42 +1661,42 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   abseil: 926fb7a82dc6d2b8e1f2ed7f3a718bce691d1e46
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BoringSSL-GRPC: 3175b25143e648463a56daeaaa499c6cb86dad33
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 4cce221dd782d3ff7c4172167bba09d58af67ccb
   FBReactNativeSpec: c6bd9e179757b3c0ecf815864fae8032377903ef
-  Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0
-  FirebaseABTesting: 09c328e6a86d562b4e1146c8a9073deadc566b77
-  FirebaseAnalytics: 0270389efbe3022b54ec4588862dabec3477ee98
-  FirebaseAppCheck: c5e49dadf9c9cbabf0066074af938e032a0cce48
-  FirebaseAppCheckInterop: f95a4feb9089867aff1a4bdc2ce309137e07736a
-  FirebaseAppDistribution: 3d681f4cfc51f7d1b3d922d9239781adbc33a958
-  FirebaseAuth: a66c1e14ec58f41d154a4b41ce1a23ea00ad4805
-  FirebaseAuthInterop: 047153f3c2928822032190aa5194e332670a0d66
-  FirebaseCore: f86a1394906b97ac445ae49c92552a9425831bed
-  FirebaseCoreExtension: 0ce5ac36042001cfa233ce7bfa28e5c313cf80f4
-  FirebaseCoreInternal: 950500ad8a08963657f6d8c67b579740c06d6aa1
-  FirebaseCrashlytics: c4d111b7430c49744c74bcc6346ea00868661ac8
-  FirebaseDatabase: 6d998d7ef2c1723b3e798a85e61a7dc0504b1ea0
-  FirebaseDynamicLinks: 1a387da899779e5ef34f4d6f8bdba882f90d0e67
-  FirebaseFirestore: f94c9541515fa4a49af52269bbc50349009424b4
-  FirebaseFunctions: d49c7920b289d85029882927e4056ad04a906e19
-  FirebaseInAppMessaging: dc24f50aebaf81a377f0b8abf360778f94208931
-  FirebaseInstallations: 7b99ef103f013624444c614397038219c45f8e63
-  FirebaseMessaging: bb2c4f6422a753038fe137d90ae7c1af57251316
-  FirebaseMessagingInterop: 9009d471dc63cb9e5a7d170e7c107fb78c469f19
-  FirebasePerformance: 1a63c51c9d14fc1190b0970d5aab96672cb0bce6
-  FirebaseRemoteConfig: bc7f260e6596956fafbb532443c19bd3c30f5258
-  FirebaseSessions: a4ee211eeb31a2224cd8d9d4e30a0fccde9aa00c
-  FirebaseSharedSwift: c4eb72d435973c77d6f155f05c963933dcba35a7
-  FirebaseStorage: 1d7ca8c8953fc61ccacaa7c612696b5402968a0d
+  Firebase: 343d7539befb614d22b2eae24759f6307b1175e9
+  FirebaseABTesting: 86ac5a4fc749088bb4d55a1cbfb2c4cb42c6d5de
+  FirebaseAnalytics: 9a12e090ead49f8877ed8132ae920e3cbbd2fcd0
+  FirebaseAppCheck: 450d9a8c46cd96bf86563a26305cdfd79bb59164
+  FirebaseAppCheckInterop: 5e12dc623d443dedffcde9c6f3ed41510125d8ef
+  FirebaseAppDistribution: 73b282faa85a589a061d247bba6f5b839d8ec710
+  FirebaseAuth: dbc8986dc6a9a8de0c3205f171a3e901d8163d0a
+  FirebaseAuthInterop: 74875bde5d15636522a8fe98beb561df7a54db58
+  FirebaseCore: 9948a31ff2c6cf323f9b040068201a95d271b68d
+  FirebaseCoreExtension: ce60f9db46d83944cf444664d6d587474128eeca
+  FirebaseCoreInternal: b342e37cd4f5b4454ec34308f073420e7920858e
+  FirebaseCrashlytics: 4679fbc4768fcb4dd6f5533101841d40256d4475
+  FirebaseDatabase: 7e34876e30ea3eb0cf42c64d171a6c48f73a4606
+  FirebaseDynamicLinks: 48cadbb115d5f93efda71b927673f79fa24ad141
+  FirebaseFirestore: 97102936578f2e07fa11455fef9ae979084f4673
+  FirebaseFunctions: 42d5444230096dcffe68261937b1ddd56ea9fcb2
+  FirebaseInAppMessaging: 5ca7539e4c83537b379e9c7f1e11a0e1f7992d20
+  FirebaseInstallations: b28af1b9f997f1a799efe818c94695a3728c352f
+  FirebaseMessaging: c2b782a6af3058b6e53ac2a6eaab84c5786200c8
+  FirebaseMessagingInterop: 593e501af43b6d8df45d7323a0803d496b179ba3
+  FirebasePerformance: 026649159518446ab398e1262fadea7885e3adda
+  FirebaseRemoteConfig: 33e0dcf43899fbb4f8ef2d84200bf5f5e32eaf05
+  FirebaseSessions: 991fb4c20b3505eef125f7cbfa20a5b5b189c2a4
+  FirebaseSharedSwift: 5c4906ecf0441ed23efff399454dc791eff8ad54
+  FirebaseStorage: f2d1a84d78a7226d97bc76d85cf1092cab5f2b7d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  GoogleAppMeasurement: 2d800fab85e7848b1e66a6f8ce5bca06c5aad892
-  GoogleAppMeasurementOnDeviceConversion: f65d325dcb9bfcae49ea75b36c4a552150bacca1
-  GoogleDataTransport: f0308f5905a745f94fb91fea9c6cbaf3831cb1bd
-  GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
+  GoogleAppMeasurement: 3ae505b44174bcc0775f5c86cecc5826259fbb1e
+  GoogleAppMeasurementOnDeviceConversion: 9200320b4e54bda9e6fd3fcb8c95dff42f75a7fb
+  GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
+  GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
   "gRPC-C++": 0968bace703459fd3e5dcb0b2bed4c573dbff046
   gRPC-Core: 17108291d84332196d3c8466b48f016fc17d816d
   GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
@@ -1705,9 +1705,9 @@ SPEC CHECKSUMS:
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
-  PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
-  PromisesSwift: cf9eb58666a43bbe007302226e510b16c1e10959
-  RCT-Folly: 0080d0a6ebf2577475bda044aa59e2ca1f909cda
+  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  PromisesSwift: 28dca69a9c40779916ac2d6985a0192a5cb4a265
+  RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: a2faf4bad4e438ca37b2040cb8f7799baa065c18
   RCTTypeSafety: cb09f3e4747b6d18331a15eb05271de7441ca0b3
   React: 13109005b5353095c052f26af37413340ccf7a5d
@@ -1716,13 +1716,13 @@ SPEC CHECKSUMS:
   React-Core: aaacca67f9ca54f142827e67f44bfbd815875eb6
   React-CoreModules: 32fab1d62416849a3b6dac6feff9d54e5ddc2d1e
   React-cxxreact: 37765b4975541105b2a3322a4b473417c158c869
-  React-debug: 452dbcadf70c1d707456951451c48357496bc3c6
+  React-debug: 36a917be4dae3477172c3beefde5fb883c7e9488
   React-hermes: 935ae71fb3d7654e947beba8498835cd5e479707
   React-jsi: ec628dc7a15ffea969f237b0ea6d2fde212b19dd
   React-jsiexecutor: 59d1eb03af7d30b7d66589c410f13151271e8006
   React-jsinspector: b511447170f561157547bc0bef3f169663860be7
   React-logger: c5b527272d5f22eaa09bb3c3a690fee8f237ae95
-  React-NativeModulesApple: 7adf7f44f1b0bca8f2bb38a00cbb8fe5b87c78e8
+  React-NativeModulesApple: efd7522c1653d2b4979fe3d80ff932679187e868
   React-perflogger: 6bd153e776e6beed54c56b0847e1220a3ff92ba5
   React-RCTActionSheet: c0b62af44e610e69d9a2049a682f5dba4e9dff17
   React-RCTAnimation: fe7005136b58f58871cab2f70732343b6e330d30
@@ -1736,27 +1736,27 @@ SPEC CHECKSUMS:
   React-RCTVibration: ea3a68a49873a54ced927c90923fc6932baf344a
   React-rncore: 9672a017af4a7da7495d911f0b690cbcae9dd18d
   React-runtimeexecutor: 369ae9bb3f83b65201c0c8f7d50b72280b5a1dbc
-  React-runtimescheduler: 38eabf40e1a6ffcd780d78cb6ae59748051f1751
-  React-utils: b9a64fa9d2fa50fcd15a866ea4ba3f0a14fecd42
-  ReactCommon: 3ad3559084d4fe0de54d5f9c8cacfba23f9e13bb
+  React-runtimescheduler: d024a125dc28fd337a9eea76d3c1fe75b6713830
+  React-utils: 042fdffcad7b1cb88ac1b6428bb87f62a0e3ce93
+  ReactCommon: a612262bc3bee65a7fe991c1f77baa3a4f3bb9d0
   RNDeviceInfo: 475a4c447168d0ad4c807e48ef5e0963a0f4eb1b
-  RNFBAnalytics: 1ce149938deb859f24bcbca1469c0e2403255809
-  RNFBApp: 9a54c7fd5a1c33684a862b51b9c00914a358061c
-  RNFBAppCheck: 7f060037c1535fcb73143b8d0a3ac6c43b1bfaec
-  RNFBAppDistribution: db580a407021d14ccc2f5e0889a2022f610786a1
-  RNFBAuth: e467cbc872eb8d73e48516b1429dcec19bad0292
-  RNFBCrashlytics: 2dafa9f70bb721ce0de23337de776a669c75a92d
-  RNFBDatabase: eb1cf473f699dd35ebeaa6a07ad68303632eb822
-  RNFBDynamicLinks: 5d86ceeb9ff22f9bd093b15316fd553082d69be4
-  RNFBFirestore: 8a552b6dd4d2ef86ebb7a75f29619cedfd49873d
-  RNFBFunctions: b1042f44a7faccaabd460310c932f8344b659df5
-  RNFBInAppMessaging: 218cf426ede6383c1a808c31814966f6f18da67f
-  RNFBInstallations: 712329a1a8ef1eb136d1685ffed5173b70270e66
-  RNFBMessaging: 5fa69e7c4f9641fc222327208d90d3b56e907f58
-  RNFBML: ed2af5970f8c45e71cb2d2b747088e6c4905a166
-  RNFBPerf: 03ab39cf4cd1153201659d3d14fc7dbf4c325262
-  RNFBRemoteConfig: d982ee16ec7709957349b4f68e5b5be510d67ef4
-  RNFBStorage: 9d0e0295015c2a5c1909c3a2344bf86180a6e92b
+  RNFBAnalytics: 15eab453f2090bf0c104c22f1a9b8ab6f636e449
+  RNFBApp: c42002203dc99167e3bd22331956817d1ebbf278
+  RNFBAppCheck: 6a1d40aa5ca4d9e7ee90a9a38efc3e13d733f7f4
+  RNFBAppDistribution: c39b4084fd999e9a7df0bdab547e73e236b3a961
+  RNFBAuth: 76d4d2a4bad222b316804ec94f842c676b273ca7
+  RNFBCrashlytics: 84881578e02e093101084dbd999b197360e8598b
+  RNFBDatabase: 1d4baf4ba71bb6cb5891e455dfbe1e178327b222
+  RNFBDynamicLinks: fe21fd619a1fa027166807d3cd7fca601f0929d4
+  RNFBFirestore: fbb391bd5c2bda999d8bee47ea1be6c24bc273ea
+  RNFBFunctions: 121d5fbc4aae0402daa23422f18a5eb7c1f883fd
+  RNFBInAppMessaging: 15c3489274927b5bb7a9cef6a3d454e8fc3c5fe6
+  RNFBInstallations: 80f342c8d2eee54da5ad8d73dca99263a6269cd2
+  RNFBMessaging: fee0f8aafc94630fe114aef6d86385127fc76a3f
+  RNFBML: b956e5115d172d5b18ec327f4f0befc8b3c438e2
+  RNFBPerf: 55f0893d3f3569706db3fcb6a73bb3e10f67844f
+  RNFBRemoteConfig: c3c72d5b51addb8a6173861fde6ff10573722640
+  RNFBStorage: 0c4401839c8e92102535e71ccb09dd9e016fb8ea
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 8796b55dba14d7004f980b54bcc9833ee45b28ce
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -62,7 +62,8 @@
         "build": "set -o pipefail && xcodebuild VALID_ARCHS=\"`uname -m`\"  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 14"
+          "type": "iPhone 14",
+          "os": "iOS 16.4"
         }
       },
       "ios.sim.release": {
@@ -70,7 +71,8 @@
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && set -o pipefail | xcodebuild  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 14"
+          "type": "iPhone 14",
+          "os": "iOS 16.4"
         }
       },
       "android.emu.debug": {


### PR DESCRIPTION
### Description

This is a fairly standard dependency update intended to adopt the latest upstream native SDKs from the Firebase team

The one part of this that I think will work but may result in feedback from users is the adoption of the crashlytics android gradle plugin 2.9.8. Recent versions of the plugin - starting at version 2.9.2 - have had a variety of issues preventing adoption of the current version. I *think* all of those are resolved with this version based on my testing, so I am adopting 2.9.8 officially now

### Related issues

#7002 - the crashlytics android plugin issue

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- passed local tests `yarn tests:ios:test && yarn tests:android:test && yarn tests:jest`
- survived a test integration in https://github.com/mikehardy/rnfbdemo/blob/main/make-demo.sh locally
- survived a test integration in my work app

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
