### PR TITLE
test(storage, ios): enable tests after upstream bug fixes released

### DIFF
--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
@@ -24,12 +24,12 @@ import com.facebook.react.bridge.*;
 import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.appcheck.FirebaseAppCheck;
+import io.invertase.firebase.common.ReactNativeFirebaseEvent;
+import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
 import io.invertase.firebase.common.ReactNativeFirebaseJSON;
 import io.invertase.firebase.common.ReactNativeFirebaseMeta;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
 import io.invertase.firebase.common.ReactNativeFirebasePreferences;
-import io.invertase.firebase.common.ReactNativeFirebaseEvent;
-import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -39,7 +39,8 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
   private static final String LOGTAG = "RNFBAppCheck";
   private static final String KEY_APPCHECK_TOKEN_REFRESH_ENABLED = "app_check_token_auto_refresh";
 
-  private static HashMap<String, FirebaseAppCheck.AppCheckListener> mAppCheckListeners = new HashMap<>();
+  private static HashMap<String, FirebaseAppCheck.AppCheckListener> mAppCheckListeners =
+      new HashMap<>();
 
   ReactNativeFirebaseAppCheckProviderFactory providerFactory =
       new ReactNativeFirebaseAppCheckProviderFactory();
@@ -110,7 +111,8 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
       String appName = (String) pair.getKey();
       FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
       FirebaseAppCheck firebaseAppCheck = FirebaseAppCheck.getInstance(firebaseApp);
-      FirebaseAppCheck.AppCheckListener mAppCheckListener = (FirebaseAppCheck.AppCheckListener) pair.getValue();
+      FirebaseAppCheck.AppCheckListener mAppCheckListener =
+          (FirebaseAppCheck.AppCheckListener) pair.getValue();
       firebaseAppCheck.removeAppCheckListener(mAppCheckListener);
       appCheckListenerIterator.remove();
     }
@@ -213,16 +215,19 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
     FirebaseAppCheck firebaseAppCheck = FirebaseAppCheck.getInstance(firebaseApp);
 
     if (mAppCheckListeners.get(appName) == null) {
-      FirebaseAppCheck.AppCheckListener newAppCheckListener = appCheckToken -> {
-        WritableMap eventBody = Arguments.createMap();
-        eventBody.putString("appName", appName); // for js side distribution
-        eventBody.putString("token", appCheckToken.getToken());
-        eventBody.putDouble("expireTimeMillis", appCheckToken.getExpireTimeMillis());
+      FirebaseAppCheck.AppCheckListener newAppCheckListener =
+          appCheckToken -> {
+            WritableMap eventBody = Arguments.createMap();
+            eventBody.putString("appName", appName); // for js side distribution
+            eventBody.putString("token", appCheckToken.getToken());
+            eventBody.putDouble("expireTimeMillis", appCheckToken.getExpireTimeMillis());
 
-        ReactNativeFirebaseEventEmitter emitter = ReactNativeFirebaseEventEmitter.getSharedInstance();
-        ReactNativeFirebaseEvent event = new ReactNativeFirebaseEvent("appCheck_token_changed", eventBody, appName);
-        emitter.sendEvent(event);
-      };
+            ReactNativeFirebaseEventEmitter emitter =
+                ReactNativeFirebaseEventEmitter.getSharedInstance();
+            ReactNativeFirebaseEvent event =
+                new ReactNativeFirebaseEvent("appCheck_token_changed", eventBody, appName);
+            emitter.sendEvent(event);
+          };
 
       firebaseAppCheck.addAppCheckListener(newAppCheckListener);
       mAppCheckListeners.put(appName, newAppCheckListener);

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -629,6 +629,26 @@ describe('storage() -> StorageReference', function () {
         });
       });
     });
