### PR TITLE
fix(android): required compatibility for android gradle plugin 8

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -200,6 +200,7 @@ Utils
 v15
 v5
 v6
+v7
 v9
 VPN
 VSCode

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,8 +47,8 @@ to your project.
 #### Generating Android credentials
 
 On the Firebase console, add a new Android application and enter your projects details. The "Android package name" must match your
-local projects package name which can be found inside of the `manifest` tag within the `/android/app/src/main/AndroidManifest.xml`
-file within your project.
+local projects package name which can be found inside of the `namespace` field in `/android/app/build.gradle`, or in the
+`manifest` tag within the `/android/app/src/main/AndroidManifest.xml` file within your project for projects using android gradle plugin v7 and below
 
 > The debug signing certificate is optional to use Firebase with your app, but is required for Dynamic Links, Invites and Phone Authentication.
 > To generate a certificate run `cd android && ./gradlew signingReport`. This generates two variant keys.

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/analytics/android/build.gradle
+++ b/packages/analytics/android/build.gradle
@@ -121,6 +121,12 @@ android {
       firebaseJsonAutomaticScreenReportingEnabled: automaticScreenReportingEnabled
     ]
   }
+
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   lintOptions {
     disable 'GradleCompatible'
     abortOnError false

--- a/packages/app-check/android/build.gradle
+++ b/packages/app-check/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/app/android/build.gradle
+++ b/packages/app/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/auth/android/build.gradle
+++ b/packages/auth/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/crashlytics/android/build.gradle
+++ b/packages/crashlytics/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/database/android/build.gradle
+++ b/packages/database/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/dynamic-links/android/build.gradle
+++ b/packages/dynamic-links/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/firestore/android/build.gradle
+++ b/packages/firestore/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/functions/android/build.gradle
+++ b/packages/functions/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/in-app-messaging/android/build.gradle
+++ b/packages/in-app-messaging/android/build.gradle
@@ -93,6 +93,12 @@ android {
       firebaseJsonAutoInitEnabled: dataCollectionEnabled
     ]
   }
+
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   lintOptions {
     disable 'GradleCompatible'
     abortOnError false

--- a/packages/installations/android/build.gradle
+++ b/packages/installations/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -102,6 +102,12 @@ android {
       firebaseJsonNotificationColor: notificationColor
     ]
   }
+
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   lintOptions {
     disable 'GradleCompatible'
     abortOnError false

--- a/packages/ml/android/build.gradle
+++ b/packages/ml/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/perf/android/build.gradle
+++ b/packages/perf/android/build.gradle
@@ -101,6 +101,12 @@ android {
       firebaseJsonCollectionDeactivated: collectionDeactivated
     ]
   }
+
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   lintOptions {
     disable 'GradleCompatible'
     abortOnError false

--- a/packages/remote-config/android/build.gradle
+++ b/packages/remote-config/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/packages/storage/android/build.gradle
+++ b/packages/storage/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:8.1.1")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/scripts/_TEMPLATE_/android/build.gradle
+++ b/scripts/_TEMPLATE_/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 
     dependencies {
-      classpath("com.android.tools.build:gradle:7.0.4")
+      classpath("com.android.tools.build:gradle:8.1.2")
     }
   }
 }

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -88,6 +88,11 @@ android {
     missingDimensionStrategy 'detox', 'full'
   }
 
+  buildFeatures {
+    // AGP 8 no longer builds config by default
+    buildConfig true
+  }
+
   signingConfigs {
     release {
       storeFile file('keystore.jks')

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -32,7 +32,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.google.gms:google-services:4.3.15' // https://developers.google.com/android/guides/google-services-plugin
-    classpath("com.android.tools.build:gradle:7.4.2")
+    classpath("com.android.tools.build:gradle:8.1.2")
     classpath("com.facebook.react:react-native-gradle-plugin")
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath 'com.google.firebase:perf-plugin:1.4.2'

--- a/tests/package.json
+++ b/tests/package.json
@@ -41,7 +41,7 @@
     "firebase-tools": "^12.6.0",
     "jest-circus": "^29.7.0",
     "jest-environment-node": "^29.7.0",
-    "jet": "^0.8.2",
+    "jet": "^0.8.3",
     "jsonwebtoken": "^9.0.2",
     "metro-react-native-babel-preset": "0.77.0",
     "mocha": "^10.2.0",

--- a/tests/patches/detox+19.12.6.patch
+++ b/tests/patches/detox+19.12.6.patch
@@ -1,3 +1,15 @@
+diff --git a/node_modules/detox/android/detox/build.gradle b/node_modules/detox/android/detox/build.gradle
+index 9185a26..9582988 100644
+--- a/node_modules/detox/android/detox/build.gradle
++++ b/node_modules/detox/android/detox/build.gradle
+@@ -13,6 +13,7 @@ def _kotlinVersion = _ext.has('detoxKotlinVersion') ? _ext.detoxKotlinVersion :
+ def _kotlinStdlib = _ext.has('detoxKotlinStdlib') ? _ext.detoxKotlinStdlib : 'kotlin-stdlib-jdk8'
+ 
+ android {
++    namespace 'com.wix.detox'
+     compileSdkVersion _compileSdkVersion
+     buildToolsVersion _buildToolsVersion
+ 
 diff --git a/node_modules/detox/android/detox/src/full/java/com/wix/detox/espresso/common/SliderHelper.kt b/node_modules/detox/android/detox/src/full/java/com/wix/detox/espresso/common/SliderHelper.kt
 index af77cda..253cfb8 100644
 --- a/node_modules/detox/android/detox/src/full/java/com/wix/detox/espresso/common/SliderHelper.kt

--- a/yarn.lock
+++ b/yarn.lock
@@ -11303,10 +11303,10 @@ jest@^29.7.0:
     import-local "^3.0.2"
     jest-cli "^29.7.0"
 
-jet@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/jet/-/jet-0.8.2.tgz#578928b284effccfb57718212c55c309e9d4dcf7"
-  integrity sha512-FzyIov7QtsUEmglenhRp6QgJcBMxja10uVEvmkwNPPwqvtz1d9SS6//2VfqRpY3AZB0nmSh5H+z8kD9GbVviQw==
+jet@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/jet/-/jet-0.8.3.tgz#3300c08007c334430074183cdf8d9283b94c1986"
+  integrity sha512-cS1dIMpeNZ4tBDiNjApIsm2Wlk/HBhLJmH4keymw+4nhleQdX+Nhm7YVHGU+dP9K28Xl/8j9w5KH26Zs1oEv2A==
   dependencies:
     chalk "^4.0.0"
     error-stack-parser "^2.0.6"


### PR DESCRIPTION
### Description

A collection of android gradle plugin 8 compatibility fixes

- Fixes all the remaining instances where react-native-firebase modules weren't compatible yet (we were mostly there, thankfully)
- Sends a PR upstream for detox https://github.com/wix/Detox/pull/4229 - although we're currently stuck on an old version, they'll need this I think, and our local patch is updated for AGP8
- adopts just released version of invertase/jet where I patched+released it for AGP8
- updates the test app here to use AGP8 to show the whole thing works...

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
