### PR TITLE
feat(analytics): allow custom event parameters for begin_checkout and purchase events

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -272,6 +272,16 @@ describe('Analytics', function () {
         }),
       ).toThrowError('firebase.analytics().logBeginCheckout(*):');
     });
+
+    it('accepts arbitrary custom event parameters', function () {
+      expect(() =>
+        firebase.analytics().logBeginCheckout({
+          value: 123,
+          currency: 'EUR',
+          foo: 'bar',
+        }),
+      ).not.toThrow();
+    });
   });
 
   describe('logGenerateLead()', function () {
@@ -458,6 +468,16 @@ describe('Analytics', function () {
           value: 123,
         }),
       ).toThrowError('firebase.analytics().logPurchase(*):');
+    });
+
+    it('accepts arbitrary custom event parameters', function () {
+      expect(() =>
+        firebase.analytics().logPurchase({
+          value: 123,
+          currency: 'EUR',
+          foo: 'bar',
+        }),
+      ).not.toThrow();
     });
   });
 

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -179,6 +179,10 @@ export namespace FirebaseAnalyticsTypes {
     coupon?: string;
 
     items?: Item[];
+    /**
+     * Custom event parameters.
+     */
+    [key: string]: any;
   }
 
   export interface CampaignDetailsEventParameters {
@@ -334,6 +338,10 @@ export namespace FirebaseAnalyticsTypes {
      * A single ID for a ecommerce group transaction.
      */
     transaction_id?: string;
+    /**
+     * Custom event parameters.
+     */
+    [key: string]: any;
   }
 
   export interface ScreenViewParameters {

--- a/packages/analytics/lib/structs.js
+++ b/packages/analytics/lib/structs.js
@@ -65,7 +65,7 @@ export const AddToWishlist = struct({
   currency: 'string?',
 });
 
-export const BeginCheckout = struct({
+export const BeginCheckout = struct.interface({
   items: struct.optional([Item]),
   value: 'number?',
   currency: 'string?',
@@ -131,7 +131,7 @@ export const Refund = struct({
   transaction_id: 'string?',
 });
 
-export const Purchase = struct({
+export const Purchase = struct.interface({
   affiliation: 'string?',
   coupon: 'string?',
   currency: 'string?',


### PR DESCRIPTION
### Description

Hello, Firebase Web SDK allows these extra params: [begin_checkout](https://github.com/firebase/firebase-js-sdk/blob/b74d8a2115b757d73bd7bf6dba27f9516b380366/packages/analytics/src/api.ts#L350), [purchase](https://github.com/firebase/firebase-js-sdk/blob/b74d8a2115b757d73bd7bf6dba27f9516b380366/packages/analytics/src/api.ts#L480).
Used the solution from a previous similar PR for screen_view events https://github.com/invertase/react-native-firebase/pull/5811
This is useful for easily tracking conversion rates depending on some parameters.

### Release Summary

Allow custom event parameters for begin_checkout and purchase events

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

* Tested on Android and iOS, visible in DebugView
