### PR TITLE
test(ci): do not pre-compress logs sent to upload-archive action

### DIFF
--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -249,14 +249,9 @@ jobs:
           path: .yarn/cache
           key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
 
-      - name: Compress Emulator Log
-        if: always()
-        run: gzip -9 adb-*.txt
-        shell: bash
-
       - name: Upload Emulator Log
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: adb_logs
-          path: adb-*.gz
+          path: adb-*.txt

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -187,16 +187,12 @@ jobs:
         timeout-minutes: 50
         run: yarn tests:ios:test-cover
 
-      - name: Compress Simulator Log
-        if: always()
-        run: gzip -9 simulator.log
-
       - name: Upload Simulator Log
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: simulator_log
-          path: simulator.log.gz
+          path: simulator.log
 
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
GHA artifacts are already compressed using zip, no need to compress them twice


