### PR TITLE
feat(ios): add initiateOnDeviceConversionMeasurementWithPhoneNumber

### DIFF
--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -470,6 +470,28 @@ describe('analytics() modular', function () {
     });
 
     // Test this last so it does not stop delivery to DebugView
+    describe('on-device conversion measurement with phone', function () {
+      it('calls native API successfully', async function () {
+        await firebase
+          .analytics()
+          .initiateOnDeviceConversionMeasurementWithPhoneNumber('+14155551212');
+      });
+      it('handles mal-formatted phone number', async function () {
+        try {
+          await firebase
+            .analytics()
+            .initiateOnDeviceConversionMeasurementWithPhoneNumber('+notaphonenumber');
+          fail('Should have returned an error for malformatted phone number');
+        } catch (e) {
+          // coerce the error message to a string and verify
+          if (!(e + '').includes('expected a string value in E.164 format')) {
+            fail('Should have returned an error for malformatted phone number');
+          }
+        }
+      });
+    });
+
+    // Test this last so it does not stop delivery to DebugView
     describe('setAnalyticsCollectionEnabled()', function () {
       it('false', async function () {
         await firebase.analytics().setAnalyticsCollectionEnabled(false);
@@ -1005,6 +1027,31 @@ describe('analytics() modular', function () {
           getAnalytics(),
           'conversionTest@example.com',
         );
+      });
+    });
+
+    // Test this last so it does not stop delivery to DebugView
+    describe('on-device conversion measurement with phone', function () {
+      it('calls native API successfully', async function () {
+        const { getAnalytics, initiateOnDeviceConversionMeasurementWithPhoneNumber } =
+          analyticsModular;
+        await initiateOnDeviceConversionMeasurementWithPhoneNumber(getAnalytics(), '+14155551212');
+      });
+      it('handles mal-formatted phone number', async function () {
+        try {
+          const { getAnalytics, initiateOnDeviceConversionMeasurementWithPhoneNumber } =
+            analyticsModular;
+          await initiateOnDeviceConversionMeasurementWithPhoneNumber(
+            getAnalytics(),
+            '+notaphonenumber',
+          );
+          fail('Should have returned an error for malformatted phone number');
+        } catch (e) {
+          // coerce the error message to a string and verify
+          if (!(e + '').includes('expected a string value in E.164 format')) {
+            fail('Should have returned an error for malformatted phone number');
+          }
+        }
       });
     });
 

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -164,6 +164,19 @@ RCT_EXPORT_METHOD(initiateOnDeviceConversionMeasurementWithEmailAddress
   return resolve([NSNull null]);
 }
 
+RCT_EXPORT_METHOD(initiateOnDeviceConversionMeasurementWithPhoneNumber
+                  : (NSString *)phoneNumber resolver
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject) {
+  @try {
+    [FIRAnalytics initiateOnDeviceConversionMeasurementWithPhoneNumber:phoneNumber];
+  } @catch (NSException *exception) {
+    return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
+  }
+
+  return resolve([NSNull null]);
+}
+
 #pragma mark -
 #pragma mark Private methods
 

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -1718,6 +1718,15 @@ export namespace FirebaseAnalyticsTypes {
      * @param emailAddress email address, properly formatted complete with domain name e.g, 'user@example.com'
      */
     initiateOnDeviceConversionMeasurementWithEmailAddress(emailAddress: string): Promise<void>;
+
+    /**
+     * start privacy-sensitive on-device conversion management.
+     * This is iOS-only.
+     * This is a no-op if you do not include '$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true' in your Podfile
+     *
+     * @param phoneNumber phone number in E.164 format - that is a leading + sign, then up to 15 digits, no dashes or spaces.
+     */
+    initiateOnDeviceConversionMeasurementWithPhoneNumber(phoneNumber: string): Promise<void>;
   }
 
   /**

--- a/packages/analytics/lib/index.js
+++ b/packages/analytics/lib/index.js
@@ -17,6 +17,7 @@
 
 import {
   isAlphaNumericUnderscore,
+  isE164PhoneNumber,
   isIOS,
   isNull,
   isNumber,
@@ -85,6 +86,7 @@ export {
   logViewSearchResults,
   setDefaultEventParameters,
   initiateOnDeviceConversionMeasurementWithEmailAddress,
+  initiateOnDeviceConversionMeasurementWithPhoneNumber,
 } from './modular/index';
 
 const ReservedEventNames = [
@@ -768,6 +770,20 @@ class FirebaseAnalyticsModule extends FirebaseModule {
     }
 
     return this.native.initiateOnDeviceConversionMeasurementWithEmailAddress(emailAddress);
+  }
+
+  initiateOnDeviceConversionMeasurementWithPhoneNumber(phoneNumber) {
+    if (!isE164PhoneNumber(phoneNumber)) {
+      throw new Error(
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithPhoneNumber(*) 'phoneNumber' expected a string value in E.164 format.",
+      );
+    }
+
+    if (!isIOS) {
+      return;
+    }
+
+    return this.native.initiateOnDeviceConversionMeasurementWithPhoneNumber(phoneNumber);
   }
 }
 

--- a/packages/analytics/lib/modular/index.d.ts
+++ b/packages/analytics/lib/modular/index.d.ts
@@ -1165,6 +1165,19 @@ export function initiateOnDeviceConversionMeasurementWithEmailAddress(
 ): Promise<void>;
 
 /**
+ * start privacy-sensitive on-device conversion management.
+ * This is iOS-only.
+ * This is a no-op if you do not include '$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true' in your Podfile
+ *
+ * @param analytics Analytics instance.
+ * @param phoneNumber phone number in E.164 format - that is a leading + sign, then up to 15 digits, no dashes or spaces.
+ */
+export function initiateOnDeviceConversionMeasurementWithPhoneNumber(
+  analytics: Analytics,
+  phoneNumber: string,
+): Promise<void>;
+
+/**
  * Checks four different things.
  * 1. Checks if it's not a browser extension environment.
  * 2. Checks if cookies are enabled in current browser.

--- a/packages/analytics/lib/modular/index.js
+++ b/packages/analytics/lib/modular/index.js
@@ -623,6 +623,18 @@ export function initiateOnDeviceConversionMeasurementWithEmailAddress(analytics,
 }
 
 /**
+ * start privacy-sensitive on-device conversion management.
+ * This is iOS-only.
+ * This is a no-op if you do not include '$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true' in your Podfile
+ *
+ * @param analytics Analytics instance.
+ * @param phoneNumber phone number in E.164 format - that is a leading + sign, then up to 15 digits, no dashes or spaces.
+ */
+export function initiateOnDeviceConversionMeasurementWithPhoneNumber(analytics, phoneNumber) {
+  return analytics.initiateOnDeviceConversionMeasurementWithPhoneNumber(phoneNumber);
+}
+
+/**
  * Checks four different things.
  * 1. Checks if it's not a browser extension environment.
  * 2. Checks if cookies are enabled in current browser.

--- a/packages/app/lib/common/validate.js
+++ b/packages/app/lib/common/validate.js
@@ -96,6 +96,16 @@ export function isNumber(value) {
 }
 
 /**
+ * Simple is phone number check for E.164 format
+ * @param value
+ * @return {boolean}
+ */
+export function isE164PhoneNumber(value) {
+  const PHONE_NUMBER = /^\+[1-9]\d{1,14}$/; // E.164
+  return PHONE_NUMBER.test(value);
+}
+
+/**
  * Simple finite check
  * @param value
  * @returns {boolean}


### PR DESCRIPTION
### Description

Note: this implies transitive requirement of firebase-ios-sdk 10.13.0, if you override your firebase-ios-sdk version locally you must increase the local override version to at least 10.13.0 to adopt this version.

### Related issues

Fixes #7355 

### Release Summary

One conventional commit, structured to create changelog release notes correctly

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

(not breaking - as mentioned on related issue, could break people that do local firebase-ios-sdk overrides but they operate at their own risk via an explicit note in the documentation for that capability)

### Test Plan

Added e2e tests, checked them positively / negatively locally, all working

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
