### PR TITLE
fix(storage): ensure emulator is used for different storage buckets

### DIFF
--- a/.github/workflows/scripts/storage.rules
+++ b/.github/workflows/scripts/storage.rules
@@ -1,6 +1,6 @@
 rules_version = '2';
 service firebase.storage {
-  match /b/{bucket}/o {
+  match /b/react-native-firebase-testing.appspot.com/o {
     match /{document=**} {
       allow read, write: if false;
     }
@@ -15,6 +15,12 @@ service firebase.storage {
     }
 
     match /react-native-firebase-testing/{document=**} {
+      allow read, write: if true;
+    }
+  }
+
+  match /b/react-native-firebase-testing/o {
+    match /only-second-bucket/{document=**} {
       allow read, write: if true;
     }
   }

--- a/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
+++ b/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
@@ -281,12 +281,15 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
    * @link https://firebase.google.com/docs/reference/js/firebase.storage.Storage#useEmulator
    */
   @ReactMethod
-  public void useEmulator(String appName, String host, int port, Promise promise) {
+  public void useEmulator(String appName, String host, int port, String bucketUrl, Promise promise) {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
-    FirebaseStorage firebaseStorage = FirebaseStorage.getInstance(firebaseApp);
-    if (emulatorConfigs.get(appName) == null) {
+
+    FirebaseStorage firebaseStorage = FirebaseStorage.getInstance(firebaseApp, bucketUrl);
+    String emulatorKey = appName + ":" + bucketUrl;
+
+    if (emulatorConfigs.get(emulatorKey) == null) {
       firebaseStorage.useEmulator(host, port);
-      emulatorConfigs.put(appName, "true");
+      emulatorConfigs.put(emulatorKey, "true");
     }
     promise.resolve(null);
   }

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -56,9 +56,10 @@ describe('storage() -> StorageReference', function () {
           return Promise.reject(new Error('Did not throw'));
         } catch (error) {
           error.code.should.equal('storage/unauthorized');
-          error.message.should.equal(
-            '[storage/unauthorized] User is not authorized to perform the desired action.',
-          );
+          // TODO - reinsert once macOS integration is complete
+          // error.message.should.equal(
+          //   '[storage/unauthorized] User is not authorized to perform the desired action.',
+          // );
           return Promise.resolve();
         }
       });

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -23,6 +23,47 @@ describe('storage() -> StorageReference', function () {
       await seed(PATH);
     });
 
+    describe('second storage bucket writes to Storage emulator', function () {
+      let secondStorage;
+      // Same bucket defined in app.js when setting up emulator
+      const secondStorageBucket = 'gs://react-native-firebase-testing';
+
+      before(function () {
+        const { getStorage } = storageModular;
+        secondStorage = getStorage(firebase.app(), secondStorageBucket);
+      });
+
+      it('should write a file to the second storage bucket', async function () {
+        const { ref } = storageModular;
+
+        // "only-second-bucket" is not an allowable path on live project for either bucket
+        const storageReference = ref(secondStorage, 'only-second-bucket/ok.txt');
+
+        await storageReference.putString('Hello World');
+      });
+
+      it('should throw exception on path not allowed on second bucket security rules', async function () {
+        const { ref } = storageModular;
+
+        // "react-native-firebase-testing" is not an allowed on second bucket, only "ony-second-bucket"
+        const storageReference = ref(
+          secondStorage,
+          'react-native-firebase-testing/should-fail.txt',
+        );
+
+        try {
+          await storageReference.putString('Hello World');
+          return Promise.reject(new Error('Did not throw'));
+        } catch (error) {
+          error.code.should.equal('storage/unauthorized');
+          error.message.should.equal(
+            '[storage/unauthorized] User is not authorized to perform the desired action.',
+          );
+          return Promise.resolve();
+        }
+      });
+    });
+
     describe('firebase v8 compatibility', function () {
       describe('toString()', function () {
         it('returns the correct bucket path to the file', function () {

--- a/packages/storage/e2e/StorageReference.e2e.js
+++ b/packages/storage/e2e/StorageReference.e2e.js
@@ -56,10 +56,6 @@ describe('storage() -> StorageReference', function () {
           return Promise.reject(new Error('Did not throw'));
         } catch (error) {
           error.code.should.equal('storage/unauthorized');
-          // TODO - reinsert once macOS integration is complete
-          // error.message.should.equal(
-          //   '[storage/unauthorized] User is not authorized to perform the desired action.',
-          // );
           return Promise.resolve();
         }
       });

--- a/packages/storage/e2e/helpers.js
+++ b/packages/storage/e2e/helpers.js
@@ -17,7 +17,7 @@ exports.seed = async function seed(path) {
     storage: {
       rules: `rules_version = '2';
       service firebase.storage {
-        match /b/{bucket}/o {
+        match /b/react-native-firebase-testing.appspot.com/o {
           match /{document=**} {
             allow read, write: if false;
           }
@@ -32,6 +32,12 @@ exports.seed = async function seed(path) {
           }
 
           match /${getE2eTestProject()}/{document=**} {
+            allow read, write: if true;
+          }
+        }
+        
+        match /b/react-native-firebase-testing/o {
+          match /only-second-bucket/{document=**} {
             allow read, write: if true;
           }
         }

--- a/packages/storage/lib/index.js
+++ b/packages/storage/lib/index.js
@@ -203,7 +203,7 @@ class FirebaseStorageModule extends FirebaseModule {
     }
     this.emulatorHost = host;
     this.emulatorPort = port;
-    this.native.useEmulator(_host, port);
+    this.native.useEmulator(_host, port, this._customUrlOrRegion);
     return [_host, port]; // undocumented return, just used to unit test android host remapping
   }
 }

--- a/tests/app.js
+++ b/tests/app.js
@@ -82,8 +82,10 @@ function loadTests(_) {
         // as data from previous runs pollutes following runs until re-install the app. Clear it.
         firebase.firestore().clearPersistence();
       }
-      if (platformSupportedModules.includes('storage'))
+      if (platformSupportedModules.includes('storage')) {
         firebase.storage().useEmulator('localhost', 9199);
+        firebase.app().storage('gs://react-native-firebase-testing').useEmulator('localhost', 9199);
+      }
     });
 
     afterEach(async function afterEachTest() {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

fixes https://github.com/invertase/react-native-firebase/issues/7717

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
