### PR TITLE
feat(deps): firebase-ios-sdk 10.24.0 / codecov ci action / android e2e use 29 for min api

### DIFF
--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -174,7 +174,7 @@ jobs:
             yarn tests:android:test-cover --headless
             yarn tests:android:test:jacoco-report
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           verbose: true
 

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -33,11 +33,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # all APIs below 23, and 27 just do not work
-        # 23-24 appears to work locally but fails in CI
+        # all APIs below 23 just do not work
+        # google-apis doesn't have an emulator for 27
+        # 23-25, 28-29 appears to work locally but fails in CI
         # 26 does not support performance tracing due to hardware acceleration bugs
-        # min-possible + max-possible skew looks like 24 and 34 then
-        api-level: [25, 34]
+        # min-possible + max-possible skew looks like 29 and 34 then
+        api-level: [30, 34]
         arch: [x86_64]
         target: [google_apis]
         # This is useful for benchmarking, do 0, 1, 2, etc (up to 256 max job-per-matrix limit) for averages

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -188,7 +188,7 @@ jobs:
           name: simulator_log
           path: simulator.log
 
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           verbose: true
 

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -54,7 +54,7 @@ jobs:
           command: yarn && yarn lerna:prepare
       - name: Jest
         run: yarn tests:jest-coverage
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           verbose: true
       - uses: actions/cache/save@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -305,7 +305,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '10.23.1'
+$FirebaseSDKVersion = '10.24.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.23.1",
+      "firebase": "10.24.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -815,7 +815,7 @@ PODS:
     - abseil/base/base_internal
     - abseil/base/config
     - abseil/meta/type_traits
-  - AppCheckCore (10.18.1):
+  - AppCheckCore (10.18.2):
     - GoogleUtilities/Environment (~> 7.11)
     - PromisesObjC (~> 2.3)
   - boost (1.83.0)
@@ -834,59 +834,59 @@ PODS:
     - React-Core (= 0.73.4)
     - React-jsi (= 0.73.4)
     - ReactCommon/turbomodule/core (= 0.73.4)
-  - Firebase/Analytics (10.23.1):
+  - Firebase/Analytics (10.24.0):
     - Firebase/Core
