### PR TITLE
docs(functions,emulator): Improve functions emulator documentation to highlight region specific difference is setup

### DIFF
--- a/docs/functions/usage/index.md
+++ b/docs/functions/usage/index.md
@@ -51,7 +51,7 @@ To learn more about deploying Functions to Firebase, view the [Writing & Deployi
 
 Whilst developing your application with Cloud Functions, it is possible to run the functions inside of a local emulator.
 
-To call the emulated functions, call the `useEmulator` method exposed by the library:
+To call the emulated functions in the **default** region, call the `useEmulator` method exposed by the library:
 
 ```js
 import functions from '@react-native-firebase/functions';
@@ -59,9 +59,11 @@ import functions from '@react-native-firebase/functions';
 // Use a local emulator in development
 if (__DEV__) {
   // If you are running on a physical device, replace http://localhost with the local ip of your PC. (http://192.168.x.x)
-  firebase.functions().useEmulator('localhost', 5001);
+  functions().useEmulator('localhost', 5001);
 }
 ```
+
+If your functions are deployed on a different region, then please see [Region-specific Functions](#region-specific-functions)
 
 ## Calling an endpoint
 


### PR DESCRIPTION
Improve functions emulator documentation to highlight region specific difference is setup

### Description

Although the documentation has the region specific documentation, I ended up spending about 45 minutes trying all sorts of different workarounds until I found the answer at the bottom of the documentation page.

This is an attempt to make the documentation explicitly call out that the code example works for the default region and in case your functions are deployed in a different region please use the following example.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Documentation change - testing plan not applicable

:fire: