### PR TITLE
docs(remote-config): onConfigUpdated error check for undefined not null

### DIFF
--- a/docs/remote-config/usage/index.md
+++ b/docs/remote-config/usage/index.md
@@ -199,7 +199,7 @@ Here is an example of how to use the feature, with comments emphasizing the key 
 // Multiple listeners are supported, so listeners may be screen-specific and only handle certain keys
 // depending on application requirements
 let remoteConfigListenerUnsubscriber = await remoteConfig().onConfigUpdated((event, error) => {
-  if (error !== null) {
+  if (error !== undefined) {
     console.log('remote-config listener subscription error: ' + JSON.stringify(error));
   } else {
     // Updated keys are keys that are added, removed, or changed value, metadata, or source


### PR DESCRIPTION
### Description

The docs for remote config `onConfigUpdated` had the incorrect check for the error condition, @JasonPan noticed it should check for `undefined` not `null`

PR from Jason is basically the same but CLA was unsigned so could not merge, just reposting it here so it can save future devs time

### Related issues

* Supercedes #7438

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Docs - CI will lint

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
