### PR TITLE
fix(firestore): remove exception throw on inequality queries on different fields

### DIFF
--- a/.github/workflows/scripts/firestore.indexes.json
+++ b/.github/workflows/scripts/firestore.indexes.json
@@ -11,6 +11,14 @@
         {
           "fieldPath": "b",
           "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "foo.bar",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "baz",
+          "order": "ASCENDING"
         }
       ]
     }

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -96,18 +96,23 @@ describe('firestore().collection().where()', function () {
       firebase.firestore().collection(COLLECTION).where('foo.bar', '!=', null);
     });
 
-    it('throws if multiple inequalities on different paths is provided', function () {
-      try {
-        firebase
-          .firestore()
-          .collection(COLLECTION)
-          .where('foo.bar', '>', 123)
-          .where('bar', '>', 123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql('All where filters with an inequality');
-        return Promise.resolve();
-      }
+    it('allows multiple inequalities (excluding `!=`) on different paths provided', async function () {
+      const colRef = firebase
+        .firestore()
+        .collection(`${COLLECTION}/filter/different-path-inequality`);
+      const expected = { foo: { bar: 300 }, bar: 200 };
+      await Promise.all([
+        colRef.add({ foo: { bar: 1 }, bar: 1 }),
+        colRef.add(expected),
+        colRef.add(expected),
+      ]);
+
+      const snapshot = await colRef.where('foo.bar', '>', 123).where('bar', '>', 123).get();
+
+      snapshot.size.should.eql(2);
+      snapshot.forEach(s => {
+        s.data().should.eql(jet.contextify(expected));
+      });
     });
 
     it('allows inequality on the same path', function () {
@@ -520,38 +525,22 @@ describe('firestore().collection().where()', function () {
       }
     });
 
-    it("should throw error when combining '!=' operator with any other inequality operator on a different field", async function () {
-      const ref = firebase.firestore().collection(COLLECTION);
+    it("should allow query when combining '!=' operator with any other inequality operator on a different field", async function () {
+      const colRef = firebase
+        .firestore()
+        .collection(`${COLLECTION}/filter/inequality-combine-not-equal`);
+      const expected = { foo: { bar: 300 }, bar: 200 };
+      await Promise.all([
+        colRef.add({ foo: { bar: 1 }, bar: 1 }),
+        colRef.add(expected),
+        colRef.add(expected),
+      ]);
 
-      try {
-        ref.where('test', '!=', 1).where('differentField', '>', 1);
-        return Promise.reject(new Error('Did not throw an Error on >.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
-
-      try {
-        ref.where('test', '!=', 1).where('differentField', '<', 1);
-        return Promise.reject(new Error('Did not throw an Error on <.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
-
-      try {
-        ref.where('test', '!=', 1).where('differentField', '<=', 1);
-        return Promise.reject(new Error('Did not throw an Error <=.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
-
-      try {
-        ref.where('test', '!=', 1).where('differentField', '>=', 1);
-        return Promise.reject(new Error('Did not throw an Error >=.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
-
-      return Promise.resolve();
+      const snapshot = await colRef.where('foo.bar', '>', 123).where('bar', '!=', 123).get();
+      snapshot.size.should.eql(2);
+      snapshot.forEach(s => {
+        s.data().should.eql(jet.contextify(expected));
+      });
     });
 
     it('should handle where clause after sort by', async function () {
@@ -659,19 +648,28 @@ describe('firestore().collection().where()', function () {
       query(collection(getFirestore(), COLLECTION), where('foo.bar', '!=', null));
     });
 
-    it('throws if multiple inequalities on different paths is provided', function () {
-      const { getFirestore, collection, query, where } = firestoreModular;
-      try {
-        query(
-          collection(getFirestore(), COLLECTION),
-          where('foo.bar', '>', 123),
-          where('bar', '>', 123),
-        );
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql('All where filters with an inequality');
-        return Promise.resolve();
-      }
+    it('allows multiple inequalities (excluding `!=`) on different paths provided', async function () {
+      const { query, where } = firestoreModular;
+
+      const colRef = firebase
+        .firestore()
+        .collection(`${COLLECTION}/filter/different-path-inequality`);
+      const expected = { foo: { bar: 300 }, bar: 200 };
+      await Promise.all([
+        colRef.add({ foo: { bar: 1 }, bar: 1 }),
+        colRef.add(expected),
+        colRef.add(expected),
+      ]);
+
+      const snapshot = await query(
+        colRef,
+        where('foo.bar', '>', 123),
+        where('bar', '>', 123),
+      ).get();
+      snapshot.size.should.eql(2);
+      snapshot.forEach(s => {
+        s.data().should.eql(jet.contextify(expected));
+      });
     });
 
     it('allows inequality on the same path', function () {
@@ -1123,39 +1121,25 @@ describe('firestore().collection().where()', function () {
       }
     });
 
-    it("should throw error when combining '!=' operator with any other inequality operator on a different field", async function () {
+    it("should allow query when combining '!=' operator with any other inequality operator on a different field", async function () {
       const { getFirestore, collection, query, where } = firestoreModular;
-      const ref = collection(getFirestore(), COLLECTION);
+      const colRef = collection(
+        getFirestore(),
+        `${COLLECTION}/filter/inequality-combine-not-equal`,
+      );
+      const expected = { foo: { bar: 300 }, bar: 200 };
+      await Promise.all([
+        colRef.add({ foo: { bar: 1 }, bar: 1 }),
+        colRef.add(expected),
+        colRef.add(expected),
+      ]);
 
-      try {
-        query(ref, where('test', '!=', 1), where('differentField', '>', 1));
-        return Promise.reject(new Error('Did not throw an Error on >.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
+      const snapshot = await query(colRef, where('foo.bar', '>', 123), where('bar', '!=', 1)).get();
 
-      try {
-        query(ref, where('test', '!=', 1), where('differentField', '<', 1));
-        return Promise.reject(new Error('Did not throw an Error on <.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
-
-      try {
-        query(ref, where('test', '!=', 1), where('differentField', '<=', 1));
-        return Promise.reject(new Error('Did not throw an Error <=.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
-
-      try {
-        query(ref, where('test', '!=', 1), where('differentField', '>=', 1));
-        return Promise.reject(new Error('Did not throw an Error >=.'));
-      } catch (error) {
-        error.message.should.containEql('must be on the same field.');
-      }
-
-      return Promise.resolve();
+      snapshot.size.should.eql(2);
+      snapshot.forEach(s => {
+        s.data().should.eql(jet.contextify(expected));
+      });
     });
 
     it('should handle where clause after sort by', async function () {

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -269,15 +269,6 @@ export default class FirestoreQueryModifiers {
         this.hasInequality = filter;
         continue;
       }
-
-      // Check the set value is the same as the new one
-      if (INEQUALITY[filter.operator] && this.hasInequality) {
-        if (this.hasInequality.fieldPath._toPath() !== filter.fieldPath._toPath()) {
-          throw new Error(
-            `Invalid query. All where filters with an inequality (<, <=, >, != or >=) must be on the same field. But you have inequality filters on '${this.hasInequality.fieldPath._toPath()}' and '${filter.fieldPath._toPath()}'`,
-          );
-        }
-      }
     }
 
     for (let i = 0; i < filters.length; i++) {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

fixes: https://github.com/invertase/react-native-firebase/issues/7845

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
