### PR TITLE
fix(auth, ios): factorId nil check

### DIFF
--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1378,6 +1378,7 @@ RCT_EXPORT_METHOD(useEmulator
     // Only phone is supported by the front-end so far
     return @"phone";
   }
+  
   return factorId;
 }
 

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1374,7 +1374,7 @@ RCT_EXPORT_METHOD(useEmulator
 }
 
 - (NSString *)getJSFactorId:(NSString *)factorId {
-  if (factorId == nil || [factorId isEqualToString:@"1"]) {
+  if ([factorId isEqualToString:@"1"]) {
     // Only phone is supported by the front-end so far
     return @"phone";
   }

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1374,11 +1374,11 @@ RCT_EXPORT_METHOD(useEmulator
 }
 
 - (NSString *)getJSFactorId:(NSString *)factorId {
-  if ([factorId isEqualToString:@"1"]) {
+  if (factorId == nil || [factorId isEqualToString:@"1"]) {
     // Only phone is supported by the front-end so far
     return @"phone";
   }
-
+    
   return factorId;
 }
 
@@ -1649,7 +1649,7 @@ RCT_EXPORT_METHOD(useEmulator
         [[[NSISO8601DateFormatter alloc] init] stringFromDate:hint.enrollmentDate];
     [enrolledFactors addObject:@{
       @"uid" : hint.UID,
-      @"factorId" : [self getJSFactorId:(hint.factorID)],
+      @"factorId" : [self getJSFactorId:(hint.factorID == nil ? nil : hint.factorID)],
       @"displayName" : hint.displayName == nil ? [NSNull null] : hint.displayName,
       @"enrollmentDate" : enrollmentDate,
     }];

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1378,7 +1378,6 @@ RCT_EXPORT_METHOD(useEmulator
     // Only phone is supported by the front-end so far
     return @"phone";
   }
-    
   return factorId;
 }
 
@@ -1650,7 +1649,7 @@ RCT_EXPORT_METHOD(useEmulator
     [enrolledFactors addObject:@{
       @"uid" : hint.UID,
       @"factorId" : [self getJSFactorId:(hint.factorID == nil ? nil : hint.factorID)],
-      @"displayName" : hint.displayName == nil ? [NSNull null] : hint.displayName,
+      @"displayName" : hint.factorID == nil ? [NSNull null] : [self getJSFactorID:(hint.factorID)],
       @"enrollmentDate" : enrollmentDate,
     }];
   }

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1378,7 +1378,7 @@ RCT_EXPORT_METHOD(useEmulator
     // Only phone is supported by the front-end so far
     return @"phone";
   }
-  
+
   return factorId;
 }
 

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1648,8 +1648,8 @@ RCT_EXPORT_METHOD(useEmulator
         [[[NSISO8601DateFormatter alloc] init] stringFromDate:hint.enrollmentDate];
     [enrolledFactors addObject:@{
       @"uid" : hint.UID,
-      @"factorId" : [self getJSFactorId:(hint.factorID == nil ? nil : hint.factorID)],
-      @"displayName" : hint.factorID == nil ? [NSNull null] : [self getJSFactorID:(hint.factorID)],
+      @"factorId" : hint.factorID == nil ? [NSNull null] : [self getJSFactorId:(hint.factorID)],
+      @"displayName" : hint.displayName == nil ? [NSNull null] : hint.displayName,
       @"enrollmentDate" : enrollmentDate,
     }];
   }


### PR DESCRIPTION
### Description

Sometimes the `hint.factorID` (in the `firebaseUserToDict` function) is retuning `nil` value and this could cause app crash. I've tried to described my journey with this issue in [this comment](https://github.com/invertase/react-native-firebase/issues/7080#issuecomment-1870635173)

### Related issues
Fixes #7080 

### Release Summary

Auth module - nil check in the getJSFactorId function

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

🔥