### PR TITLE
docs: note incompatibility between react-native < 0.72 and google services plugin > 4.3.15

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,8 @@ First, add the `google-services` plugin as a dependency inside of your `/android
 buildscript {
   dependencies {
     // ... other dependencies
+    // NOTE: if you are on react-native 0.71 or below, you must not update
+    //       the google-services plugin past version 4.3.15
     classpath 'com.google.gms:google-services:4.4.0'
     // Add me --- /\
   }


### PR DESCRIPTION

### Description

There seems to be an incompatibility between react-native's gradle setup in versions < 0.72 and the google-services-plugin > 4.4.0 - it fails to parse the google-services.json file and generate the correct android/app/.../res/...values.xml files

### Related issues

https://github.com/invertase/react-native-firebase/discussions/7462

### Release Summary

docs only


### Test Plan

Determined with an rn71 build branch on my demonstrator: https://github.com/mikehardy/rnfbdemo/commit/eb99638b1d11a470c25b94e6a6a178c02031acae

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
