### PR TITLE
docs(auth): un-cross docs for two states in PhoneAuthState enum

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -241,11 +241,11 @@ export namespace FirebaseAuthTypes {
    */
   export interface PhoneAuthState {
     /**
-     * The timeout specified in {@link auth#verifyPhoneNumber} has expired.
+     * SMS message with verification code sent to phone number.
      */
     CODE_SENT: 'sent';
     /**
-     * SMS message with verification code sent to phone number.
+     * The timeout specified in {@link auth#verifyPhoneNumber} has expired.
      */
     AUTO_VERIFY_TIMEOUT: 'timeout';
     /**


### PR DESCRIPTION
### Description

Just fixing some documentation

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [🔥] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I didn't change any code.
