### PR TITLE
fix(auth): use correct app instance (vs always default) in multifactor and phone auth

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.20.0",
+      "firebase": "10.19.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.19.0",
+      "firebase": "10.20.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -151,7 +151,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     mMultiFactorSessions.clear();
   }
 
-    @ReactMethod
+  @ReactMethod
   public void configureAuthDomain(final String appName) {
     Log.d(TAG, "configureAuthDomain");
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -68,7 +68,6 @@ import com.google.firebase.auth.PhoneMultiFactorInfo;
 import com.google.firebase.auth.TwitterAuthProvider;
 import com.google.firebase.auth.UserInfo;
 import com.google.firebase.auth.UserProfileChangeRequest;
-import io.invertase.firebase.app.ReactNativeFirebaseAppModule;
 import io.invertase.firebase.common.ReactNativeFirebaseEvent;
 import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
@@ -149,26 +148,6 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
 
     mCachedResolvers.clear();
     mMultiFactorSessions.clear();
-  }
-
-  @ReactMethod
-  public void configureAuthDomain(final String appName) {
-    Log.d(TAG, "configureAuthDomain");
-    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
-    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
-    String authDomain = ReactNativeFirebaseAppModule.authDomains.get(appName);
-    Log.d(TAG, "configureAuthDomain - app " + appName + " domain? " + authDomain);
-    if (authDomain != null) {
-      firebaseAuth.setCustomAuthDomain(authDomain);
-    }
-  }
-
-  @ReactMethod
-  public void getCustomAuthDomain(final String appName, final Promise promise) {
-    Log.d(TAG, "configureAuthDomain");
-    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
-    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
-    promise.resolve(firebaseAuth.getCustomAuthDomain());
   }
 
   /** Add a new auth state listener - if one doesn't exist already */
@@ -1140,10 +1119,11 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
           promise, "unknown", "Unsupported second factor. Only phone factors are supported.");
       return;
     }
-
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
     final Activity activity = getCurrentActivity();
     final PhoneAuthOptions phoneAuthOptions =
-        PhoneAuthOptions.newBuilder()
+        PhoneAuthOptions.newBuilder(firebaseAuth)
             .setActivity(activity)
             .setMultiFactorHint((PhoneMultiFactorInfo) selectedHint)
             .setTimeout(30L, TimeUnit.SECONDS)
@@ -1184,9 +1164,10 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
       rejectPromiseWithCodeAndMessage(promise, "unknown", "can't find session for provided key");
       return;
     }
-
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
     final PhoneAuthOptions phoneAuthOptions =
-        PhoneAuthOptions.newBuilder()
+        PhoneAuthOptions.newBuilder(firebaseAuth)
             .setPhoneNumber(phoneNumber)
             .setActivity(getCurrentActivity())
             .setTimeout(30L, TimeUnit.SECONDS)

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -150,6 +150,26 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     mMultiFactorSessions.clear();
   }
 
