### PR TITLE
fix(app, android): bump google play-services-auth to 21.0.0

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -85,7 +85,7 @@
       "firebaseCrashlyticsGradle": "2.9.9",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.1",
-      "playServicesAuth": "20.7.0"
+      "playServicesAuth": "21.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description

May fix crash seen but not reproduced upstream

### Related issues

- https://github.com/firebase/firebase-android-sdk/issues/5768#issuecomment-2020388078


### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Local run of e2e test + CI

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
