### PR TITLE
fix: Add string type to `DocumentSnapshot.get`

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -565,7 +565,7 @@ export namespace FirebaseFirestoreTypes {
      *
      * @param fieldPath The path (e.g. 'foo' or 'foo.bar') to a specific field.
      */
-    get<fieldType extends DocumentFieldType>(fieldPath: keyof T | FieldPath): fieldType;
+    get<fieldType extends DocumentFieldType>(fieldPath: keyof T | string | FieldPath): fieldType;
 
     /**
      * Returns true if this `DocumentSnapshot` is equal to the provided one.


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

The comment above this change even gives an example of a dot notation string.

Taking string type from @google-cloud/firestore types: https://github.com/googleapis/nodejs-firestore/blob/22ac90f0a043e493f89834604bd249f69c5dc036/types/firestore.d.ts#L1587

Also the same on firebase-js-sdk:
https://github.com/firebase/firebase-js-sdk/blob/991fa271c867d59e2bed44c69c0512fdeb54bbb4/packages/firestore/src/lite-api/snapshot.ts#L359

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #7592 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
Fix the typing for `DocumentSnapshot.get` to allow dot notation object values

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
