### PR TITLE
feat: Adding support for Firebase Messaging via Expo config plugin.

### DIFF
--- a/packages/app/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/app/plugin/__tests__/androidPlugin.test.ts
@@ -1,9 +1,14 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { beforeAll, describe, expect, it } from '@jest/globals';
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
 
 import { applyPlugin } from '../src/android/applyPlugin';
 import { setBuildscriptDependency } from '../src/android/buildscriptDependency';
+import { setFireBaseMessagingAndroidManifest } from '../src/android/setupFirebaseNotifationIcon';
+import { ExpoConfig } from '@expo/config-types';
+import expoConfigExample from './fixtures/expo-config-example';
+import manifestApplicationExample from './fixtures/application-example';
+import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
 
 describe('Config Plugin Android Tests', function () {
   let appBuildGradle: string;
@@ -28,5 +33,60 @@ describe('Config Plugin Android Tests', function () {
   it('applies changes to app/build.gradle', async function () {
     const result = applyPlugin(appBuildGradle);
     expect(result).toMatchSnapshot();
+  });
+
+  it('applies changes to app/src/main/AndroidManifest.xml with color', async function () {
+    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExample));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_color',
+        'android:resource': '@color/notification_color',
+        'tools:replace': 'android:resource',
+      },
+    });
+  });
+
+  it('applies changes to app/src/main/AndroidManifest.xml without color', async function () {
+    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExample));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    config.notification!.color = undefined;
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+    expect(manifestApplication['meta-data']).not.toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+        'tools:replace': 'android:resource',
+      },
+    });
+  });
+
+  it('applies changes to app/src/main/AndroidManifest.xml without notification', async function () {
+    const warnSpy = jest.spyOn(console, 'warn');
+    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExample));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    config.notification = undefined;
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/packages/app/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/app/plugin/__tests__/androidPlugin.test.ts
@@ -50,7 +50,7 @@ describe('Config Plugin Android Tests', function () {
     expect(manifestApplication['meta-data']).toContainEqual({
       $: {
         'android:name': 'com.google.firebase.messaging.default_notification_color',
-        'android:resource': '@color/notification_color',
+        'android:resource': '@color/notification_icon_color',
         'tools:replace': 'android:resource',
       },
     });

--- a/packages/app/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/app/plugin/__tests__/androidPlugin.test.ts
@@ -72,7 +72,7 @@ describe('Config Plugin Android Tests', function () {
     expect(manifestApplication['meta-data']).not.toContainEqual({
       $: {
         'android:name': 'com.google.firebase.messaging.default_notification_icon',
-        'android:resource': '@drawable/notification_icon',
+        'android:resource': '@drawable/notification_icon_color',
         'tools:replace': 'android:resource',
       },
     });

--- a/packages/app/plugin/__tests__/fixtures/application-example.ts
+++ b/packages/app/plugin/__tests__/fixtures/application-example.ts
@@ -1,0 +1,12 @@
+import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
+
+/**
+ * @type {import('"@expo/config-plugins/build/android/Manifest"').ManifestApplication}
+ */
+const manifestApplicationExample: ManifestApplication = {
+  $: {
+    'android:name': '',
+  },
+};
+
+export default manifestApplicationExample;

--- a/packages/app/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/app/plugin/__tests__/fixtures/expo-config-example.ts
@@ -1,0 +1,15 @@
+import { ExpoConfig } from '@expo/config-types';
+
+/**
+ * @type {import('@expo/config-types').ExpoConfig}
+ */
+const expoConfigExample: ExpoConfig = {
+  name: 'FirebaseMessagingTest',
+  slug: 'fire-base-messaging-test',
+  notification: {
+    icon: 'IconAsset',
+    color: '#1D172D',
+  },
+};
+
+export default expoConfigExample;

--- a/packages/app/plugin/src/android/index.ts
+++ b/packages/app/plugin/src/android/index.ts
@@ -1,5 +1,11 @@
 import { withApplyGoogleServicesPlugin } from './applyPlugin';
 import { withBuildscriptDependency } from './buildscriptDependency';
 import { withCopyAndroidGoogleServices } from './copyGoogleServices';
+import { withExpoPluginFirebaseNotification } from './setupFirebaseNotifationIcon';
 
-export { withBuildscriptDependency, withApplyGoogleServicesPlugin, withCopyAndroidGoogleServices };
+export {
+  withBuildscriptDependency,
+  withApplyGoogleServicesPlugin,
+  withCopyAndroidGoogleServices,
+  withExpoPluginFirebaseNotification,
+};

--- a/packages/app/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/app/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -69,7 +69,7 @@ export function setFireBaseMessagingAndroidManifest(
     metaData.push({
       $: {
         'android:name': 'com.google.firebase.messaging.default_notification_color',
-        'android:resource': '@color/notification_color',
+        'android:resource': '@color/notification_icon_color',
         // @react-native-firebase/messaging will automatically configure the notification color from the 'firebase.json' file, setting 'tools:replace' = 'android:resource' to overwrite it.
         // @ts-ignore
         'tools:replace': 'android:resource',

--- a/packages/app/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/app/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -1,0 +1,81 @@
+import { ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
+import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
+import { ExpoConfig } from '@expo/config-types';
+
+/**
+ * Check if the developer has installed '@react-native-firebase/messaging'
+ *
+ * @return {boolean}
+ */
+function hasMessagingDependency(): boolean {
+  try {
+    require.resolve('@react-native-firebase/messaging');
+  } catch (error) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Create `com.google.firebase.messaging.default_notification_icon` and `com.google.firebase.messaging.default_notification_color`
+ */
+export const withExpoPluginFirebaseNotification: ConfigPlugin = config => {
+  return withAndroidManifest(config, async config => {
+    const messagingInstalled = hasMessagingDependency();
+    //  If the developer is not using '@react-native-firebase/messaging', there is no need to do anything
+    if (!messagingInstalled) {
+      return config;
+    }
+    // If there is no need to build an Android program, there is no need to do anything
+    if (!config.android) {
+      return config;
+    }
+    const application = config.modResults.manifest.application![0];
+    setFireBaseMessagingAndroidManifest(config, application);
+    return config;
+  });
+};
+
+export function setFireBaseMessagingAndroidManifest(
+  config: ExpoConfig,
+  application: ManifestApplication,
+) {
+  // If the notification object is not defined, print a friendly warning
+  if (!config.notification) {
+    // This warning is important because the notification icon can only use pure white on Android. By default, the system uses the app icon as the notification icon, but the app icon is usually not pure white, so you need to set the notification icon
+    // eslint-disable-next-line no-console
+    console.warn(
+      'For Android 8.0 and above, it is necessary to set the notification icon to ensure correct display. Otherwise, the notification will not show the correct icon. For more information, visit https://docs.expo.dev/versions/latest/config/app/#notification',
+    );
+    return config;
+  }
+
+  // Defensive code
+  application['meta-data'] ??= [];
+
+  const metaData = application['meta-data'];
+
+  if (config.notification.icon) {
+    // Expo will automatically create '@drawable/notification_icon' resource if you specify config.notification.icon.
+    metaData.push({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+  }
+
+  if (config.notification.color) {
+    metaData.push({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_color',
+        'android:resource': '@color/notification_color',
+        // @react-native-firebase/messaging will automatically configure the notification color from the 'firebase.json' file, setting 'tools:replace' = 'android:resource' to overwrite it.
+        // @ts-ignore
+        'tools:replace': 'android:resource',
+      },
+    });
+  }
+
+  return application;
+}

--- a/packages/app/plugin/src/index.ts
+++ b/packages/app/plugin/src/index.ts
@@ -4,6 +4,7 @@ import {
   withApplyGoogleServicesPlugin,
   withBuildscriptDependency,
   withCopyAndroidGoogleServices,
+  withExpoPluginFirebaseNotification,
 } from './android';
 import { withFirebaseAppDelegate, withIosGoogleServicesFile } from './ios';
 
@@ -20,6 +21,7 @@ const withRnFirebaseApp: ConfigPlugin = config => {
     withBuildscriptDependency,
     withApplyGoogleServicesPlugin,
     withCopyAndroidGoogleServices,
+    withExpoPluginFirebaseNotification,
   ]);
 };
 


### PR DESCRIPTION
### Description

This PR adds support for Firebase Messaging in Expo projects via a config plugin. This is mainly achieved by setting the appropriate keys (`com.google.firebase.messaging.default_notification_icon` and `com.google.firebase.messaging.default_notification_color`) in the AndroidManifest of the Android project during the build stage. The addition of this plugin will automatically enable Firebase Messaging support for developers using `@react-native-firebase/messaging` in their Expo projects which have the necessary notification configuration.

Displaying notifications correctly on Android requires setting a pure white icon. By default, the system uses the app's own icon as the notification icon, which usually isn't purely white. Therefore, it's necessary to specify a notification icon. If no notification configuration is detected from the Expo configuration, a friendly warning will be printed.


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

Added support for Firebase Messaging in Expo projects via a config plugin.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I created the repo to test the feature.

https://github.com/MonchiLin/firebase-messaging-test-app