+
+    describe('put secondaryApp', function () {
+      it('allows valid metadata properties for upload', async function () {
+        const storageReference = firebase
+          .storage(firebase.app('secondaryFromNative'))
+          // .storage()
+          .ref(`${PATH}/metadataTest.jpeg`);
+        await storageReference.put(new jet.context.window.ArrayBuffer(), {
+          contentType: 'image/jpg',
+          md5hash: '123412341234',
+          cacheControl: 'true',
+          contentDisposition: 'disposed',
+          contentEncoding: 'application/octet-stream',
+          contentLanguage: 'de',
+          customMetadata: {
+            customMetadata1: 'metadata1value',
+          },
+        });
+      });
+    });
   });
 
   describe('StorageReference modular', function () {
@@ -1344,6 +1364,29 @@ describe('storage() -> StorageReference', function () {
       it('allows valid metadata properties for upload', async function () {
         const { getStorage, ref, uploadBytesResumable } = storageModular;
         const storageReference = ref(getStorage(), `${PATH}/metadataTest.jpeg`);
+
+        await uploadBytesResumable(storageReference, new jet.context.window.ArrayBuffer(), {
+          contentType: 'image/jpg',
+          md5hash: '123412341234',
+          cacheControl: 'true',
+          contentDisposition: 'disposed',
+          contentEncoding: 'application/octet-stream',
+          contentLanguage: 'de',
+          customMetadata: {
+            customMetadata1: 'metadata1value',
+          },
+        });
+      });
+    });
+
+    describe('put secondaryApp', function () {
+      it('allows valid metadata properties for upload', async function () {
+        const { getStorage, ref, uploadBytesResumable } = storageModular;
+        const { getApp } = modular;
+        const storageReference = ref(
+          getStorage(getApp('secondaryFromNative')),
+          `${PATH}/metadataTest.jpeg`,
+        );
 
         await uploadBytesResumable(storageReference, new jet.context.window.ArrayBuffer(), {
           contentType: 'image/jpg',

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -149,8 +149,7 @@ describe('storage() -> StorageReference', function () {
       describe('getDownloadURL', function () {
         it('should return a download url for a file', async function () {
           // This is frequently flaky in CI - but works sometimes. Skipping only in CI for now.
-          // Disabled for iOS pending: https://github.com/firebase/firebase-ios-sdk/pull/10370
-          if (!isCI && device.getPlatform() !== 'ios') {
+          if (!isCI) {
             const storageReference = firebase.storage().ref(`${PATH}/list/file1.txt`);
             const downloadUrl = await storageReference.getDownloadURL();
             downloadUrl.should.be.a.String();
@@ -777,8 +776,7 @@ describe('storage() -> StorageReference', function () {
       it('should return a download url for a file', async function () {
         const { getStorage, ref, getDownloadURL } = storageModular;
         // This is frequently flaky in CI - but works sometimes. Skipping only in CI for now.
-        // Disabled for iOS pending: https://github.com/firebase/firebase-ios-sdk/pull/10370
-        if (!isCI && device.getPlatform() !== 'ios') {
+        if (!isCI) {
           const storageReference = ref(getStorage(), `${PATH}/list/file1.txt`);
           const downloadUrl = await getDownloadURL(storageReference);
           downloadUrl.should.be.a.String();

--- a/tests/patches/detox+19.12.6.patch
+++ b/tests/patches/detox+19.12.6.patch
@@ -135,3 +135,16 @@ index fb4b820..d2dc87d 100644
          notifyIdle()
          return true
      }
+diff --git a/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js b/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+index 585c99b..46e4b83 100644
+--- a/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
++++ b/node_modules/detox/src/devices/common/drivers/ios/tools/AppleSimUtils.js
+@@ -272,7 +272,7 @@ class AppleSimUtils {
+       // want to make sure it isn't now.
+       if (err.code === 3 &&
+           (err.stderr.includes(`the app is not currently running`) ||
+-           err.stderr.includes(`The operation couldn’t be completed. found nothing to terminate`))) {
++           err.stderr.includes(`found nothing to terminate`))) {
+         return;
+       }
+ 


### PR DESCRIPTION
### Description

There was an older branch I noticed that had two exploratory test cases I used to collaborate with firebase-ios-sdk in order to work through some upstream issues. They are fixed upstream and released now, so we can adopt the tests in our main branch

Patched them up to work with the new modular e2e files since that happened in the interim


----

Includes 2 random commits that help local testing and don't deserve a separate PR:

- a detox fix that is backwards-compatible but allows me to test things easily locally now that I've got Xcode 15 / iOS 17 in use in some local environments
- a java lint fix from a previous PR since android lint silently fails in CI at the moment

### Related issues

https://github.com/firebase/firebase-ios-sdk/pull/10370
https://github.com/firebase/firebase-ios-sdk/issues/10463

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

This was all testing / collaboration (via testing...) with firebase-ios-sdk 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
