### PR TITLE
fix(storage, android): honor android_bypass_emulator_url_remap flag

### DIFF
--- a/packages/storage/lib/index.js
+++ b/packages/storage/lib/index.js
@@ -184,9 +184,9 @@ class FirebaseStorageModule extends FirebaseModule {
     if (!host || !isString(host) || !port || !isNumber(port)) {
       throw new Error('firebase.storage().useEmulator() takes a non-empty host and port');
     }
-    
+
     let _host = host;
-    
+
     const androidBypassEmulatorUrlRemap =
       typeof this.firebaseJson.android_bypass_emulator_url_remap === 'boolean' &&
       this.firebaseJson.android_bypass_emulator_url_remap;

--- a/packages/storage/lib/index.js
+++ b/packages/storage/lib/index.js
@@ -184,8 +184,13 @@ class FirebaseStorageModule extends FirebaseModule {
     if (!host || !isString(host) || !port || !isNumber(port)) {
       throw new Error('firebase.storage().useEmulator() takes a non-empty host and port');
     }
+    
     let _host = host;
-    if (isAndroid && _host) {
+    
+    const androidBypassEmulatorUrlRemap =
+      typeof this.firebaseJson.android_bypass_emulator_url_remap === 'boolean' &&
+      this.firebaseJson.android_bypass_emulator_url_remap;
+    if (!androidBypassEmulatorUrlRemap && isAndroid && _host) {
       if (_host === 'localhost' || _host === '127.0.0.1') {
         _host = '10.0.2.2';
         // eslint-disable-next-line no-console


### PR DESCRIPTION
### Description

The _android_bypass_emulator_url_remap_ flag is not being validated on the storage package. It works as expected on the packages for functions and authentication but this one in specific remaps the hosts anyway.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

The code added was copied from the working code on the functions packasge.

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
