### PR TITLE
feat(messaging): Adding support for Firebase Messaging via Expo config plugin.

### DIFF
--- a/packages/messaging/app.plugin.js
+++ b/packages/messaging/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build');

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -24,7 +24,16 @@
     "messaging"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "18.6.2"
+    "@react-native-firebase/app": "18.6.2",
+    "expo": ">=47.0.0"
+  },
+  "devDependencies": {
+    "expo": "^49.0.0"
+  },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "genversion --semi lib/version.js",
     "build:clean": "rimraf android/build && rimraf ios/build",
-    "prepare": "yarn run build"
+    "build:plugin": "rimraf plugin/build && tsc --build plugin",
+    "lint:plugin": "eslint plugin/src/*",
+    "prepare": "yarn run build && yarn run build:plugin"
   },
   "repository": {
     "type": "git",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -28,7 +28,7 @@
     "expo": ">=47.0.0"
   },
   "devDependencies": {
-    "expo": "^49.0.0"
+    "expo": "^49.0.20"
   },
   "peerDependenciesMeta": {
     "expo": {

--- a/packages/messaging/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/messaging/plugin/__tests__/androidPlugin.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { setFireBaseMessagingAndroidManifest } from '../src/android/setupFirebaseNotifationIcon';
+import { ExpoConfig } from '@expo/config-types';
+import expoConfigExample from './fixtures/expo-config-example';
+import manifestApplicationExample from './fixtures/application-example';
+import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
+
+describe('Config Plugin Android Tests', function () {
+  it('applies changes to app/src/main/AndroidManifest.xml with color', async function () {
+    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExample));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_color',
+        'android:resource': '@color/notification_icon_color',
+        'tools:replace': 'android:resource',
+      },
+    });
+  });
+
+  it('applies changes to app/src/main/AndroidManifest.xml without color', async function () {
+    const config = JSON.parse(JSON.stringify(expoConfigExample));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    config.notification!.color = undefined;
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+    expect(manifestApplication['meta-data']).not.toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon_color',
+        'tools:replace': 'android:resource',
+      },
+    });
+  });
+
+  it('applies changes to app/src/main/AndroidManifest.xml without notification', async function () {
+    const warnSpy = jest.spyOn(console, 'warn');
+    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExample));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    config.notification = undefined;
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/messaging/plugin/__tests__/fixtures/application-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/application-example.ts
@@ -1,0 +1,12 @@
+import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
+
+/**
+ * @type {import('"@expo/config-plugins/build/android/Manifest"').ManifestApplication}
+ */
+const manifestApplicationExample: ManifestApplication = {
+  $: {
+    'android:name': '',
+  },
+};
+
+export default manifestApplicationExample;

--- a/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
@@ -1,0 +1,15 @@
+import { ExpoConfig } from '@expo/config-types';
+
+/**
+ * @type {import('@expo/config-types').ExpoConfig}
+ */
+const expoConfigExample: ExpoConfig = {
+  name: 'FirebaseMessagingTest',
+  slug: 'fire-base-messaging-test',
+  notification: {
+    icon: 'IconAsset',
+    color: '#1D172D',
+  },
+};
+
+export default expoConfigExample;

