### PR TITLE
docs(messaging, server-integration): document new / non-deprecated APIs / JSON fields

### DIFF
--- a/docs/messaging/server-integration.md
+++ b/docs/messaging/server-integration.md
@@ -114,22 +114,24 @@ async function onUserPictureLiked(ownerId, userId, picture) {
   // Get the users details
   const user = admin.firestore().collection('users').doc(userId).get();
 
-  await admin.messaging().sendToDevice(
-    owner.tokens, // ['token_1', 'token_2', ...]
-    {
-      data: {
-        owner: JSON.stringify(owner),
-        user: JSON.stringify(user),
-        picture: JSON.stringify(picture),
+  await admin.messaging().sendEachForMulticast({
+    tokens: owner.tokens, // ['token_1', 'token_2', ...]
+    data: {
+      owner: JSON.stringify(owner),
+      user: JSON.stringify(user),
+      picture: JSON.stringify(picture),
+    },
+    apns: {
+      payload: {
+        aps: {
+          // Required for background/quit data-only messages on iOS
+          'content-available': true,
+          // Required for background/quit data-only messages on Android
+          priority: 'high',
+        },
       },
     },
-    {
-      // Required for background/quit data-only messages on iOS
-      contentAvailable: true,
-      // Required for background/quit data-only messages on Android
-      priority: 'high',
-    },
-  );
+  });
 }
 ```
 
@@ -258,8 +260,8 @@ const payload = {
         'mutable-content': 1, // 1 or true
       },
     },
-    fcm_options: {
-      image: 'image-url',
+    fcmOptions: {
+      imageUrl: 'image-url',
     },
   },
 };
@@ -279,7 +281,7 @@ const payload = {
   },
   android: {
     notification: {
-      image: 'image-url',
+      imageUrl: 'image-url',
     },
   },
 };
@@ -310,20 +312,20 @@ const message = {
         'mutable-content': 1,
       },
     },
-    fcm_options: {
-      image: 'image-url',
+    fcmOptions: {
+      imageUrl: 'image-url',
     },
   },
   android: {
     notification: {
-      image: 'image-url',
+      imageUrl: 'image-url',
     },
   },
 };
 
 admin
   .messaging()
-  .send(message)
+  .sendEachForMulticast(message)
   .then(response => {
     console.log('Successfully sent message:', response);
   })

--- a/docs/messaging/server-integration.md
+++ b/docs/messaging/server-integration.md
@@ -125,6 +125,9 @@ async function onUserPictureLiked(ownerId, userId, picture) {
       payload: {
         aps: {
           // Required for background/quit data-only messages on iOS
+          // Note: iOS frequently will receive the message but decline to deliver it to your app.
+          //           This is an Apple design choice to favor user battery life over data-only delivery 
+          //           reliability. It is not under app control, though you may see the behavior in device logs.
           'content-available': true,
           // Required for background/quit data-only messages on Android
           priority: 'high',

--- a/docs/messaging/server-integration.md
+++ b/docs/messaging/server-integration.md
@@ -126,7 +126,7 @@ async function onUserPictureLiked(ownerId, userId, picture) {
         aps: {
           // Required for background/quit data-only messages on iOS
           // Note: iOS frequently will receive the message but decline to deliver it to your app.
-          //           This is an Apple design choice to favor user battery life over data-only delivery 
+          //           This is an Apple design choice to favor user battery life over data-only delivery
           //           reliability. It is not under app control, though you may see the behavior in device logs.
           'content-available': true,
           // Required for background/quit data-only messages on Android


### PR DESCRIPTION
### Description

- Deprecated API: [sendToDevice](https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.messaging.md#messagingsendtodevice)
    - Use [sendEachForMulticast](https://firebase.google.com/docs/reference/admin/node/firebase-admin.messaging.messaging.md#messagingsendeachformulticast) instead for sending messages to multiple devices.
- Correct `Message` field names:
    - fcm_options -> fcmOptions
    - image -> imageUrl.

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Just docs.

:fire: