### PR TITLE
fix(app, sdks): adopt ios sdk 10.15.0 / android sdk 32.3.1

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -218,7 +218,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "32.2.3"
+        bom           : "32.3.1"
       ],
     ],
   ])
@@ -233,7 +233,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '10.14.0'
+$FirebaseSDKVersion = '10.15.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.14.0",
+      "firebase": "10.15.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },
@@ -81,11 +81,11 @@
       "minSdk": 19,
       "targetSdk": 33,
       "compileSdk": 33,
-      "firebase": "32.2.3",
+      "firebase": "32.3.1",
       "firebaseCrashlyticsGradle": "2.9.9",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.15",
-      "playServicesAuth": "20.6.0"
+      "playServicesAuth": "20.7.0"
     }
   }
 }

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -644,59 +644,59 @@ PODS:
     - React-Core (= 0.72.4)
     - React-jsi (= 0.72.4)
     - ReactCommon/turbomodule/core (= 0.72.4)
-  - Firebase/Analytics (10.14.0):
+  - Firebase/Analytics (10.15.0):
     - Firebase/Core
-  - Firebase/AppCheck (10.14.0):
+  - Firebase/AppCheck (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 10.14.0)
-  - Firebase/AppDistribution (10.14.0):
+    - FirebaseAppCheck (~> 10.15.0)
+  - Firebase/AppDistribution (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 10.14.0-beta)
-  - Firebase/Auth (10.14.0):
+    - FirebaseAppDistribution (~> 10.15.0-beta)
+  - Firebase/Auth (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.14.0)
-  - Firebase/Core (10.14.0):
+    - FirebaseAuth (~> 10.15.0)
+  - Firebase/Core (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.14.0)
-  - Firebase/CoreOnly (10.14.0):
-    - FirebaseCore (= 10.14.0)
-  - Firebase/Crashlytics (10.14.0):
+    - FirebaseAnalytics (~> 10.15.0)
+  - Firebase/CoreOnly (10.15.0):
+    - FirebaseCore (= 10.15.0)
+  - Firebase/Crashlytics (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.14.0)
-  - Firebase/Database (10.14.0):
+    - FirebaseCrashlytics (~> 10.15.0)
+  - Firebase/Database (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 10.14.0)
-  - Firebase/DynamicLinks (10.14.0):
+    - FirebaseDatabase (~> 10.15.0)
+  - Firebase/DynamicLinks (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.14.0)
-  - Firebase/Firestore (10.14.0):
+    - FirebaseDynamicLinks (~> 10.15.0)
+  - Firebase/Firestore (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.14.0)
-  - Firebase/Functions (10.14.0):
+    - FirebaseFirestore (~> 10.15.0)
+  - Firebase/Functions (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 10.14.0)
-  - Firebase/InAppMessaging (10.14.0):
+    - FirebaseFunctions (~> 10.15.0)
+  - Firebase/InAppMessaging (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 10.14.0-beta)
-  - Firebase/Installations (10.14.0):
+    - FirebaseInAppMessaging (~> 10.15.0-beta)
+  - Firebase/Installations (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 10.14.0)
-  - Firebase/Messaging (10.14.0):
+    - FirebaseInstallations (~> 10.15.0)
+  - Firebase/Messaging (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.14.0)
-  - Firebase/Performance (10.14.0):
+    - FirebaseMessaging (~> 10.15.0)
+  - Firebase/Performance (10.15.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 10.14.0)
-  - Firebase/RemoteConfig (10.14.0):
+    - FirebasePerformance (~> 10.15.0)
+  - Firebase/RemoteConfig (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 10.14.0)
-  - Firebase/Storage (10.14.0):
+    - FirebaseRemoteConfig (~> 10.15.0)
+  - Firebase/Storage (10.15.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.14.0)
-  - FirebaseABTesting (10.14.0):
+    - FirebaseStorage (~> 10.15.0)
+  - FirebaseABTesting (10.15.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseAnalytics (10.14.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.14.0)
+  - FirebaseAnalytics (10.15.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.15.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -704,42 +704,42 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.14.0):
+  - FirebaseAnalytics/AdIdSupport (10.15.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.14.0)
+    - GoogleAppMeasurement (= 10.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseAppCheck (10.14.0):
+  - FirebaseAppCheck (10.15.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseAppCheckInterop (10.14.0)
-  - FirebaseAppDistribution (10.14.0-beta):
+  - FirebaseAppCheckInterop (10.15.0)
+  - FirebaseAppDistribution (10.15.0-beta):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-  - FirebaseAuth (10.14.0):
+  - FirebaseAuth (10.15.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.14.0)
-  - FirebaseCore (10.14.0):
+  - FirebaseAuthInterop (10.15.0)
+  - FirebaseCore (10.15.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreExtension (10.14.0):
+  - FirebaseCoreExtension (10.15.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.14.0):
+  - FirebaseCoreInternal (10.15.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.14.0):
+  - FirebaseCrashlytics (10.15.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseSessions (~> 10.5)
@@ -747,12 +747,12 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (10.14.0):
+  - FirebaseDatabase (10.15.0):
     - FirebaseCore (~> 10.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (10.14.0):
+  - FirebaseDynamicLinks (10.15.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseFirestore (10.14.0):
+  - FirebaseFirestore (10.15.0):
     - abseil/algorithm (~> 1.20220623.0)
     - abseil/base (~> 1.20220623.0)
     - abseil/container/flat_hash_map (~> 1.20220623.0)
@@ -765,7 +765,7 @@ PODS:
     - "gRPC-C++ (~> 1.50.1)"
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseFunctions (10.14.0):
+  - FirebaseFunctions (10.15.0):
     - FirebaseAppCheckInterop (~> 10.10)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -773,18 +773,18 @@ PODS:
     - FirebaseMessagingInterop (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseInAppMessaging (10.14.0-beta):
+  - FirebaseInAppMessaging (10.15.0-beta):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseInstallations (10.14.0):
+  - FirebaseInstallations (10.15.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.14.0):
+  - FirebaseMessaging (10.15.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.2)
@@ -793,8 +793,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseMessagingInterop (10.14.0)
-  - FirebasePerformance (10.14.0):
+  - FirebaseMessagingInterop (10.15.0)
+  - FirebasePerformance (10.15.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfig (~> 10.0)
@@ -804,13 +804,13 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (10.14.0):
+  - FirebaseRemoteConfig (10.15.0):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseSessions (10.14.0):
+  - FirebaseSessions (10.15.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -818,8 +818,8 @@ PODS:
     - GoogleUtilities/Environment (~> 7.10)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (10.14.0)
-  - FirebaseStorage (10.14.0):
+  - FirebaseSharedSwift (10.15.0)
+  - FirebaseStorage (10.15.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -827,27 +827,27 @@ PODS:
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (10.14.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.14.0)
+  - GoogleAppMeasurement (10.15.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.14.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.14.0)
+  - GoogleAppMeasurement/AdIdSupport (10.15.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.15.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.14.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.15.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30910.0, >= 2.30908.0)
-  - GoogleAppMeasurementOnDeviceConversion (10.14.0)
+  - GoogleAppMeasurementOnDeviceConversion (10.15.0)
   - GoogleDataTransport (9.2.5):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
@@ -1362,75 +1362,75 @@ PODS:
   - RecaptchaInterop (100.0.0)
   - RNDeviceInfo (10.9.0):
     - React-Core
-  - RNFBAnalytics (18.3.2):
-    - Firebase/Analytics (= 10.14.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 10.14.0)
+  - RNFBAnalytics (18.4.0):
+    - Firebase/Analytics (= 10.15.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (18.3.2):
-    - Firebase/CoreOnly (= 10.14.0)
+  - RNFBApp (18.4.0):
+    - Firebase/CoreOnly (= 10.15.0)
     - React-Core
-  - RNFBAppCheck (18.3.2):
-    - Firebase/AppCheck (= 10.14.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (18.3.2):
-    - Firebase/AppDistribution (= 10.14.0)
+  - RNFBAppCheck (18.4.0):
+    - Firebase/AppCheck (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (18.3.2):
-    - Firebase/Auth (= 10.14.0)
+  - RNFBAppDistribution (18.4.0):
+    - Firebase/AppDistribution (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (18.3.2):
-    - Firebase/Crashlytics (= 10.14.0)
-    - FirebaseCoreExtension (= 10.14.0)
+  - RNFBAuth (18.4.0):
+    - Firebase/Auth (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (18.3.2):
-    - Firebase/Database (= 10.14.0)
+  - RNFBCrashlytics (18.4.0):
+    - Firebase/Crashlytics (= 10.15.0)
+    - FirebaseCoreExtension (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (18.3.2):
-    - Firebase/DynamicLinks (= 10.14.0)
+  - RNFBDatabase (18.4.0):
+    - Firebase/Database (= 10.15.0)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (18.4.0):
+    - Firebase/DynamicLinks (= 10.15.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (18.3.2):
-    - Firebase/Firestore (= 10.14.0)
+  - RNFBFirestore (18.4.0):
+    - Firebase/Firestore (= 10.15.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (18.3.2):
-    - Firebase/Functions (= 10.14.0)
+  - RNFBFunctions (18.4.0):
+    - Firebase/Functions (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (18.3.2):
-    - Firebase/InAppMessaging (= 10.14.0)
+  - RNFBInAppMessaging (18.4.0):
+    - Firebase/InAppMessaging (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (18.3.2):
-    - Firebase/Installations (= 10.14.0)
+  - RNFBInstallations (18.4.0):
+    - Firebase/Installations (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (18.3.2):
-    - Firebase/Messaging (= 10.14.0)
-    - FirebaseCoreExtension (= 10.14.0)
+  - RNFBMessaging (18.4.0):
+    - Firebase/Messaging (= 10.15.0)
+    - FirebaseCoreExtension (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBML (18.3.2):
+  - RNFBML (18.4.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (18.3.2):
-    - Firebase/Performance (= 10.14.0)
+  - RNFBPerf (18.4.0):
+    - Firebase/Performance (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (18.3.2):
-    - Firebase/RemoteConfig (= 10.14.0)
+  - RNFBRemoteConfig (18.4.0):
+    - Firebase/RemoteConfig (= 10.15.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (18.3.2):
-    - Firebase/Storage (= 10.14.0)
+  - RNFBStorage (18.4.0):
+    - Firebase/Storage (= 10.15.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.6.1)
@@ -1669,35 +1669,35 @@ SPEC CHECKSUMS:
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 5d4a3b7f411219a45a6d952f77d2c0a6c9989da5
   FBReactNativeSpec: 3fc2d478e1c4b08276f9dd9128f80ec6d5d85c1f
-  Firebase: 6c1bf3f534bc422d52af2e41fe0d50bf08b6b773
-  FirebaseABTesting: e1535073fac4ff55c7537a6e041155c72d9e6906
-  FirebaseAnalytics: 5c6d58814afa4db82cf7fdbc02b0b0e2fa3d43ff
-  FirebaseAppCheck: 476ec4e3e3e67dca98b0aca68c57d1822edcd8c8
-  FirebaseAppCheckInterop: c87f1d5421c852413dd936b2b2340b21e62501a0
-  FirebaseAppDistribution: 25dfacb443e46ede519b27e5c107b22ac66f6c32
-  FirebaseAuth: bd1ae3d28beb83bfe9247e50eb82688b683dd770
-  FirebaseAuthInterop: 23be77be1ca68e4bd15214f403f807a6ca70d7e0
-  FirebaseCore: 6fc17ac9f03509d51c131298aacb3ee5698b4f02
-  FirebaseCoreExtension: 976638051b1a46b503afce7ec80277f9161f2040
-  FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
-  FirebaseCrashlytics: 0fbfa4efa57e8a09d8bf195393b50c237e3322b5
-  FirebaseDatabase: fa6f8e2747c3f168e6996a5fca6daf5c11ebd11b
-  FirebaseDynamicLinks: 0eaabff2d0e5d0e576c0227227b00771aa2f3aaf
-  FirebaseFirestore: 808dd08cbc1c7be9052055f62ab312fdae611e37
-  FirebaseFunctions: 27438b6b4592e9327a343e85ee093ad0f5398bcf
-  FirebaseInAppMessaging: e18a904aaa14594386045a9385b14973fcecb9eb
-  FirebaseInstallations: f672b1eda64e6381c21d424a2f680a943fd83f3b
-  FirebaseMessaging: 1077a4499f0c0a140b9a2e34fe08a1acc806b36d
-  FirebaseMessagingInterop: 5f5ed52481b3956190bf9df2c231d1c72ad14f8d
-  FirebasePerformance: 6747735bc7e2ff8f22af27803ddcb7b4425f327d
-  FirebaseRemoteConfig: e22a706fa7ecc64135325f4c430a15af1e795535
-  FirebaseSessions: f145e7365d36bec0d724c4574a8750e6f82fa6c8
-  FirebaseSharedSwift: 0eec812f08b6ec9e03196fc27635739781513028
-  FirebaseStorage: e97b4bdd84b21ec060d5737a9c4f8f8fc6a0d041
+  Firebase: 66043bd4579e5b73811f96829c694c7af8d67435
+  FirebaseABTesting: 7fa3bca17f79ac433301d20d5cd33401f7738dca
+  FirebaseAnalytics: 47cef43728f81a839cf1306576bdd77ffa2eac7e
+  FirebaseAppCheck: 66eea1c882cddd1bce9d92a0a7efd596f7204782
+  FirebaseAppCheckInterop: a8c555b1c2db1d9445e6c3a08a848167ddb7eb51
+  FirebaseAppDistribution: bfbbaa837919c3e1e6a2f9559f27709bcbf0824c
+  FirebaseAuth: a55ec5f7f8a5b1c2dd750235c1bb419bfb642445
+  FirebaseAuthInterop: b566e21e2bc5e44a4d44babc56d05a7e5c10493b
+  FirebaseCore: 2cec518b43635f96afe7ac3a9c513e47558abd2e
+  FirebaseCoreExtension: d3f1ea3725fb41f56e8fbfb29eeaff54e7ffb8f6
+  FirebaseCoreInternal: 2f4bee5ed00301b5e56da0849268797a2dd31fb4
+  FirebaseCrashlytics: a83f26fb922a3fe181eb738fb4dcf0c92bba6455
+  FirebaseDatabase: f93f1481c7e9e3d77af960cdff82a408d37693e6
+  FirebaseDynamicLinks: 206d4ed3efd2b722822598017f3980d9fda89815
+  FirebaseFirestore: b4c0eaaf24efda5732ec21d9e6c788d083118ca6
+  FirebaseFunctions: e5a95bdd33077eefc3232381d24495ae66d3b1a7
+  FirebaseInAppMessaging: 00746f589c1f3481530b5bdcca2bed3b44dccbe4
+  FirebaseInstallations: cae95cab0f965ce05b805189de1d4c70b11c76fb
+  FirebaseMessaging: 0c0ae1eb722ef0c07f7801e5ded8dccd1357d6d4
+  FirebaseMessagingInterop: 83f7b1a363bfe30ec8bbff1aa708d38e9d456373
+  FirebasePerformance: b7988bc06c87e9c3b9e6b1ae854cd460b646ebd6
+  FirebaseRemoteConfig: 64b6ada098c649304114a817effd7e5f87229b11
+  FirebaseSessions: ee59a7811bef4c15f65ef6472f3210faa293f9c8
+  FirebaseSharedSwift: 34b11d9e675e14ee55e160cb7645bba30a192d14
+  FirebaseStorage: 1d4be239ea32fb3c0f3680a6f2b706d6cabe37f2
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
-  GoogleAppMeasurement: 7fee012a868315d418f365fbc8d394d8e020e749
-  GoogleAppMeasurementOnDeviceConversion: fa8c7b0b878c0a9c008e34bdce2b75b12b549be8
+  GoogleAppMeasurement: 722db6550d1e6d552b08398b69a975ac61039338
+  GoogleAppMeasurementOnDeviceConversion: 992ab96638cd0e2ad89485adfeaf2bbb04b28b4d
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
   "gRPC-C++": 0968bace703459fd3e5dcb0b2bed4c573dbff046
@@ -1719,13 +1719,13 @@ SPEC CHECKSUMS:
   React-Core: 34da8c952844e21f5a69bf46438fb6bf063900d0
   React-CoreModules: 621243df8863055ff30f3bb2ff71573ffa7b16c8
   React-cxxreact: 4ad1cc861e32fb533dad6ff7a4ea25680fa1c994
-  React-debug: 47a64749b1c25d3bbc7a60e0a25cc92e3bb879f0
+  React-debug: 67e65578b43a9f456577e2209bdeedb8ebf4f988
   React-hermes: 37377d0a56aa0cf55c65248271866ce3268cde3f
   React-jsi: 6de8b0ccc6b765b58e4eee9ee38049dbeaf5c221
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  React-NativeModulesApple: 6a0437b0057729b0fcbc8d7c1e72a9eb0eb3a59f
+  React-NativeModulesApple: 8dd91e77f394b74f8d991e5998b77af10f1e6c29
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
   React-RCTAnimation: e44fe5053708c5be762943087c78dc5a6a3c645c
@@ -1739,28 +1739,28 @@ SPEC CHECKSUMS:
   React-RCTVibration: 35eec7201c8ffdaccdd908a5ec874b7055f975f3
   React-rncore: 46133d523155fc84572338bd6a7c461c1d873efc
   React-runtimeexecutor: d465ba0c47ef3ed8281143f59605cacc2244d5c7
-  React-runtimescheduler: 3bbc67fc16f4b4e863d7b6971e879bace85e2ffb
-  React-utils: 6bf1ff5467eb63a4e2c2183f643ed26a09cc9c94
-  ReactCommon: bf48d06fa8aafa912991f7e5f826926fd57a6eab
+  React-runtimescheduler: 6441f54619302476ca186125c2d067db02e55faa
+  React-utils: bdb4284d5194e6488863a3e616d885d1fedb2c20
+  ReactCommon: eb79304863aeeef7f39c9fbcc590a58ae248b2f5
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNDeviceInfo: 02ea8b23e2280fa18e00a06d7e62804d74028579
-  RNFBAnalytics: 77c9f67e22d489699c9c6db438b6af668d56aa47
-  RNFBApp: 8060d3ea89359ae78e0d1e6362a8ce9d2f5d19a8
-  RNFBAppCheck: c9689855cd341f30a31ddf7d74f2ef031d3ff7fd
-  RNFBAppDistribution: 0eb44ed130b03ba31c63edce972f3df68ec9ceb3
-  RNFBAuth: 5db7274fc2d8701b1e9cc3fd76eba677f5260648
-  RNFBCrashlytics: 7da3ac10d763c5743f1de2701a7c718390c00c0a
-  RNFBDatabase: 6a5404e90279494f3191b020c5178e8f55837296
-  RNFBDynamicLinks: 1fbec753fcd8bd1c9c9af875c1116323100ca557
-  RNFBFirestore: 8bbf230c05f1cfc41fb52ff33b64fc3547174e5f
-  RNFBFunctions: b4b09cdee5d3903370e678f9b48bcda39f5291f6
-  RNFBInAppMessaging: a92de4116faba33cd899831da63175a5738afef0
-  RNFBInstallations: 3bf11afae4cb58c5fb182fa97d917b6eea118dbd
-  RNFBMessaging: 40f7d8b2dd76b888b38df6baf54898867caef5fe
-  RNFBML: aac4e32f2f516a508972bd68a470e683808a87c8
-  RNFBPerf: 01e15e46ad63ac096c9c3e86874d7abf4e890bc9
-  RNFBRemoteConfig: d997e4ea547a61fbe7494a6683ee7b70f0441579
-  RNFBStorage: 7ac38e8bfb14458de59b88954a94be44ff0315e6
+  RNFBAnalytics: 1c52719e895ca738e93b6dbda2a9d56c706bed0d
+  RNFBApp: 48a7c41f3fa34da17679544f3634b085a4440f7b
+  RNFBAppCheck: f4160999055609df47f1790988f75885a2c2d9b8
+  RNFBAppDistribution: 06b803ce0ab7e0b622f5639d6bf222e8a83648ef
+  RNFBAuth: 4344dd7aeb2a5f4ee50a1264fc80fbddb9b1e336
+  RNFBCrashlytics: 8ff1225ba826cabc6717183768d4e24c93211f8d
+  RNFBDatabase: 75158d6857a1eaf12a13a7041036818775026f63
+  RNFBDynamicLinks: 66030cc031a4f9eeb8d1e2c7fc635707984df308
+  RNFBFirestore: 1133a7659048fc32a579f7a53d1d00af0754fde9
+  RNFBFunctions: 440593b1fe86a10f9be450a2af20fabe740d1b0e
+  RNFBInAppMessaging: 1acd6f6be521334a39a688f8d679d7d926f5217f
+  RNFBInstallations: 7cc66e6131253751336379aad23c854b4464f648
+  RNFBMessaging: 8efd0398dbea8c4dfb2e6d20964e86b9c7d9602f
+  RNFBML: 5253fca1bf2486d76c2587caa5044873f7560ba0
+  RNFBPerf: 57d7f24f1bc594d125bd2e29e700053d6f12898f
+  RNFBRemoteConfig: ce6aadee4790572f5ca868c8e3242a657e75b92b
+  RNFBStorage: 3c96a058111fcf1bf9f3a4884815fe37acefc965
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
 


### PR DESCRIPTION
### Description

also includes a bump to play-services-auth 20.7.0

these are feature releases for upstream (primarily to add the new firestore local persistent cache index manager) but those are new symbols and if we adopted them here it would be a breaking change as it would transitivey require users that are overriding the SDK versions to use these new SDKs as a minimum. We will defer that


### Release Summary

a single conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Run the full e2e test suite locally - everything works ✅ 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