--- a/packages/messaging/plugin/src/android/index.ts
+++ b/packages/messaging/plugin/src/android/index.ts
@@ -1,0 +1,3 @@
+import { withExpoPluginFirebaseNotification } from './setupFirebaseNotifationIcon';
+
+export { withExpoPluginFirebaseNotification };

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -1,0 +1,71 @@
+import { ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
+import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
+import { ExpoConfig } from '@expo/config-types';
+
+/**
+ * 判断 ManifestApplication 是否存在某个属性
+ */
+const hasMetaData = (application: ManifestApplication, metaData: string) => {
+  return application['meta-data']?.some(item => item['$']['android:name'] === metaData);
+};
+
+/**
+ * Create `com.google.firebase.messaging.default_notification_icon` and `com.google.firebase.messaging.default_notification_color`
+ */
+export const withExpoPluginFirebaseNotification: ConfigPlugin = config => {
+  return withAndroidManifest(config, async config => {
+    const application = config.modResults.manifest.application![0];
+    setFireBaseMessagingAndroidManifest(config, application);
+    return config;
+  });
+};
+
+export function setFireBaseMessagingAndroidManifest(
+  config: ExpoConfig,
+  application: ManifestApplication,
+) {
+  // If the notification object is not defined, print a friendly warning
+  if (!config.notification) {
+    // This warning is important because the notification icon can only use pure white on Android. By default, the system uses the app icon as the notification icon, but the app icon is usually not pure white, so you need to set the notification icon
+    // eslint-disable-next-line no-console
+    console.warn(
+      'For Android 8.0 and above, it is necessary to set the notification icon to ensure correct display. Otherwise, the notification will not show the correct icon. For more information, visit https://docs.expo.dev/versions/latest/config/app/#notification',
+    );
+    return config;
+  }
+
+  // Defensive code
+  application['meta-data'] ??= [];
+
+  const metaData = application['meta-data'];
+
+  if (
+    config.notification.icon &&
+    !hasMetaData(application, 'com.google.firebase.messaging.default_notification_icon')
+  ) {
+    // Expo will automatically create '@drawable/notification_icon' resource if you specify config.notification.icon.
+    metaData.push({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+  }
+
+  if (
+    config.notification.color &&
+    !hasMetaData(application, 'com.google.firebase.messaging.default_notification_color')
+  ) {
+    metaData.push({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_color',
+        'android:resource': '@color/notification_icon_color',
+        // @react-native-firebase/messaging will automatically configure the notification color from the 'firebase.json' file, setting 'tools:replace' = 'android:resource' to overwrite it.
+        // @ts-ignore
+        'tools:replace': 'android:resource',
+      },
+    });
+  }
+
+  return application;
+}

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -3,7 +3,7 @@ import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest
 import { ExpoConfig } from '@expo/config-types';
 
 /**
- * 判断 ManifestApplication 是否存在某个属性
+ * Determine whether a ManifestApplication has an attribute.
  */
 const hasMetaData = (application: ManifestApplication, metaData: string) => {
   return application['meta-data']?.some(item => item['$']['android:name'] === metaData);

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -14,6 +14,12 @@ const hasMetaData = (application: ManifestApplication, metaData: string) => {
  */
 export const withExpoPluginFirebaseNotification: ConfigPlugin = config => {
   return withAndroidManifest(config, async config => {
+    // Add NS `xmlns:tools to handle boundary conditions.
+    config.modResults.manifest.$ = {
+      ...config.modResults.manifest.$,
+      'xmlns:tools': 'http://schemas.android.com/tools',
+    };
+
     const application = config.modResults.manifest.application![0];
     setFireBaseMessagingAndroidManifest(config, application);
     return config;

--- a/packages/messaging/plugin/src/index.ts
+++ b/packages/messaging/plugin/src/index.ts
@@ -1,0 +1,17 @@
+import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
+import { withExpoPluginFirebaseNotification } from './android';
+
+/**
+ * A config plugin for configuring `@react-native-firebase/app`
+ */
+const withRnFirebaseApp: ConfigPlugin = config => {
+  return withPlugins(config, [
+    // iOS
+
+    // Android
+    withExpoPluginFirebaseNotification,
+  ]);
+};
+
+const pak = require('@react-native-firebase/messaging/package.json');
+export default createRunOncePlugin(withRnFirebaseApp, pak.name, pak.version);

--- a/packages/messaging/plugin/tsconfig.json
+++ b/packages/messaging/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node12/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["./src"]
+}

--- a/packages/messaging/plugin/tsconfig.json
+++ b/packages/messaging/plugin/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node12/tsconfig.json",
+  "extends": "@tsconfig/node-lts/tsconfig",
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5054,8 +5054,14 @@ __metadata:
 "@react-native-firebase/messaging@npm:18.6.2, @react-native-firebase/messaging@workspace:packages/messaging":
   version: 0.0.0-use.local
   resolution: "@react-native-firebase/messaging@workspace:packages/messaging"
+  dependencies:
+    expo: "npm:^49.0.20"
   peerDependencies:
     "@react-native-firebase/app": 18.6.2
+    expo: ">=47.0.0"
+  peerDependenciesMeta:
+    expo:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

This PR adds support for Firebase Messaging in Expo projects via a config plugin. This is mainly achieved by setting the appropriate keys (`com.google.firebase.messaging.default_notification_icon` and `com.google.firebase.messaging.default_notification_color`) in the AndroidManifest of the Android project during the build stage. The addition of this plugin will automatically enable Firebase Messaging support for developers using `@react-native-firebase/messaging` in their Expo projects which have the necessary notification configuration.

Displaying notifications correctly on Android requires setting a pure white icon. By default, the system uses the app's own icon as the notification icon, which usually isn't purely white. Therefore, it's necessary to specify a notification icon. If no notification configuration is detected from the Expo configuration, a friendly warning will be printed.


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

Added support for Firebase Messaging in Expo projects via a config plugin.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I created the repo to test the feature.

https://github.com/MonchiLin/firebase-messaging-test-app

