### PR TITLE
fix(storage): bump iOS SDK to v10.22.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -305,7 +305,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '10.21.0'
+$FirebaseSDKVersion = '10.22.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tests:ios:test-reuse": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
     "tests:ios:test-cover": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 ./node_modules/.bin/nyc yarn detox test --configuration ios.sim.debug --loglevel warn",
     "tests:ios:test-cover-reuse": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 node_modules/.bin/nyc yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
-    "tests:ios:pod:install": "cd tests && rm -rf ios/ReactNativeFirebaseDemo.xcworkspace && yarn pod-install",
+    "tests:ios:pod:install": "cd tests && rm -f ios/Podfile.lock && rm -rf ios/ReactNativeFirebaseDemo.xcworkspace && yarn pod-install",
     "format:markdown": "prettier --write \"docs/**/*.md\""
   },
   "devDependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.21.0",
+      "firebase": "10.22.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },


### PR DESCRIPTION
### Description

Since yesterday, we have been getting errors when trying to create an iOS build:

```
(/Users/expo/workingdir/build/packages/app/ios/Pods/FirebaseStorage/FirebaseStorage/Sources/Storage.swift:73:12)

  71 |     let provider = ComponentType<StorageProvider>.instance(for: StorageProvider.self,
  72 |                                                            in: app.container)
> 73 |     return provider.storage(for: Storage.bucket(for: app))
     |            ^ value of optional type '?' must be unwrapped to refer to member 'storage' of wrapped base type 'any StorageProvider'
  74 |   }
  75 | 
  76 |   /**
```

It seems that this issue has already been fixed in the Firebase iOS SDK.

See: https://github.com/firebase/firebase-ios-sdk/commit/1ed6d66b2010539bf21abf66b942dcf89384bd75

```swift
guard let provider = ComponentType<StorageProvider>.instance(for: StorageProvider.self,
                                                                 in: app.container) else {
      fatalError("No \(StorageProvider.self) instance found for Firebase app: \(app.name)")
    }
    return provider.storage(for: Storage.bucket(for: app, urlString: url))
```

### Related issues

- Fixes #7666
- https://github.com/firebase/flutterfire/issues/12429
- https://github.com/firebase/flutterfire/pull/12430

### Release Summary

Upgrade firebase iOS SDK from v10.21.0 to v10.22.0

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
