### PR TITLE
test(deps): adopt Xcode 15 / iOS 17 in CI

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 'latest-stable'
+          xcode-version: 'latest'
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -137,6 +137,9 @@ jobs:
           max_attempts: 3
           command: HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew && HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils xcbeautify && applesimutils --list
 
+      - name: Get available simulators
+        run: applesimutils --list
+
       - name: Build iOS App
         run: |
           export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"

--- a/tests/package.json
+++ b/tests/package.json
@@ -64,7 +64,7 @@
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 14",
-          "os": "iOS 16.4"
+          "os": "iOS 17.0"
         }
       },
       "ios.sim.release": {
@@ -73,7 +73,7 @@
         "type": "ios.simulator",
         "device": {
           "type": "iPhone 14",
-          "os": "iOS 16.4"
+          "os": "iOS 17.0"
         }
       },
       "android.emu.debug": {


### PR DESCRIPTION
### Description

- update our device type / os definitions to be iPhone 15 / iOS 17.0

This is to match with the current new installation values you get when installing Xcode 15 - iPhone 14 / iOS 16.4 are not available by default and you have to install them manually if you want them

- update CI xcode from xcode-current to 15

Note that this may not work, I'm not sure what Xcode is actually available in the current runner images, so this is a little speculative and the CI run log will need examination

- update Detox with patch to handle slightly different error message for terminateApp when app was not running - Xcode 15 apparently changed it

### Release Summary

conventional commit, won't trigger a release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Tested locally and everything appears to work except some timing-related flakiness on remote-config onConfigUpdated that I also saw on the old Simulator - so I'm curious how it goes in CI

Nabeel also mentioned a compile issue that required a new build flag but I was not able to reproduce a need for this locally. Detailed as:

> All I had to do was adding the ld64 flag in Other Linker Flags in the Xcode project settings

If it reproduces in CI I'll adopt that change in this PR

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
