### PR TITLE
feat(analytics): allow custom event parameters for Item in events

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -311,6 +311,12 @@ describe('Analytics', function () {
         }),
       ).toThrowError('firebase.analytics().logAddToWishlist(*):');
     });
+
+    it('items accept arbitrary custom event parameters', function () {
+      expect(() =>
+        firebase.analytics().logAddToWishlist({ items: [{ foo: 'bar' }] }),
+      ).not.toThrow();
+    });
   });
 
   describe('logBeginCheckout()', function () {

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -141,6 +141,11 @@ export namespace FirebaseAnalyticsTypes {
      * The promotion name associated with the item.
      */
     promotion_name?: string;
+    /**
+     * Custom event parameters. The parameter names can be up to 40 characters long and must start with an alphabetic character and contain only alphanumeric characters and underscores. String parameter values can be up to 100 characters long.
+     * The "firebase_", "google_" and "ga_" prefixes are reserved and should not be used for parameter names.
+     */
+    [key: string]: string | number;
   }
 
   export interface AddPaymentInfoEventParameters {

--- a/packages/analytics/lib/structs.js
+++ b/packages/analytics/lib/structs.js
@@ -15,7 +15,7 @@
  */
 import struct from '@react-native-firebase/app/lib/common/struct';
 
-const Item = struct({
+const Item = struct.interface({
   item_brand: 'string?',
   item_id: 'string?',
   item_name: 'string?',


### PR DESCRIPTION
### Description

We wanted to add custom parameters to the items for ecommerce events. Firebase supports it (https://developers.google.com/analytics/devguides/collection/ga4/item-scoped-ecommerce), but it was not yet supported by react-native-firebase. 
This MR is inspired by https://github.com/invertase/react-native-firebase/pull/5811

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I added a test case.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
