### PR TITLE
fix(app, sdk): adopt firebase-android-sdk 32.4.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -281,7 +281,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "32.3.1"
+        bom           : "32.4.0"
       ],
     ],
   ])

--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -96,11 +96,11 @@ dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   // TODO remove the specific version once it is out of beta and participates in bom versioning
-  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta10'
+  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta11'
   // TODO demonstrate how to only include this in certain build variants
   // - perhaps have firebase.json name the variants to include, then roll through variants here and only
   //   add the dependency to variants that match? Or... (PRs welcome...)
-  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta10'
+  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta11'
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
       "minSdk": 19,
       "targetSdk": 33,
       "compileSdk": 33,
-      "firebase": "32.3.1",
+      "firebase": "32.4.0",
       "firebaseCrashlyticsGradle": "2.9.9",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.3.15",


### PR DESCRIPTION
### Description

Bump of firebase-android-sdk, nothing to change at the user level that I'm aware of

### Related issues

I want to stage this after a release of #7412 since that one is pretty critical and I'm having bad luck recently with new upstream SDK versions - don't want to have something critical for users released after something that may not work, meaning people won't be able to rollback without losing the critical fix...

### Release Summary

there is only conventional commits, this is the way

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

local e2e test runs, CI will run it as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
