### PR TITLE
fix(firestore): increase amount of maximum disjunctions in firebase

### DIFF
--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -178,7 +178,7 @@ describe(' firestore().collection().where(AND Filters)', function () {
 
     it('throws if in query array length is greater than 30', function () {
       try {
-        const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+        const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
         firebase
           .firestore()
@@ -835,7 +835,7 @@ describe(' firestore().collection().where(AND Filters)', function () {
 
     it('throws if in query array length is greater than 30', function () {
       const { getFirestore, collection, query, and, where } = firestoreModular;
-      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+      const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
       try {
         query(

--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -176,15 +176,17 @@ describe(' firestore().collection().where(AND Filters)', function () {
       }
     });
 
-    it('throws if in query array length is greater than 10', function () {
+    it('throws if in query array length is greater than 30', function () {
       try {
+        const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+
         firebase
           .firestore()
           .collection(COLLECTION)
           .where(
             Filter.and(
-              Filter('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-              Filter('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+              Filter('foo.bar', 'in', queryArray),
+              Filter('foo.bar', 'in', queryArray),
             ),
           );
 
@@ -831,14 +833,16 @@ describe(' firestore().collection().where(AND Filters)', function () {
       }
     });
 
-    it('throws if in query array length is greater than 10', function () {
+    it('throws if in query array length is greater than 30', function () {
       const { getFirestore, collection, query, and, where } = firestoreModular;
+      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+
       try {
         query(
           collection(getFirestore(), COLLECTION),
           and(
-            where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-            where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+            where('foo.bar', 'in', queryArray),
+            where('foo.bar', 'in', queryArray),
           ),
         );
 

--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -184,10 +184,7 @@ describe(' firestore().collection().where(AND Filters)', function () {
           .firestore()
           .collection(COLLECTION)
           .where(
-            Filter.and(
-              Filter('foo.bar', 'in', queryArray),
-              Filter('foo.bar', 'in', queryArray),
-            ),
+            Filter.and(Filter('foo.bar', 'in', queryArray), Filter('foo.bar', 'in', queryArray)),
           );
 
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -840,10 +837,7 @@ describe(' firestore().collection().where(AND Filters)', function () {
       try {
         query(
           collection(getFirestore(), COLLECTION),
-          and(
-            where('foo.bar', 'in', queryArray),
-            where('foo.bar', 'in', queryArray),
-          ),
+          and(where('foo.bar', 'in', queryArray), where('foo.bar', 'in', queryArray)),
         );
 
         return Promise.reject(new Error('Did not throw an Error.'));

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -145,7 +145,7 @@ describe('firestore().collection().where()', function () {
         firebase.firestore().collection(COLLECTION).where('foo.bar', 'in', queryArray);
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
-        error.message.should.containEql('maximum of 10 elements in the value');
+        error.message.should.containEql('maximum of 30 elements in the value');
         return Promise.resolve();
       }
     });
@@ -482,13 +482,14 @@ describe('firestore().collection().where()', function () {
 
     it("should throw error when 'not-in' filter has a list of more than 10 items", async function () {
       const ref = firebase.firestore().collection(COLLECTION);
+      const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
       try {
-        ref.where('test', 'not-in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+        ref.where('test', 'not-in', queryArray);
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql(
-          'filters support a maximum of 10 elements in the value array.',
+          'filters support a maximum of 30 elements in the value array.',
         );
         return Promise.resolve();
       }
@@ -715,7 +716,7 @@ describe('firestore().collection().where()', function () {
         query(collection(getFirestore(), COLLECTION), where('foo.bar', 'in', queryArray));
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
-        error.message.should.containEql('maximum of 10 elements in the value');
+        error.message.should.containEql('maximum of 30 elements in the value');
         return Promise.resolve();
       }
     });
@@ -1084,13 +1085,14 @@ describe('firestore().collection().where()', function () {
     it("should throw error when 'not-in' filter has a list of more than 10 items", async function () {
       const { getFirestore, collection, query, where } = firestoreModular;
       const ref = collection(getFirestore(), COLLECTION);
+      const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
       try {
-        query(ref, where('test', 'not-in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]));
+        query(ref, where('test', 'not-in', queryArray));
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql(
-          'filters support a maximum of 10 elements in the value array.',
+          'filters support a maximum of 30 elements in the value array.',
         );
         return Promise.resolve();
       }

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -140,7 +140,7 @@ describe('firestore().collection().where()', function () {
 
     it('throws if in query array length is greater than 30', function () {
       try {
-        const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+        const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
         firebase
           .firestore()
@@ -712,7 +712,7 @@ describe('firestore().collection().where()', function () {
 
     it('throws if in query array length is greater than 30', function () {
       const { getFirestore, collection, query, where } = firestoreModular;
-      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+      const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
       try {
         query(

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -142,10 +142,7 @@ describe('firestore().collection().where()', function () {
       try {
         const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
-        firebase
-          .firestore()
-          .collection(COLLECTION)
-          .where('foo.bar', 'in', queryArray);
+        firebase.firestore().collection(COLLECTION).where('foo.bar', 'in', queryArray);
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql('maximum of 10 elements in the value');
@@ -715,10 +712,7 @@ describe('firestore().collection().where()', function () {
       const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
       try {
-        query(
-          collection(getFirestore(), COLLECTION),
-          where('foo.bar', 'in', queryArray),
-        );
+        query(collection(getFirestore(), COLLECTION), where('foo.bar', 'in', queryArray));
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql('maximum of 10 elements in the value');

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -138,12 +138,14 @@ describe('firestore().collection().where()', function () {
       }
     });
 
-    it('throws if in query array length is greater than 10', function () {
+    it('throws if in query array length is greater than 30', function () {
       try {
+        const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+
         firebase
           .firestore()
           .collection(COLLECTION)
-          .where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+          .where('foo.bar', 'in', queryArray);
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql('maximum of 10 elements in the value');
@@ -708,12 +710,14 @@ describe('firestore().collection().where()', function () {
       }
     });
 
-    it('throws if in query array length is greater than 10', function () {
+    it('throws if in query array length is greater than 30', function () {
       const { getFirestore, collection, query, where } = firestoreModular;
+      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+
       try {
         query(
           collection(getFirestore(), COLLECTION),
-          where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+          where('foo.bar', 'in', queryArray),
         );
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {

--- a/packages/firestore/e2e/Query/where.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.filter.e2e.js
@@ -168,7 +168,7 @@ describe('firestore().collection().where(Filters)', function () {
 
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {
-      error.message.should.containEql('maximum of 10 elements in the value');
+      error.message.should.containEql('maximum of 30 elements in the value');
       return Promise.resolve();
     }
   });
@@ -245,16 +245,15 @@ describe('firestore().collection().where(Filters)', function () {
 
   it("should throw error when 'not-in' filter has a list of more than 10 items", async function () {
     const ref = firebase.firestore().collection(COLLECTION);
+    const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
     try {
-      ref
-        .where(Filter('foo.bar', '==', 1))
-        .where(Filter('foo.bar', 'not-in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]));
+      ref.where(Filter('foo.bar', '==', 1)).where(Filter('foo.bar', 'not-in', queryArray));
 
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {
       error.message.should.containEql(
-        'filters support a maximum of 10 elements in the value array.',
+        'filters support a maximum of 30 elements in the value array.',
       );
       return Promise.resolve();
     }

--- a/packages/firestore/e2e/Query/where.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.filter.e2e.js
@@ -159,7 +159,7 @@ describe('firestore().collection().where(Filters)', function () {
 
   it('throws if in query array length is greater than 30', function () {
     try {
-      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+      const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
       firebase
         .firestore()

--- a/packages/firestore/e2e/Query/where.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.filter.e2e.js
@@ -157,12 +157,14 @@ describe('firestore().collection().where(Filters)', function () {
     }
   });
 
-  it('throws if in query array length is greater than 10', function () {
+  it('throws if in query array length is greater than 30', function () {
     try {
+      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+
       firebase
         .firestore()
         .collection(COLLECTION)
-        .where(Filter('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]));
+        .where(Filter('foo.bar', 'in', queryArray));
 
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {

--- a/packages/firestore/e2e/Query/where.or.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.or.filter.e2e.js
@@ -271,7 +271,7 @@ describe('firestore().collection().where(OR Filters)', function () {
 
     it('throws if in query array length is greater than 30', function () {
       try {
-        const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+        const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
         firebase
           .firestore()
@@ -1330,7 +1330,7 @@ describe('firestore().collection().where(OR Filters)', function () {
 
     it('throws if in query array length is greater than 30', function () {
       const { getFirestore, collection, where, or, and, query } = firestoreModular;
-      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+      const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
 
       try {
         query(

--- a/packages/firestore/e2e/Query/where.or.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.or.filter.e2e.js
@@ -278,14 +278,8 @@ describe('firestore().collection().where(OR Filters)', function () {
           .collection(COLLECTION)
           .where(
             Filter.or(
-              Filter.and(
-                Filter('foo.bar', 'in', queryArray),
-                Filter('foo.bar', 'in', queryArray),
-              ),
-              Filter.and(
-                Filter('foo.bar', 'in', queryArray),
-                Filter('foo.bar', 'in', queryArray),
-              ),
+              Filter.and(Filter('foo.bar', 'in', queryArray), Filter('foo.bar', 'in', queryArray)),
+              Filter.and(Filter('foo.bar', 'in', queryArray), Filter('foo.bar', 'in', queryArray)),
             ),
           );
 
@@ -1336,14 +1330,8 @@ describe('firestore().collection().where(OR Filters)', function () {
         query(
           collection(getFirestore(), COLLECTION),
           or(
-            and(
-              where('foo.bar', 'in', queryArray),
-              where('foo.bar', 'in', queryArray),
-            ),
-            and(
-              where('foo.bar', 'in', queryArray),
-              where('foo.bar', 'in', queryArray),
-            ),
+            and(where('foo.bar', 'in', queryArray), where('foo.bar', 'in', queryArray)),
+            and(where('foo.bar', 'in', queryArray), where('foo.bar', 'in', queryArray)),
           ),
         );
 

--- a/packages/firestore/e2e/Query/where.or.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.or.filter.e2e.js
@@ -269,20 +269,22 @@ describe('firestore().collection().where(OR Filters)', function () {
       }
     });
 
-    it('throws if in query array length is greater than 10', function () {
+    it('throws if in query array length is greater than 30', function () {
       try {
+        const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+
         firebase
           .firestore()
           .collection(COLLECTION)
           .where(
             Filter.or(
               Filter.and(
-                Filter('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-                Filter('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+                Filter('foo.bar', 'in', queryArray),
+                Filter('foo.bar', 'in', queryArray),
               ),
               Filter.and(
-                Filter('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-                Filter('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+                Filter('foo.bar', 'in', queryArray),
+                Filter('foo.bar', 'in', queryArray),
               ),
             ),
           );
@@ -1326,19 +1328,21 @@ describe('firestore().collection().where(OR Filters)', function () {
       }
     });
 
-    it('throws if in query array length is greater than 10', function () {
+    it('throws if in query array length is greater than 30', function () {
       const { getFirestore, collection, where, or, and, query } = firestoreModular;
+      const queryArray = Array.from({ length: 30 }, (_, i) => i + 1);
+
       try {
         query(
           collection(getFirestore(), COLLECTION),
           or(
             and(
-              where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-              where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+              where('foo.bar', 'in', queryArray),
+              where('foo.bar', 'in', queryArray),
             ),
             and(
-              where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
-              where('foo.bar', 'in', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]),
+              where('foo.bar', 'in', queryArray),
+              where('foo.bar', 'in', queryArray),
             ),
           ),
         );

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -471,9 +471,9 @@ export default class FirestoreQuery {
           );
         }
 
-        if (value.length > 10) {
+        if (value.length > 30) {
           throw new Error(
-            `firebase.firestore().collection().where(_, _, *) 'value' is invalid. '${opStr}' filters support a maximum of 10 elements in the value array.`,
+            `firebase.firestore().collection().where(_, _, *) 'value' is invalid. '${opStr}' filters support a maximum of 30 elements in the value array.`,
           );
         }
       }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Increased amount of maximum disjunctions in firebase from 10 up to 30
 
### Related issues

- Fixes #7542

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
