### PR TITLE
docs(messaging, ios): clarify that some simulators may get FCM messages now

### DIFF
--- a/docs/messaging/usage/ios-setup.md
+++ b/docs/messaging/usage/ios-setup.md
@@ -9,9 +9,9 @@ Integrating the Cloud Messaging module on iOS devices requires additional setup 
 There are also a number of prerequisites which are required to enable messaging:
 
 - You must have an active [Apple Developer Account](https://developer.apple.com/membercenter/index.action).
-- You must have a physical iOS device to receive messages.
+- You may use a physical iOS device to receive messages _or_ an iOS Simulator if you are on macOS 13+ on Apple Silicon using a Simulator running iOS 16+
   - Firebase Cloud Messaging integrates with the [Apple Push Notification service (APNs)](https://developer.apple.com/notifications/),
-    however APNs only works with real devices.
+    however APNs only works with real devices or Apple Silicon macs running relatively new versions
 
 ## Configuring your app
 


### PR DESCRIPTION

### Description

Attempting to clarify that modern simulators on modern macs may actually get APNs tokens and receive messages now. This was confusing before as the feature was announced earlier as part of breaking changes in react-native-firebase v17 but there was still some documentation around stating exactly the opposite

### Related issues

#6893

### Release Summary

docs, no release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Just docs, but if there was a typo or something, CI will find it...

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
