### PR TITLE
docs(remote-config): error param for onConfigUpdated may be undefined but not null

### DIFF
--- a/docs/remote-config/usage/index.md
+++ b/docs/remote-config/usage/index.md
@@ -199,7 +199,7 @@ Here is an example of how to use the feature, with comments emphasizing the key 
 // Multiple listeners are supported, so listeners may be screen-specific and only handle certain keys
 // depending on application requirements
 let remoteConfigListenerUnsubscriber = await remoteConfig().onConfigUpdated((event, error) => {
-  if (error !== null) {
+  if (error !== undefined) {
     console.log('remote-config listener subscription error: ' + JSON.stringify(error));
   } else {
     // Updated keys are keys that are added, removed, or changed value, metadata, or source


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Minor fix for docs - the error param cannot be `null`, should be checking for `undefined`. The e2e tests confirm this behaviour.

I thought something else in my code was wrong, so will save a min or two for the next user if we correct this.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
