### PR TITLE
docs(auth): fix sign in/out typo + add info about GoogleSignin.revokeAccess()

### DIFF
--- a/docs/auth/usage/index.md
+++ b/docs/auth/usage/index.md
@@ -189,6 +189,8 @@ auth()
 Once successfully signed out, any [`onAuthStateChanged`](#listening-to-authentication-state) listeners will trigger an event
 with the `user` parameter being a `null` value.
 
+Additionally, using `GoogleSignin.revokeAccess()` forgets the user. This means that the next time someone signs in, they will see the account selection popup. If you don't use this function, the last account will be automatically used without showing the account selection popup.
+
 ## Other sign-in methods
 
 Firebase also supports authenticating with external provides. To learn more, view the documentation for your authentication

--- a/docs/auth/usage/index.md
+++ b/docs/auth/usage/index.md
@@ -186,7 +186,7 @@ auth()
   .then(() => console.log('User signed out!'));
 ```
 
-Once successfully created and/or signed in, any [`onAuthStateChanged`](#listening-to-authentication-state) listeners will trigger an event
+Once successfully signed out, any [`onAuthStateChanged`](#listening-to-authentication-state) listeners will trigger an event
 with the `user` parameter being a `null` value.
 
 ## Other sign-in methods


### PR DESCRIPTION
### Description
1. Fixed a typo where `signin` should be `signout`
2. Added additional info about signing out completely with `GoogleSignin.revokeAccess()`

### Related issues

This was mentioned on #1956

### Release Summary

Additional signout information on docs

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
