### PR TITLE
Update Dynamic Link Warning

### DIFF
--- a/docs/dynamic-links/usage/index.md
+++ b/docs/dynamic-links/usage/index.md
@@ -7,7 +7,7 @@ previous: /database/presence-detection
 ---
 
 > [!WARNING]
-> Deprecated: Firebase Dynamic Links is deprecated and should not be adopted in projects that don't already use it. The service will shut down on August 25, 2025. See the [Dynamic Links Deprecation FAQ](https://firebase.google.com/support/dynamic-links-faq) for more information.
+> Deprecated: Firebase Dynamic Links is deprecated and should not be adopted in projects that don't already use it. Functionality for the primary use cases of store/web routing and deferred/regular deep-linking will shut down on August 25, 2025. Firebase Authentication currently uses, and will continue to use, Firebase Dynamic Links to customize Authentication links (passwordless sign in, password reset, etc.) beyond the August 25, 2025 deadline. See the [Dynamic Links Deprecation FAQ](https://firebase.google.com/support/dynamic-links-faq) for more information.
 
 # Installation
 


### PR DESCRIPTION
Firebase Dynamic Links is deprecated for primary use cases of store/web routing and regular/deferred deep-linking.

It is NOT deprecated for the usage of Firebase Authentication.  It is, and will continue to be, required as a dependency for the handling of password reset and password-less sign in links beyond the August 25, 2025 deadline.

### Description

Firebase Dynamic-Links deprecation documentation is currently incomplete.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No