-  - Firebase/AppCheck (10.23.1):
+  - Firebase/AppCheck (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 10.23.0)
-  - Firebase/AppDistribution (10.23.1):
+    - FirebaseAppCheck (~> 10.24.0)
+  - Firebase/AppDistribution (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 10.23.0-beta)
-  - Firebase/Auth (10.23.1):
+    - FirebaseAppDistribution (~> 10.24.0-beta)
+  - Firebase/Auth (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.23.0)
-  - Firebase/Core (10.23.1):
+    - FirebaseAuth (~> 10.24.0)
+  - Firebase/Core (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.23.1)
-  - Firebase/CoreOnly (10.23.1):
-    - FirebaseCore (= 10.23.1)
-  - Firebase/Crashlytics (10.23.1):
+    - FirebaseAnalytics (~> 10.24.0)
+  - Firebase/CoreOnly (10.24.0):
+    - FirebaseCore (= 10.24.0)
+  - Firebase/Crashlytics (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.23.0)
-  - Firebase/Database (10.23.1):
+    - FirebaseCrashlytics (~> 10.24.0)
+  - Firebase/Database (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 10.23.0)
-  - Firebase/DynamicLinks (10.23.1):
+    - FirebaseDatabase (~> 10.24.0)
+  - Firebase/DynamicLinks (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.23.0)
-  - Firebase/Firestore (10.23.1):
+    - FirebaseDynamicLinks (~> 10.24.0)
+  - Firebase/Firestore (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.23.0)
-  - Firebase/Functions (10.23.1):
+    - FirebaseFirestore (~> 10.24.0)
+  - Firebase/Functions (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 10.23.0)
-  - Firebase/InAppMessaging (10.23.1):
+    - FirebaseFunctions (~> 10.24.0)
+  - Firebase/InAppMessaging (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 10.23.0-beta)
-  - Firebase/Installations (10.23.1):
+    - FirebaseInAppMessaging (~> 10.24.0-beta)
+  - Firebase/Installations (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 10.23.0)
-  - Firebase/Messaging (10.23.1):
+    - FirebaseInstallations (~> 10.24.0)
+  - Firebase/Messaging (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.23.0)
-  - Firebase/Performance (10.23.1):
+    - FirebaseMessaging (~> 10.24.0)
+  - Firebase/Performance (10.24.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 10.23.0)
-  - Firebase/RemoteConfig (10.23.1):
+    - FirebasePerformance (~> 10.24.0)
+  - Firebase/RemoteConfig (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 10.23.0)
-  - Firebase/Storage (10.23.1):
+    - FirebaseRemoteConfig (~> 10.24.0)
+  - Firebase/Storage (10.24.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.23.0)
-  - FirebaseABTesting (10.23.0):
+    - FirebaseStorage (~> 10.24.0)
+  - FirebaseABTesting (10.24.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseAnalytics (10.23.1):
-    - FirebaseAnalytics/AdIdSupport (= 10.23.1)
+  - FirebaseAnalytics (10.24.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.24.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -894,44 +894,44 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.23.1):
+  - FirebaseAnalytics/AdIdSupport (10.24.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.23.1)
+    - GoogleAppMeasurement (= 10.24.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseAppCheck (10.23.0):
+  - FirebaseAppCheck (10.24.0):
     - AppCheckCore (~> 10.18)
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseAppCheckInterop (10.23.0)
-  - FirebaseAppDistribution (10.23.0-beta):
+  - FirebaseAppCheckInterop (10.24.0)
+  - FirebaseAppDistribution (10.24.0-beta):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-  - FirebaseAuth (10.23.0):
+  - FirebaseAuth (10.24.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.23.0)
-  - FirebaseCore (10.23.1):
+  - FirebaseAuthInterop (10.24.0)
+  - FirebaseCore (10.24.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreExtension (10.23.0):
+  - FirebaseCoreExtension (10.24.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.23.0):
+  - FirebaseCoreInternal (10.24.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.23.0):
+  - FirebaseCrashlytics (10.24.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfigInterop (~> 10.23)
@@ -940,19 +940,19 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (10.23.0):
+  - FirebaseDatabase (10.24.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (10.23.0):
+  - FirebaseDynamicLinks (10.24.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseFirestore (10.23.0):
+  - FirebaseFirestore (10.24.0):
     - FirebaseCore (~> 10.0)
     - FirebaseCoreExtension (~> 10.0)
-    - FirebaseFirestoreInternal (~> 10.17)
+    - FirebaseFirestoreInternal (= 10.24.0)
     - FirebaseSharedSwift (~> 10.0)
-  - FirebaseFirestoreInternal (10.23.0):
+  - FirebaseFirestoreInternal (10.24.0):
     - abseil/algorithm (~> 1.20240116.1)
     - abseil/base (~> 1.20240116.1)
     - abseil/container/flat_hash_map (~> 1.20240116.1)
@@ -967,7 +967,7 @@ PODS:
     - gRPC-Core (~> 1.62.0)
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseFunctions (10.23.0):
+  - FirebaseFunctions (10.24.0):
     - FirebaseAppCheckInterop (~> 10.10)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -975,18 +975,18 @@ PODS:
     - FirebaseMessagingInterop (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseInAppMessaging (10.23.0-beta):
+  - FirebaseInAppMessaging (10.24.0-beta):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseInstallations (10.23.0):
+  - FirebaseInstallations (10.24.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.23.0):
+  - FirebaseMessaging (10.24.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.3)
@@ -995,8 +995,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseMessagingInterop (10.23.0)
-  - FirebasePerformance (10.23.0):
+  - FirebaseMessagingInterop (10.24.0)
+  - FirebasePerformance (10.24.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfig (~> 10.0)
@@ -1006,7 +1006,7 @@ PODS:
     - GoogleUtilities/ISASwizzler (~> 7.8)
     - GoogleUtilities/MethodSwizzler (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (10.23.0):
+  - FirebaseRemoteConfig (10.24.0):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -1014,8 +1014,8 @@ PODS:
     - FirebaseSharedSwift (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseRemoteConfigInterop (10.23.0)
-  - FirebaseSessions (10.23.0):
+  - FirebaseRemoteConfigInterop (10.24.0)
+  - FirebaseSessions (10.24.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -1023,8 +1023,8 @@ PODS:
     - GoogleUtilities/Environment (~> 7.10)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (10.23.0)
-  - FirebaseStorage (10.23.0):
+  - FirebaseSharedSwift (10.24.0)
+  - FirebaseStorage (10.24.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.0)
     - FirebaseCore (~> 10.0)
@@ -1032,27 +1032,27 @@ PODS:
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - GoogleAppMeasurement (10.23.1):
-    - GoogleAppMeasurement/AdIdSupport (= 10.23.1)
+  - GoogleAppMeasurement (10.24.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.24.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.23.1):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.23.1)
+  - GoogleAppMeasurement/AdIdSupport (10.24.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.24.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.23.1):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.24.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurementOnDeviceConversion (10.23.1)
+  - GoogleAppMeasurementOnDeviceConversion (10.24.0)
   - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30911.0, >= 2.30908.0)
@@ -2222,75 +2222,75 @@ PODS:
   - RecaptchaInterop (100.0.0)
   - RNDeviceInfo (10.12.0):
     - React-Core
-  - RNFBAnalytics (19.1.1):
-    - Firebase/Analytics (= 10.23.1)
-    - GoogleAppMeasurementOnDeviceConversion (= 10.23.1)
+  - RNFBAnalytics (19.1.2):
+    - Firebase/Analytics (= 10.24.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (19.1.1):
-    - Firebase/CoreOnly (= 10.23.1)
+  - RNFBApp (19.1.2):
+    - Firebase/CoreOnly (= 10.24.0)
     - React-Core
-  - RNFBAppCheck (19.1.1):
-    - Firebase/AppCheck (= 10.23.1)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (19.1.1):
-    - Firebase/AppDistribution (= 10.23.1)
+  - RNFBAppCheck (19.1.2):
+    - Firebase/AppCheck (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (19.1.1):
-    - Firebase/Auth (= 10.23.1)
+  - RNFBAppDistribution (19.1.2):
+    - Firebase/AppDistribution (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (19.1.1):
-    - Firebase/Crashlytics (= 10.23.1)
+  - RNFBAuth (19.1.2):
+    - Firebase/Auth (= 10.24.0)
+    - React-Core
+    - RNFBApp
+  - RNFBCrashlytics (19.1.2):
+    - Firebase/Crashlytics (= 10.24.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (19.1.1):
-    - Firebase/Database (= 10.23.1)
+  - RNFBDatabase (19.1.2):
+    - Firebase/Database (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (19.1.1):
-    - Firebase/DynamicLinks (= 10.23.1)
+  - RNFBDynamicLinks (19.1.2):
+    - Firebase/DynamicLinks (= 10.24.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (19.1.1):
-    - Firebase/Firestore (= 10.23.1)
+  - RNFBFirestore (19.1.2):
+    - Firebase/Firestore (= 10.24.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (19.1.1):
-    - Firebase/Functions (= 10.23.1)
+  - RNFBFunctions (19.1.2):
+    - Firebase/Functions (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (19.1.1):
-    - Firebase/InAppMessaging (= 10.23.1)
+  - RNFBInAppMessaging (19.1.2):
+    - Firebase/InAppMessaging (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (19.1.1):
-    - Firebase/Installations (= 10.23.1)
+  - RNFBInstallations (19.1.2):
+    - Firebase/Installations (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (19.1.1):
-    - Firebase/Messaging (= 10.23.1)
+  - RNFBMessaging (19.1.2):
+    - Firebase/Messaging (= 10.24.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (19.1.1):
+  - RNFBML (19.1.2):
     - React-Core
     - RNFBApp
-  - RNFBPerf (19.1.1):
-    - Firebase/Performance (= 10.23.1)
+  - RNFBPerf (19.1.2):
+    - Firebase/Performance (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (19.1.1):
-    - Firebase/RemoteConfig (= 10.23.1)
+  - RNFBRemoteConfig (19.1.2):
+    - Firebase/RemoteConfig (= 10.24.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (19.1.1):
-    - Firebase/Storage (= 10.23.1)
+  - RNFBStorage (19.1.2):
+    - Firebase/Storage (= 10.24.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.6.1)
@@ -2555,43 +2555,43 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   abseil: ebec4f56469dd7ce9ab08683c0319a68aa0ad86e
-  AppCheckCore: d0d4bcb6f90fd9f69958da5350467b79026b38c7
+  AppCheckCore: ef7a5f4ae432941d2835c7c9ba14131028aa33bd
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   BoringSSL-GRPC: 1e2348957acdbcad360b80a264a90799984b2ba6
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: 84f6edbe225f38aebd9deaf1540a4160b1f087d7
   FBReactNativeSpec: d0086a479be91c44ce4687a962956a352d2dc697
-  Firebase: cf09623f98ae25a3ad484e23c7e0e5f464152d80
-  FirebaseABTesting: aec61ed9a34d85a95e2013a3fdf051426a2419df
-  FirebaseAnalytics: fd35d51e6da86ef1aa2c3fe1f64ab2482cc01ba5
-  FirebaseAppCheck: 4bb8047366c2c975583c9eff94235f8f2c5b342d
-  FirebaseAppCheckInterop: a1955ce8c30f38f87e7d091630e871e91154d65d
-  FirebaseAppDistribution: 3be8867e5d62391a3c7ee2b5a5e639b456f236b8
-  FirebaseAuth: 22eb85d3853141de7062bfabc131aa7d6335cade
-  FirebaseAuthInterop: a458e398bb1e9b71b9b42d46e54acc666b021d0f
-  FirebaseCore: c43f9f0437b50a965e930cac4ad243200d12a984
-  FirebaseCoreExtension: cb88851781a24e031d1b58e0bd01eb1f46b044b5
-  FirebaseCoreInternal: 6a292e6f0bece1243a737e81556e56e5e19282e3
-  FirebaseCrashlytics: b7aca2d52dd2440257a13741d2909ad80745ac6c
-  FirebaseDatabase: 50f243af7bbf3c7d50faf355b963b1502049d5c5
-  FirebaseDynamicLinks: a900d2f42c1cb12e49c4a657cb1d1a307cef6396
-  FirebaseFirestore: 3478b0580f6c16d895460611b4fcec93955f4717
-  FirebaseFirestoreInternal: 627b23f682c1c2aad38ba1345ed3ca6574c5a89c
-  FirebaseFunctions: cded4f8bab16758f92060133c73c9e9b0747c056
-  FirebaseInAppMessaging: 763a17a4aa1f8f5f67d8cb34962235e8e5b65356
-  FirebaseInstallations: 42d6ead4605d6eafb3b6683674e80e18eb6f2c35
-  FirebaseMessaging: 1b2270e66c81bbf184f70184db1d6a736ad0def5
-  FirebaseMessagingInterop: 4e285daa3ec0522b06c11a675d0c8b952c304689
-  FirebasePerformance: 702cd035354b2d2b2896e128129b978b41d02ad7
-  FirebaseRemoteConfig: 70ebe9542cf5242d762d1c0b4d53bfc472e0a4ce
-  FirebaseRemoteConfigInterop: cbc87ffa4932719a7911a08e94510f18f026f5a7
-  FirebaseSessions: f06853e30f99fe42aa511014d7ee6c8c319f08a3
-  FirebaseSharedSwift: c92645b392db3c41a83a0aa967de16f8bad25568
-  FirebaseStorage: 96fd765b2ef632c53b214057691e257538b8c496
+  Firebase: 91fefd38712feb9186ea8996af6cbdef41473442
+  FirebaseABTesting: 4431c2c56ac6e56f463b9cab05cc111078639f99
+  FirebaseAnalytics: b5efc493eb0f40ec560b04a472e3e1a15d39ca13
+  FirebaseAppCheck: afb42367002c12bbb5f58c4a954ecd2f0a171182
+  FirebaseAppCheckInterop: fecc08c89936c8acb1428d8088313aabedb348e4
+  FirebaseAppDistribution: 5b63bda4675668b41f5db790107eb34e5dc43cc3
+  FirebaseAuth: 711d01cccefaf10035b3090a92956d0dd4f99088
+  FirebaseAuthInterop: 29336ab84df12fc0f340ba5fe58d3e5811a4192d
+  FirebaseCore: 11dc8a16dfb7c5e3c3f45ba0e191a33ac4f50894
+  FirebaseCoreExtension: af5fd85e817ea9d19f9a2659a376cf9cf99f03c0
+  FirebaseCoreInternal: bcb5acffd4ea05e12a783ecf835f2210ce3dc6af
+  FirebaseCrashlytics: af38ea4adfa606f6e63fcc22091b61e7938fcf66
+  FirebaseDatabase: 09752515c6abf792b6f61ca6d0354952a8c1feb9
+  FirebaseDynamicLinks: 96e59750f0c383258c35f5b20e3c18e14b57933a
+  FirebaseFirestore: 6df1bc70a56c15921286ff2a3096fa2d350b8823
+  FirebaseFirestoreInternal: d9a6e08e9bb4016ce7c0b3544f1cf7abcd7cf26f
+  FirebaseFunctions: 9cd2df872ec76f96c205496a4341ac2e9c13f945
+  FirebaseInAppMessaging: a1374493c04fabef91f3ff54b818c5087b98fb67
+  FirebaseInstallations: 8f581fca6478a50705d2bd2abd66d306e0f5736e
+  FirebaseMessaging: 4d52717dd820707cc4eadec5eb981b4832ec8d5d
+  FirebaseMessagingInterop: 85b013ab9a66b8fc8b64dcdc11ff05cc49c6be0c
+  FirebasePerformance: 78fed7cf7907f67af3c1e9667d2d1881765f11e2
+  FirebaseRemoteConfig: 95dddc50496b37eef199dadce850d5652b534b43
+  FirebaseRemoteConfigInterop: 6c349a466490aeace3ce9c091c86be1730711634
+  FirebaseSessions: 2651b464e241c93fd44112f995d5ab663c970487
+  FirebaseSharedSwift: 76e1529c32101d80e4f1ca2fba7c39d59f0a390a
+  FirebaseStorage: 03710f9a0e3824d3069ed1128601a3d3a5e7d817
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  GoogleAppMeasurement: 794d1d2f71fdf77a077a3986258a5c2dac0f9d48
-  GoogleAppMeasurementOnDeviceConversion: 14406f5cba03b7b722aa501e0976402a4b4d4b41
+  GoogleAppMeasurement: f3abf08495ef2cba7829f15318c373b8d9226491
+  GoogleAppMeasurementOnDeviceConversion: e79ed8cfa9df63c5d9d92f430288beb482c75e81
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
   "gRPC-C++": 12f33a422dcab88dcd0c53e52cd549a929f0f244
@@ -2647,23 +2647,23 @@ SPEC CHECKSUMS:
   ReactCommon: dcc65c813041388dead6c8b477444757425ce961
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNDeviceInfo: db5c64a060e66e5db3102d041ebe3ef307a85120
-  RNFBAnalytics: ab742a6a468a324a6a994afc173d6484d6499cba
-  RNFBApp: f57d1f0bb37f379e71ba6f6487752bdc36cb270d
-  RNFBAppCheck: 2a97776884ede9191068c354e2df0020e0baaecb
-  RNFBAppDistribution: 87150e5d18c4bbd4de5461b63ca3e146a4618fb2
-  RNFBAuth: 8df7c798f33f9ef86e300344125e84e369c46abb
-  RNFBCrashlytics: 1701dfbc236a9405faa1ed7502605293e6e13239
-  RNFBDatabase: 0aa93172a0e58a4cdb836948e412e26524a34f0a
-  RNFBDynamicLinks: 67fffcfb1e62552970328e8e2aa3197efde1ec66
-  RNFBFirestore: bb879d4c1b5050bd7d3f650d12ed34f26e1df755
-  RNFBFunctions: 30ff981fce6fb1f6b93598bc350b7cc53465d55c
-  RNFBInAppMessaging: 00b0e07284535766dda9acd6dca62b44c13d78e6
-  RNFBInstallations: d1bbd9d1b23ee94903d016857b2bbdbfc0922c89
-  RNFBMessaging: 4fb5ceb2a4299f7fdf7e7d05ace54ad9383c87df
-  RNFBML: e6096f368eab1ece2bf3067f05dcafc0484c313f
-  RNFBPerf: 246c66888b8fc423a0bf165a72fcad1901b0a990
-  RNFBRemoteConfig: 153c97123bc599027cf2161baafa1f89976f1754
-  RNFBStorage: 70e673e4b82e330250326ba1c5b64aa3858489d3
+  RNFBAnalytics: 51edb80a6be0cabb0cd92e19704fbed5ed7e6309
+  RNFBApp: 94cca19e8b3bfb44214cfe342f375b2c4ead76fb
+  RNFBAppCheck: 259ba2b070c5e8e1606495709bb8e5ce8756751e
+  RNFBAppDistribution: 52bffaed44370abfe0dc13d05725c7a19fbc58a0
+  RNFBAuth: 84a06706027c51b1df7b6690012219e0bfdb12ae
+  RNFBCrashlytics: b083de9edcd9fdb383b901f3bf88735afd457b5b
+  RNFBDatabase: 00da80b8b5dd3ee763572882050749f67c807487
+  RNFBDynamicLinks: 36b2c0667197ca899046aeb7272194249c636c63
+  RNFBFirestore: 7d1302f2a9dfe2ec4a77a889fe727b248d87a265
+  RNFBFunctions: 451d72c0d77d73ffb4bec3a50be35805a76e875e
+  RNFBInAppMessaging: 927532f303ace741edf3deca7556bff2bab95c85
+  RNFBInstallations: fa634f068b1b10ef0df3bb9318dc48f0b19baaf6
+  RNFBMessaging: 10c8871d4a64c812682528e9b1f40d7a8d5999ae
+  RNFBML: 4dfc13666237687e899d8864af4c37eb80c491a2
+  RNFBPerf: bfe638d9254036ebaaffedb5f094df3917730640
+  RNFBRemoteConfig: 6e74b868efe01314b216a4d4bba1b4d5b23955b4
+  RNFBStorage: 257e3ccabaeee9fce6a88fbb262af4799751803f
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
 


### PR DESCRIPTION
### Description

Two small test-only changes as described in summary
One big change in the firebase-ios-sdk update - it's non-breaking but the signed frameworks are a big deal to meet Apple privacy requirements coming in force shortly.

Long road getting to this point on the iOS privacy requirements!

### Related issues

- Fixes #7743 

### Release Summary

conventional commits

### Test Plan

- verify codecov uploaded in ios, android, and jest workflows
- verify the API27 emulator run worked
- run of ios e2e locally, verify it runs in CI

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
