### PR TITLE
feat: support mfa un-enrollment

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1250,6 +1250,33 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
             });
   }
 
+  @ReactMethod
+  public void unenrollMultiFactor(
+    final String appName,
+    final String factorUid,
+    final Promise promise
+  ) {
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+
+    firebaseAuth
+      .getCurrentUser()
+      .getMultiFactor()
+      .unenroll(factorUid)
+      .addOnCompleteListener(
+        getExecutor(),
+        task -> {
+          if (task.isSuccessful()) {
+            Log.d(TAG, "unenrollMultiFactor:onComplete:success");
+            promise.resolve(null);
+          } else {
+            Exception exception = task.getException();
+            Log.e(TAG, "unenrollMultiFactor:onComplete:failure", exception);
+            promiseRejectAuthException(promise, exception);
+          }
+        });
+  }
+
   /**
    * This method is intended to resolve a {@link PhoneAuthCredential} obtained through a
    * multi-factor authentication flow. A credential can either be obtained using:

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -965,6 +965,25 @@ RCT_EXPORT_METHOD(finalizeMultiFactorEnrollment
                              }];
 }
 
+RCT_EXPORT_METHOD(unenrollMultiFactor
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)factorUID
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+
+  FIRUser *user = [FIRAuth authWithApp:firebaseApp].currentUser;
+  [user.multiFactor unenrollWithFactorUID:factorUID
+                             completion:^(NSError *_Nullable error) {
+                               if (error != nil) {
+                                 [self promiseRejectAuthException:reject error:error];
+                                 return;
+                               }
+
+                               resolve(nil);
+                               return;
+                             }];
+}
+
 RCT_EXPORT_METHOD(verifyPhoneNumber
                   : (FIRApp *)firebaseApp
                   : (NSString *)phoneNumber

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -577,6 +577,11 @@ export namespace FirebaseAuthTypes {
      * The method will ensure the user state is reloaded after successfully enrolling a factor.
      */
     enroll(assertion: MultiFactorAssertion, displayName?: string): Promise<void>;
+
+    /**
+    * Unenroll a previously enrolled factor.
+    */
+    unenroll(multiFactorInfoOrFactorUid: MultiFactorInfo | string): Promise<void>;
   }
 
   /**

--- a/packages/auth/lib/multiFactor.js
+++ b/packages/auth/lib/multiFactor.js
@@ -34,7 +34,11 @@ export class MultiFactorUser {
     return this._auth.currentUser.reload();
   }
 
-  unenroll() {
-    return Promise.reject(new Error('No implemented yet.'));
+  async unenroll(multiFactorInfoOrFactorUid) {
+    const factorUid = typeof multiFactorInfoOrFactorUid === "string" ? multiFactorInfoOrFactorUid : multiFactorInfoOrFactorUid.uid
+
+    await this._auth.native.unenrollMultiFactor(factorUid)
+
+    return this._auth.currentUser.reload();
   }
 }


### PR DESCRIPTION
### Description
implements the unenroll method, receiving either a factor uid or factor info, and then calling the underlying unenroll by factor uid overload to avoid marshaling the factor info object.

ref:
- https://firebase.google.com/docs/reference/js/auth.multifactoruser#multifactoruserunenroll
- https://firebase.google.com/docs/reference/ios/firebaseauth/api/reference/Classes/FIRMultiFactor#-unenrollwithinfo:completion:
- https://firebase.google.com/docs/reference/android/com/google/firebase/auth/MultiFactor#unenroll(java.lang.String)

### Related issues
#7483

### Release Summary
Support un-enrolling MFA factors
<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
Tested on Android emulator, observed:
- Failure due to needing to re-authenticate raises the correct exception
- Success path correctly removes the factor

I've not tested that a auth state change event is emitted correctly yet.
<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---
:fire: