### PR TITLE
fix(app): react-native 0.74 bridgeless mode compatibility

### DIFF
--- a/packages/app/lib/internal/registry/nativeModule.js
+++ b/packages/app/lib/internal/registry/nativeModule.js
@@ -65,7 +65,8 @@ function nativeModuleWrapped(namespace, NativeModule, argToPrepend) {
     return NativeModule;
   }
 
-  const properties = Object.keys(NativeModule);
+  let properties = Object.keys(Object.getPrototypeOf(NativeModule));
+  if (!properties.length) properties = Object.keys(NativeModule);
 
   for (let i = 0, len = properties.length; i < len; i++) {
     const property = properties[i];

--- a/packages/app/lib/internal/registry/nativeModule.js
+++ b/packages/app/lib/internal/registry/nativeModule.js
@@ -60,7 +60,7 @@ function nativeModuleMethodWrapped(namespace, method, argToPrepend) {
  * @param argToPrepend
  */
 function nativeModuleWrapped(namespace, NativeModule, argToPrepend) {
-  const native = NativeModule;
+  const native = {};
   if (!NativeModule) {
     return NativeModule;
   }
@@ -71,6 +71,8 @@ function nativeModuleWrapped(namespace, NativeModule, argToPrepend) {
     const property = properties[i];
     if (typeof NativeModule[property] === 'function') {
       native[property] = nativeModuleMethodWrapped(namespace, NativeModule[property], argToPrepend);
+    } else {
+      native[property] = NativeModule[property];
     }
   }
 

--- a/packages/app/lib/internal/registry/nativeModule.js
+++ b/packages/app/lib/internal/registry/nativeModule.js
@@ -60,7 +60,7 @@ function nativeModuleMethodWrapped(namespace, method, argToPrepend) {
  * @param argToPrepend
  */
 function nativeModuleWrapped(namespace, NativeModule, argToPrepend) {
-  const native = {};
+  const native = NativeModule;
   if (!NativeModule) {
     return NativeModule;
   }
@@ -71,8 +71,6 @@ function nativeModuleWrapped(namespace, NativeModule, argToPrepend) {
     const property = properties[i];
     if (typeof NativeModule[property] === 'function') {
       native[property] = nativeModuleMethodWrapped(namespace, NativeModule[property], argToPrepend);
-    } else {
-      native[property] = NativeModule[property];
     }
   }
 


### PR DESCRIPTION
### Description

When trying to use `@react-native-firebase/app` with the new architecture and bridgeless mode on (react-native version 0.74.0-rc.3), the user is faced with an unhandled promise rejection 

<img width="446" alt="image" src="https://github.com/invertase/react-native-firebase/assets/11707729/85c7c341-08ac-4809-83ec-50d781db00cd">



Very similar case to https://github.com/react-native-netinfo/react-native-netinfo/pull/717

----
This error happens because of the following code inside nativeModule.js
 
https://github.com/invertase/react-native-firebase/blob/b40d44c57e81a4110cbb4e6204c400cb8f78b00a/packages/app/lib/internal/registry/nativeModule.js#L62-L79

Currently we cannot copy functions  directly from the React Native's NativeModules object, given that the module object is a host object.

After this change everything works as expected and the compatibility layer allows `@react-native-firebase/app` to be used with bridgeless mode on


### Release Summary

Add support for react-native 0.74 bridgeless mode

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Tested running on Android and iOS with: 
- new arch, bridgeless off
- new arch, bridgeless on
- old arch

:fire: