### PR TITLE
fix: enrolledFactors rather than enrolledFactor

### DIFF
--- a/packages/auth/lib/multiFactor.js
+++ b/packages/auth/lib/multiFactor.js
@@ -15,6 +15,8 @@ export class MultiFactorUser {
     }
     this._user = user;
     this.enrolledFactors = user.multiFactor.enrolledFactors;
+    // @deprecated kept for backwards compatibility, please use enrolledFactors
+    this.enrolledFactor = user.multiFactor.enrolledFactors;
   }
 
   getSession() {

--- a/packages/auth/lib/multiFactor.js
+++ b/packages/auth/lib/multiFactor.js
@@ -14,7 +14,7 @@ export class MultiFactorUser {
       user = auth.currentUser;
     }
     this._user = user;
-    this.enrolledFactor = user.multiFactor.enrolledFactors;
+    this.enrolledFactors = user.multiFactor.enrolledFactors;
   }
 
   getSession() {


### PR DESCRIPTION
### Description
the typescript definitions specify it as `enrolledFactors` reflecting that it is an array, but the javascript was actually setting it as `enrolledFactor` at runtime.

the original `enrolledFactor` property is kept for backwards compatibility, but could be removed in a future major version.

ref:
- typings: https://github.com/invertase/react-native-firebase/blob/main/packages/auth/lib/index.d.ts#L568
- android: https://github.com/invertase/react-native-firebase/blob/main/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java#L2476
- ios: https://github.com/invertase/react-native-firebase/blob/main/packages/auth/ios/RNFBAuth/RNFBAuthModule.m#L1681
- web sdk: https://github.com/firebase/firebase-js-sdk/blob/master/packages/auth/src/mfa/mfa_user.ts#L34

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No