### PR TITLE
fix(auth, android): avoid crash on react-native < 0.63

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1944,7 +1944,10 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
    */
   private void promiseRejectAuthException(Promise promise, Exception exception) {
     WritableMap error = getJSError(exception);
-    final String sessionId = error.getString("sessionId");
+    String sessionId = null;
+    if (error.hasKey("sessionId")) {
+      sessionId = error.getString("sessionId");
+    }
     final MultiFactorResolver multiFactorResolver = mCachedResolvers.get(sessionId);
     WritableMap resolverAsMap = Arguments.createMap();
     if (multiFactorResolver != null) {


### PR DESCRIPTION
### Description

At minimum phone OTP auth and perhaps other scenarios may crash on very old react-native, because old react-native used to throw an exception if a map didn't contain a key, whereas newer react-native just returns null

Newer code here related to multi-factor auth relied on that returns-null behavior and did not handle the case where an exception may be thrown if a key didn't exist

Avoid this exception+crash by explicitly checking for our desired key prior to getting its value

### Related issues

Fixes #7304

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

This one is difficult to test in an automated way, as it will never reproduce on react-native >= 0.63.
Ideally with such a small / defensive-coding-oriented change there will be no unexpected consequences

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
