### PR TITLE
feat(analytics, ios): add Podfile toggle to optionally link AdSupport

### DIFF
--- a/docs/analytics/usage/index.md
+++ b/docs/analytics/usage/index.md
@@ -157,6 +157,18 @@ of your app handle data in a way that requires ATT)
 
 Note that for obvious reasons, configuring Firebase Analytics for use without IDFA is incompatible with AdMob
 
+# Device Identification
+
+If you would like to enable Firebase Analytics to generate automatic audience metrics for iOS (as it does by default in Android), you must link additional iOS libraries, [as documented by the Google Firebase team](https://support.google.com/firebase/answer/6318039). Specifically you need to link in `AdSupport.framework`.
+
+The way to do this using CocoaPods is to add this variable to your `Podfile` so `@react-native-firebase/analytics` will link it in for you:
+
+```ruby
+$RNFirebaseAnalyticsEnableAdSupport = true
+```
+
+Note: this is setting will have no effect if you disabled Ad IDs as described above, since this setting is specifically linking in the `AdSupport` framework which requires the Ad IDs.
+
 # firebase.json
 
 ## Disable Auto-Initialization

--- a/docs/analytics/usage/installation/ios.md
+++ b/docs/analytics/usage/installation/ios.md
@@ -25,27 +25,12 @@ end
 You may need to update your local Pods in order for the `RNFBAnalytics` Pod to be installed in your project:
 
 ```bash
-$ cd ios/
-$ pod install --repo-update
+cd ios/
+pod install --repo-update
 ```
 
 Once the Pods have installed locally, rebuild your iOS project:
 
 ```bash
 npx react-native run-ios
-```
-
-# Device Identification
-
-If you would like to enable Firebase Analytics to generate automatic audience metrics for iOS (as it does by default in Android), you must link additional iOS libraries, [as documented by the Google Firebase team](https://support.google.com/firebase/answer/6318039). Specifically you need `libAdIdAccess.a` and `AdSupport.framework`.
-
-The way to do this using CocoaPods is to add this to your `Podfile` (though please use [the most current Pod version](https://cocoapods.org/pods/GoogleIDFASupport) supported by React Native Firebase):
-
-```ruby
-# ...
-target 'app' do
-  # ...
-  pod 'RNFBAnalytics', :path => '../node_modules/@react-native-firebase/analytics'
-  pod 'GoogleIDFASupport', '~> 3.14.0'
-end
 ```

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -52,6 +52,12 @@ Pod::Spec.new do |s|
       Pod::UI.puts "#{s.name}: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids."
     end
     s.dependency          'Firebase/Analytics', firebase_sdk_version
+
+    # Special pod for on-device conversion
+    if defined?($RNFirebaseAnalyticsEnableAdSupport) && ($RNFirebaseAnalyticsEnableAdSupport == true)
+      Pod::UI.puts "#{s.name}: Adding Apple AdSupport.framework dependency for optional analytics features"
+      s.frameworks =       'AdSupport'
+    end
   end
 
   # Special pod for on-device conversion

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -10,7 +10,7 @@ appPackage = JSON.parse(File.read(File.join('..', 'node_modules', '@react-native
 $FirebaseSDKVersion = appPackage['sdkVersions']['ios']['firebase']
 # $FirebaseSDKVersion = '10.17.0' # https://firebase.google.com/support/release-notes/ios
 Pod::UI.puts "react-native-firebase/tests: Using Firebase SDK version '#{$FirebaseSDKVersion}'"
-$RNFirebaseAsStaticFramework = true # toggle this to true (and set 'use_frameworks!' below to test static frameworks)
+$RNFirebaseAnalyticsEnableAdSupport = true # toggle this to true (and set 'use_frameworks!' below to test static frameworks)
 
 # Toggle this to true for the no-ad-tracking Analytics subspec. Useful at minimum for Kids category apps.
 # See: https://firebase.google.com/support/release-notes/ios#analytics - requires firebase-ios-sdk 7.11.0+
@@ -18,6 +18,9 @@ $RNFirebaseAsStaticFramework = true # toggle this to true (and set 'use_framewor
 
 # Toggle this to true if you want to include support for on device conversion measurement APIs
 $RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
+
+# Toggle this to true if you want to include optional support for extended analytics features
+$RNFirebaseAnalyticsEnableAdSupport = true
 
 # react-native 0.73 is currently iOS 13.4 as a minimum
 min_ios_version_supported = 13.4

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -2004,74 +2004,74 @@ PODS:
   - RecaptchaInterop (100.0.0)
   - RNDeviceInfo (10.12.0):
     - React-Core
-  - RNFBAnalytics (18.8.0):
+  - RNFBAnalytics (18.9.0):
     - Firebase/Analytics (= 10.21.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (18.8.0):
+  - RNFBApp (18.9.0):
     - Firebase/CoreOnly (= 10.21.0)
     - React-Core
-  - RNFBAppCheck (18.8.0):
+  - RNFBAppCheck (18.9.0):
     - Firebase/AppCheck (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (18.8.0):
+  - RNFBAppDistribution (18.9.0):
     - Firebase/AppDistribution (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (18.8.0):
+  - RNFBAuth (18.9.0):
     - Firebase/Auth (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (18.8.0):
+  - RNFBCrashlytics (18.9.0):
     - Firebase/Crashlytics (= 10.21.0)
     - FirebaseCoreExtension (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (18.8.0):
+  - RNFBDatabase (18.9.0):
     - Firebase/Database (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (18.8.0):
+  - RNFBDynamicLinks (18.9.0):
     - Firebase/DynamicLinks (= 10.21.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (18.8.0):
+  - RNFBFirestore (18.9.0):
     - Firebase/Firestore (= 10.21.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (18.8.0):
+  - RNFBFunctions (18.9.0):
     - Firebase/Functions (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (18.8.0):
+  - RNFBInAppMessaging (18.9.0):
     - Firebase/InAppMessaging (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (18.8.0):
+  - RNFBInstallations (18.9.0):
     - Firebase/Installations (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (18.8.0):
+  - RNFBMessaging (18.9.0):
     - Firebase/Messaging (= 10.21.0)
     - FirebaseCoreExtension (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBML (18.8.0):
+  - RNFBML (18.9.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (18.8.0):
+  - RNFBPerf (18.9.0):
     - Firebase/Performance (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (18.8.0):
+  - RNFBRemoteConfig (18.9.0):
     - Firebase/RemoteConfig (= 10.21.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (18.8.0):
+  - RNFBStorage (18.9.0):
     - Firebase/Storage (= 10.21.0)
     - React-Core
     - RNFBApp
@@ -2427,26 +2427,26 @@ SPEC CHECKSUMS:
   ReactCommon: dcc65c813041388dead6c8b477444757425ce961
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
-  RNFBAnalytics: ff81444ec0af9a0d32fc2e085585834e4879411e
-  RNFBApp: 56a281957e52f9c23f024f16dc17d8f0a610f244
-  RNFBAppCheck: dbbf105bcda64b4bd978bf34295ca1f047177f74
-  RNFBAppDistribution: 82028d037519ab87795a9ae41e0651c6f132f77f
-  RNFBAuth: d5ee2761b9748fe730d5cdd470d568bcafc1f8eb
-  RNFBCrashlytics: 3f3dff6239d00a5a9a9a47d8df2f88fe3a65e981
-  RNFBDatabase: 8fff0ee1052d384a7a844bd813f8e6d41368de76
-  RNFBDynamicLinks: 6878b413bcb72c5bd01819506be8a13f3c60756b
-  RNFBFirestore: ab1c7a336ea8ce19da8243731286cabb03953c53
-  RNFBFunctions: 1f2b93a3a2016e8fe2b9b25c1068f48d31232a8f
-  RNFBInAppMessaging: 91000e8458ea2a2c91bac6f741ee8e488be3902d
-  RNFBInstallations: 8825144a553575d99f698976cbaf52ea5c8e2609
-  RNFBMessaging: 0be46df1f7009af910e45ff6e47a45b6b19fef27
-  RNFBML: 1d9637b717778133a057ddf86d1915d016d9aabf
-  RNFBPerf: a58db4862d77c1e32f5fbf37089540faee123021
-  RNFBRemoteConfig: 68281f1dcdf2cdab0d8bb1be339d2dcefd7169a2
-  RNFBStorage: 0d25208f4fc71500b6fee6e9d9b7f5f360a1b906
+  RNFBAnalytics: 28840e05f67e0b063c4a6642febf46c274da8bf5
+  RNFBApp: 9ad5e218542797f24df746b89887f47900519671
+  RNFBAppCheck: ba152b4c52ffe737729466a3021fc53081b34e6d
+  RNFBAppDistribution: d5af915085f83d3c88185616bf0c52ad7c06437e
+  RNFBAuth: 38326a2195bd8913e971ddda59b409aef3ab9897
+  RNFBCrashlytics: 671a91763469cdbfae711ac9357dafcf06eb829b
+  RNFBDatabase: 32f1f0a67f418e43df6b8a318c28d283b3964b40
+  RNFBDynamicLinks: 48a5e45e6a835d860a155a76a42bb8fd8154a1f2
+  RNFBFirestore: 7970e0b69768477c5832976b0adeabb8aa27f0b2
+  RNFBFunctions: c73d51f0ba1bde31d646c570ea0da96dc21c59aa
+  RNFBInAppMessaging: cd28938866f1626b51c914414dcd64c01efd3d92
+  RNFBInstallations: 8eb55cf03245658b7e3a49d173808b5f724a4ade
+  RNFBMessaging: 5b0918878553a92797497037e70a020caf26d710
+  RNFBML: f61cb56fb8d4dcdc650dd6ec966c872d177cde82
+  RNFBPerf: 6f4993ccd261fb28815966cd491a0596c1e4d7ce
+  RNFBRemoteConfig: fd694687de1e60e0c0728d1e39e7003fd229d694
+  RNFBStorage: 0e42af1e780858bd342478a92413f0b93d1be194
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 
-PODFILE CHECKSUM: fd2f683bc28d2fe2477257935924fd91d3c54766
+PODFILE CHECKSUM: 116cc4e9d1ef07a0b698eff4bacd90df81838371
 
 COCOAPODS: 1.14.3


### PR DESCRIPTION
### Description

See https://firebase.google.com/support/guides/analytics-adsupport

Ads the ability to define '$RNFirebaseAnalyticsEnableAdSupport' in order to handle the linking for you to get the optional features.

For example, in. Podfile near the top, you may do this and it should Just Work:

```ruby
$RNFirebaseAnalyticsEnableAdSupport = true
```

Note that this will only work with the AdId support enabled, it is mutually exclusive with `RNFirebaseAnalyticsWithoutAdIdSupport` Podfile toggle, as it makes no sense to link the `AdSupport` framework while linking the Firebase Analytics pod that does not contain AdId support

### Related issues

Fixes
- #7027

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


### Test Plan

This is an optional toggle in a Podfile that did not exist before so it cannot by definition break things.

Needs user testing over time to see if the use of this toggle is sufficient to include the optional extra analytics features, but it does align with the documentation from upstream firebase analytics and apple though

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
