### PR TITLE
fix(messaging, ios): fixed isHeadless for react-native-navigation

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
@@ -96,8 +96,8 @@
 
   if (notification.userInfo[UIApplicationLaunchOptionsRemoteNotificationKey]) {
     if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
+      isHeadless = YES;
       if (rctRootView != nil) {
-        isHeadless = YES;
         NSMutableDictionary *appPropertiesDict = rctRootView.appProperties != nil
                                                      ? [rctRootView.appProperties mutableCopy]
                                                      : [NSMutableDictionary dictionary];
@@ -120,8 +120,8 @@
       [[UIApplication sharedApplication] registerForRemoteNotifications];
       // #endif
     } else {
+      isHeadless = NO;
       if (rctRootView != nil) {
-        isHeadless = NO;
         NSMutableDictionary *appPropertiesDict = rctRootView.appProperties != nil
                                                      ? [rctRootView.appProperties mutableCopy]
                                                      : [NSMutableDictionary dictionary];
@@ -133,8 +133,8 @@
       }
     }
   } else {
+    isHeadless = NO;
     if (rctRootView != nil) {
-      isHeadless = NO;
       NSMutableDictionary *appPropertiesDict = rctRootView.appProperties != nil
                                                    ? [rctRootView.appProperties mutableCopy]
                                                    : [NSMutableDictionary dictionary];
@@ -148,6 +148,7 @@
 }
 
 - (void)application_onDidEnterForeground {
+  isHeadless = NO;
   if ([UIApplication sharedApplication].delegate != nil &&
       [UIApplication sharedApplication].delegate.window != nil &&
       [UIApplication sharedApplication].delegate.window.rootViewController != nil &&
@@ -160,7 +161,6 @@
     if (rctRootView.appProperties != nil &&
         [rctRootView.appProperties[@"isHeadless"] isEqual:@(YES)]) {
       NSMutableDictionary *appPropertiesDict = [rctRootView.appProperties mutableCopy];
-      isHeadless = NO;
       if ([appPropertiesDict objectForKey:@"isHeadless"] != nil &&
           [appPropertiesDict[@"isHeadless"] isEqual:@([RCTConvert BOOL:@(YES)])]) {
         appPropertiesDict[@"isHeadless"] = @([RCTConvert BOOL:@(isHeadless)]);


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

#6429

### Release Summary

Moved the setter of `isHeadless` to before the check for rctView that does not exists on *react-native-navigation*

![image](https://github.com/invertase/react-native-firebase/assets/66485277/7f9edd0c-cc5e-4096-8dc8-e37efbc4018b)


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
I sent a remote notification with content-available to true, and opened the app before it shut itself down.
![image](https://github.com/invertase/react-native-firebase/assets/66485277/f2f33f80-fa55-4ed4-afc9-fe65acac755f)
