### PR TITLE
fix: typing for firestore `orderBy`

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -1288,7 +1288,7 @@ export namespace FirebaseFirestoreTypes {
      * @param fieldPath The field to sort by. Either a string or FieldPath instance.
      * @param directionStr Optional direction to sort by (`asc` or `desc`). If not specified, order will be ascending.
      */
-    orderBy(fieldPath: keyof T | FieldPath, directionStr?: 'asc' | 'desc'): Query<T>;
+    orderBy(fieldPath: keyof T | string | FieldPath, directionStr?: 'asc' | 'desc'): Query<T>;
 
     /**
      * Creates and returns a new Query that starts after the provided document (exclusive). The start


### PR DESCRIPTION
Commit to fix #7147 

Taking `string` type from `@google-cloud/firestore` types: https://github.com/googleapis/nodejs-firestore/blob/22ac90f0a043e493f89834604bd249f69c5dc036/types/firestore.d.ts#L1719

Also the same on `firebase-js-sdk`:
https://github.com/firebase/firebase-js-sdk/blob/991fa271c867d59e2bed44c69c0512fdeb54bbb4/packages/firestore/src/lite-api/query.ts#L478

and the documentation for the `firebase-js-sdk`:
https://github.com/firebase/firebase-js-sdk/blob/991fa271c867d59e2bed44c69c0512fdeb54bbb4/common/api-review/firestore.api.md?plain=1#L473
