### PR TITLE
feat(functions): add support for enabling App Check Replay Protection

### DIFF
--- a/packages/functions/android/src/main/java/io/invertase/firebase/functions/UniversalFirebaseFunctionsModule.java
+++ b/packages/functions/android/src/main/java/io/invertase/firebase/functions/UniversalFirebaseFunctionsModule.java
@@ -53,7 +53,9 @@ public class UniversalFirebaseFunctionsModule extends UniversalFirebaseModule {
           FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
           FirebaseFunctions functionsInstance = FirebaseFunctions.getInstance(firebaseApp, region);
 
-          HttpsCallableReference httpReference = functionsInstance.getHttpsCallable(name);
+          HttpsCallableReference httpReference = options.hasKey("requireLimitedUseAppCheckTokens") && options.getBoolean("requireLimitedUseAppCheckTokens")
+              ? functionsInstance.getHttpsCallable(name, new HttpsCallableOptions.Builder().setRequireLimitedUseAppCheckToken(true).build())
+              : functionsInstance.getHttpsCallable(name);
 
           if (options.hasKey("timeout")) {
             httpReference.setTimeout((long) options.getInt("timeout"), TimeUnit.SECONDS);
@@ -81,8 +83,9 @@ public class UniversalFirebaseFunctionsModule extends UniversalFirebaseModule {
           FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
           FirebaseFunctions functionsInstance = FirebaseFunctions.getInstance(firebaseApp, region);
           URL parsedUrl = new URL(url);
-          HttpsCallableReference httpReference =
-              functionsInstance.getHttpsCallableFromUrl(parsedUrl);
+          HttpsCallableReference httpReference = options.hasKey("requireLimitedUseAppCheckTokens") && options.getBoolean("requireLimitedUseAppCheckTokens")
+              ? functionsInstance.getHttpsCallableFromUrl(parsedUrl, new HttpsCallableOptions.Builder().setRequireLimitedUseAppCheckToken(true).build())
+              : functionsInstance.getHttpsCallableFromUrl(parsedUrl);
 
           if (options.hasKey("timeout")) {
             httpReference.setTimeout((long) options.getInt("timeout"), TimeUnit.SECONDS);

--- a/packages/functions/ios/RNFBFunctions/RNFBFunctionsModule.m
+++ b/packages/functions/ios/RNFBFunctions/RNFBFunctionsModule.m
@@ -50,7 +50,10 @@ RCT_EXPORT_METHOD(httpsCallable
     [functions useEmulatorWithHost:host port:[port intValue]];
   }
 
-  FIRHTTPSCallable *callable = [functions HTTPSCallableWithName:name];
+  FIRHTTPSCallable *callable = 
+      (options[@"requireLimitedUseAppCheckTokens"])
+          ? [functions HTTPSCallableWithName:name options:[[FIRHTTPSCallableOptions alloc] initWithRequireLimitedUseAppCheckTokens: [options[@"requireLimitedUseAppCheckTokens"] boolValue]]]
+          : [functions HTTPSCallableWithName:name];
 
   if (options[@"timeout"]) {
     callable.timeoutInterval = [options[@"timeout"] doubleValue];
@@ -102,7 +105,10 @@ RCT_EXPORT_METHOD(httpsCallableFromUrl
 
   NSURL *functionUrl = [NSURL URLWithString:url];
 
-  FIRHTTPSCallable *callable = [functions HTTPSCallableWithURL:functionUrl];
+  FIRHTTPSCallable *callable = 
+      (options[@"requireLimitedUseAppCheckTokens"])
+          ? [functions HTTPSCallableWithURL:functionUrl options:[[FIRHTTPSCallableOptions alloc] initWithRequireLimitedUseAppCheckTokens: [options[@"requireLimitedUseAppCheckTokens"] boolValue]]]
+          : [functions HTTPSCallableWithURL:functionUrl];
 
   if (options[@"timeout"]) {
     callable.timeoutInterval = [options[@"timeout"] doubleValue];

--- a/packages/functions/lib/index.d.ts
+++ b/packages/functions/lib/index.d.ts
@@ -166,6 +166,11 @@ export namespace FirebaseFunctionsTypes {
      * ```
      */
     timeout?: number;
+
+    /**
+     * Whether or not to protect the callable function with a limited-use App Check token.
+     */
+    requireLimitedUseAppCheckTokens?: boolean;
   }
 
   /**


### PR DESCRIPTION
### Description

[This issue](https://github.com/invertase/react-native-firebase/issues/7394) describes the initial App Check Replay Protection implementation, but the corresponding PR doesn't wire up the required calls to make use of this feature with Firebase Functions. The scope of this PR is to enable that.

### Related issues

Related issue: https://github.com/invertase/react-native-firebase/issues/7394

### Release Summary

Add support for enabling App Check Replay Protection when using Firebase Functions

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

:fire:
