### PR TITLE
fix: ios enrollmentDate -> enrollmentTime

### DIFF
--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1686,13 +1686,15 @@ RCT_EXPORT_METHOD(useEmulator
   NSMutableArray *enrolledFactors = [NSMutableArray array];
 
   for (FIRPhoneMultiFactorInfo *hint in hints) {
-    NSString *enrollmentDate =
+    NSString *enrollmentTime =
         [[[NSISO8601DateFormatter alloc] init] stringFromDate:hint.enrollmentDate];
     [enrolledFactors addObject:@{
       @"uid" : hint.UID,
       @"factorId" : [self getJSFactorId:(hint.factorID)],
       @"displayName" : hint.displayName == nil ? [NSNull null] : hint.displayName,
-      @"enrollmentDate" : enrollmentDate,
+      @"enrollmentTime" : enrollmentTime,
+      // @deprecated enrollmentDate kept for backwards compatibility, please use enrollmentTime
+      @"enrollmentDate" : enrollmentTime,
     }];
   }
   return enrolledFactors;


### PR DESCRIPTION
### Description
rename `enrollmentDate` -> `enrollmentTime` on iOS to match Android/Web (ref: https://firebase.google.com/docs/reference/js/auth.multifactorinfo)
    
keep `enrollmentDate` around on ios for backwards compatibility, mark as deprecated.

ref:
- https://github.com/invertase/react-native-firebase/blob/main/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java#L2500
- https://github.com/invertase/react-native-firebase/blob/main/packages/auth/lib/index.d.ts#L483

BREAKING CHANGE: `enrollmentDate` renamed to `enrollmentTime` on iOS

split from #7565

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
