### PR TITLE
fix(database): fixes modular imports exports

### DIFF
--- a/packages/database/__tests__/database.test.ts
+++ b/packages/database/__tests__/database.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import database, { firebase } from '../lib';
+import database, { firebase, onValue, runTransaction } from '../lib';
 
 describe('Database', function () {
   describe('namespace', function () {
@@ -43,6 +43,16 @@ describe('Database', function () {
 
       const bar = database().useEmulator('127.0.0.1', 9000);
       expect(bar).toEqual(['10.0.2.2', 9000]);
+    });
+  });
+
+  describe('modular', function () {
+    it('`onValue` query method is properly exposed to end user', function () {
+      expect(onValue).toBeDefined();
+    });
+
+    it('`runTransaction` transaciton method is properly exposed to end user', function () {
+      expect(runTransaction).toBeDefined();
     });
   });
 });

--- a/packages/database/__tests__/database.test.ts
+++ b/packages/database/__tests__/database.test.ts
@@ -1,6 +1,50 @@
 import { describe, expect, it } from '@jest/globals';
 
-import database, { firebase, onValue, runTransaction } from '../lib';
+import database, {
+  firebase,
+  runTransaction,
+  getDatabase,
+  connectDatabaseEmulator,
+  goOffline,
+  goOnline,
+  ref,
+  refFromURL,
+  setPersistenceEnabled,
+  setLoggingEnabled,
+  setPersistenceCacheSizeBytes,
+  forceLongPolling,
+  forceWebSockets,
+  getServerTime,
+  serverTimestamp,
+  increment,
+  endAt,
+  endBefore,
+  startAt,
+  startAfter,
+  limitToFirst,
+  limitToLast,
+  orderByChild,
+  orderByKey,
+  orderByPriority,
+  orderByValue,
+  equalTo,
+  query,
+  onValue,
+  onChildAdded,
+  onChildChanged,
+  onChildMoved,
+  onChildRemoved,
+  set,
+  setPriority,
+  setWithPriority,
+  get,
+  child,
+  onDisconnect,
+  keepSynced,
+  push,
+  remove,
+  update,
+} from '../lib';
 
 describe('Database', function () {
   describe('namespace', function () {
@@ -51,8 +95,172 @@ describe('Database', function () {
       expect(onValue).toBeDefined();
     });
 
-    it('`runTransaction` transaciton method is properly exposed to end user', function () {
+    it('`runTransaction` transaction method is properly exposed to end user', function () {
       expect(runTransaction).toBeDefined();
+    });
+
+    it('`getDatabase` function is properly exposed to end user', function () {
+      expect(getDatabase).toBeDefined();
+    });
+
+    it('`connectDatabaseEmulator` function is properly exposed to end user', function () {
+      expect(connectDatabaseEmulator).toBeDefined();
+    });
+
+    it('`goOffline` function is properly exposed to end user', function () {
+      expect(goOffline).toBeDefined();
+    });
+
+    it('`goOnline` function is properly exposed to end user', function () {
+      expect(goOnline).toBeDefined();
+    });
+
+    it('`ref` function is properly exposed to end user', function () {
+      expect(ref).toBeDefined();
+    });
+
+    it('`refFromURL` function is properly exposed to end user', function () {
+      expect(refFromURL).toBeDefined();
+    });
+
+    it('`setPersistenceEnabled` function is properly exposed to end user', function () {
+      expect(setPersistenceEnabled).toBeDefined();
+    });
+
+    it('`setLoggingEnabled` function is properly exposed to end user', function () {
+      expect(setLoggingEnabled).toBeDefined();
+    });
+
+    it('`setPersistenceCacheSizeBytes` function is properly exposed to end user', function () {
+      expect(setPersistenceCacheSizeBytes).toBeDefined();
+    });
+
+    it('`forceLongPolling` function is properly exposed to end user', function () {
+      expect(forceLongPolling).toBeDefined();
+    });
+
+    it('`forceWebSockets` function is properly exposed to end user', function () {
+      expect(forceWebSockets).toBeDefined();
+    });
+
+    it('`getServerTime` function is properly exposed to end user', function () {
+      expect(getServerTime).toBeDefined();
+    });
+
+    it('`serverTimestamp` function is properly exposed to end user', function () {
+      expect(serverTimestamp).toBeDefined();
+    });
+
+    it('`increment` function is properly exposed to end user', function () {
+      expect(increment).toBeDefined();
+    });
+
+    it('`endAt` function is properly exposed to end user', function () {
+      expect(endAt).toBeDefined();
+    });
+
+    it('`endBefore` function is properly exposed to end user', function () {
+      expect(endBefore).toBeDefined();
+    });
+
+    it('`startAt` function is properly exposed to end user', function () {
+      expect(startAt).toBeDefined();
+    });
+
+    it('`startAfter` function is properly exposed to end user', function () {
+      expect(startAfter).toBeDefined();
+    });
+
+    it('`limitToFirst` function is properly exposed to end user', function () {
+      expect(limitToFirst).toBeDefined();
+    });
+
+    it('`limitToLast` function is properly exposed to end user', function () {
+      expect(limitToLast).toBeDefined();
+    });
+
+    it('`orderByChild` function is properly exposed to end user', function () {
+      expect(orderByChild).toBeDefined();
+    });
+
+    it('`orderByKey` function is properly exposed to end user', function () {
+      expect(orderByKey).toBeDefined();
+    });
+
+    it('`orderByPriority` function is properly exposed to end user', function () {
+      expect(orderByPriority).toBeDefined();
+    });
+
+    it('`orderByValue` function is properly exposed to end user', function () {
+      expect(orderByValue).toBeDefined();
+    });
+
+    it('`equalTo` function is properly exposed to end user', function () {
+      expect(equalTo).toBeDefined();
+    });
+
+    it('`query` function is properly exposed to end user', function () {
+      expect(query).toBeDefined();
+    });
+
+    it('`onValue` function is properly exposed to end user', function () {
+      expect(onValue).toBeDefined();
+    });
+
+    it('`onChildAdded` function is properly exposed to end user', function () {
+      expect(onChildAdded).toBeDefined();
+    });
+
+    it('`onChildChanged` function is properly exposed to end user', function () {
+      expect(onChildChanged).toBeDefined();
+    });
+
+    it('`onChildMoved` function is properly exposed to end user', function () {
+      expect(onChildMoved).toBeDefined();
+    });
+
+    it('`onChildRemoved` function is properly exposed to end user', function () {
+      expect(onChildRemoved).toBeDefined();
+    });
+
+    it('`set` function is properly exposed to end user', function () {
+      expect(set).toBeDefined();
+    });
+
+    it('`setPriority` function is properly exposed to end user', function () {
+      expect(setPriority).toBeDefined();
+    });
+
+    it('`setWithPriority` function is properly exposed to end user', function () {
+      expect(setWithPriority).toBeDefined();
+    });
+
+    it('`get` function is properly exposed to end user', function () {
+      expect(get).toBeDefined();
+    });
+
+    it('`child` function is properly exposed to end user', function () {
+      expect(child).toBeDefined();
+    });
+
+    it('`onDisconnect` function is properly exposed to end user', function () {
+      expect(onDisconnect).toBeDefined();
+    });
+
+    it('`keepSynced` function is properly exposed to end user', function () {
+      expect(keepSynced).toBeDefined();
+    });
+
+    it('`push` function is properly exposed to end user', function () {
+      expect(push).toBeDefined();
+    });
+
+    it('`remove` function is properly exposed to end user', function () {
+      expect(remove).toBeDefined();
+    });
+
+    it('`update` function is properly exposed to end user', function () {
+      expect(update).toBeDefined();
     });
   });
 });

--- a/packages/database/e2e/DatabaseStatics.e2e.js
+++ b/packages/database/e2e/DatabaseStatics.e2e.js
@@ -89,7 +89,7 @@ describe('database.X', function () {
         timestamp['.sv'].should.eql('timestamp');
       });
 
-      it.only('populates the property with a Unix timestamp', async function () {
+      it('populates the property with a Unix timestamp', async function () {
         const { serverTimestamp, getDatabase, ref, set } = databaseModular;
         const dbRef = ref(getDatabase(), `${TEST_PATH}/timestamp`);
         await set(dbRef, serverTimestamp());

--- a/packages/database/e2e/DatabaseStatics.e2e.js
+++ b/packages/database/e2e/DatabaseStatics.e2e.js
@@ -32,6 +32,13 @@ describe('database.X', function () {
         TIMESTAMP.should.have.property('.sv');
         TIMESTAMP['.sv'].should.eql('timestamp');
       });
+
+      it('populates the property with a Unix timestamp', async function () {
+        const ref = firebase.database().ref(`${TEST_PATH}/timestamp`);
+        await ref.set(firebase.database.ServerValue.TIMESTAMP);
+        const snapshot = await ref.once('value');
+        snapshot.val().should.be.a.Number();
+      });
     });
 
     describe('ServerValue.increment', function () {
@@ -80,6 +87,14 @@ describe('database.X', function () {
         should.equal(Object.keys(timestamp).length, 1);
         timestamp.should.have.property('.sv');
         timestamp['.sv'].should.eql('timestamp');
+      });
+
+      it.only('populates the property with a Unix timestamp', async function () {
+        const { serverTimestamp, getDatabase, ref, set } = databaseModular;
+        const dbRef = ref(getDatabase(), `${TEST_PATH}/timestamp`);
+        await set(dbRef, serverTimestamp());
+        const snapshot = await dbRef.once('value');
+        snapshot.val().should.be.a.Number();
       });
     });
 

--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -1296,8 +1296,6 @@ export const firebase: ReactNativeFirebase.Module & {
 };
 
 export * from './modular';
-export * from './modular/query';
-export * from './modular/transaction';
 
 export default defaultExport;
 

--- a/packages/database/lib/index.d.ts
+++ b/packages/database/lib/index.d.ts
@@ -1295,6 +1295,10 @@ export const firebase: ReactNativeFirebase.Module & {
   ): ReactNativeFirebase.FirebaseApp & { database(): FirebaseDatabaseTypes.Module };
 };
 
+export * from './modular';
+export * from './modular/query';
+export * from './modular/transaction';
+
 export default defaultExport;
 
 /**

--- a/packages/database/lib/modular/index.d.ts
+++ b/packages/database/lib/modular/index.d.ts
@@ -215,3 +215,6 @@ export function serverTimestamp(): object;
  * @returns A placeholder value for modifying data atomically server-side.
  */
 export function increment(delta: number): object;
+
+export * from './query';
+export * from './transaction';

--- a/packages/database/lib/modular/index.d.ts
+++ b/packages/database/lib/modular/index.d.ts
@@ -208,6 +208,10 @@ export declare function forceWebSockets(): void;
 export function serverTimestamp(): object;
 
 /**
+ * Returns the current Firebase Database server time as a JavaScript Date object.
+ */
+export function getServerTime(db: Database): Promise<number>;
+/**
  * Returns a placeholder value that can be used to atomically increment the
  * current database value by the provided delta.
  *

--- a/packages/database/lib/modular/query.d.ts
+++ b/packages/database/lib/modular/query.d.ts
@@ -1,14 +1,9 @@
 import { FirebaseDatabaseTypes } from '../..';
 
-import Query = FirebaseDatabaseTypes.Query;
-import DataSnapshot = FirebaseDatabaseTypes.DataSnapshot;
-import DatabaseReference = FirebaseDatabaseTypes.Reference;
-import OnDisconnect = FirebaseDatabaseTypes.OnDisconnect;
-
-export type Query = Query;
-export type DataSnapshot = DataSnapshot;
-export type DatabaseReference = DatabaseReference;
-export type OnDisconnect = OnDisconnect;
+export type Query = FirebaseDatabaseTypes.Query;
+export type DataSnapshot = FirebaseDatabaseTypes.DataSnapshot;
+export type DatabaseReference = FirebaseDatabaseTypes.Reference;
+export type OnDisconnect = FirebaseDatabaseTypes.OnDisconnect;
 
 /**
  * A `Promise` that can also act as a `DatabaseReference` when returned by

--- a/packages/database/lib/modular/transaction.d.ts
+++ b/packages/database/lib/modular/transaction.d.ts
@@ -1,9 +1,7 @@
-import { FirebaseDatabaseTypes } from '../../index';
+import { FirebaseDatabaseTypes } from '../..';
 
-import TransactionResult = FirebaseDatabaseTypes.TransactionResult;
+export type TransactionResult = FirebaseDatabaseTypes.TransactionResult;
 import DatabaseReference = FirebaseDatabaseTypes.Reference;
-
-export { TransactionResult };
 
 /**
  * An options object to configure transactions.


### PR DESCRIPTION
### Description

Fixes exports of modular imports, this logic is already implemented in other packages.
Without this fix, this is how I get VSCode to import modular:
```ts
import { getDatabase, ref } from "@react-native-firebase/database/lib/modular";
import {
  Unsubscribe,
  onValue,
  set,
} from "@react-native-firebase/database/lib/modular/query";
```
### Release Summary

fix(database): fixes exports of modular imports
Related to: https://github.com/invertase/react-native-firebase/issues/7924
### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
