### PR TITLE
feat(app): ios sdk 10.27.0 / android sdk 33.1.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ buildscript {
     // ... other dependencies
     // NOTE: if you are on react-native 0.71 or below, you must not update
     //       the google-services plugin past version 4.3.15 as it requires gradle >= 7.3.0
-    classpath 'com.google.gms:google-services:4.4.1'
+    classpath 'com.google.gms:google-services:4.4.2'
     // Add me --- /\
   }
 }
@@ -290,7 +290,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "33.0.0"
+        bom           : "33.1.0"
       ],
     ],
   ])
@@ -305,7 +305,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '10.25.0'
+$FirebaseSDKVersion = '10.27.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app-distribution/android/build.gradle
+++ b/packages/app-distribution/android/build.gradle
@@ -96,11 +96,11 @@ dependencies {
   api appProject
   implementation platform("com.google.firebase:firebase-bom:${ReactNative.ext.getVersion("firebase", "bom")}")
   // TODO remove the specific version once it is out of beta and participates in bom versioning
-  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta12'
+  implementation 'com.google.firebase:firebase-appdistribution-api:16.0.0-beta13'
   // TODO demonstrate how to only include this in certain build variants
   // - perhaps have firebase.json name the variants to include, then roll through variants here and only
   //   add the dependency to variants that match? Or... (PRs welcome...)
-  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta12'
+  // implementation 'com.google.firebase:firebase-appdistribution:16.0.0-beta13'
 }
 
 ReactNative.shared.applyPackageVersion()

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "10.25.0",
+      "firebase": "10.27.0",
       "iosTarget": "11.0",
       "macosTarget": "10.13"
     },
@@ -81,10 +81,10 @@
       "minSdk": 21,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "33.0.0",
+      "firebase": "33.1.0",
       "firebaseCrashlyticsGradle": "3.0.0",
       "firebasePerfGradle": "1.4.2",
-      "gmsGoogleServicesGradle": "4.4.1",
+      "gmsGoogleServicesGradle": "4.4.2",
       "playServicesAuth": "21.1.1"
     }
   }

--- a/packages/app/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -138,7 +138,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.gms:google-services:4.4.1'
+        classpath 'com.google.gms:google-services:4.4.2'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -31,12 +31,12 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.gms:google-services:4.4.1' // https://developers.google.com/android/guides/google-services-plugin
+    classpath 'com.google.gms:google-services:4.4.2' // https://developers.google.com/android/guides/google-services-plugin
     classpath("com.android.tools.build:gradle:8.4.0")
     classpath("com.facebook.react:react-native-gradle-plugin")
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     classpath 'com.google.firebase:perf-plugin:1.4.2'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.0'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.1'
     classpath 'com.google.firebase:firebase-appdistribution-gradle:5.0.0'
   }
 }

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -959,59 +959,59 @@ PODS:
   - BoringSSL-GRPC/Interface (0.0.32)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.74.1)
-  - Firebase/Analytics (10.25.0):
+  - Firebase/Analytics (10.27.0):
     - Firebase/Core
