### PR TITLE
docs(messaging): add `use_frameworks` to notification images Podfile code snippet

### DIFF
--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -33,7 +33,7 @@ Ensure that your new extension has access to Firebase/Messaging pod by adding it
 
 ```Ruby
 target 'ImageNotification' do
-  use_frameworks! :linkage => :static 
+  use_frameworks! :linkage => :static
   pod 'Firebase/Messaging'
 end
 ```

--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -33,7 +33,7 @@ Ensure that your new extension has access to Firebase/Messaging pod by adding it
 
 ```Ruby
 target 'ImageNotification' do
-  use_frameworks! :linkage => :static
+  use_frameworks! :linkage => :static 
   pod 'Firebase/Messaging', '~> VERSION_NUMBER' # eg 6.31.0
 end
 ```

--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -34,7 +34,7 @@ Ensure that your new extension has access to Firebase/Messaging pod by adding it
 ```Ruby
 target 'ImageNotification' do
   use_frameworks! :linkage => :static 
-  pod 'Firebase/Messaging', '~> VERSION_NUMBER' # eg 6.31.0
+  pod 'Firebase/Messaging'
 end
 ```
 

--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -33,6 +33,7 @@ Ensure that your new extension has access to Firebase/Messaging pod by adding it
 
 ```Ruby
 target 'ImageNotification' do
+  use_frameworks! :linkage => :static
   pod 'Firebase/Messaging', '~> VERSION_NUMBER' # eg 6.31.0
 end
 ```


### PR DESCRIPTION
Adding:
```
  use_frameworks! :linkage => :static
```

Because we use it on our main target and it solve this error:

```
[!] Unable to integrate the following embedded targets with their respective host targets (a host target is a "parent" target which embeds a "child" target like a framework or extension):

- XXX (true) and ImageNotification (false) do not both set use_frameworks!.
```

### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
