### PR TITLE
fix(storage, ios): remove '443' port from iOS download URLs

### DIFF
--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -110,7 +110,14 @@ RCT_EXPORT_METHOD(getDownloadURL
     if (error != nil) {
       [self promiseRejectStorageException:reject error:error];
     } else {
-      resolve([URL absoluteString]);
+      NSString *url = URL.absoluteString;
+
+      if ([url rangeOfString:@":443"].location != NSNotFound) {
+        NSRange replaceRange = [url rangeOfString:@":443"];
+        url = [url stringByReplacingCharactersInRange:replaceRange withString:@""];
+      }
+
+      resolve(url);
     }
   }];
 }


### PR DESCRIPTION
### Description

On iOS the download URL returned as '443' port in it, which differs from android and web and makes the package non-platform-independent, contrary to the platform independent goal

This removes ':443' from the URL returned, if it is present

### Related issues

Fixes #7363 

### Release Summary

One conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Made sure e2e tests run correctly (which now include downloadURL tests on iOS after re-enabling it in #7361 !)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