+    @ReactMethod
+  public void configureAuthDomain(final String appName) {
+    Log.d(TAG, "configureAuthDomain");
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+    String authDomain = ReactNativeFirebaseAppModule.authDomains.get(appName);
+    Log.d(TAG, "configureAuthDomain - app " + appName + " domain? " + authDomain);
+    if (authDomain != null) {
+      firebaseAuth.setCustomAuthDomain(authDomain);
+    }
+  }
+
+  @ReactMethod
+  public void getCustomAuthDomain(final String appName, final Promise promise) {
+    Log.d(TAG, "configureAuthDomain");
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+    promise.resolve(firebaseAuth.getCustomAuthDomain());
+  }
+
   /** Add a new auth state listener - if one doesn't exist already */
   @ReactMethod
   public void addAuthStateListener(final String appName) {

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -68,6 +68,7 @@ import com.google.firebase.auth.PhoneMultiFactorInfo;
 import com.google.firebase.auth.TwitterAuthProvider;
 import com.google.firebase.auth.UserInfo;
 import com.google.firebase.auth.UserProfileChangeRequest;
+import io.invertase.firebase.app.ReactNativeFirebaseAppModule;
 import io.invertase.firebase.common.ReactNativeFirebaseEvent;
 import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(addAuthStateListener : (FIRApp *)firebaseApp) {
 
 RCT_EXPORT_METHOD(removeAuthStateListener : (FIRApp *)firebaseApp) {
   if ([authStateHandlers valueForKey:firebaseApp.name]) {
-     [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
         removeAuthStateDidChangeListener:[authStateHandlers valueForKey:firebaseApp.name]];
     [authStateHandlers removeObjectForKey:firebaseApp.name];
   }
@@ -136,7 +136,7 @@ RCT_EXPORT_METHOD(removeAuthStateListener : (FIRApp *)firebaseApp) {
 
 RCT_EXPORT_METHOD(addIdTokenListener : (FIRApp *)firebaseApp) {
   if (![idTokenHandlers valueForKey:firebaseApp.name]) {
-    FIRIDTokenDidChangeListenerHandle newListenerHandle =  [[FIRAuth authWithApp:firebaseApp]
+    FIRIDTokenDidChangeListenerHandle newListenerHandle = [[FIRAuth authWithApp:firebaseApp]
         addIDTokenDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
           if (user != nil) {
             [RNFBSharedUtils sendJSEventForApp:firebaseApp
@@ -154,7 +154,7 @@ RCT_EXPORT_METHOD(addIdTokenListener : (FIRApp *)firebaseApp) {
 
 RCT_EXPORT_METHOD(removeIdTokenListener : (FIRApp *)firebaseApp) {
   if ([idTokenHandlers valueForKey:firebaseApp.name]) {
-     [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
         removeIDTokenDidChangeListener:[idTokenHandlers valueForKey:firebaseApp.name]];
     [idTokenHandlers removeObjectForKey:firebaseApp.name];
   }
@@ -185,12 +185,12 @@ RCT_EXPORT_METHOD(useUserAccessGroup
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   NSError *error;
-   [[FIRAuth authWithApp:firebaseApp] useUserAccessGroup:userAccessGroup error:&error];
+  [[FIRAuth authWithApp:firebaseApp] useUserAccessGroup:userAccessGroup error:&error];
 
   if (!error) {
     [self promiseNoUser:resolve rejecter:reject isError:NO];
   } else {
-      [self promiseRejectAuthException:reject error:error];
+    [self promiseRejectAuthException:reject error:error];
   }
   return;
 }
@@ -203,7 +203,7 @@ RCT_EXPORT_METHOD(signOut
 
   if (user) {
     NSError *error;
-      [[FIRAuth authWithApp:firebaseApp] signOut:&error];
+    [[FIRAuth authWithApp:firebaseApp] signOut:&error];
     if (!error) {
       [self promiseNoUser:resolve rejecter:reject isError:NO];
     } else {
@@ -219,7 +219,7 @@ RCT_EXPORT_METHOD(signInAnonymously
                   : (FIRApp *)firebaseApp
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       signInAnonymouslyWithCompletion:^(FIRAuthDataResult *authResult, NSError *error) {
         if (error) {
           [self promiseRejectAuthException:reject error:error];
@@ -235,11 +235,10 @@ RCT_EXPORT_METHOD(signInWithEmailAndPassword
                   : (NSString *)password
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       signInWithEmail:email
              password:password
            completion:^(FIRAuthDataResult *authResult, NSError *error) {
-        
              if (error) {
                [self promiseRejectAuthException:reject error:error];
              } else {
@@ -254,7 +253,7 @@ RCT_EXPORT_METHOD(signInWithEmailLink
                   : (NSString *)emailLink
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       signInWithEmail:email
                  link:emailLink
            completion:^(FIRAuthDataResult *authResult, NSError *error) {
@@ -272,7 +271,7 @@ RCT_EXPORT_METHOD(createUserWithEmailAndPassword
                   : (NSString *)password
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       createUserWithEmail:email
                  password:password
                completion:^(FIRAuthDataResult *authResult, NSError *error) {
@@ -309,7 +308,7 @@ RCT_EXPORT_METHOD(reload
                   : (RCTPromiseRejectBlock)reject) {
   FIRUser *user = [FIRAuth authWithApp:firebaseApp].currentUser;
   if (user) {
-      [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
+    [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
   } else {
     [self promiseNoUser:resolve rejecter:reject isError:YES];
   }
@@ -383,7 +382,10 @@ RCT_EXPORT_METHOD(updateEmail
              if (error) {
                [self promiseRejectAuthException:reject error:error];
              } else {
-               [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
+               [self reloadAndReturnUser:user
+                                resolver:resolve
+                                rejecter:reject
+                             firebaseApp:firebaseApp];
              }
            }];
   } else {
@@ -427,7 +429,7 @@ RCT_EXPORT_METHOD(updatePhoneNumber
         (FIRPhoneAuthCredential *)[self getCredentialForProvider:provider
                                                            token:authToken
                                                           secret:authSecret
-                                                          firebaseApp:firebaseApp];
+                                                     firebaseApp:firebaseApp];
 
     if (credential == nil) {
       [RNFBSharedUtils
@@ -567,7 +569,7 @@ RCT_EXPORT_METHOD(signInWithCredential
   FIRAuthCredential *credential = [self getCredentialForProvider:provider
                                                            token:authToken
                                                           secret:authSecret
-                                                        firebaseApp:firebaseApp];
+                                                     firebaseApp:firebaseApp];
   if (credential == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
                                       userInfo:(NSMutableDictionary *)@{
@@ -576,8 +578,7 @@ RCT_EXPORT_METHOD(signInWithCredential
                                                      @"has expired or is not currently supported.",
                                       }];
   }
-DLog(@"using app SignInWithCredential: %@", firebaseApp.name)
-    [[FIRAuth authWithApp:firebaseApp]
+  DLog(@"using app SignInWithCredential: %@", firebaseApp.name)[[FIRAuth authWithApp:firebaseApp]
       signInWithCredential:credential
                 completion:^(FIRAuthDataResult *authResult, NSError *error) {
                   if (error) {
@@ -603,7 +604,8 @@ RCT_EXPORT_METHOD(signInWithProvider
                                       }];
   }
 
-    __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
+  __block FIROAuthProvider *builder =
+      [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
   // Add scopes if present
   if (provider[@"scopes"]) {
     [builder setScopes:provider[@"scopes"]];
@@ -621,7 +623,7 @@ RCT_EXPORT_METHOD(signInWithProvider
                                 return;
                               }
                               if (credential) {
-                                  [[FIRAuth authWithApp:firebaseApp]
+                                [[FIRAuth authWithApp:firebaseApp]
                                     signInWithCredential:credential
                                               completion:^(FIRAuthDataResult *_Nullable authResult,
                                                            NSError *_Nullable error) {
@@ -651,7 +653,7 @@ RCT_EXPORT_METHOD(confirmPasswordReset
                   : (NSString *)newPassword
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-      [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       confirmPasswordResetWithCode:code
                        newPassword:newPassword
                         completion:^(NSError *_Nullable error) {
@@ -668,7 +670,7 @@ RCT_EXPORT_METHOD(applyActionCode
                   : (NSString *)code
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       applyActionCode:code
            completion:^(NSError *_Nullable error) {
              if (error) {
@@ -686,7 +688,7 @@ RCT_EXPORT_METHOD(checkActionCode
                   : (NSString *)code
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       checkActionCode:code
            completion:^(FIRActionCodeInfo *_Nullable info, NSError *_Nullable error) {
              if (error) {
@@ -742,7 +744,7 @@ RCT_EXPORT_METHOD(revokeToken
                   : (NSString *)authorizationCode
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       revokeTokenWithAuthorizationCode:authorizationCode
                             completion:^(NSError *_Nullable error) {
                               if (error) {
@@ -769,11 +771,11 @@ RCT_EXPORT_METHOD(sendPasswordResetEmail
 
   if (actionCodeSettings) {
     FIRActionCodeSettings *settings = [self buildActionCodeSettings:actionCodeSettings];
-      [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email
+    [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email
                                                actionCodeSettings:settings
                                                        completion:handler];
   } else {
-      [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email completion:handler];
+    [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email completion:handler];
   }
 }
 
@@ -792,7 +794,7 @@ RCT_EXPORT_METHOD(sendSignInLinkToEmail
   };
 
   FIRActionCodeSettings *settings = [self buildActionCodeSettings:actionCodeSettings];
-    [[FIRAuth authWithApp:firebaseApp] sendSignInLinkToEmail:email
+  [[FIRAuth authWithApp:firebaseApp] sendSignInLinkToEmail:email
                                         actionCodeSettings:settings
                                                 completion:handler];
 }
@@ -802,7 +804,7 @@ RCT_EXPORT_METHOD(signInWithCustomToken
                   : (NSString *)customToken
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       signInWithCustomToken:customToken
                  completion:^(FIRAuthDataResult *authResult, NSError *error) {
                    if (error) {
@@ -818,8 +820,8 @@ RCT_EXPORT_METHOD(signInWithPhoneNumber
                   : (NSString *)phoneNumber
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    DLog(@"SignInWthPhoneNumber instance: %@", firebaseApp.name)
-  [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+  DLog(@"SignInWthPhoneNumber instance: %@",
+       firebaseApp.name)[[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
       verifyPhoneNumber:phoneNumber
              UIDelegate:nil
              completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
@@ -838,7 +840,6 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
                   : (NSString *)sessionKey
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    
   if ([cachedResolver valueForKey:sessionKey] == nil) {
     [RNFBSharedUtils
         rejectPromiseWithUserInfo:reject
@@ -861,8 +862,8 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
                                       }];
     return;
   }
-  DLog(@"using instance verifyPhoneNumberWithMultiFactorInfo: %@", firebaseApp.name)
-  [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+  DLog(@"using instance verifyPhoneNumberWithMultiFactorInfo: %@",
+       firebaseApp.name)[[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
       verifyPhoneNumberWithMultiFactorInfo:hint
                                 UIDelegate:nil
                         multiFactorSession:session
@@ -872,7 +873,7 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
                                     [self promiseRejectAuthException:reject error:error];
                                   } else {
                                     DLog(@"verificationID: %@", verificationID)
-                                    resolve(verificationID);
+                                        resolve(verificationID);
                                   }
                                 }];
 }
@@ -884,8 +885,8 @@ RCT_EXPORT_METHOD(verifyPhoneNumberForMultiFactor
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   FIRMultiFactorSession *session = cachedSessions[sessionId];
-    DLog(@"using instance VerifyPhoneNumberForMultifactor: %@",firebaseApp.name)
-  [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+  DLog(@"using instance VerifyPhoneNumberForMultifactor: %@",
+       firebaseApp.name)[[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
        verifyPhoneNumber:phoneNumber
               UIDelegate:nil
       multiFactorSession:session
@@ -906,25 +907,22 @@ RCT_EXPORT_METHOD(resolveMultiFactorSignIn
                   : (NSString *)verificationCode
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    DLog(@"using instance resolve MultiFactorSignIn: %@", firebaseApp.name)
-  FIRPhoneAuthCredential *credential =
-      [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
-          credentialWithVerificationID:verificationId
-                      verificationCode:verificationCode];
-DLog(@"credential: %@", credential)
-  FIRMultiFactorAssertion *assertion =
+  DLog(@"using instance resolve MultiFactorSignIn: %@", firebaseApp.name)
+      FIRPhoneAuthCredential *credential =
+          [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+              credentialWithVerificationID:verificationId
+                          verificationCode:verificationCode];
+  DLog(@"credential: %@", credential) FIRMultiFactorAssertion *assertion =
       [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
-    
-    
-    [cachedResolver[sessionKey] resolveSignInWithAssertion:assertion
+
+  [cachedResolver[sessionKey] resolveSignInWithAssertion:assertion
                                               completion:^(FIRAuthDataResult *_Nullable authResult,
                                                            NSError *_Nullable error) {
-                                                
-                                                DLog(@"authError: %@", error)
-                                                if (error) {
+                                                DLog(@"authError: %@", error) if (error) {
                                                   [self promiseRejectAuthException:reject
                                                                              error:error];
-                                                } else {
+                                                }
+                                                else {
                                                   [self promiseWithAuthResult:resolve
                                                                      rejecter:reject
                                                                    authResult:authResult];
@@ -957,12 +955,13 @@ RCT_EXPORT_METHOD(finalizeMultiFactorEnrollment
                   : (NSString *_Nullable)displayName
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    DLog(@"using instance finalizeMultifactorEnrollment: %@", firebaseApp.name)
-  FIRPhoneAuthCredential *credential =
-      [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]credentialWithVerificationID:verificationId
-                                                 verificationCode:verificationCode];
+  DLog(@"using instance finalizeMultifactorEnrollment: %@", firebaseApp.name)
+      FIRPhoneAuthCredential *credential =
+          [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+              credentialWithVerificationID:verificationId
+                          verificationCode:verificationCode];
   FIRMultiFactorAssertion *assertion =
-    [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
+      [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
   FIRUser *user = [FIRAuth authWithApp:firebaseApp].currentUser;
   [user.multiFactor enrollWithAssertion:assertion
                             displayName:displayName
@@ -981,13 +980,13 @@ RCT_EXPORT_METHOD(verifyPhoneNumber
                   : (FIRApp *)firebaseApp
                   : (NSString *)phoneNumber
                   : (NSString *)requestKey) {
-    DLog(@"using instance verifyPhoneNumber: %@", firebaseApp.name)
-  [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+  DLog(@"using instance verifyPhoneNumber: %@",
+       firebaseApp.name)[[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
       verifyPhoneNumber:phoneNumber
              UIDelegate:nil
              completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
                if (error) {
-                   NSDictionary *jsError = [self getJSError:error];
+                 NSDictionary *jsError = [self getJSError:error];
                  NSDictionary *body = @{
                    @"type" : @"onVerificationFailed",
                    @"requestKey" : requestKey,
@@ -1020,15 +1019,14 @@ RCT_EXPORT_METHOD(confirmationResultConfirm
   NSString *verificationId = [defaults stringForKey:@"authVerificationID"];
 
   FIRAuthCredential *credential =
-    [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]] credentialWithVerificationID:verificationId
-                                                   verificationCode:verificationCode];
+      [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+          credentialWithVerificationID:verificationId
+                      verificationCode:verificationCode];
 
-   
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       signInWithCredential:credential
                 completion:^(FIRAuthDataResult *authResult, NSError *error) {
-                
-                DLog(@"auth error: %long", (long)error.code);
+                  DLog(@"auth error: %long", (long)error.code);
                   if (error) {
                     [self promiseRejectAuthException:reject error:error];
                   } else {
@@ -1047,7 +1045,7 @@ RCT_EXPORT_METHOD(linkWithCredential
   FIRAuthCredential *credential = [self getCredentialForProvider:provider
                                                            token:authToken
                                                           secret:authSecret
-                                                        firebaseApp:firebaseApp];
+                                                     firebaseApp:firebaseApp];
 
   if (credential == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
@@ -1094,7 +1092,8 @@ RCT_EXPORT_METHOD(linkWithProvider
     return;
   }
 
-  __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
+  __block FIROAuthProvider *builder =
+      [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
   // Add scopes if present
   if (provider[@"scopes"]) {
     [builder setScopes:provider[@"scopes"]];
@@ -1148,7 +1147,10 @@ RCT_EXPORT_METHOD(unlink
                     if (error) {
                       [self promiseRejectAuthException:reject error:error];
                     } else {
-                      [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
+                      [self reloadAndReturnUser:user
+                                       resolver:resolve
+                                       rejecter:reject
+                                    firebaseApp:firebaseApp];
                     }
                   }];
   } else {
@@ -1166,7 +1168,7 @@ RCT_EXPORT_METHOD(reauthenticateWithCredential
   FIRAuthCredential *credential = [self getCredentialForProvider:provider
                                                            token:authToken
                                                           secret:authSecret
-                                                        firebaseApp:firebaseApp];
+                                                     firebaseApp:firebaseApp];
 
   if (credential == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
@@ -1201,7 +1203,6 @@ RCT_EXPORT_METHOD(reauthenticateWithProvider
                   : (NSDictionary *)provider
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-
   NSString *providerId = provider[@"providerId"];
   if (providerId == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
@@ -1218,7 +1219,8 @@ RCT_EXPORT_METHOD(reauthenticateWithProvider
     return;
   }
 
-  __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
+  __block FIROAuthProvider *builder =
+      [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
   // Add scopes if present
   if (provider[@"scopes"]) {
     [builder setScopes:provider[@"scopes"]];
@@ -1265,7 +1267,7 @@ RCT_EXPORT_METHOD(fetchSignInMethodsForEmail
                   : (NSString *)email
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       fetchSignInMethodsForEmail:email
                       completion:^(NSArray<NSString *> *_Nullable providers,
                                    NSError *_Nullable error) {
@@ -1284,7 +1286,7 @@ RCT_EXPORT_METHOD(setLanguageCode : (FIRApp *)firebaseApp : (NSString *)code) {
   if (code) {
     [FIRAuth authWithApp:firebaseApp].languageCode = code;
   } else {
-      [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
+    [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
   }
 }
 
@@ -1293,7 +1295,7 @@ RCT_EXPORT_METHOD(setTenantId : (FIRApp *)firebaseApp : (NSString *)tenantID) {
 }
 
 RCT_EXPORT_METHOD(useDeviceLanguage : (FIRApp *)firebaseApp) {
-    [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
+  [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
 }
 
 RCT_EXPORT_METHOD(verifyPasswordResetCode
@@ -1301,7 +1303,7 @@ RCT_EXPORT_METHOD(verifyPasswordResetCode
                   : (NSString *)code
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-    [[FIRAuth authWithApp:firebaseApp]
+  [[FIRAuth authWithApp:firebaseApp]
       verifyPasswordResetCode:code
                    completion:^(NSString *_Nullable email, NSError *_Nullable error) {
                      if (error) {
@@ -1317,7 +1319,6 @@ RCT_EXPORT_METHOD(useEmulator
                   : (nonnull NSString *)host
                   : (NSInteger)port) {
   if (!emulatorConfigs[firebaseApp.name]) {
-    
     [[FIRAuth authWithApp:firebaseApp] useEmulatorWithHost:host port:port];
     emulatorConfigs[firebaseApp.name] = @YES;
   }
@@ -1326,7 +1327,7 @@ RCT_EXPORT_METHOD(useEmulator
 - (FIRAuthCredential *)getCredentialForProvider:(NSString *)provider
                                           token:(NSString *)authToken
                                          secret:(NSString *)authTokenSecret
-                                    firebaseApp:(FIRApp *)firebaseApp{
+                                    firebaseApp:(FIRApp *)firebaseApp {
   FIRAuthCredential *credential;
 
   // First check if we cached an authToken
@@ -1355,9 +1356,10 @@ RCT_EXPORT_METHOD(useEmulator
   } else if ([provider compare:@"github.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIRGitHubAuthProvider credentialWithToken:authToken];
   } else if ([provider compare:@"phone" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-      DLog(@"using app credGen: %@", firebaseApp.name)
-    credential = [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]] credentialWithVerificationID:authToken
-         verificationCode:authTokenSecret];
+    DLog(@"using app credGen: %@", firebaseApp.name) credential =
+        [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
+            credentialWithVerificationID:authToken
+                        verificationCode:authTokenSecret];
   } else if ([provider compare:@"oauth" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIROAuthProvider credentialWithProviderID:@"oauth"
                                                     IDToken:authToken
@@ -1378,7 +1380,7 @@ RCT_EXPORT_METHOD(useEmulator
 - (void)reloadAndReturnUser:(FIRUser *)user
                    resolver:(RCTPromiseResolveBlock)resolve
                    rejecter:(RCTPromiseRejectBlock)reject
-                firebaseApp:(FIRApp*)firebaseApp{
+                firebaseApp:(FIRApp *)firebaseApp {
   [user reloadWithCompletion:^(NSError *_Nullable error) {
     if (error) {
       [self promiseRejectAuthException:reject error:error];
@@ -1409,7 +1411,7 @@ RCT_EXPORT_METHOD(useEmulator
   return @{
     @"hints" : [self convertMultiFactorData:resolver.hints],
     @"session" : sessionHash,
-    @"auth": resolver.auth
+    @"auth" : resolver.auth
   };
 }
 
@@ -1422,10 +1424,9 @@ RCT_EXPORT_METHOD(useEmulator
   return factorId;
 }
 
-- (void)promiseRejectAuthException:(RCTPromiseRejectBlock)reject error:(NSError *)error{
-    
-    NSDictionary *jsError = [self getJSError:error];
-    
+- (void)promiseRejectAuthException:(RCTPromiseRejectBlock)reject error:(NSError *)error {
+  NSDictionary *jsError = [self getJSError:error];
+
   [RNFBSharedUtils
       rejectPromiseWithUserInfo:reject
                        userInfo:(NSMutableDictionary *)@{
@@ -1521,12 +1522,12 @@ RCT_EXPORT_METHOD(useEmulator
     FIRAuthCredential *authCredential = [error userInfo][FIRAuthErrorUserInfoUpdatedCredentialKey];
     authCredentialDict = [self authCredentialToDict:authCredential];
   }
- 
+
   NSDictionary *resolverDict = nil;
   if ([error userInfo][FIRAuthErrorUserInfoMultiFactorResolverKey] != nil) {
-      FIRMultiFactorResolver* resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
+    FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
     resolverDict = [self multiFactorResolverToDict:resolver];
-    
+
     NSString *sessionKey = [NSString stringWithFormat:@"%@", @([resolver.session hash])];
     cachedResolver[sessionKey] = resolver;
   }

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -474,7 +474,7 @@ RCT_EXPORT_METHOD(updateProfile
           [changeRequest setValue:props[key] forKey:key];
         }
       } @catch (NSException *exception) {
-        
+        DLog(@"Exception occurred while configuring: %@", exception);
       }
     }
 

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -90,14 +90,14 @@ RCT_EXPORT_MODULE();
   for (NSString *key in authStateHandlers) {
     FIRApp *firebaseApp = [RCTConvert firAppFromString:key];
 
-     [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
         removeAuthStateDidChangeListener:[authStateHandlers valueForKey:key]];
   }
   [authStateHandlers removeAllObjects];
 
   for (NSString *key in idTokenHandlers) {
     FIRApp *firebaseApp = [RCTConvert firAppFromString:key];
-     [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
         removeIDTokenDidChangeListener:[idTokenHandlers valueForKey:key]];
   }
   [idTokenHandlers removeAllObjects];
@@ -112,7 +112,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(addAuthStateListener : (FIRApp *)firebaseApp) {
   if (![authStateHandlers valueForKey:firebaseApp.name]) {
-    FIRAuthStateDidChangeListenerHandle newListenerHandle =   [[FIRAuth authWithApp:firebaseApp]
+    FIRAuthStateDidChangeListenerHandle newListenerHandle = [[FIRAuth authWithApp:firebaseApp]
         addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
           if (user != nil) {
             [RNFBSharedUtils sendJSEventForApp:firebaseApp

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -90,14 +90,14 @@ RCT_EXPORT_MODULE();
   for (NSString *key in authStateHandlers) {
     FIRApp *firebaseApp = [RCTConvert firAppFromString:key];
 
-    [[FIRAuth authWithApp:firebaseApp]
+     [[FIRAuth authWithApp:firebaseApp]
         removeAuthStateDidChangeListener:[authStateHandlers valueForKey:key]];
   }
   [authStateHandlers removeAllObjects];
 
   for (NSString *key in idTokenHandlers) {
     FIRApp *firebaseApp = [RCTConvert firAppFromString:key];
-    [[FIRAuth authWithApp:firebaseApp]
+     [[FIRAuth authWithApp:firebaseApp]
         removeIDTokenDidChangeListener:[idTokenHandlers valueForKey:key]];
   }
   [idTokenHandlers removeAllObjects];
@@ -112,7 +112,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(addAuthStateListener : (FIRApp *)firebaseApp) {
   if (![authStateHandlers valueForKey:firebaseApp.name]) {
-    FIRAuthStateDidChangeListenerHandle newListenerHandle = [[FIRAuth authWithApp:firebaseApp]
+    FIRAuthStateDidChangeListenerHandle newListenerHandle =   [[FIRAuth authWithApp:firebaseApp]
         addAuthStateDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
           if (user != nil) {
             [RNFBSharedUtils sendJSEventForApp:firebaseApp
@@ -128,7 +128,7 @@ RCT_EXPORT_METHOD(addAuthStateListener : (FIRApp *)firebaseApp) {
 
 RCT_EXPORT_METHOD(removeAuthStateListener : (FIRApp *)firebaseApp) {
   if ([authStateHandlers valueForKey:firebaseApp.name]) {
-    [[FIRAuth authWithApp:firebaseApp]
+     [[FIRAuth authWithApp:firebaseApp]
         removeAuthStateDidChangeListener:[authStateHandlers valueForKey:firebaseApp.name]];
     [authStateHandlers removeObjectForKey:firebaseApp.name];
   }
@@ -136,7 +136,7 @@ RCT_EXPORT_METHOD(removeAuthStateListener : (FIRApp *)firebaseApp) {
 
 RCT_EXPORT_METHOD(addIdTokenListener : (FIRApp *)firebaseApp) {
   if (![idTokenHandlers valueForKey:firebaseApp.name]) {
-    FIRIDTokenDidChangeListenerHandle newListenerHandle = [[FIRAuth authWithApp:firebaseApp]
+    FIRIDTokenDidChangeListenerHandle newListenerHandle =  [[FIRAuth authWithApp:firebaseApp]
         addIDTokenDidChangeListener:^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
           if (user != nil) {
             [RNFBSharedUtils sendJSEventForApp:firebaseApp
@@ -154,7 +154,7 @@ RCT_EXPORT_METHOD(addIdTokenListener : (FIRApp *)firebaseApp) {
 
 RCT_EXPORT_METHOD(removeIdTokenListener : (FIRApp *)firebaseApp) {
   if ([idTokenHandlers valueForKey:firebaseApp.name]) {
-    [[FIRAuth authWithApp:firebaseApp]
+     [[FIRAuth authWithApp:firebaseApp]
         removeIDTokenDidChangeListener:[idTokenHandlers valueForKey:firebaseApp.name]];
     [idTokenHandlers removeObjectForKey:firebaseApp.name];
   }
@@ -185,12 +185,12 @@ RCT_EXPORT_METHOD(useUserAccessGroup
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   NSError *error;
-  [[FIRAuth authWithApp:firebaseApp] useUserAccessGroup:userAccessGroup error:&error];
+   [[FIRAuth authWithApp:firebaseApp] useUserAccessGroup:userAccessGroup error:&error];
 
   if (!error) {
     [self promiseNoUser:resolve rejecter:reject isError:NO];
   } else {
-    [self promiseRejectAuthException:reject error:error];
+      [self promiseRejectAuthException:reject error:error];
   }
   return;
 }
@@ -203,7 +203,7 @@ RCT_EXPORT_METHOD(signOut
 
   if (user) {
     NSError *error;
-    [[FIRAuth authWithApp:firebaseApp] signOut:&error];
+      [[FIRAuth authWithApp:firebaseApp] signOut:&error];
     if (!error) {
       [self promiseNoUser:resolve rejecter:reject isError:NO];
     } else {
@@ -219,7 +219,7 @@ RCT_EXPORT_METHOD(signInAnonymously
                   : (FIRApp *)firebaseApp
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       signInAnonymouslyWithCompletion:^(FIRAuthDataResult *authResult, NSError *error) {
         if (error) {
           [self promiseRejectAuthException:reject error:error];
@@ -235,10 +235,11 @@ RCT_EXPORT_METHOD(signInWithEmailAndPassword
                   : (NSString *)password
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       signInWithEmail:email
              password:password
            completion:^(FIRAuthDataResult *authResult, NSError *error) {
+        
              if (error) {
                [self promiseRejectAuthException:reject error:error];
              } else {
@@ -253,7 +254,7 @@ RCT_EXPORT_METHOD(signInWithEmailLink
                   : (NSString *)emailLink
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       signInWithEmail:email
                  link:emailLink
            completion:^(FIRAuthDataResult *authResult, NSError *error) {
@@ -271,7 +272,7 @@ RCT_EXPORT_METHOD(createUserWithEmailAndPassword
                   : (NSString *)password
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       createUserWithEmail:email
                  password:password
                completion:^(FIRAuthDataResult *authResult, NSError *error) {
@@ -307,9 +308,8 @@ RCT_EXPORT_METHOD(reload
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   FIRUser *user = [FIRAuth authWithApp:firebaseApp].currentUser;
-
   if (user) {
-    [self reloadAndReturnUser:user resolver:resolve rejecter:reject];
+      [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
   } else {
     [self promiseNoUser:resolve rejecter:reject isError:YES];
   }
@@ -383,7 +383,7 @@ RCT_EXPORT_METHOD(updateEmail
              if (error) {
                [self promiseRejectAuthException:reject error:error];
              } else {
-               [self reloadAndReturnUser:user resolver:resolve rejecter:reject];
+               [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
              }
            }];
   } else {
@@ -426,7 +426,8 @@ RCT_EXPORT_METHOD(updatePhoneNumber
     FIRPhoneAuthCredential *credential =
         (FIRPhoneAuthCredential *)[self getCredentialForProvider:provider
                                                            token:authToken
-                                                          secret:authSecret];
+                                                          secret:authSecret
+                                                          firebaseApp:firebaseApp];
 
     if (credential == nil) {
       [RNFBSharedUtils
@@ -473,7 +474,7 @@ RCT_EXPORT_METHOD(updateProfile
           [changeRequest setValue:props[key] forKey:key];
         }
       } @catch (NSException *exception) {
-        DLog(@"Exception occurred while configuring: %@", exception);
+        
       }
     }
 
@@ -481,7 +482,7 @@ RCT_EXPORT_METHOD(updateProfile
       if (error) {
         [self promiseRejectAuthException:reject error:error];
       } else {
-        [self reloadAndReturnUser:user resolver:resolve rejecter:reject];
+        [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
       }
     }];
   } else {
@@ -565,8 +566,8 @@ RCT_EXPORT_METHOD(signInWithCredential
                   : (RCTPromiseRejectBlock)reject) {
   FIRAuthCredential *credential = [self getCredentialForProvider:provider
                                                            token:authToken
-                                                          secret:authSecret];
-
+                                                          secret:authSecret
+                                                        firebaseApp:firebaseApp];
   if (credential == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
                                       userInfo:(NSMutableDictionary *)@{
@@ -575,8 +576,8 @@ RCT_EXPORT_METHOD(signInWithCredential
                                                      @"has expired or is not currently supported.",
                                       }];
   }
-
-  [[FIRAuth authWithApp:firebaseApp]
+DLog(@"using app SignInWithCredential: %@", firebaseApp.name)
+    [[FIRAuth authWithApp:firebaseApp]
       signInWithCredential:credential
                 completion:^(FIRAuthDataResult *authResult, NSError *error) {
                   if (error) {
@@ -602,7 +603,7 @@ RCT_EXPORT_METHOD(signInWithProvider
                                       }];
   }
 
-  __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId];
+    __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
   // Add scopes if present
   if (provider[@"scopes"]) {
     [builder setScopes:provider[@"scopes"]];
@@ -620,7 +621,7 @@ RCT_EXPORT_METHOD(signInWithProvider
                                 return;
                               }
                               if (credential) {
-                                [[FIRAuth auth]
+                                  [[FIRAuth authWithApp:firebaseApp]
                                     signInWithCredential:credential
                                               completion:^(FIRAuthDataResult *_Nullable authResult,
                                                            NSError *_Nullable error) {
@@ -650,7 +651,7 @@ RCT_EXPORT_METHOD(confirmPasswordReset
                   : (NSString *)newPassword
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+      [[FIRAuth authWithApp:firebaseApp]
       confirmPasswordResetWithCode:code
                        newPassword:newPassword
                         completion:^(NSError *_Nullable error) {
@@ -667,7 +668,7 @@ RCT_EXPORT_METHOD(applyActionCode
                   : (NSString *)code
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       applyActionCode:code
            completion:^(NSError *_Nullable error) {
              if (error) {
@@ -685,7 +686,7 @@ RCT_EXPORT_METHOD(checkActionCode
                   : (NSString *)code
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       checkActionCode:code
            completion:^(FIRActionCodeInfo *_Nullable info, NSError *_Nullable error) {
              if (error) {
@@ -741,7 +742,7 @@ RCT_EXPORT_METHOD(revokeToken
                   : (NSString *)authorizationCode
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       revokeTokenWithAuthorizationCode:authorizationCode
                             completion:^(NSError *_Nullable error) {
                               if (error) {
@@ -768,11 +769,11 @@ RCT_EXPORT_METHOD(sendPasswordResetEmail
 
   if (actionCodeSettings) {
     FIRActionCodeSettings *settings = [self buildActionCodeSettings:actionCodeSettings];
-    [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email
+      [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email
                                                actionCodeSettings:settings
                                                        completion:handler];
   } else {
-    [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email completion:handler];
+      [[FIRAuth authWithApp:firebaseApp] sendPasswordResetWithEmail:email completion:handler];
   }
 }
 
@@ -791,7 +792,7 @@ RCT_EXPORT_METHOD(sendSignInLinkToEmail
   };
 
   FIRActionCodeSettings *settings = [self buildActionCodeSettings:actionCodeSettings];
-  [[FIRAuth authWithApp:firebaseApp] sendSignInLinkToEmail:email
+    [[FIRAuth authWithApp:firebaseApp] sendSignInLinkToEmail:email
                                         actionCodeSettings:settings
                                                 completion:handler];
 }
@@ -801,7 +802,7 @@ RCT_EXPORT_METHOD(signInWithCustomToken
                   : (NSString *)customToken
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       signInWithCustomToken:customToken
                  completion:^(FIRAuthDataResult *authResult, NSError *error) {
                    if (error) {
@@ -817,6 +818,7 @@ RCT_EXPORT_METHOD(signInWithPhoneNumber
                   : (NSString *)phoneNumber
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
+    DLog(@"SignInWthPhoneNumber instance: %@", firebaseApp.name)
   [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
       verifyPhoneNumber:phoneNumber
              UIDelegate:nil
@@ -836,6 +838,7 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
                   : (NSString *)sessionKey
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
+    
   if ([cachedResolver valueForKey:sessionKey] == nil) {
     [RNFBSharedUtils
         rejectPromiseWithUserInfo:reject
@@ -858,8 +861,8 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
                                       }];
     return;
   }
-
-  [FIRPhoneAuthProvider.provider
+  DLog(@"using instance verifyPhoneNumberWithMultiFactorInfo: %@", firebaseApp.name)
+  [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
       verifyPhoneNumberWithMultiFactorInfo:hint
                                 UIDelegate:nil
                         multiFactorSession:session
@@ -868,6 +871,7 @@ RCT_EXPORT_METHOD(verifyPhoneNumberWithMultiFactorInfo
                                   if (error) {
                                     [self promiseRejectAuthException:reject error:error];
                                   } else {
+                                    DLog(@"verificationID: %@", verificationID)
                                     resolve(verificationID);
                                   }
                                 }];
@@ -880,7 +884,8 @@ RCT_EXPORT_METHOD(verifyPhoneNumberForMultiFactor
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   FIRMultiFactorSession *session = cachedSessions[sessionId];
-  [FIRPhoneAuthProvider.provider
+    DLog(@"using instance VerifyPhoneNumberForMultifactor: %@",firebaseApp.name)
+  [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
        verifyPhoneNumber:phoneNumber
               UIDelegate:nil
       multiFactorSession:session
@@ -901,15 +906,21 @@ RCT_EXPORT_METHOD(resolveMultiFactorSignIn
                   : (NSString *)verificationCode
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
+    DLog(@"using instance resolve MultiFactorSignIn: %@", firebaseApp.name)
   FIRPhoneAuthCredential *credential =
       [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
           credentialWithVerificationID:verificationId
                       verificationCode:verificationCode];
+DLog(@"credential: %@", credential)
   FIRMultiFactorAssertion *assertion =
       [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
-  [cachedResolver[sessionKey] resolveSignInWithAssertion:assertion
+    
+    
+    [cachedResolver[sessionKey] resolveSignInWithAssertion:assertion
                                               completion:^(FIRAuthDataResult *_Nullable authResult,
                                                            NSError *_Nullable error) {
+                                                
+                                                DLog(@"authError: %@", error)
                                                 if (error) {
                                                   [self promiseRejectAuthException:reject
                                                                              error:error];
@@ -946,11 +957,12 @@ RCT_EXPORT_METHOD(finalizeMultiFactorEnrollment
                   : (NSString *_Nullable)displayName
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
+    DLog(@"using instance finalizeMultifactorEnrollment: %@", firebaseApp.name)
   FIRPhoneAuthCredential *credential =
-      [FIRPhoneAuthProvider.provider credentialWithVerificationID:verificationId
+      [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]credentialWithVerificationID:verificationId
                                                  verificationCode:verificationCode];
   FIRMultiFactorAssertion *assertion =
-      [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
+    [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
   FIRUser *user = [FIRAuth authWithApp:firebaseApp].currentUser;
   [user.multiFactor enrollWithAssertion:assertion
                             displayName:displayName
@@ -969,12 +981,13 @@ RCT_EXPORT_METHOD(verifyPhoneNumber
                   : (FIRApp *)firebaseApp
                   : (NSString *)phoneNumber
                   : (NSString *)requestKey) {
-  [FIRPhoneAuthProvider.provider
+    DLog(@"using instance verifyPhoneNumber: %@", firebaseApp.name)
+  [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
       verifyPhoneNumber:phoneNumber
              UIDelegate:nil
              completion:^(NSString *_Nullable verificationID, NSError *_Nullable error) {
                if (error) {
-                 NSDictionary *jsError = [self getJSError:(error)];
+                   NSDictionary *jsError = [self getJSError:error];
                  NSDictionary *body = @{
                    @"type" : @"onVerificationFailed",
                    @"requestKey" : requestKey,
@@ -1007,12 +1020,15 @@ RCT_EXPORT_METHOD(confirmationResultConfirm
   NSString *verificationId = [defaults stringForKey:@"authVerificationID"];
 
   FIRAuthCredential *credential =
-      [[FIRPhoneAuthProvider provider] credentialWithVerificationID:verificationId
+    [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]] credentialWithVerificationID:verificationId
                                                    verificationCode:verificationCode];
 
-  [[FIRAuth authWithApp:firebaseApp]
+   
+    [[FIRAuth authWithApp:firebaseApp]
       signInWithCredential:credential
                 completion:^(FIRAuthDataResult *authResult, NSError *error) {
+                
+                DLog(@"auth error: %long", (long)error.code);
                   if (error) {
                     [self promiseRejectAuthException:reject error:error];
                   } else {
@@ -1030,7 +1046,8 @@ RCT_EXPORT_METHOD(linkWithCredential
                   : (RCTPromiseRejectBlock)reject) {
   FIRAuthCredential *credential = [self getCredentialForProvider:provider
                                                            token:authToken
-                                                          secret:authSecret];
+                                                          secret:authSecret
+                                                        firebaseApp:firebaseApp];
 
   if (credential == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
@@ -1077,7 +1094,7 @@ RCT_EXPORT_METHOD(linkWithProvider
     return;
   }
 
-  __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId];
+  __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
   // Add scopes if present
   if (provider[@"scopes"]) {
     [builder setScopes:provider[@"scopes"]];
@@ -1131,7 +1148,7 @@ RCT_EXPORT_METHOD(unlink
                     if (error) {
                       [self promiseRejectAuthException:reject error:error];
                     } else {
-                      [self reloadAndReturnUser:user resolver:resolve rejecter:reject];
+                      [self reloadAndReturnUser:user resolver:resolve rejecter:reject firebaseApp:firebaseApp];
                     }
                   }];
   } else {
@@ -1148,7 +1165,8 @@ RCT_EXPORT_METHOD(reauthenticateWithCredential
                   : (RCTPromiseRejectBlock)reject) {
   FIRAuthCredential *credential = [self getCredentialForProvider:provider
                                                            token:authToken
-                                                          secret:authSecret];
+                                                          secret:authSecret
+                                                        firebaseApp:firebaseApp];
 
   if (credential == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
@@ -1183,6 +1201,7 @@ RCT_EXPORT_METHOD(reauthenticateWithProvider
                   : (NSDictionary *)provider
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
+
   NSString *providerId = provider[@"providerId"];
   if (providerId == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
@@ -1199,7 +1218,7 @@ RCT_EXPORT_METHOD(reauthenticateWithProvider
     return;
   }
 
-  __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId];
+  __block FIROAuthProvider *builder = [FIROAuthProvider providerWithProviderID:providerId auth:[FIRAuth authWithApp:firebaseApp]];
   // Add scopes if present
   if (provider[@"scopes"]) {
     [builder setScopes:provider[@"scopes"]];
@@ -1246,7 +1265,7 @@ RCT_EXPORT_METHOD(fetchSignInMethodsForEmail
                   : (NSString *)email
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       fetchSignInMethodsForEmail:email
                       completion:^(NSArray<NSString *> *_Nullable providers,
                                    NSError *_Nullable error) {
@@ -1265,7 +1284,7 @@ RCT_EXPORT_METHOD(setLanguageCode : (FIRApp *)firebaseApp : (NSString *)code) {
   if (code) {
     [FIRAuth authWithApp:firebaseApp].languageCode = code;
   } else {
-    [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
+      [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
   }
 }
 
@@ -1274,7 +1293,7 @@ RCT_EXPORT_METHOD(setTenantId : (FIRApp *)firebaseApp : (NSString *)tenantID) {
 }
 
 RCT_EXPORT_METHOD(useDeviceLanguage : (FIRApp *)firebaseApp) {
-  [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
+    [[FIRAuth authWithApp:firebaseApp] useAppLanguage];
 }
 
 RCT_EXPORT_METHOD(verifyPasswordResetCode
@@ -1282,7 +1301,7 @@ RCT_EXPORT_METHOD(verifyPasswordResetCode
                   : (NSString *)code
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRAuth authWithApp:firebaseApp]
+    [[FIRAuth authWithApp:firebaseApp]
       verifyPasswordResetCode:code
                    completion:^(NSString *_Nullable email, NSError *_Nullable error) {
                      if (error) {
@@ -1298,6 +1317,7 @@ RCT_EXPORT_METHOD(useEmulator
                   : (nonnull NSString *)host
                   : (NSInteger)port) {
   if (!emulatorConfigs[firebaseApp.name]) {
+    
     [[FIRAuth authWithApp:firebaseApp] useEmulatorWithHost:host port:port];
     emulatorConfigs[firebaseApp.name] = @YES;
   }
@@ -1305,7 +1325,8 @@ RCT_EXPORT_METHOD(useEmulator
 
 - (FIRAuthCredential *)getCredentialForProvider:(NSString *)provider
                                           token:(NSString *)authToken
-                                         secret:(NSString *)authTokenSecret {
+                                         secret:(NSString *)authTokenSecret
+                                    firebaseApp:(FIRApp *)firebaseApp{
   FIRAuthCredential *credential;
 
   // First check if we cached an authToken
@@ -1334,8 +1355,9 @@ RCT_EXPORT_METHOD(useEmulator
   } else if ([provider compare:@"github.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIRGitHubAuthProvider credentialWithToken:authToken];
   } else if ([provider compare:@"phone" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
-    credential = [[FIRPhoneAuthProvider provider] credentialWithVerificationID:authToken
-                                                              verificationCode:authTokenSecret];
+      DLog(@"using app credGen: %@", firebaseApp.name)
+    credential = [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]] credentialWithVerificationID:authToken
+         verificationCode:authTokenSecret];
   } else if ([provider compare:@"oauth" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIROAuthProvider credentialWithProviderID:@"oauth"
                                                     IDToken:authToken
@@ -1355,7 +1377,8 @@ RCT_EXPORT_METHOD(useEmulator
 // correctly refresh the user object when performing certain operations
 - (void)reloadAndReturnUser:(FIRUser *)user
                    resolver:(RCTPromiseResolveBlock)resolve
-                   rejecter:(RCTPromiseRejectBlock)reject {
+                   rejecter:(RCTPromiseRejectBlock)reject
+                firebaseApp:(FIRApp*)firebaseApp{
   [user reloadWithCompletion:^(NSError *_Nullable error) {
     if (error) {
       [self promiseRejectAuthException:reject error:error];
@@ -1386,6 +1409,7 @@ RCT_EXPORT_METHOD(useEmulator
   return @{
     @"hints" : [self convertMultiFactorData:resolver.hints],
     @"session" : sessionHash,
+    @"auth": resolver.auth
   };
 }
 
@@ -1398,9 +1422,10 @@ RCT_EXPORT_METHOD(useEmulator
   return factorId;
 }
 
-- (void)promiseRejectAuthException:(RCTPromiseRejectBlock)reject error:(NSError *)error {
-  NSDictionary *jsError = [self getJSError:(error)];
-
+- (void)promiseRejectAuthException:(RCTPromiseRejectBlock)reject error:(NSError *)error{
+    
+    NSDictionary *jsError = [self getJSError:error];
+    
   [RNFBSharedUtils
       rejectPromiseWithUserInfo:reject
                        userInfo:(NSMutableDictionary *)@{
@@ -1496,13 +1521,12 @@ RCT_EXPORT_METHOD(useEmulator
     FIRAuthCredential *authCredential = [error userInfo][FIRAuthErrorUserInfoUpdatedCredentialKey];
     authCredentialDict = [self authCredentialToDict:authCredential];
   }
-
+ 
   NSDictionary *resolverDict = nil;
   if ([error userInfo][FIRAuthErrorUserInfoMultiFactorResolverKey] != nil) {
-    FIRMultiFactorResolver *resolver =
-        (FIRMultiFactorResolver *)error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
+      FIRMultiFactorResolver* resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
     resolverDict = [self multiFactorResolverToDict:resolver];
-
+    
     NSString *sessionKey = [NSString stringWithFormat:@"%@", @([resolver.session hash])];
     cachedResolver[sessionKey] = resolver;
   }
@@ -1665,7 +1689,7 @@ RCT_EXPORT_METHOD(useEmulator
         [[[NSISO8601DateFormatter alloc] init] stringFromDate:hint.enrollmentDate];
     [enrolledFactors addObject:@{
       @"uid" : hint.UID,
-      @"factorId" : hint.factorID == nil ? [NSNull null] : [self getJSFactorId:(hint.factorID)],
+      @"factorId" : [self getJSFactorId:(hint.factorID)],
       @"displayName" : hint.displayName == nil ? [NSNull null] : hint.displayName,
       @"enrollmentDate" : enrollmentDate,
     }];

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -118,17 +118,17 @@
     didReceiveRemoteNotification:(NSDictionary *)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
 #if __has_include(<FirebaseAuth/FirebaseAuth.h>)
-    
-   for(id appId in [FIRApp allApps])
-   {
-       FIRApp* app = [[FIRApp allApps] objectForKey:appId];
-       if([[FIRAuth authWithApp:app] canHandleNotification:userInfo])
-       {
-           DLog(@"didReceiveRemoteNotification Firebase Auth handeled the notification with instance: %@", app.name);
-           completionHandler(UIBackgroundFetchResultNoData);
-           return;
-       }
-   }
+
+  for (id appId in [FIRApp allApps]) {
+    FIRApp *app = [[FIRApp allApps] objectForKey:appId];
+    if ([[FIRAuth authWithApp:app] canHandleNotification:userInfo]) {
+      DLog(
+          @"didReceiveRemoteNotification Firebase Auth handeled the notification with instance: %@",
+          app.name);
+      completionHandler(UIBackgroundFetchResultNoData);
+      return;
+    }
+  }
 
   // If the notification is a probe notification, always call the completion
   // handler with UIBackgroundFetchResultNoData.

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -118,11 +118,17 @@
     didReceiveRemoteNotification:(NSDictionary *)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
 #if __has_include(<FirebaseAuth/FirebaseAuth.h>)
-  if ([[FIRAuth auth] canHandleNotification:userInfo]) {
-    DLog(@"didReceiveRemoteNotification Firebase Auth handeled the notification");
-    completionHandler(UIBackgroundFetchResultNoData);
-    return;
-  }
+    
+   for(id appId in [FIRApp allApps])
+   {
+       FIRApp* app = [[FIRApp allApps] objectForKey:appId];
+       if([[FIRAuth authWithApp:app] canHandleNotification:userInfo])
+       {
+           DLog(@"didReceiveRemoteNotification Firebase Auth handeled the notification with instance: %@", app.name);
+           completionHandler(UIBackgroundFetchResultNoData);
+           return;
+       }
+   }
 
   // If the notification is a probe notification, always call the completion
   // handler with UIBackgroundFetchResultNoData.


### PR DESCRIPTION
### Description

There is was/is a bug in the firebase sdk(12th of january 2024) that prevents multifactor login from being completed with a secondary app instance, but after that is updated, secondary instances should work with mfa

### Related issues

- Related issue upstream: [#12265](https://github.com/firebase/firebase-ios-sdk/issues/12265)
- Fixes #7339

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire: