### PR TITLE
fix(crashlytics, ios): init w/componentsToRegister vs configureWithApp

### DIFF
--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.h
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.h
@@ -30,8 +30,4 @@
 /// FIRApp and participate in dependency resolution and injection.
 + (NSArray<FIRComponent *> *)componentsToRegister;
 
-/// Implement this method if the library needs notifications for lifecycle events. This method is
-/// called when the developer calls `FirebaseApp.configure()`.
-+ (void)configureWithApp:(FIRApp *)app;
-
 @end


### PR DESCRIPTION

### Description

configureWithApp is scheduled for removal upstream, the initialization logic we need to execute appears to operate fine in componentsToRegister

@ncooke3 - it can't really be this easy can it? I'm immediately suspicious, but...the logic seems to execute just fine - the logic we execute is idempotent as well, so it's okay if it executes more than once so long as it executes at least once...

### Related issues

Fixes:
- Fixes #4241

### Release Summary

conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

If you see "RNFBCrashlyticsInit initialization successful" in the iOS log file while running `yarn tests:ios:test` with this change, the initialization logic executed

You may see that by following our standard crashlytics configuration / testing advice blog which tells you to run this:

> xcrun simctl spawn booted log stream --level debug --style compact |grep RNFBCrashlyticsInit

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
