### PR TITLE
build(ios): specify script runs every time, fix crashlytics input file path

### DIFF
--- a/packages/app/react-native.config.js
+++ b/packages/app/react-native.config.js
@@ -11,6 +11,7 @@ module.exports = {
             path: './ios_config.sh',
             execution_position: 'after_compile',
             input_files: ['$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)'],
+            always_out_of_date: '1',
           },
         ],
       },

--- a/packages/crashlytics/react-native.config.js
+++ b/packages/crashlytics/react-native.config.js
@@ -27,6 +27,7 @@ module.exports = {
               '${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}',
               '$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)',
             ],
+            always_out_of_date: '1',
           },
         ],
       },

--- a/packages/crashlytics/react-native.config.js
+++ b/packages/crashlytics/react-native.config.js
@@ -25,7 +25,7 @@ module.exports = {
             execution_position: 'after_compile',
             input_files: [
               '${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}',
-              '$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)',
+              '$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)',
             ],
             always_out_of_date: '1',
           },

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -115,3 +115,22 @@ target 'testing' do
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
   end
 end
+
+# Fix Xcode 14 warnings like:
+# warning: Run script build phase '[CP] Copy XCFrameworks' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'ATargetNameHere' from project 'YourProjectName')
+# Ref.: https://github.com/CocoaPods/CocoaPods/issues/11444
+post_integrate do |installer|
+  main_project = installer.aggregate_targets[0].user_project
+  pods_project = installer.pods_project
+  targets = main_project.targets + pods_project.targets
+  targets.each do |target|
+    run_script_build_phases = target.build_phases.filter { |phase| phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) }
+    cocoapods_run_script_build_phases = run_script_build_phases.filter { |phase| (phase.name&.start_with?("Create Symlinks to Header Folders") || phase.name&.start_with?("Bundle React Native") || phase.name&.start_with?("Copy Detox Framework")) }
+    cocoapods_run_script_build_phases.each do |run_script|
+      next unless (run_script.input_paths || []).empty? && (run_script.output_paths || []).empty?
+      run_script.always_out_of_date = "1"
+    end
+  end
+  main_project.save
+  pods_project.save
+end

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -19,6 +19,9 @@ $RNFirebaseAsStaticFramework = true # toggle this to true (and set 'use_framewor
 # Toggle this to true if you want to include support for on device conversion measurement APIs
 $RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
 
+# react-native 0.72 is currently iOS 12.4 as a minimum
+min_ios_version_supported = 12.4
+
 # Resolve react_native_pods.rb with node to allow for hoisting
 require Pod::Executable.execute_command('node', ['-p',
   'require.resolve(
@@ -93,13 +96,19 @@ target 'testing' do
 
 
     # Turn off warnings on non-RNFB dependencies - some of them are really really noisy
-    # Also bumps minimum deploy target to ours (which is >12.4): https://github.com/facebook/react-native/issues/34106
     installer.pods_project.targets.each do |target|
       if !target.name.include? "RNFB"
         target.build_configurations.each do |config|
           config.build_settings["GCC_WARN_INHIBIT_ALL_WARNINGS"] = "YES"
-          config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = min_ios_version_supported
         end
+      end
+    end
+
+    # Bumps minimum deploy target to ours (which is >12.4): https://github.com/facebook/react-native/issues/34106
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings["GCC_WARN_INHIBIT_ALL_WARNINGS"] = "YES"
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = min_ios_version_supported
       end
     end
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -947,7 +947,7 @@ PODS:
     - BoringSSL-GRPC (= 0.0.24)
     - gRPC-Core/Interface (= 1.49.1)
   - gRPC-Core/Interface (1.49.1)
-  - GTMSessionFetcher/Core (3.1.1)
+  - GTMSessionFetcher/Core (3.2.0)
   - hermes-engine (0.72.7):
     - hermes-engine/Pre-built (= 0.72.7)
   - hermes-engine/Pre-built (0.72.7)
@@ -1720,7 +1720,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 0759d1a57ebb953965c2dfe0ba4c82e95ccc2e34
   "gRPC-C++": 2df8cba576898bdacd29f0266d5236fa0e26ba6a
   gRPC-Core: a21a60aefc08c68c247b439a9ef97174b0c54f96
-  GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
+  GTMSessionFetcher: 41b9ef0b4c08a6db4b7eb51a21ae5183ec99a2c8
   hermes-engine: 9180d43df05c1ed658a87cc733dc3044cf90c00a
   Jet: 115c08882ff1bd917e1aa32af128641169d04ffd
   leveldb-library: f03246171cce0484482ec291f88b6d563699ee06
@@ -1782,6 +1782,6 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 4c3aa327e4a6a23eeacd71f61c81df1bcdf677d5
 
-PODFILE CHECKSUM: d02eebd9139761d802f97283433d3bff73c7dbae
+PODFILE CHECKSUM: 5caae5837b030c78814189f970734b1e39decf1d
 
 COCOAPODS: 1.14.3

--- a/tests/ios/testing.xcodeproj/project.pbxproj
+++ b/tests/ios/testing.xcodeproj/project.pbxproj
@@ -337,7 +337,7 @@
 			);
 			inputPaths = (
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
-				"$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
+				"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)",
 			);
 			name = "[CP-User] [RNFB] Crashlytics Configuration";
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tests/ios/testing.xcodeproj/project.pbxproj
+++ b/tests/ios/testing.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -315,6 +316,7 @@
 		};
 		7D57265F10EEF7CD92D7973F /* Copy Detox Framework */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -329,6 +331,7 @@
 		};
 		8512258DB46D3EF726067919 /* [CP-User] [RNFB] Crashlytics Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -343,6 +346,7 @@
 		};
 		DAB1A184ED1FB4A446CF5BBC /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/tests/ios/testing.xcodeproj/project.pbxproj
+++ b/tests/ios/testing.xcodeproj/project.pbxproj
@@ -163,8 +163,8 @@
 				7D57265F10EEF7CD92D7973F /* Copy Detox Framework */,
 				DAB1A184ED1FB4A446CF5BBC /* [CP-User] [RNFB] Core Configuration */,
 				8512258DB46D3EF726067919 /* [CP-User] [RNFB] Crashlytics Configuration */,
-				747DA0B230C3CCED1B55F7B8 /* [CP] Embed Pods Frameworks */,
 				2603193C849419258196E68A /* [CP] Copy Pods Resources */,
+				64F0A53627116CEBA061920E /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -297,7 +297,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		747DA0B230C3CCED1B55F7B8 /* [CP] Embed Pods Frameworks */ = {
+		64F0A53627116CEBA061920E /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (


### PR DESCRIPTION
### Description

A couple small tweaks to our run scripts so they operate more smoothly + quietly

### Related issues

* https://www.rubydoc.info/gems/cocoapods-core/Pod/Podfile/DSL#script_phase-instance_method
* https://github.com/react-native-community/cli/pull/2182

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Checked behavior of the `always_out_of_date` attr locally, plus you can see in the pod-generated xcodeproj that it was carried through correctly.

Checking the build log confirms that the previous warnings about the run script phase always running are no longer present

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
