### PR TITLE
build(ci): fix patch set generation to handle modern react-native / yarn

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -58,6 +58,9 @@ jobs:
           command: DETOX_DISABLE_POSTINSTALL=1 yarn && yarn lerna:prepare
 
       - name: Create Patches
+        env:
+          # yarn3+ by default disables lockfile alteration in CI. We want it.
+          YARN_ENABLE_IMMUTABLE_INSTALLS: false
         run: |
           PACKAGE_LIST=`find packages -maxdepth 1 -mindepth 1 -type d -exec basename {} \; | egrep -v 'template|invites'`
           mkdir $HOME/packages

--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -85,6 +85,8 @@ jobs:
             if [ -d node_modules/@react-native-firebase/$PACKAGE ]; then
               pushd node_modules/@react-native-firebase
               tar -zxf $HOME/packages/react-native-firebase-${PACKAGE}.tgz
+              # yarn3+ pack does not handle the executable bits on our scripts correctly. Fix.
+              chmod 755 package/ios_config.sh && true
               mv $PACKAGE/package.json package/
               \rm -fr $PACKAGE
               mv package $PACKAGE

--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -77,7 +77,7 @@ jobs:
           npx react-native init template --skip-install --skip-git-init
           cd template
           yarn
-          yarn add patch-package --save-dev
+          yarn add patch-package --dev
           mkdir patches || true
           for PACKAGE in $PACKAGE_LIST; do
             echo "Installing package $PACKAGE into fresh template app, then clobbering with PR version"

--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -71,7 +71,7 @@ jobs:
           done
           ls -la $HOME/packages/
           cd $HOME
-          npx react-native init template --skip-install
+          npx react-native init template --skip-install --skip-git-init
           cd template
           yarn
           yarn add patch-package --save-dev


### PR DESCRIPTION
### Description

react-native 0.74+ tries to init a git repository which doesn't work well for us in CI
react-native 0.74+ uses yarn3+ by default which has 3 problems with our usage:
- it needs `--dev` not `--save-dev` to install a devDependency
- you have to turn off immutability (on by default in CI) for it to init a project like we do
- it does not handle executable bits correctly of our ios_config.sh scripts during the `pack` of our modules

### Release Summary

conventional commits

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Extensive testing during development. After merge, should rebase this out of #7565 and #7774 where pieces of it are also present

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
