### PR TITLE
fix(sdk, android): adopt firebase-android-sdk 32.7.0

### DIFF
--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   android:
     name: Android
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 90
     strategy:
       fail-fast: false

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   ios:
     name: iOS
-    runs-on: macos-13
+    runs-on: macos-12
     # TODO matrix across APIs, at least 11 and 15 (lowest to highest)
     timeout-minutes: 100
     env:

--- a/docs/index.md
+++ b/docs/index.md
@@ -287,7 +287,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "32.6.0"
+        bom           : "32.7.0"
       ],
     ],
   ])

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -81,7 +81,7 @@
       "minSdk": 19,
       "targetSdk": 33,
       "compileSdk": 33,
-      "firebase": "32.6.0",
+      "firebase": "32.7.0",
       "firebaseCrashlyticsGradle": "2.9.9",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -63,7 +63,7 @@
         "build": "set -o pipefail && xcodebuild VALID_ARCHS=\"`uname -m`\"  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 15"
+          "type": "iPhone 14"
         }
       },
       "ios.sim.release": {
@@ -71,7 +71,7 @@
         "build": "export RCT_NO_LAUNCH_PACKAGER=true && set -o pipefail | xcodebuild  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify",
         "type": "ios.simulator",
         "device": {
-          "type": "iPhone 15"
+          "type": "iPhone 14"
         }
       },
       "android.emu.debug": {


### PR DESCRIPTION
### Description

Nearly trivial change for the SDK, definitely trivial for us, but best practice to have current SDKs available



### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I ran e2e tests on android and ios locally, all green

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
