### PR TITLE
docs(app, ios): note pod install required for ios_config changes

### DIFF
--- a/packages/app/ios_config.sh
+++ b/packages/app/ios_config.sh
@@ -14,6 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+##########################################################################
+##########################################################################
+#
+#  NOTE THAT IF YOU CHANGE THIS FILE YOU MUST RUN pod install AFTERWARDS
+#
+#  This file is installed as an Xcode build script in the project file
+#  by cocoapods, and you will not see your changes until you pod install
+#
+##########################################################################
+##########################################################################
+
 set -e
 
 _MAX_LOOKUPS=2;


### PR DESCRIPTION

### Description

This wastes developer time and deserves a big note

### Related issues

Idea from https://github.com/invertase/react-native-google-mobile-ads/pull/550

### Release Summary

docs only, no release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Documentation in form of shell script comments only, no tests needed though obviously iOS e2e should pass to confirm that

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