-  - Firebase/AppCheck (10.25.0):
+  - Firebase/AppCheck (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 10.25.0)
-  - Firebase/AppDistribution (10.25.0):
+    - FirebaseAppCheck (~> 10.27.0)
+  - Firebase/AppDistribution (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 10.25.0-beta)
-  - Firebase/Auth (10.25.0):
+    - FirebaseAppDistribution (~> 10.27.0-beta)
+  - Firebase/Auth (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 10.25.0)
-  - Firebase/Core (10.25.0):
+    - FirebaseAuth (~> 10.27.0)
+  - Firebase/Core (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 10.25.0)
-  - Firebase/CoreOnly (10.25.0):
-    - FirebaseCore (= 10.25.0)
-  - Firebase/Crashlytics (10.25.0):
+    - FirebaseAnalytics (~> 10.27.0)
+  - Firebase/CoreOnly (10.27.0):
+    - FirebaseCore (= 10.27.0)
+  - Firebase/Crashlytics (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 10.25.0)
-  - Firebase/Database (10.25.0):
+    - FirebaseCrashlytics (~> 10.27.0)
+  - Firebase/Database (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 10.25.0)
-  - Firebase/DynamicLinks (10.25.0):
+    - FirebaseDatabase (~> 10.27.0)
+  - Firebase/DynamicLinks (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.25.0)
-  - Firebase/Firestore (10.25.0):
+    - FirebaseDynamicLinks (~> 10.27.0)
+  - Firebase/Firestore (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 10.25.0)
-  - Firebase/Functions (10.25.0):
+    - FirebaseFirestore (~> 10.27.0)
+  - Firebase/Functions (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 10.25.0)
-  - Firebase/InAppMessaging (10.25.0):
+    - FirebaseFunctions (~> 10.27.0)
+  - Firebase/InAppMessaging (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 10.25.0-beta)
-  - Firebase/Installations (10.25.0):
+    - FirebaseInAppMessaging (~> 10.27.0-beta)
+  - Firebase/Installations (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 10.25.0)
-  - Firebase/Messaging (10.25.0):
+    - FirebaseInstallations (~> 10.27.0)
+  - Firebase/Messaging (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.25.0)
-  - Firebase/Performance (10.25.0):
+    - FirebaseMessaging (~> 10.27.0)
+  - Firebase/Performance (10.27.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 10.25.0)
-  - Firebase/RemoteConfig (10.25.0):
+    - FirebasePerformance (~> 10.27.0)
+  - Firebase/RemoteConfig (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 10.25.0)
-  - Firebase/Storage (10.25.0):
+    - FirebaseRemoteConfig (~> 10.27.0)
+  - Firebase/Storage (10.27.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 10.25.0)
-  - FirebaseABTesting (10.25.0):
+    - FirebaseStorage (~> 10.27.0)
+  - FirebaseABTesting (10.27.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseAnalytics (10.25.0):
-    - FirebaseAnalytics/AdIdSupport (= 10.25.0)
+  - FirebaseAnalytics (10.27.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.27.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
@@ -1019,45 +1019,45 @@ PODS:
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseAnalytics/AdIdSupport (10.25.0):
+  - FirebaseAnalytics/AdIdSupport (10.27.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
-    - GoogleAppMeasurement (= 10.25.0)
+    - GoogleAppMeasurement (= 10.27.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseAppCheck (10.25.0):
+  - FirebaseAppCheck (10.27.0):
     - AppCheckCore (~> 10.19)
     - FirebaseAppCheckInterop (~> 10.17)
-    - FirebaseCore (~> 10.0)
+    - FirebaseCore (~> 10.18)
     - GoogleUtilities/Environment (~> 7.13)
     - GoogleUtilities/UserDefaults (~> 7.13)
     - PromisesObjC (~> 2.1)
-  - FirebaseAppCheckInterop (10.25.0)
-  - FirebaseAppDistribution (10.25.0-beta):
+  - FirebaseAppCheckInterop (10.27.0)
+  - FirebaseAppDistribution (10.27.0-beta):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
-  - FirebaseAuth (10.25.0):
+  - FirebaseAuth (10.27.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
     - GoogleUtilities/Environment (~> 7.8)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (10.25.0)
-  - FirebaseCore (10.25.0):
+  - FirebaseAuthInterop (10.27.0)
+  - FirebaseCore (10.27.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreExtension (10.25.0):
+  - FirebaseCoreExtension (10.27.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseCoreInternal (10.25.0):
+  - FirebaseCoreInternal (10.27.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseCrashlytics (10.25.0):
+  - FirebaseCrashlytics (10.27.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfigInterop (~> 10.23)
@@ -1066,20 +1066,20 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesObjC (~> 2.1)
-  - FirebaseDatabase (10.25.0):
+  - FirebaseDatabase (10.27.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - GoogleUtilities/UserDefaults (~> 7.13)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (10.25.0):
+  - FirebaseDynamicLinks (10.27.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseFirestore (10.25.0):
+  - FirebaseFirestore (10.27.0):
     - FirebaseCore (~> 10.0)
     - FirebaseCoreExtension (~> 10.0)
-    - FirebaseFirestoreInternal (= 10.25.0)
+    - FirebaseFirestoreInternal (= 10.27.0)
     - FirebaseSharedSwift (~> 10.0)
-  - FirebaseFirestoreInternal (10.25.0):
+  - FirebaseFirestoreInternal (10.27.0):
     - abseil/algorithm (~> 1.20240116.1)
     - abseil/base (~> 1.20240116.1)
     - abseil/container/flat_hash_map (~> 1.20240116.1)
@@ -1094,7 +1094,7 @@ PODS:
     - gRPC-Core (~> 1.62.0)
     - leveldb-library (~> 1.22)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseFunctions (10.25.0):
+  - FirebaseFunctions (10.27.0):
     - FirebaseAppCheckInterop (~> 10.10)
     - FirebaseAuthInterop (~> 10.25)
     - FirebaseCore (~> 10.0)
@@ -1102,19 +1102,19 @@ PODS:
     - FirebaseMessagingInterop (~> 10.0)
     - FirebaseSharedSwift (~> 10.0)
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
-  - FirebaseInAppMessaging (10.25.0-beta):
+  - FirebaseInAppMessaging (10.27.0-beta):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleUtilities/Environment (~> 7.13)
     - GoogleUtilities/UserDefaults (~> 7.13)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseInstallations (10.25.0):
+  - FirebaseInstallations (10.27.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.25.0):
+  - FirebaseMessaging (10.27.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.3)
@@ -1123,8 +1123,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseMessagingInterop (10.25.0)
-  - FirebasePerformance (10.25.0):
+  - FirebaseMessagingInterop (10.27.0)
+  - FirebasePerformance (10.27.0):
     - FirebaseCore (~> 10.5)
     - FirebaseInstallations (~> 10.0)
     - FirebaseRemoteConfig (~> 10.0)
@@ -1135,7 +1135,7 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 7.13)
     - GoogleUtilities/UserDefaults (~> 7.13)
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - FirebaseRemoteConfig (10.25.0):
+  - FirebaseRemoteConfig (10.27.0):
     - FirebaseABTesting (~> 10.0)
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -1143,8 +1143,8 @@ PODS:
     - FirebaseSharedSwift (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseRemoteConfigInterop (10.25.0)
-  - FirebaseSessions (10.25.0):
+  - FirebaseRemoteConfigInterop (10.27.0)
+  - FirebaseSessions (10.27.0):
     - FirebaseCore (~> 10.5)
     - FirebaseCoreExtension (~> 10.0)
     - FirebaseInstallations (~> 10.0)
@@ -1153,8 +1153,8 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.13)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (10.25.0)
-  - FirebaseStorage (10.25.0):
+  - FirebaseSharedSwift (10.27.0)
+  - FirebaseStorage (10.27.0):
     - FirebaseAppCheckInterop (~> 10.0)
     - FirebaseAuthInterop (~> 10.25)
     - FirebaseCore (~> 10.0)
@@ -1163,27 +1163,27 @@ PODS:
     - GTMSessionFetcher/Core (< 4.0, >= 2.1)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - GoogleAppMeasurement (10.25.0):
-    - GoogleAppMeasurement/AdIdSupport (= 10.25.0)
+  - GoogleAppMeasurement (10.27.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.27.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurement/AdIdSupport (10.25.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.25.0)
+  - GoogleAppMeasurement/AdIdSupport (10.27.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.27.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (10.25.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.27.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
     - GoogleUtilities/MethodSwizzler (~> 7.11)
     - GoogleUtilities/Network (~> 7.11)
     - "GoogleUtilities/NSData+zlib (~> 7.11)"
     - nanopb (< 2.30911.0, >= 2.30908.0)
-  - GoogleAppMeasurementOnDeviceConversion (10.25.0)
+  - GoogleAppMeasurementOnDeviceConversion (10.27.0)
   - GoogleDataTransport (9.4.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30911.0, >= 2.30908.0)
@@ -2471,75 +2471,75 @@ PODS:
   - RecaptchaInterop (100.0.0)
   - RNDeviceInfo (10.13.2):
     - React-Core
-  - RNFBAnalytics (19.2.2):
-    - Firebase/Analytics (= 10.25.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 10.25.0)
+  - RNFBAnalytics (20.0.0):
+    - Firebase/Analytics (= 10.27.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (19.2.2):
-    - Firebase/CoreOnly (= 10.25.0)
+  - RNFBApp (20.0.0):
+    - Firebase/CoreOnly (= 10.27.0)
     - React-Core
-  - RNFBAppCheck (19.2.2):
-    - Firebase/AppCheck (= 10.25.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (19.2.2):
-    - Firebase/AppDistribution (= 10.25.0)
+  - RNFBAppCheck (20.0.0):
+    - Firebase/AppCheck (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (19.2.2):
-    - Firebase/Auth (= 10.25.0)
+  - RNFBAppDistribution (20.0.0):
+    - Firebase/AppDistribution (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (19.2.2):
-    - Firebase/Crashlytics (= 10.25.0)
+  - RNFBAuth (20.0.0):
+    - Firebase/Auth (= 10.27.0)
+    - React-Core
+    - RNFBApp
+  - RNFBCrashlytics (20.0.0):
+    - Firebase/Crashlytics (= 10.27.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (19.2.2):
-    - Firebase/Database (= 10.25.0)
+  - RNFBDatabase (20.0.0):
+    - Firebase/Database (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (19.2.2):
-    - Firebase/DynamicLinks (= 10.25.0)
+  - RNFBDynamicLinks (20.0.0):
+    - Firebase/DynamicLinks (= 10.27.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (19.2.2):
-    - Firebase/Firestore (= 10.25.0)
+  - RNFBFirestore (20.0.0):
+    - Firebase/Firestore (= 10.27.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (19.2.2):
-    - Firebase/Functions (= 10.25.0)
+  - RNFBFunctions (20.0.0):
+    - Firebase/Functions (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (19.2.2):
-    - Firebase/InAppMessaging (= 10.25.0)
+  - RNFBInAppMessaging (20.0.0):
+    - Firebase/InAppMessaging (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (19.2.2):
-    - Firebase/Installations (= 10.25.0)
+  - RNFBInstallations (20.0.0):
+    - Firebase/Installations (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (19.2.2):
-    - Firebase/Messaging (= 10.25.0)
+  - RNFBMessaging (20.0.0):
+    - Firebase/Messaging (= 10.27.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (19.2.2):
+  - RNFBML (20.0.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (19.2.2):
-    - Firebase/Performance (= 10.25.0)
+  - RNFBPerf (20.0.0):
+    - Firebase/Performance (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (19.2.2):
-    - Firebase/RemoteConfig (= 10.25.0)
+  - RNFBRemoteConfig (20.0.0):
+    - Firebase/RemoteConfig (= 10.27.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (19.2.2):
-    - Firebase/Storage (= 10.25.0)
+  - RNFBStorage (20.0.0):
+    - Firebase/Storage (= 10.27.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.7.0)
@@ -2824,37 +2824,37 @@ SPEC CHECKSUMS:
   BoringSSL-GRPC: 1e2348957acdbcad360b80a264a90799984b2ba6
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: 898d14d17bf19e2435cafd9ea2a1033efe445709
-  Firebase: 0312a2352584f782ea56f66d91606891d4607f06
-  FirebaseABTesting: e6e3c3e0e35813874f571d1b7bdae2aab319dd38
-  FirebaseAnalytics: ec00fe8b93b41dc6fe4a28784b8e51da0647a248
-  FirebaseAppCheck: 148fa858b8070710c8f83d3f545b5f1e85d104a4
-  FirebaseAppCheckInterop: 5da5ce93e8797a215e3f677fb0654b74e736c8b8
-  FirebaseAppDistribution: 6e834c729b23f394a389dc1333d384ca5e077419
-  FirebaseAuth: c0f93dcc570c9da2bffb576969d793e95c344fbb
-  FirebaseAuthInterop: 2753ef68cb3cd5aefebe0f58082671cede78350f
-  FirebaseCore: 7ec4d0484817f12c3373955bc87762d96842d483
-  FirebaseCoreExtension: 8a47811d0b155501559ef05d089518152a0a1677
-  FirebaseCoreInternal: 910a81992c33715fec9263ca7381d59ab3a750b7
-  FirebaseCrashlytics: 4b96efb0ce73b38b2a85e8b8bd1bd8f63f09d015
-  FirebaseDatabase: faa489a42f5f868d23a55dd442d6e2099348458e
-  FirebaseDynamicLinks: 12c9f5b643943e0565ed28080373f89cbcb914a3
-  FirebaseFirestore: 977ccc27a3caa5d68279f209c3b0450f85b9dc5f
-  FirebaseFirestoreInternal: 04b8afa77b4e5b84e86ab5ad985193e9573239fa
-  FirebaseFunctions: 93b1c7f352aec3922925a0e856cb1d6a09197083
-  FirebaseInAppMessaging: 7baba5c4610a12f0cadd6da00e1b3c90495f105b
-  FirebaseInstallations: 91950fe859846fff0fbd296180909dd273103b09
-  FirebaseMessaging: 88950ba9485052891ebe26f6c43a52bb62248952
-  FirebaseMessagingInterop: 326242e7641e6acd4232151f8cec095720f980b9
-  FirebasePerformance: bae7778c4448b37f2a75cb72d30c2df7d10ff227
-  FirebaseRemoteConfig: 9f3935cefecd85d5b312192117f444957de24a75
-  FirebaseRemoteConfigInterop: b25018791b204c0d78a90e394d6c62d9b1f22da8
-  FirebaseSessions: c0939656253a1fa0e94ecc266ccf770cc8b33732
-  FirebaseSharedSwift: 0274086954b1b2d5fd7e829eccc587044d72a4ba
-  FirebaseStorage: 44f4e25073f6fa0d4d8c09f5bec299ee9e4eb985
+  Firebase: 26b040b20866a55f55eb3611b9fcf3ae64816b86
+  FirebaseABTesting: 038a7d5f1e36ba7208cf34f6f596946d8f70d6c3
+  FirebaseAnalytics: f9211b719db260cc91aebee8bb539cb367d0dfd1
+  FirebaseAppCheck: 2395c0d724d32911bba468f1ffde26d836a8d3ec
+  FirebaseAppCheckInterop: 0dd062c9926a76332ca5711dbed6f1a9ac540b54
+  FirebaseAppDistribution: 96444753d420dc589e053c40b3d5a99e61566383
+  FirebaseAuth: 77a012b7e08042bf44d0db835ca2e86e6ca7bbd3
+  FirebaseAuthInterop: 0344acef098654eaf59f6add4c93254349bc5de4
+  FirebaseCore: a2b95ae4ce7c83ceecfbbbe3b6f1cddc7415a808
+  FirebaseCoreExtension: 4ec89dd0c6de93d6becde32122d68b7c35f6bf5d
+  FirebaseCoreInternal: 4b297a2d56063dbea2c1d0d04222d44a8d058862
+  FirebaseCrashlytics: 81ea6ec96519388687f6061beb838a8eec482293
+  FirebaseDatabase: 0e7f9f98f425a92b16a06cf9ca09810456e2dc80
+  FirebaseDynamicLinks: 087bf18ffabe8b6abe0c80301fd16ba2225ce373
+  FirebaseFirestore: 7169b75e7db8f9796d4130e3c2157ed444f100d4
+  FirebaseFirestoreInternal: 7ba63f170a554ae49392da44f9430e5b7915a7ff
+  FirebaseFunctions: d95bacf9a201ebabd2df7d2412281538016a07dd
+  FirebaseInAppMessaging: bcf768c1b0b4825c91c94fe25c5abcbd6ee08c1d
+  FirebaseInstallations: 766dabca09fd94aef922538aaf144cc4a6fb6869
+  FirebaseMessaging: 585984d0a1df120617eb10b44cad8968b859815e
+  FirebaseMessagingInterop: 8e911a5387664e849d316c5cd257c33fa1d37529
+  FirebasePerformance: a8f82970bbae75d9b0088696c31246e90e56d30b
+  FirebaseRemoteConfig: 37a2ba3c8c454be8553a41ba1a2f4a4f0b845670
+  FirebaseRemoteConfigInterop: c55a739f5ab121792776e191d9fd437dc624a541
+  FirebaseSessions: 2fdf949f9e58295a57703ae8f2efc44f9fa3aa16
+  FirebaseSharedSwift: a03fe7a59ee646fef71099a887f774fe25d745b8
+  FirebaseStorage: 255526c3d04c49874d7a5e3886964a79f77d6f33
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  GoogleAppMeasurement: 9abf64b682732fed36da827aa2a68f0221fd2356
-  GoogleAppMeasurementOnDeviceConversion: b0a3f476505bf2eaa79a2bddd5cad1d42d4846b0
+  GoogleAppMeasurement: f65fc137531af9ad647f1c0a42f3b6a4d3a98049
+  GoogleAppMeasurementOnDeviceConversion: fe2fdb4051ddc1d107aaaef3f330a96eb85833a6
   GoogleDataTransport: 6c09b596d841063d76d4288cc2d2f42cc36e1e2a
   GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
   "gRPC-C++": e725ef63c4475d7cdb7e2cf16eb0fde84bd9ee51
@@ -2915,26 +2915,26 @@ SPEC CHECKSUMS:
   ReactCommon: eb4c4a9c43fcc0d93f922d0fdada24638429e515
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNDeviceInfo: 42aadf1282ffa0a88dc38a504a7be145eb010dfa
-  RNFBAnalytics: 8ad6cdf10e9e06627bad71f3423d223ed594e32b
-  RNFBApp: 7e48f531f96372478041fd5662ed33de301e3a0f
-  RNFBAppCheck: b4c6dbee857cce5e73e65ad072f12fa93808def0
-  RNFBAppDistribution: 47fcfb81278fcde39cedace7bdb0f3b4b4c7725a
-  RNFBAuth: 5511f104a47a9236874e7d29e93a1f069a8f2fa0
-  RNFBCrashlytics: 2f75acbe3b2ae0e359b3fe183e4241a7f6e175cc
-  RNFBDatabase: 924a83a6ba67272e0f48db7f73db318aca8ea370
-  RNFBDynamicLinks: f021d7810850465ba80cf249958ad3d1af70cbc5
-  RNFBFirestore: 5241bd408f2e0266e16282b14aab90cfdb04ab96
-  RNFBFunctions: ae4fbca6f410f0c2b4aa6318519196e52184bf46
-  RNFBInAppMessaging: 6b4b0ed7559ce30bc89f7f18e1bde3f8f422f7a5
-  RNFBInstallations: 89f56aa4fe8afaa026e6d5583020cc906e075deb
-  RNFBMessaging: 046392d618af6a69554b6d7930074c3538e5feb9
-  RNFBML: db53076bf007dd84b755e7d412656a35cd6ec489
-  RNFBPerf: aa2975d4d9a7cce6a15f70d69f10ec444ee32902
-  RNFBRemoteConfig: 9f8a0437b6d4da93ee3d45615ce7d41d9aff4cfe
-  RNFBStorage: 1013da9ddf4aab98b956c66531d2568bd3ea4b9f
+  RNFBAnalytics: 93faa022cda0a11e568e32915d27b7f3d323879f
+  RNFBApp: e8741d453a1602371d6da7edc9483d3001cddcaa
+  RNFBAppCheck: 0f90c99edb6c99a699976d81cb1d7767bddb01f1
+  RNFBAppDistribution: f7ec542f682fc907a4782e09b538f1c260a86675
+  RNFBAuth: 7624bf5bdeee9a22613f4fb948ab052627e6b0a8
+  RNFBCrashlytics: 1fd8ee4d464b551fe09f2965b1400a6fa875035e
+  RNFBDatabase: 179b9315e5ac3344f928b4ab1a8b444c1d3cf496
+  RNFBDynamicLinks: 563db0ee2ec286ae1a49509860c81361e3000b56
+  RNFBFirestore: f2455a94b3388c193c78910468c0f7ffbae4f578
+  RNFBFunctions: 9ad149b1f1bfa190eb6d19fd3b0a233860a0c331
+  RNFBInAppMessaging: 01aa6e53050d659836f6d7e44fd11a4e90d9bdc8
+  RNFBInstallations: 968344e65f14b4a8725e22b7e3fdb90a38fbc471
+  RNFBMessaging: 75ce4a5ed174750c56d5bf8d04ccf9fe0c3a2f25
+  RNFBML: f4bc3f12dd4a2f71cfbe1b1fd2e39be552972823
+  RNFBPerf: 062cbe8a174870792c631543cfa276300672e726
+  RNFBRemoteConfig: 253b3be4e9972442229667b9fc543dc215cbbd54
+  RNFBStorage: f7766f48a4b96b4e91e6e85b0297e65eb400aee9
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: dafebc41bc66910af33077aaa41078e89fd635bf
 
-PODFILE CHECKSUM: 25b65c6c22d7b3ec69e8718f88b230cbaf4e2e23
+PODFILE CHECKSUM: a83a0adae6210dd30029d996615dde4180bdab0f
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION

Pretty standard update, however the android tests are failing for me locally, so I expect an e2e android test failure here, in the database test suite

If that occurs obviously will need to investigate for root cause, and even if it does not occur then I will need to determine what the environmental difference is such that it fails for me locally but not in CI

We'll see...