### PR TITLE
chore(android): add support for AGP 8 

### DIFF
--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -125,10 +125,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
+
   sourceSets {
     main {
       java.srcDirs = ['src/main/java', 'src/reactnative/java']

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -105,6 +105,11 @@ if (rootProject.ext && rootProject.ext.firebaseJson) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.analytics'
+  }
+
   defaultConfig {
     multiDexEnabled true
     manifestPlaceholders = [

--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.appcheck'
+  }
+
   defaultConfig {
     multiDexEnabled true
     // Here we add a build config field to allow devs to provide a

--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -81,9 +81,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
   sourceSets {
     main {

--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -71,6 +71,12 @@ android {
     // FIREBASE_APP_CHECK_DEBUG_TOKEN to be used in debug mode.
     buildConfigField "String", "FIREBASE_APP_CHECK_DEBUG_TOKEN", "\"${System.env.FIREBASE_APP_CHECK_DEBUG_TOKEN}\""
   }
+
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   lintOptions {
     disable 'GradleCompatible'
     abortOnError false

--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -72,10 +72,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
+
   sourceSets {
     main {
       java.srcDirs = ['src/main/java', 'src/reactnative/java']

--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.appdistribution'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -80,9 +80,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
 
   sourceSets {

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -59,6 +59,11 @@ if (rootProject.ext && rootProject.ext.firebaseJson) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase'
+  }
+
   defaultConfig {
     multiDexEnabled true
     manifestPlaceholders = [

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -70,6 +70,12 @@ android {
       firebaseJsonDataCollectionDefaultEnabled: dataCollectionDefaultEnabled
     ]
   }
+
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   lintOptions {
     disable 'GradleCompatible'
     abortOnError false

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -71,9 +71,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
 }
 

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -59,6 +59,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.auth'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -68,6 +68,12 @@ android {
   defaultConfig {
     multiDexEnabled true
   }
+
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   lintOptions {
     disable 'GradleCompatible'
     abortOnError false

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -78,9 +78,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
 }
 

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.crashlytics'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/database/android/build.gradle
+++ b/packages/database/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.database'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/database/android/build.gradle
+++ b/packages/database/android/build.gradle
@@ -72,9 +72,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
   sourceSets {
     main {

--- a/packages/dynamic-links/android/build.gradle
+++ b/packages/dynamic-links/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.dynamiclinks'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/dynamic-links/android/build.gradle
+++ b/packages/dynamic-links/android/build.gradle
@@ -72,9 +72,12 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
 }
 

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.firestore'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -72,9 +72,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
   sourceSets {
     main {

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.functions'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -72,10 +72,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
+
   sourceSets {
     main {
       java.srcDirs = ['src/main/java', 'src/reactnative/java']

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -97,10 +97,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
+
   sourceSets {
     main {
       java.srcDirs = ['src/main/java', 'src/reactnative/java']

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -82,6 +82,11 @@ if (rootProject.ext && rootProject.ext.firebaseJson) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.fiam'
+  }
+
   defaultConfig {
     multiDexEnabled true
     manifestPlaceholders = [

--- a/packages/installations/android/build.gradle
+++ b/packages/installations/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.installations'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/installations/android/build.gradle
+++ b/packages/installations/android/build.gradle
@@ -72,10 +72,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
+
   sourceSets {
     main {
       java.srcDirs = ['src/main/java', 'src/reactnative/java']

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -106,9 +106,12 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
 }
 

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -89,6 +89,11 @@ if (rootProject.ext && rootProject.ext.firebaseJson) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.messaging'
+  }
+
   defaultConfig {
     multiDexEnabled true
     manifestPlaceholders = [

--- a/packages/ml/android/build.gradle
+++ b/packages/ml/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.ml'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/ml/android/build.gradle
+++ b/packages/ml/android/build.gradle
@@ -72,10 +72,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
+
   sourceSets {
     main {
       java.srcDirs = ['src/main/java', 'src/reactnative/java']

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -89,6 +89,11 @@ if (rootProject.ext && rootProject.ext.firebaseJson) {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.perf'
+  }
+
   defaultConfig {
     multiDexEnabled true
     manifestPlaceholders = [

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -105,10 +105,14 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
+
   sourceSets {
     main {
       java.srcDirs = ['src/main/java', 'src/reactnative/java']

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.config'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -72,9 +72,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
   sourceSets {
     main {

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -72,9 +72,12 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
 }
 

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase.storage'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }

--- a/scripts/_TEMPLATE_/android/build.gradle
+++ b/scripts/_TEMPLATE_/android/build.gradle
@@ -72,9 +72,11 @@ android {
     disable 'GradleCompatible'
     abortOnError false
   }
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+  if (agpVersion < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
   }
   sourceSets {
     main {

--- a/scripts/_TEMPLATE_/android/build.gradle
+++ b/scripts/_TEMPLATE_/android/build.gradle
@@ -60,6 +60,11 @@ project.ext {
 }
 
 android {
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+  if (agpVersion >= 7) {
+    namespace 'io.invertase.firebase._template_'
+  }
+
   defaultConfig {
     multiDexEnabled true
   }


### PR DESCRIPTION
### Description

Change to support AGP 8 as mentioned here: https://github.com/react-native-community/discussions-and-proposals/issues/671

This does not remove package attribute from AndroidManifest to not lose compatibility with AGP < 8 (React Native < 0.71 versions). 

I don't think it's worth maintaining logic to remove that attribute contitionally since it will [only cause a warning to users on AGP 8](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1607191009) and above. 

[See Kudo's comment on AGP 8 issues with BuildConfig and setting JVM versions.](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1677632448)


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
