### PR TITLE
fix: export modular types

### DIFF
--- a/packages/app-distribution/lib/index.d.ts
+++ b/packages/app-distribution/lib/index.d.ts
@@ -143,6 +143,8 @@ export const firebase: ReactNativeFirebase.Module & {
   ): ReactNativeFirebase.FirebaseApp & { appDistribution(): FirebaseAppDistributionTypes.Module };
 };
 
+export * from './modular';
+
 export default defaultExport;
 
 /**

--- a/packages/crashlytics/lib/index.d.ts
+++ b/packages/crashlytics/lib/index.d.ts
@@ -264,6 +264,8 @@ export const firebase: ReactNativeFirebase.Module & {
   ): ReactNativeFirebase.FirebaseApp & { crashlytics(): FirebaseCrashlyticsTypes.Module };
 };
 
+export * from './modular';
+
 export default defaultExport;
 
 /**

--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -1295,6 +1295,8 @@ export const firebase: ReactNativeFirebase.Module & {
   ): ReactNativeFirebase.FirebaseApp & { database(): FirebaseDatabaseTypes.Module };
 };
 
+export * from './modular';
+
 export default defaultExport;
 
 /**

--- a/packages/dynamic-links/lib/index.d.ts
+++ b/packages/dynamic-links/lib/index.d.ts
@@ -625,6 +625,8 @@ export const firebase: ReactNativeFirebase.Module & {
   ): ReactNativeFirebase.FirebaseApp & { dynamicLinks(): FirebaseDynamicLinksTypes.Module };
 };
 
+export * from './modular';
+
 export default defaultExport;
 
 /**

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -2342,6 +2342,8 @@ export const firebase: ReactNativeFirebase.Module & {
 
 export const Filter: FilterFunction;
 
+export * from './modular';
+
 export default defaultExport;
 
 /**

--- a/packages/in-app-messaging/lib/index.d.ts
+++ b/packages/in-app-messaging/lib/index.d.ts
@@ -159,6 +159,8 @@ export const firebase: ReactNativeFirebase.Module & {
   ): ReactNativeFirebase.FirebaseApp & { inAppMessaging(): FirebaseInAppMessagingTypes.Module };
 };
 
+export * from './modular';
+
 export default defaultExport;
 
 /**


### PR DESCRIPTION
Fixes typescript error:
```
Module '"@react-native-firebase/x"' has no exported member 'y'.
Did you mean to use 'import y from "@react-native-firebase/x" instead?' [2164]"
```

### Description

Typescript types weren't working for the firestore's new modular API. This pull request exports modular typings in all packages that have them.
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire: