### PR TITLE
docs(notifications): iOS entitlements

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -12,6 +12,7 @@ APNs
 AppAttest
 AppCheck
 AppDelegate.m
+aps-environment
 async
 ATT
 ATT-compatible
@@ -138,6 +139,7 @@ pre-configured
 pre-fetched
 pre-release
 pre-rendered
+prebuild
 preflight
 preloaded
 prepended
@@ -163,6 +165,7 @@ screenview
 scrollable
 SDK
 SDK.
+SDK51
 SDKs
 SDKs.
 serverless

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -30,6 +30,24 @@ cd ios/ && pod install
 If you're using an older version of React Native without auto-linking support, or wish to integrate into an existing project,
 you can follow the manual installation steps for [iOS](/messaging/usage/installation/ios) and [Android](/messaging/usage/installation/android).
 
+
+# Expo
+
+## iOS - Notifications entitlement
+Since Expo SDK51, Notifications entitlement is no longer always added to iOS projects during prebuild. If your project uses push notifications, you may need to add the aps-environment entitlement to your app config:
+
+```json
+{
+  "expo": {
+    "ios": {
+      "entitlements": {
+        "aps-environment": “production”
+      }
+    }
+  }
+}
+```
+
 # What does it do
 
 React Native Firebase provides native integration of Firebase Cloud Messaging (FCM) for both Android & iOS. FCM is a cost

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -30,10 +30,10 @@ cd ios/ && pod install
 If you're using an older version of React Native without auto-linking support, or wish to integrate into an existing project,
 you can follow the manual installation steps for [iOS](/messaging/usage/installation/ios) and [Android](/messaging/usage/installation/android).
 
-
 # Expo
 
 ## iOS - Notifications entitlement
+
 Since Expo SDK51, Notifications entitlement is no longer always added to iOS projects during prebuild. If your project uses push notifications, you may need to add the aps-environment entitlement to your app config:
 
 ```json


### PR DESCRIPTION


### Description

Since Expo SDK51, Notifications entitlement is no longer always added to iOS projects during prebuild

See : [SDK51 changelog](https://expo.dev/changelog/2024/05-07-sdk-51#deprecations-renamings-and-removals)

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`


Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
