### PR TITLE
fix(auth, android)!: correct error messages for finalizeMultiFactorEnrollment

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1243,12 +1243,14 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
         .enroll(assertion, displayName)
         .addOnCompleteListener(
             task -> {
-              if (!task.isSuccessful()) {
-                rejectPromiseWithExceptionMap(promise, task.getException());
+              if (task.isSuccessful()) {
+                Log.d(TAG, "finalizeMultiFactorEnrollment:onComplete:success");
+                promise.resolve(null);
+              } else {
+                Exception exception = task.getException();
+                Log.e(TAG, "finalizeMultiFactorEnrollment:onComplete:failure", exception);
+                promiseRejectAuthException(promise, exception);
               }
-
-              // Need to reload user to make it all visible?
-              promise.resolve("yes");
             });
   }
 


### PR DESCRIPTION
### Description
Use `promiseRejectAuthException` and add logging consistent with other methods.

**Before**
```
Error: [auth/unknown] The verification code from SMS/TOTP is invalid. Please check and enter the correct verification code again.
NativeFirebaseError: [auth/unknown] The verification code from SMS/TOTP is invalid. Please check and enter the correct verification code again.
```

**After**
```
Error: [auth/invalid-verification-code] The verification code from SMS/TOTP is invalid. Please check and enter the correct verification code again.
NativeFirebaseError: [auth/invalid-verification-code] The verification code from SMS/TOTP is invalid. Please check and enter the correct verification code again.
```

Arguably a breaking change since the errror codes thrown change.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Release Summary
Errors thrown by `finalizeMultiFactorEnrollment` on Android are no longer of code `auth/unknown`
<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Test Plan
Tested in Android emulator

---
:fire: 