### PR TITLE
feat(firestore): support for second database

### DIFF
--- a/.github/workflows/scripts/firestore.rules
+++ b/.github/workflows/scripts/firestore.rules
@@ -9,9 +9,13 @@ service cloud.firestore {
     }
   match /firestore/{document=**} {
       allow read, write: if true;
-    } 
+    }
   match /{path=**}/collectionGroup/{documentId} {
       allow read, write: if true;
-    }  
+    }
+  match /second-database/{document=**} {
+    // separate rules are not supported so we need to use the same rules for both databases to prove it is querying different databases
+    allow read, write: if database == "second-rnfb";
+  }
   }
 }

--- a/packages/app/lib/internal/registry/namespace.js
+++ b/packages/app/lib/internal/registry/namespace.js
@@ -15,6 +15,7 @@
  *
  */
 
+import { isString } from '../../common';
 import FirebaseApp from '../../FirebaseApp';
 import SDK_VERSION from '../../version';
 import { DEFAULT_APP_NAME, KNOWN_NAMESPACES } from '../constants';
@@ -28,7 +29,6 @@ import {
   setOnAppCreate,
   setOnAppDestroy,
 } from './app';
-import { isUndefined } from '../../common';
 
 // firebase.X
 let FIREBASE_ROOT = null;
@@ -95,16 +95,13 @@ function getOrCreateModuleForApp(app, moduleNamespace) {
 
   // e.g. firebase.storage(customUrlOrRegion), firebase.functions(customUrlOrRegion), firebase.firestore(databaseId), firebase.database(url)
   function firebaseModuleWithArgs(customUrlOrRegionOrDatabaseId) {
-    if (!isUndefined(customUrlOrRegionOrDatabaseId)) {
+    if (customUrlOrRegion !== undefined) {
       if (!hasCustomUrlOrRegionSupport) {
-        // TODO update tests for those not supported
-        throw new Error(
-          [
-            `You attempted to call "firebase.app('${app.name}').${moduleNamespace}(${customUrlOrRegionOrDatabaseId})" but; '${moduleNamespace}()' does not support an argument.`,
-            '',
-            `Ensure you call '${moduleNamespace}()' without any arguments.`,
-          ].join('\r\n'),
-        );
+        // TODO throw Module does not support arguments error
+      }
+
+      if (!isString(customUrlOrRegion)) {
+        // TODO throw Module first argument must be a string error
       }
     }
 

--- a/packages/app/lib/internal/registry/namespace.js
+++ b/packages/app/lib/internal/registry/namespace.js
@@ -95,12 +95,12 @@ function getOrCreateModuleForApp(app, moduleNamespace) {
 
   // e.g. firebase.storage(customUrlOrRegion), firebase.functions(customUrlOrRegion), firebase.firestore(databaseId), firebase.database(url)
   function firebaseModuleWithArgs(customUrlOrRegionOrDatabaseId) {
-    if (customUrlOrRegion !== undefined) {
+    if (customUrlOrRegionOrDatabaseId !== undefined) {
       if (!hasCustomUrlOrRegionSupport) {
         // TODO throw Module does not support arguments error
       }
 
-      if (!isString(customUrlOrRegion)) {
+      if (!isString(customUrlOrRegionOrDatabaseId)) {
         // TODO throw Module first argument must be a string error
       }
     }

--- a/packages/app/lib/internal/registry/nativeModule.js
+++ b/packages/app/lib/internal/registry/nativeModule.js
@@ -153,7 +153,10 @@ function initialiseNativeModule(module) {
 function subscribeToNativeModuleEvent(eventName) {
   if (!NATIVE_MODULE_EVENT_SUBSCRIPTIONS[eventName]) {
     RNFBNativeEventEmitter.addListener(eventName, event => {
-      if (event.appName) {
+      if (event.appName && event.databaseId) {
+        // Firestore requires both appName and databaseId to prefix
+        SharedEventEmitter.emit(`${event.appName}-${event.databaseId}-${eventName}`, event);
+      } else if (event.appName) {
         // native event has an appName property - auto prefix and internally emit
         SharedEventEmitter.emit(`${event.appName}-${eventName}`, event);
       } else {

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
@@ -29,8 +29,13 @@ import java.util.WeakHashMap;
 public class UniversalFirebaseFirestoreCommon {
   static WeakHashMap<String, WeakReference<FirebaseFirestore>> instanceCache = new WeakHashMap<>();
 
-  static FirebaseFirestore getFirestoreForApp(String appName) {
-    WeakReference<FirebaseFirestore> cachedInstance = instanceCache.get(appName);
+  static String createFirestoreKey(String appName, String databaseId) {
+    return appName + ":" + databaseId;
+  }
+
+  static FirebaseFirestore getFirestoreForApp(String appName, String databaseId) {
+    String firestoreKey = createFirestoreKey(appName, databaseId);
+    WeakReference<FirebaseFirestore> cachedInstance = instanceCache.get(firestoreKey);
 
     if (cachedInstance != null) {
       return cachedInstance.get();
@@ -38,24 +43,24 @@ public class UniversalFirebaseFirestoreCommon {
 
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
 
-    FirebaseFirestore instance = FirebaseFirestore.getInstance(firebaseApp);
+    FirebaseFirestore instance = FirebaseFirestore.getInstance(firebaseApp, databaseId);
 
-    setFirestoreSettings(instance, appName);
+    setFirestoreSettings(instance, firestoreKey);
 
     instanceCache.put(appName, new WeakReference<FirebaseFirestore>(instance));
 
     return instance;
   }
 
-  private static void setFirestoreSettings(FirebaseFirestore firebaseFirestore, String appName) {
+  private static void setFirestoreSettings(FirebaseFirestore firebaseFirestore, String firestoreKey) {
 
     UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
     FirebaseFirestoreSettings.Builder firestoreSettings = new FirebaseFirestoreSettings.Builder();
 
-    String cacheSizeKey = UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + appName;
-    String hostKey = UniversalFirebaseFirestoreStatics.FIRESTORE_HOST + "_" + appName;
-    String persistenceKey = UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + appName;
-    String sslKey = UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + appName;
+    String cacheSizeKey = UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + firestoreKey;
+    String hostKey = UniversalFirebaseFirestoreStatics.FIRESTORE_HOST + "_" + firestoreKey;
+    String persistenceKey = UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + firestoreKey;
+    String sslKey = UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + firestoreKey;
 
     int cacheSizeBytes =
         preferences.getIntValue(

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
@@ -52,14 +52,17 @@ public class UniversalFirebaseFirestoreCommon {
     return instance;
   }
 
-  private static void setFirestoreSettings(FirebaseFirestore firebaseFirestore, String firestoreKey) {
+  private static void setFirestoreSettings(
+      FirebaseFirestore firebaseFirestore, String firestoreKey) {
 
     UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
     FirebaseFirestoreSettings.Builder firestoreSettings = new FirebaseFirestoreSettings.Builder();
 
-    String cacheSizeKey = UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + firestoreKey;
+    String cacheSizeKey =
+        UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + firestoreKey;
     String hostKey = UniversalFirebaseFirestoreStatics.FIRESTORE_HOST + "_" + firestoreKey;
-    String persistenceKey = UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + firestoreKey;
+    String persistenceKey =
+        UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + firestoreKey;
     String sslKey = UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + firestoreKey;
 
     int cacheSizeBytes =

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
@@ -129,10 +129,10 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
 
   Task<Void> terminate(String appName, String databaseId) {
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
-
-    if (instanceCache.get(appName) != null) {
-      instanceCache.get(appName).clear();
-      instanceCache.remove(appName);
+    String firestoreKey = createFirestoreKey(appName, databaseId);
+    if (instanceCache.get(firestoreKey) != null) {
+      instanceCache.get(firestoreKey).clear();
+      instanceCache.remove(firestoreKey);
     }
 
     return firebaseFirestore.terminate();

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
@@ -17,6 +17,7 @@ package io.invertase.firebase.firestore;
  *
  */
 
+import static io.invertase.firebase.firestore.UniversalFirebaseFirestoreCommon.createFirestoreKey;
 import static io.invertase.firebase.firestore.UniversalFirebaseFirestoreCommon.getFirestoreForApp;
 import static io.invertase.firebase.firestore.UniversalFirebaseFirestoreCommon.instanceCache;
 
@@ -40,27 +41,28 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
     super(context, serviceName);
   }
 
-  Task<Void> disableNetwork(String appName) {
-    return getFirestoreForApp(appName).disableNetwork();
+  Task<Void> disableNetwork(String appName, String databaseId) {
+    return getFirestoreForApp(appName, databaseId).disableNetwork();
   }
 
-  Task<Void> enableNetwork(String appName) {
-    return getFirestoreForApp(appName).enableNetwork();
+  Task<Void> enableNetwork(String appName, String databaseId) {
+    return getFirestoreForApp(appName, databaseId).enableNetwork();
   }
 
-  Task<Void> useEmulator(String appName, String host, int port) {
+  Task<Void> useEmulator(String appName, String databaseId, String host, int port) {
     return Tasks.call(
         getExecutor(),
         () -> {
-          if (emulatorConfigs.get(appName) == null) {
-            emulatorConfigs.put(appName, "true");
-            getFirestoreForApp(appName).useEmulator(host, port);
+          String firestoreKey = createFirestoreKey(appName, databaseId);
+          if (emulatorConfigs.get(firestoreKey) == null) {
+            emulatorConfigs.put(firestoreKey, "true");
+            getFirestoreForApp(appName, databaseId).useEmulator(host, port);
           }
           return null;
         });
   }
 
-  Task<Void> settings(String appName, Map<String, Object> settings) {
+  Task<Void> settings(String firestoreKey, Map<String, Object> settings) {
     return Tasks.call(
         getExecutor(),
         () -> {
@@ -70,7 +72,7 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
 
             UniversalFirebasePreferences.getSharedInstance()
                 .setIntValue(
-                    UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + appName,
+                    UniversalFirebaseFirestoreStatics.FIRESTORE_CACHE_SIZE + "_" + firestoreKey,
                     Objects.requireNonNull(cacheSizeBytesDouble).intValue());
           }
 
@@ -78,7 +80,7 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
           if (settings.containsKey("host")) {
             UniversalFirebasePreferences.getSharedInstance()
                 .setStringValue(
-                    UniversalFirebaseFirestoreStatics.FIRESTORE_HOST + "_" + appName,
+                    UniversalFirebaseFirestoreStatics.FIRESTORE_HOST + "_" + firestoreKey,
                     (String) settings.get("host"));
           }
 
@@ -86,7 +88,7 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
           if (settings.containsKey("persistence")) {
             UniversalFirebasePreferences.getSharedInstance()
                 .setBooleanValue(
-                    UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + appName,
+                    UniversalFirebaseFirestoreStatics.FIRESTORE_PERSISTENCE + "_" + firestoreKey,
                     (boolean) settings.get("persistence"));
           }
 
@@ -94,7 +96,7 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
           if (settings.containsKey("ssl")) {
             UniversalFirebasePreferences.getSharedInstance()
                 .setBooleanValue(
-                    UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + appName,
+                    UniversalFirebaseFirestoreStatics.FIRESTORE_SSL + "_" + firestoreKey,
                     (boolean) settings.get("ssl"));
           }
 
@@ -104,7 +106,7 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
                 .setStringValue(
                     UniversalFirebaseFirestoreStatics.FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR
                         + "_"
-                        + appName,
+                        + firestoreKey,
                     (String) settings.get("serverTimestampBehavior"));
           }
 
@@ -112,21 +114,21 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
         });
   }
 
-  LoadBundleTask loadBundle(String appName, String bundle) {
+  LoadBundleTask loadBundle(String appName, String databaseId, String bundle) {
     byte[] bundleData = bundle.getBytes(StandardCharsets.UTF_8);
-    return getFirestoreForApp(appName).loadBundle(bundleData);
+    return getFirestoreForApp(appName, databaseId).loadBundle(bundleData);
   }
 
-  Task<Void> clearPersistence(String appName) {
-    return getFirestoreForApp(appName).clearPersistence();
+  Task<Void> clearPersistence(String appName, String databaseId) {
+    return getFirestoreForApp(appName, databaseId).clearPersistence();
   }
 
-  Task<Void> waitForPendingWrites(String appName) {
-    return getFirestoreForApp(appName).waitForPendingWrites();
+  Task<Void> waitForPendingWrites(String appName, String databaseId) {
+    return getFirestoreForApp(appName, databaseId).waitForPendingWrites();
   }
 
-  Task<Void> terminate(String appName) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+  Task<Void> terminate(String appName, String databaseId) {
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
 
     if (instanceCache.get(appName) != null) {
       instanceCache.get(appName).clear();

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -77,8 +77,9 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
                 } else {
                   ReactNativeFirebaseFirestoreQuery firestoreQuery =
                       new ReactNativeFirebaseFirestoreQuery(
-                          appName, query, filters, orders, options);
-                  handleQueryOnSnapshot(firestoreQuery, appName, databaseId, listenerId, listenerOptions);
+                          appName, databaseId, query, filters, orders, options);
+                  handleQueryOnSnapshot(
+                      firestoreQuery, appName, databaseId, listenerId, listenerOptions);
                 }
               } else {
                 sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
@@ -104,7 +105,12 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     ReactNativeFirebaseFirestoreQuery firestoreQuery =
         new ReactNativeFirebaseFirestoreQuery(
-            appName, getQueryForFirestore(firebaseFirestore, path, type), filters, orders, options);
+            appName,
+            databaseId,
+            getQueryForFirestore(firebaseFirestore, path, type),
+            filters,
+            orders,
+            options);
 
     handleQueryOnSnapshot(firestoreQuery, appName, databaseId, listenerId, listenerOptions);
   }
@@ -142,7 +148,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
                 } else {
                   ReactNativeFirebaseFirestoreQuery firestoreQuery =
                       new ReactNativeFirebaseFirestoreQuery(
-                          appName, query, filters, orders, options);
+                          appName, databaseId, query, filters, orders, options);
                   handleQueryGet(firestoreQuery, getSource(getOptions), promise);
                 }
               } else {
@@ -164,7 +170,12 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     ReactNativeFirebaseFirestoreQuery firestoreQuery =
         new ReactNativeFirebaseFirestoreQuery(
-            appName, getQueryForFirestore(firebaseFirestore, path, type), filters, orders, options);
+            appName,
+            databaseId,
+            getQueryForFirestore(firebaseFirestore, path, type),
+            filters,
+            orders,
+            options);
 
     AggregateQuery aggregateQuery = firestoreQuery.query.count();
 
@@ -196,7 +207,12 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     ReactNativeFirebaseFirestoreQuery firestoreQuery =
         new ReactNativeFirebaseFirestoreQuery(
-            appName, getQueryForFirestore(firebaseFirestore, path, type), filters, orders, options);
+            appName,
+            databaseId,
+            getQueryForFirestore(firebaseFirestore, path, type),
+            filters,
+            orders,
+            options);
     handleQueryGet(firestoreQuery, getSource(getOptions), promise);
   }
 
@@ -258,7 +274,9 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       MetadataChanges metadataChanges) {
     Tasks.call(
             getTransactionalExecutor(Integer.toString(listenerId)),
-            () -> snapshotToWritableMap(appName, "onSnapshot", querySnapshot, metadataChanges))
+            () ->
+                snapshotToWritableMap(
+                    appName, databaseId, "onSnapshot", querySnapshot, metadataChanges))
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -281,7 +299,8 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
             });
   }
 
-  private void sendOnSnapshotError(String appName, String databaseId, int listenerId, Exception exception) {
+  private void sendOnSnapshotError(
+      String appName, String databaseId, int listenerId, Exception exception) {
     WritableMap body = Arguments.createMap();
     WritableMap error = Arguments.createMap();
 
@@ -301,7 +320,11 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
 
     emitter.sendEvent(
         new ReactNativeFirebaseFirestoreEvent(
-            ReactNativeFirebaseFirestoreEvent.COLLECTION_EVENT_SYNC, body, appName, databaseId, listenerId));
+            ReactNativeFirebaseFirestoreEvent.COLLECTION_EVENT_SYNC,
+            body,
+            appName,
+            databaseId,
+            listenerId));
   }
 
   private Source getSource(ReadableMap getOptions) {

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -73,15 +73,15 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
               if (task.isSuccessful()) {
                 Query query = task.getResult();
                 if (query == null) {
-                  sendOnSnapshotError(appName, listenerId, new NullPointerException());
+                  sendOnSnapshotError(appName, databaseId, listenerId, new NullPointerException());
                 } else {
                   ReactNativeFirebaseFirestoreQuery firestoreQuery =
                       new ReactNativeFirebaseFirestoreQuery(
                           appName, query, filters, orders, options);
-                  handleQueryOnSnapshot(firestoreQuery, appName, listenerId, listenerOptions);
+                  handleQueryOnSnapshot(firestoreQuery, appName, databaseId, listenerId, listenerOptions);
                 }
               } else {
-                sendOnSnapshotError(appName, listenerId, task.getException());
+                sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
               }
             });
   }
@@ -106,7 +106,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
         new ReactNativeFirebaseFirestoreQuery(
             appName, getQueryForFirestore(firebaseFirestore, path, type), filters, orders, options);
 
-    handleQueryOnSnapshot(firestoreQuery, appName, listenerId, listenerOptions);
+    handleQueryOnSnapshot(firestoreQuery, appName, databaseId, listenerId, listenerOptions);
   }
 
   @ReactMethod
@@ -203,6 +203,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   private void handleQueryOnSnapshot(
       ReactNativeFirebaseFirestoreQuery firestoreQuery,
       String appName,
+      String databaseId,
       int listenerId,
       ReadableMap listenerOptions) {
     MetadataChanges metadataChanges;
@@ -223,9 +224,9 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
               listenerRegistration.remove();
               collectionSnapshotListeners.remove(listenerId);
             }
-            sendOnSnapshotError(appName, listenerId, exception);
+            sendOnSnapshotError(appName, databaseId, listenerId, exception);
           } else {
-            sendOnSnapshotEvent(appName, listenerId, querySnapshot, metadataChanges);
+            sendOnSnapshotEvent(appName, databaseId, listenerId, querySnapshot, metadataChanges);
           }
         };
 
@@ -251,6 +252,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
 
   private void sendOnSnapshotEvent(
       String appName,
+      String databaseId,
       int listenerId,
       QuerySnapshot querySnapshot,
       MetadataChanges metadataChanges) {
@@ -271,14 +273,15 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
                         ReactNativeFirebaseFirestoreEvent.COLLECTION_EVENT_SYNC,
                         body,
                         appName,
+                        databaseId,
                         listenerId));
               } else {
-                sendOnSnapshotError(appName, listenerId, task.getException());
+                sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
               }
             });
   }
 
-  private void sendOnSnapshotError(String appName, int listenerId, Exception exception) {
+  private void sendOnSnapshotError(String appName, String databaseId, int listenerId, Exception exception) {
     WritableMap body = Arguments.createMap();
     WritableMap error = Arguments.createMap();
 
@@ -298,7 +301,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
 
     emitter.sendEvent(
         new ReactNativeFirebaseFirestoreEvent(
-            ReactNativeFirebaseFirestoreEvent.COLLECTION_EVENT_SYNC, body, appName, listenerId));
+            ReactNativeFirebaseFirestoreEvent.COLLECTION_EVENT_SYNC, body, appName, databaseId, listenerId));
   }
 
   private Source getSource(ReadableMap getOptions) {

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -53,6 +53,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   @ReactMethod
   public void namedQueryOnSnapshot(
       String appName,
+      String databaseId,
       String queryName,
       String type,
       ReadableArray filters,
@@ -64,7 +65,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       return;
     }
 
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     firebaseFirestore
         .getNamedQuery(queryName)
         .addOnCompleteListener(
@@ -88,6 +89,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   @ReactMethod
   public void collectionOnSnapshot(
       String appName,
+      String databaseId,
       String path,
       String type,
       ReadableArray filters,
@@ -99,7 +101,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       return;
     }
 
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     ReactNativeFirebaseFirestoreQuery firestoreQuery =
         new ReactNativeFirebaseFirestoreQuery(
             appName, getQueryForFirestore(firebaseFirestore, path, type), filters, orders, options);
@@ -108,7 +110,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   }
 
   @ReactMethod
-  public void collectionOffSnapshot(String appName, int listenerId) {
+  public void collectionOffSnapshot(String appName, String databaseId, int listenerId) {
     ListenerRegistration listenerRegistration = collectionSnapshotListeners.get(listenerId);
     if (listenerRegistration != null) {
       listenerRegistration.remove();
@@ -120,6 +122,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   @ReactMethod
   public void namedQueryGet(
       String appName,
+      String databaseId,
       String queryName,
       String type,
       ReadableArray filters,
@@ -127,7 +130,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       ReadableMap options,
       ReadableMap getOptions,
       Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     firebaseFirestore
         .getNamedQuery(queryName)
         .addOnCompleteListener(
@@ -151,13 +154,14 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   @ReactMethod
   public void collectionCount(
       String appName,
+      String databaseId,
       String path,
       String type,
       ReadableArray filters,
       ReadableArray orders,
       ReadableMap options,
       Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     ReactNativeFirebaseFirestoreQuery firestoreQuery =
         new ReactNativeFirebaseFirestoreQuery(
             appName, getQueryForFirestore(firebaseFirestore, path, type), filters, orders, options);
@@ -181,6 +185,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   @ReactMethod
   public void collectionGet(
       String appName,
+      String databaseId,
       String path,
       String type,
       ReadableArray filters,
@@ -188,7 +193,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       ReadableMap options,
       ReadableMap getOptions,
       Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     ReactNativeFirebaseFirestoreQuery firestoreQuery =
         new ReactNativeFirebaseFirestoreQuery(
             appName, getQueryForFirestore(firebaseFirestore, path, type), filters, orders, options);

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCommon.java
@@ -19,6 +19,7 @@ package io.invertase.firebase.firestore;
 
 import static io.invertase.firebase.common.ReactNativeFirebaseModule.rejectPromiseWithCodeAndMessage;
 import static io.invertase.firebase.common.ReactNativeFirebaseModule.rejectPromiseWithExceptionMap;
+import static io.invertase.firebase.firestore.UniversalFirebaseFirestoreCommon.createFirestoreKey;
 
 import com.facebook.react.bridge.Promise;
 import com.google.firebase.firestore.DocumentSnapshot;
@@ -48,10 +49,12 @@ class ReactNativeFirebaseFirestoreCommon {
     }
   }
 
-  static DocumentSnapshot.ServerTimestampBehavior getServerTimestampBehavior(String appName) {
+  static DocumentSnapshot.ServerTimestampBehavior getServerTimestampBehavior(
+      String appName, String databaseId) {
+    String firestoreKey = createFirestoreKey(appName, databaseId);
     UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
     String key =
-        UniversalFirebaseFirestoreStatics.FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR + "_" + appName;
+        UniversalFirebaseFirestoreStatics.FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR + "_" + firestoreKey;
     String behavior = preferences.getStringValue(key, "none");
 
     if ("estimate".equals(behavior)) {

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -104,7 +104,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentGet(String appName, String databaseId, String path, ReadableMap getOptions, Promise promise) {
+  public void documentGet(
+      String appName, String databaseId, String path, ReadableMap getOptions, Promise promise) {
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
@@ -127,7 +128,7 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
             getExecutor(),
             () -> {
               DocumentSnapshot documentSnapshot = Tasks.await(documentReference.get(source));
-              return snapshotToWritableMap(appName, documentSnapshot);
+              return snapshotToWritableMap(appName, databaseId, documentSnapshot);
             })
         .addOnCompleteListener(
             task -> {
@@ -156,7 +157,12 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
   @ReactMethod
   public void documentSet(
-      String appName, String databaseId, String path, ReadableMap data, ReadableMap options, Promise promise) {
+      String appName,
+      String databaseId,
+      String path,
+      ReadableMap data,
+      ReadableMap options,
+      Promise promise) {
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
@@ -195,7 +201,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentUpdate(String appName, String databaseId, String path, ReadableMap data, Promise promise) {
+  public void documentUpdate(
+      String appName, String databaseId, String path, ReadableMap data, Promise promise) {
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
@@ -214,7 +221,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentBatch(String appName, String databaseId, ReadableArray writes, Promise promise) {
+  public void documentBatch(
+      String appName, String databaseId, ReadableArray writes, Promise promise) {
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
 
     Tasks.call(getTransactionalExecutor(), () -> parseDocumentBatches(firebaseFirestore, writes))
@@ -282,8 +290,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   private void sendOnSnapshotEvent(
-      String appName,String databaseId, int listenerId, DocumentSnapshot documentSnapshot) {
-    Tasks.call(getExecutor(), () -> snapshotToWritableMap(appName, documentSnapshot))
+      String appName, String databaseId, int listenerId, DocumentSnapshot documentSnapshot) {
+    Tasks.call(getExecutor(), () -> snapshotToWritableMap(appName, databaseId, documentSnapshot))
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -306,7 +314,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
             });
   }
 
-  private void sendOnSnapshotError(String appName, String databaseId, int listenerId, Exception exception) {
+  private void sendOnSnapshotError(
+      String appName, String databaseId, int listenerId, Exception exception) {
     WritableMap body = Arguments.createMap();
     WritableMap error = Arguments.createMap();
 
@@ -326,6 +335,10 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
     emitter.sendEvent(
         new ReactNativeFirebaseFirestoreEvent(
-            ReactNativeFirebaseFirestoreEvent.DOCUMENT_EVENT_SYNC, body, appName, databaseId, listenerId));
+            ReactNativeFirebaseFirestoreEvent.DOCUMENT_EVENT_SYNC,
+            body,
+            appName,
+            databaseId,
+            listenerId));
   }
 }

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -56,12 +56,12 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
   @ReactMethod
   public void documentOnSnapshot(
-      String appName, String path, int listenerId, ReadableMap listenerOptions) {
+      String appName, String databaseId, String path, int listenerId, ReadableMap listenerOptions) {
     if (documentSnapshotListeners.get(listenerId) != null) {
       return;
     }
 
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
     final EventListener<DocumentSnapshot> listener =
@@ -95,7 +95,7 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentOffSnapshot(String appName, int listenerId) {
+  public void documentOffSnapshot(String appName, String databaseId, int listenerId) {
     ListenerRegistration listenerRegistration = documentSnapshotListeners.get(listenerId);
     if (listenerRegistration != null) {
       listenerRegistration.remove();
@@ -104,8 +104,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentGet(String appName, String path, ReadableMap getOptions, Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+  public void documentGet(String appName, String databaseId, String path, ReadableMap getOptions, Promise promise) {
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
     Source source;
@@ -140,8 +140,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentDelete(String appName, String path, Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+  public void documentDelete(String appName, String databaseId, String path, Promise promise) {
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
     Tasks.call(getTransactionalExecutor(), documentReference::delete)
         .addOnCompleteListener(
@@ -156,8 +156,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
   @ReactMethod
   public void documentSet(
-      String appName, String path, ReadableMap data, ReadableMap options, Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+      String appName, String databaseId, String path, ReadableMap data, ReadableMap options, Promise promise) {
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
     Tasks.call(getTransactionalExecutor(), () -> parseReadableMap(firebaseFirestore, data))
@@ -195,8 +195,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentUpdate(String appName, String path, ReadableMap data, Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+  public void documentUpdate(String appName, String databaseId, String path, ReadableMap data, Promise promise) {
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
     Tasks.call(getTransactionalExecutor(), () -> parseReadableMap(firebaseFirestore, data))
@@ -214,8 +214,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @ReactMethod
-  public void documentBatch(String appName, ReadableArray writes, Promise promise) {
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+  public void documentBatch(String appName, String databaseId, ReadableArray writes, Promise promise) {
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
 
     Tasks.call(getTransactionalExecutor(), () -> parseDocumentBatches(firebaseFirestore, writes))
         .continueWithTask(

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -72,9 +72,9 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
               listenerRegistration.remove();
               documentSnapshotListeners.remove(listenerId);
             }
-            sendOnSnapshotError(appName, listenerId, exception);
+            sendOnSnapshotError(appName, databaseId, listenerId, exception);
           } else {
-            sendOnSnapshotEvent(appName, listenerId, documentSnapshot);
+            sendOnSnapshotEvent(appName, databaseId, listenerId, documentSnapshot);
           }
         };
 
@@ -282,7 +282,7 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   private void sendOnSnapshotEvent(
-      String appName, int listenerId, DocumentSnapshot documentSnapshot) {
+      String appName,String databaseId, int listenerId, DocumentSnapshot documentSnapshot) {
     Tasks.call(getExecutor(), () -> snapshotToWritableMap(appName, documentSnapshot))
         .addOnCompleteListener(
             task -> {
@@ -298,14 +298,15 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
                         ReactNativeFirebaseFirestoreEvent.DOCUMENT_EVENT_SYNC,
                         body,
                         appName,
+                        databaseId,
                         listenerId));
               } else {
-                sendOnSnapshotError(appName, listenerId, task.getException());
+                sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
               }
             });
   }
 
-  private void sendOnSnapshotError(String appName, int listenerId, Exception exception) {
+  private void sendOnSnapshotError(String appName, String databaseId, int listenerId, Exception exception) {
     WritableMap body = Arguments.createMap();
     WritableMap error = Arguments.createMap();
 
@@ -325,6 +326,6 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
     emitter.sendEvent(
         new ReactNativeFirebaseFirestoreEvent(
-            ReactNativeFirebaseFirestoreEvent.DOCUMENT_EVENT_SYNC, body, appName, listenerId));
+            ReactNativeFirebaseFirestoreEvent.DOCUMENT_EVENT_SYNC, body, appName, databaseId, listenerId));
   }
 }

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreEvent.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreEvent.java
@@ -30,16 +30,19 @@ public class ReactNativeFirebaseFirestoreEvent implements NativeEvent {
   private static final String KEY_BODY = "body";
   private static final String KEY_APP_NAME = "appName";
   private static final String KEY_EVENT_NAME = "eventName";
+  private static final String DATABASE_ID = "databaseId";
   private String eventName;
   private WritableMap eventBody;
   private String appName;
+  private String databaseId;
   private int listenerId;
 
   ReactNativeFirebaseFirestoreEvent(
-      String eventName, WritableMap eventBody, String appName, int listenerId) {
+      String eventName, WritableMap eventBody, String appName, String databaseId, int listenerId) {
     this.eventName = eventName;
     this.eventBody = eventBody;
     this.appName = appName;
+    this.databaseId = databaseId;
     this.listenerId = listenerId;
   }
 
@@ -54,6 +57,7 @@ public class ReactNativeFirebaseFirestoreEvent implements NativeEvent {
     event.putInt(KEY_ID, listenerId);
     event.putMap(KEY_BODY, eventBody);
     event.putString(KEY_APP_NAME, appName);
+    event.putString(DATABASE_ID, databaseId);
     event.putString(KEY_EVENT_NAME, eventName);
     return event;
   }

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreModule.java
@@ -19,6 +19,7 @@ package io.invertase.firebase.firestore;
 
 import static io.invertase.firebase.common.RCTConvertFirebase.toHashMap;
 import static io.invertase.firebase.firestore.ReactNativeFirebaseFirestoreCommon.rejectPromiseFirestoreException;
+import static io.invertase.firebase.firestore.UniversalFirebaseFirestoreCommon.createFirestoreKey;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -49,9 +50,9 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void loadBundle(String appName, String bundle, Promise promise) {
+  public void loadBundle(String appName, String databaseId, String bundle, Promise promise) {
     module
-        .loadBundle(appName, bundle)
+        .loadBundle(appName, databaseId, bundle)
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -64,9 +65,9 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void clearPersistence(String appName, Promise promise) {
+  public void clearPersistence(String appName, String databaseId, Promise promise) {
     module
-        .clearPersistence(appName)
+        .clearPersistence(appName, databaseId)
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -78,9 +79,9 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void waitForPendingWrites(String appName, Promise promise) {
+  public void waitForPendingWrites(String appName,String databaseId, Promise promise) {
     module
-        .waitForPendingWrites(appName)
+        .waitForPendingWrites(appName, databaseId)
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -92,9 +93,9 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void disableNetwork(String appName, Promise promise) {
+  public void disableNetwork(String appName, String databaseId, Promise promise) {
     module
-        .disableNetwork(appName)
+        .disableNetwork(appName, databaseId)
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -106,9 +107,9 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void enableNetwork(String appName, Promise promise) {
+  public void enableNetwork(String appName, String databaseId, Promise promise) {
     module
-        .enableNetwork(appName)
+        .enableNetwork(appName, databaseId)
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -120,9 +121,9 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void useEmulator(String appName, String host, int port, Promise promise) {
+  public void useEmulator(String appName, String databaseId, String host, int port, Promise promise) {
     module
-        .useEmulator(appName, host, port)
+        .useEmulator(appName, databaseId, host, port)
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -134,9 +135,10 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void settings(String appName, ReadableMap settings, Promise promise) {
+  public void settings(String appName, String databaseId, ReadableMap settings, Promise promise) {
+    String firestoreKey = createFirestoreKey(appName, databaseId);
     module
-        .settings(appName, toHashMap(settings))
+        .settings(firestoreKey, toHashMap(settings))
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {
@@ -148,9 +150,9 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void terminate(String appName, Promise promise) {
+  public void terminate(String appName, String databaseId, Promise promise) {
     module
-        .terminate(appName)
+        .terminate(appName, databaseId)
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreModule.java
@@ -79,7 +79,7 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void waitForPendingWrites(String appName,String databaseId, Promise promise) {
+  public void waitForPendingWrites(String appName, String databaseId, Promise promise) {
     module
         .waitForPendingWrites(appName, databaseId)
         .addOnCompleteListener(
@@ -121,7 +121,8 @@ public class ReactNativeFirebaseFirestoreModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
-  public void useEmulator(String appName, String databaseId, String host, int port, Promise promise) {
+  public void useEmulator(
+      String appName, String databaseId, String host, int port, Promise promise) {
     module
         .useEmulator(appName, databaseId, host, port)
         .addOnCompleteListener(

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
@@ -38,10 +38,12 @@ import java.util.concurrent.Executor;
 
 public class ReactNativeFirebaseFirestoreQuery {
   String appName;
+  String databaseId;
   Query query;
 
   ReactNativeFirebaseFirestoreQuery(
       String appName,
+      String databaseId,
       Query query,
       ReadableArray filters,
       ReadableArray orders,
@@ -58,7 +60,7 @@ public class ReactNativeFirebaseFirestoreQuery {
         executor,
         () -> {
           QuerySnapshot querySnapshot = Tasks.await(query.get(source));
-          return snapshotToWritableMap(this.appName, "get", querySnapshot, null);
+          return snapshotToWritableMap(this.appName, this.databaseId, "get", querySnapshot, null);
         });
   }
 

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreSerialize.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreSerialize.java
@@ -98,7 +98,8 @@ public class ReactNativeFirebaseFirestoreSerialize {
    * @param documentSnapshot DocumentSnapshot
    * @return WritableMap
    */
-  static WritableMap snapshotToWritableMap(String appName, DocumentSnapshot documentSnapshot) {
+  static WritableMap snapshotToWritableMap(
+      String appName, String databaseId, DocumentSnapshot documentSnapshot) {
     WritableArray metadata = Arguments.createArray();
     WritableMap documentMap = Arguments.createMap();
     SnapshotMetadata snapshotMetadata = documentSnapshot.getMetadata();
@@ -112,7 +113,7 @@ public class ReactNativeFirebaseFirestoreSerialize {
     documentMap.putBoolean(KEY_EXISTS, documentSnapshot.exists());
 
     DocumentSnapshot.ServerTimestampBehavior timestampBehavior =
-        getServerTimestampBehavior(appName);
+        getServerTimestampBehavior(appName, databaseId);
 
     if (documentSnapshot.exists()) {
       if (documentSnapshot.getData(timestampBehavior) != null) {
@@ -132,6 +133,7 @@ public class ReactNativeFirebaseFirestoreSerialize {
    */
   static WritableMap snapshotToWritableMap(
       String appName,
+      String databaseId,
       String source,
       QuerySnapshot querySnapshot,
       @Nullable MetadataChanges metadataChanges) {
@@ -148,7 +150,8 @@ public class ReactNativeFirebaseFirestoreSerialize {
       // indicating the data does not include these changes
       writableMap.putBoolean("excludesMetadataChanges", true);
       writableMap.putArray(
-          KEY_CHANGES, documentChangesToWritableArray(appName, documentChangesList, null));
+          KEY_CHANGES,
+          documentChangesToWritableArray(appName, databaseId, documentChangesList, null));
     } else {
       // If listening to metadata changes, get the changes list with document changes array.
       // To indicate whether a document change was because of metadata change, we check whether
@@ -159,7 +162,7 @@ public class ReactNativeFirebaseFirestoreSerialize {
       writableMap.putArray(
           KEY_CHANGES,
           documentChangesToWritableArray(
-              appName, documentMetadataChangesList, documentChangesList));
+              appName, databaseId, documentMetadataChangesList, documentChangesList));
     }
 
     SnapshotMetadata snapshotMetadata = querySnapshot.getMetadata();
@@ -167,7 +170,7 @@ public class ReactNativeFirebaseFirestoreSerialize {
 
     // set documents
     for (DocumentSnapshot documentSnapshot : documentSnapshots) {
-      documents.pushMap(snapshotToWritableMap(appName, documentSnapshot));
+      documents.pushMap(snapshotToWritableMap(appName, databaseId, documentSnapshot));
     }
     writableMap.putArray(KEY_DOCUMENTS, documents);
 
@@ -188,6 +191,7 @@ public class ReactNativeFirebaseFirestoreSerialize {
    */
   private static WritableArray documentChangesToWritableArray(
       String appName,
+      String databaseId,
       List<DocumentChange> documentChanges,
       @Nullable List<DocumentChange> comparableDocumentChanges) {
     WritableArray documentChangesWritable = Arguments.createArray();
@@ -212,7 +216,7 @@ public class ReactNativeFirebaseFirestoreSerialize {
       }
 
       documentChangesWritable.pushMap(
-          documentChangeToWritableMap(appName, documentChange, isMetadataChange));
+          documentChangeToWritableMap(appName, databaseId, documentChange, isMetadataChange));
     }
 
     return documentChangesWritable;
@@ -225,7 +229,7 @@ public class ReactNativeFirebaseFirestoreSerialize {
    * @return WritableMap
    */
   private static WritableMap documentChangeToWritableMap(
-      String appName, DocumentChange documentChange, boolean isMetadataChange) {
+      String appName, String databaseId, DocumentChange documentChange, boolean isMetadataChange) {
     WritableMap documentChangeMap = Arguments.createMap();
     documentChangeMap.putBoolean("isMetadataChange", isMetadataChange);
 
@@ -242,7 +246,8 @@ public class ReactNativeFirebaseFirestoreSerialize {
     }
 
     documentChangeMap.putMap(
-        KEY_DOC_CHANGE_DOCUMENT, snapshotToWritableMap(appName, documentChange.getDocument()));
+        KEY_DOC_CHANGE_DOCUMENT,
+        snapshotToWritableMap(appName, databaseId, documentChange.getDocument()));
 
     documentChangeMap.putInt(KEY_DOC_CHANGE_NEW_INDEX, documentChange.getNewIndex());
     documentChangeMap.putInt(KEY_DOC_CHANGE_OLD_INDEX, documentChange.getOldIndex());

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
@@ -79,7 +79,9 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
 
     Tasks.call(
             getTransactionalExecutor(),
-            () -> snapshotToWritableMap(appName, transactionHandler.getDocument(documentReference)))
+            () ->
+                snapshotToWritableMap(
+                    appName, databaseId, transactionHandler.getDocument(documentReference)))
         .addOnCompleteListener(
             task -> {
               if (task.isSuccessful()) {

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
@@ -138,6 +138,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
                                 ReactNativeFirebaseFirestoreEvent.TRANSACTION_EVENT_SYNC,
                                 eventMap,
                                 transactionHandler.getAppName(),
+                                databaseId,
                                 transactionHandler.getTransactionId()));
                       });
 
@@ -227,6 +228,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
                         ReactNativeFirebaseFirestoreEvent.TRANSACTION_EVENT_SYNC,
                         eventMap,
                         transactionHandler.getAppName(),
+                        databaseId,
                         transactionHandler.getTransactionId()));
               } else {
                 eventMap.putString("type", "error");
@@ -247,6 +249,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
                         ReactNativeFirebaseFirestoreEvent.TRANSACTION_EVENT_SYNC,
                         eventMap,
                         transactionHandler.getAppName(),
+                        databaseId,
                         transactionHandler.getTransactionId()));
               }
             });

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
@@ -62,7 +62,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
 
   @ReactMethod
   public void transactionGetDocument(
-      String appName, int transactionId, String path, Promise promise) {
+      String appName, String databaseId, int transactionId, String path, Promise promise) {
     ReactNativeFirebaseFirestoreTransactionHandler transactionHandler =
         transactionHandlers.get(transactionId);
 
@@ -74,7 +74,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
       return;
     }
 
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
     Tasks.call(
@@ -91,7 +91,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
   }
 
   @ReactMethod
-  public void transactionDispose(String appName, int transactionId) {
+  public void transactionDispose(String appName, String databaseId, int transactionId) {
     ReactNativeFirebaseFirestoreTransactionHandler transactionHandler =
         transactionHandlers.get(transactionId);
 
@@ -103,7 +103,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
 
   @ReactMethod
   public void transactionApplyBuffer(
-      String appName, int transactionId, ReadableArray commandBuffer) {
+      String appName, String databaseId, int transactionId, ReadableArray commandBuffer) {
     ReactNativeFirebaseFirestoreTransactionHandler handler = transactionHandlers.get(transactionId);
 
     if (handler != null) {
@@ -112,12 +112,12 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
   }
 
   @ReactMethod
-  public void transactionBegin(String appName, int transactionId) {
+  public void transactionBegin(String appName, String databaseId, int transactionId) {
     ReactNativeFirebaseFirestoreTransactionHandler transactionHandler =
         new ReactNativeFirebaseFirestoreTransactionHandler(appName, transactionId);
     transactionHandlers.put(transactionId, transactionHandler);
 
-    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName);
+    FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     ReactNativeFirebaseEventEmitter emitter = ReactNativeFirebaseEventEmitter.getSharedInstance();
 
     // Provides its own executor

--- a/packages/firestore/e2e/SecondDatabase.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase.e2e.js
@@ -1,0 +1,1091 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const { wipe } = require('./helpers');
+
+// This collection is only allowed on the second database
+const COLLECTION = 'second-database';
+const SECOND_DATABASE_ID = 'second-rnfb';
+
+describe('Second Database', function () {
+  describe('firestore().collection().where()', function () {
+    let firestore;
+
+    before(function () {
+      firestore = firebase.app().firestore(SECOND_DATABASE_ID);
+    });
+
+    beforeEach(async function () {
+      return await wipe(false, SECOND_DATABASE_ID);
+    });
+
+    describe('v8 compatibility', function () {
+      it('throws if fieldPath is invalid', function () {
+        try {
+          firestore.collection(COLLECTION).where(123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            'must be a string, instance of FieldPath or instance of Filter',
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if fieldPath string is invalid', function () {
+        try {
+          firestore.collection(COLLECTION).where('.foo.bar');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'fieldPath' Invalid field path");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if operator string is invalid', function () {
+        try {
+          firestore.collection(COLLECTION).where('foo.bar', '!');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'opStr' is invalid");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if query contains multiple array-contains', function () {
+        try {
+          firestore
+            .collection(COLLECTION)
+            .where('foo.bar', 'array-contains', 123)
+            .where('foo.bar', 'array-contains', 123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('Queries only support a single array-contains filter');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if value is not defined', function () {
+        try {
+          firestore.collection(COLLECTION).where('foo.bar', 'array-contains');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'value' argument expected");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if null value and no equal operator', function () {
+        try {
+          firestore.collection(COLLECTION).where('foo.bar', 'array-contains', null);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('You can only perform equals comparisons on null');
+          return Promise.resolve();
+        }
+      });
+
+      it('allows null to be used with equal operator', function () {
+        firestore.collection(COLLECTION).where('foo.bar', '==', null);
+      });
+
+      it('allows null to be used with not equal operator', function () {
+        firestore.collection(COLLECTION).where('foo.bar', '!=', null);
+      });
+
+      it('allows inequality on the same path', function () {
+        firestore
+          .collection(COLLECTION)
+          .where('foo.bar', '>', 123)
+          .where(new firebase.firestore.FieldPath('foo', 'bar'), '>', 1234);
+      });
+
+      it('throws if in query with no array value', function () {
+        try {
+          firestore.collection(COLLECTION).where('foo.bar', 'in', '123');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('A non-empty array is required');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if array-contains-any query with no array value', function () {
+        try {
+          firestore.collection(COLLECTION).where('foo.bar', 'array-contains-any', '123');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('A non-empty array is required');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if in query array length is greater than 30', function () {
+        try {
+          const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
+
+          firestore.collection(COLLECTION).where('foo.bar', 'in', queryArray);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('maximum of 30 elements in the value');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if query has multiple array-contains-any filter', function () {
+        try {
+          firestore
+            .collection(COLLECTION)
+            .where('foo.bar', 'array-contains-any', [1])
+            .where('foo.bar', 'array-contains-any', [2]);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "You cannot use more than one 'array-contains-any' filter",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      /* Queries */
+
+      it('returns with where equal filter', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/equal`);
+
+        const search = Date.now();
+        await Promise.all([
+          colRef.add({ foo: search }),
+          colRef.add({ foo: search }),
+          colRef.add({ foo: search + 1234 }),
+        ]);
+
+        const snapshot = await colRef.where('foo', '==', search).get();
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.eql(search);
+        });
+      });
+
+      it('returns with where greater than filter', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/greater`);
+
+        const search = Date.now();
+        await Promise.all([
+          colRef.add({ foo: search - 1234 }),
+          colRef.add({ foo: search }),
+          colRef.add({ foo: search + 1234 }),
+          colRef.add({ foo: search + 1234 }),
+        ]);
+
+        const snapshot = await colRef.where('foo', '>', search).get();
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.eql(search + 1234);
+        });
+      });
+
+      it('returns with where greater than or equal filter', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/greaterequal`);
+
+        const search = Date.now();
+        await Promise.all([
+          colRef.add({ foo: search - 1234 }),
+          colRef.add({ foo: search }),
+          colRef.add({ foo: search + 1234 }),
+          colRef.add({ foo: search + 1234 }),
+        ]);
+
+        const snapshot = await colRef.where('foo', '>=', search).get();
+
+        snapshot.size.should.eql(3);
+        snapshot.forEach(s => {
+          s.data().foo.should.be.aboveOrEqual(search);
+        });
+      });
+
+      it('returns with where less than filter', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/less`);
+
+        const search = -Date.now();
+        await Promise.all([
+          colRef.add({ foo: search + -1234 }),
+          colRef.add({ foo: search + -1234 }),
+          colRef.add({ foo: search }),
+        ]);
+
+        const snapshot = await colRef.where('foo', '<', search).get();
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.be.below(search);
+        });
+      });
+
+      it('returns with where less than or equal filter', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/lessequal`);
+
+        const search = -Date.now();
+        await Promise.all([
+          colRef.add({ foo: search + -1234 }),
+          colRef.add({ foo: search + -1234 }),
+          colRef.add({ foo: search }),
+          colRef.add({ foo: search + 1234 }),
+        ]);
+
+        const snapshot = await colRef.where('foo', '<=', search).get();
+
+        snapshot.size.should.eql(3);
+        snapshot.forEach(s => {
+          s.data().foo.should.be.belowOrEqual(search);
+        });
+      });
+
+      it('returns when combining greater than and lesser than on the same nested field', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/greaterandless`);
+
+        await Promise.all([
+          colRef.doc('doc1').set({ foo: { bar: 1 } }),
+          colRef.doc('doc2').set({ foo: { bar: 2 } }),
+          colRef.doc('doc3').set({ foo: { bar: 3 } }),
+        ]);
+
+        const snapshot = await colRef
+          .where('foo.bar', '>', 1)
+          .where('foo.bar', '<', 3)
+          .orderBy('foo.bar')
+          .get();
+
+        snapshot.size.should.eql(1);
+      });
+
+      it('returns when combining greater than and lesser than on the same nested field using FieldPath', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/greaterandless`);
+
+        await Promise.all([
+          colRef.doc('doc1').set({ foo: { bar: 1 } }),
+          colRef.doc('doc2').set({ foo: { bar: 2 } }),
+          colRef.doc('doc3').set({ foo: { bar: 3 } }),
+        ]);
+
+        const snapshot = await colRef
+          .where(new firebase.firestore.FieldPath('foo', 'bar'), '>', 1)
+          .where(new firebase.firestore.FieldPath('foo', 'bar'), '<', 3)
+          .orderBy(new firebase.firestore.FieldPath('foo', 'bar'))
+          .get();
+
+        snapshot.size.should.eql(1);
+      });
+
+      it('returns with where array-contains filter', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/array-contains`);
+
+        const match = Date.now();
+        await Promise.all([
+          colRef.add({ foo: [1, '2', match] }),
+          colRef.add({ foo: [1, '2', match.toString()] }),
+          colRef.add({ foo: [1, '2', match.toString()] }),
+        ]);
+
+        const snapshot = await colRef.where('foo', 'array-contains', match.toString()).get();
+        const expected = [1, '2', match.toString()];
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.eql(jet.contextify(expected));
+        });
+      });
+
+      it('returns with in filter', async function () {
+        const colRef = firestore.collection(`${COLLECTION}/filter/in${Date.now() + ''}`);
+
+        await Promise.all([
+          colRef.add({ status: 'Ordered' }),
+          colRef.add({ status: 'Ready to Ship' }),
+          colRef.add({ status: 'Ready to Ship' }),
+          colRef.add({ status: 'Incomplete' }),
+        ]);
+
+        const expect = ['Ready to Ship', 'Ordered'];
+        const snapshot = await colRef.where('status', 'in', expect).get();
+        snapshot.size.should.eql(3);
+
+        snapshot.forEach(s => {
+          s.data().status.should.equalOneOf(...expect);
+        });
+      });
+
+      it('returns with array-contains-any filter', async function () {
+        const colRef = firestore.collection(
+          `${COLLECTION}/filter/array-contains-any${Date.now() + ''}`,
+        );
+
+        await Promise.all([
+          colRef.add({ category: ['Appliances', 'Housewares', 'Cooking'] }),
+          colRef.add({ category: ['Appliances', 'Electronics', 'Nursery'] }),
+          colRef.add({ category: ['Audio/Video', 'Electronics'] }),
+          colRef.add({ category: ['Beauty'] }),
+        ]);
+
+        const expect = ['Appliances', 'Electronics'];
+        const snapshot = await colRef.where('category', 'array-contains-any', expect).get();
+        snapshot.size.should.eql(3); // 2nd record should only be returned once
+      });
+
+      it('returns with a FieldPath', async function () {
+        const colRef = firestore.collection(
+          `${COLLECTION}/filter/where-fieldpath${Date.now() + ''}`,
+        );
+        const fieldPath = new firebase.firestore.FieldPath('map', 'foo.bar@gmail.com');
+
+        await colRef.add({
+          map: {
+            'foo.bar@gmail.com': true,
+          },
+        });
+        await colRef.add({
+          map: {
+            'bar.foo@gmail.com': true,
+          },
+        });
+
+        const snapshot = await colRef.where(fieldPath, '==', true).get();
+        snapshot.size.should.eql(1); // 2nd record should only be returned once
+        const data = snapshot.docs[0].data();
+        should.equal(data.map['foo.bar@gmail.com'], true);
+      });
+
+      it('should throw an error if you use a FieldPath on a filter in conjunction with an orderBy() parameter that is not FieldPath', async function () {
+        try {
+          firestore
+            .collection(COLLECTION)
+            .where(firebase.firestore.FieldPath.documentId(), 'in', ['document-id'])
+            .orderBy('differentOrderBy', 'desc');
+
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'FirestoreFieldPath' cannot be used in conjunction");
+          return Promise.resolve();
+        }
+      });
+
+      it('should correctly query integer values with in operator', async function () {
+        const ref = firestore.collection(`${COLLECTION}/filter/int-in${Date.now() + ''}`);
+
+        await ref.add({ status: 1 });
+
+        const items = [];
+        await ref
+          .where('status', 'in', [1, 2])
+          .get()
+          .then($ => $.forEach(doc => items.push(doc.data())));
+
+        items.length.should.equal(1);
+      });
+
+      it('should correctly query integer values with array-contains operator', async function () {
+        const ref = firestore.collection(
+          `${COLLECTION}/filter/int-array-contains${Date.now() + ''}`,
+        );
+
+        await ref.add({ status: [1, 2, 3] });
+
+        const items = [];
+        await ref
+          .where('status', 'array-contains', 2)
+          .get()
+          .then($ => $.forEach(doc => items.push(doc.data())));
+
+        items.length.should.equal(1);
+      });
+
+      it("should correctly retrieve data when using 'not-in' operator", async function () {
+        const ref = firestore.collection(`${COLLECTION}/filter/not-in${Date.now() + ''}`);
+
+        await Promise.all([ref.add({ notIn: 'here' }), ref.add({ notIn: 'now' })]);
+
+        const result = await ref.where('notIn', 'not-in', ['here', 'there', 'everywhere']).get();
+        should(result.docs.length).equal(1);
+        should(result.docs[0].data().notIn).equal('now');
+      });
+
+      it("should throw error when using 'not-in' operator twice", async function () {
+        const ref = firestore.collection(COLLECTION);
+
+        try {
+          ref.where('test', 'not-in', [1]).where('test', 'not-in', [2]);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("You cannot use more than one 'not-in' filter.");
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when combining 'not-in' operator with '!=' operator", async function () {
+        const ref = firestore.collection(COLLECTION);
+
+        try {
+          ref.where('test', '!=', 1).where('test', 'not-in', [1]);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "You cannot use 'not-in' filters with '!=' inequality filters",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when combining 'not-in' operator with 'in' operator", async function () {
+        const ref = firestore.collection(COLLECTION);
+
+        try {
+          ref.where('test', 'in', [2]).where('test', 'not-in', [1]);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("You cannot use 'not-in' filters with 'in' filters.");
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when combining 'not-in' operator with 'array-contains-any' operator", async function () {
+        const ref = firestore.collection(COLLECTION);
+
+        try {
+          ref.where('test', 'array-contains-any', [2]).where('test', 'not-in', [1]);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "You cannot use 'not-in' filters with 'array-contains-any' filters.",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when 'not-in' filter has a list of more than 10 items", async function () {
+        const ref = firestore.collection(COLLECTION);
+        const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
+
+        try {
+          ref.where('test', 'not-in', queryArray);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            'filters support a maximum of 30 elements in the value array.',
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it("should correctly retrieve data when using '!=' operator", async function () {
+        const ref = firestore.collection(`${COLLECTION}/filter/bang-equals${Date.now() + ''}`);
+
+        await Promise.all([ref.add({ notEqual: 'here' }), ref.add({ notEqual: 'now' })]);
+
+        const result = await ref.where('notEqual', '!=', 'here').get();
+
+        should(result.docs.length).equal(1);
+        should(result.docs[0].data().notEqual).equal('now');
+      });
+
+      it("should throw error when using '!=' operator twice ", async function () {
+        const ref = firestore.collection(COLLECTION);
+
+        try {
+          ref.where('test', '!=', 1).where('test', '!=', 2);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("You cannot use more than one '!=' inequality filter.");
+          return Promise.resolve();
+        }
+      });
+
+      it('should handle where clause after sort by', async function () {
+        const ref = firestore.collection(`${COLLECTION}/filter/sort-by-where${Date.now() + ''}`);
+
+        await ref.add({ status: 1 });
+        await ref.add({ status: 2 });
+        await ref.add({ status: 3 });
+
+        const items = [];
+        await ref
+          .orderBy('status', 'desc')
+          .where('status', '<=', 2)
+          .get()
+          .then($ => $.forEach(doc => items.push(doc.data())));
+
+        items.length.should.equal(2);
+        items[0].status.should.equal(2);
+        items[1].status.should.equal(1);
+      });
+    });
+
+    describe('modular', function () {
+      let firestore;
+
+      before(function () {
+        const { getFirestore } = firestoreModular;
+        firestore = getFirestore(null, SECOND_DATABASE_ID);
+      });
+
+      it('throws if fieldPath is invalid', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(collection(firestore, COLLECTION), where(123));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            'must be a string, instance of FieldPath or instance of Filter',
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if fieldPath string is invalid', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(collection(firestore, COLLECTION), where('.foo.bar'));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'fieldPath' Invalid field path");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if operator string is invalid', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(collection(firestore, COLLECTION), where('foo.bar', '!'));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'opStr' is invalid");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if query contains multiple array-contains', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(
+            collection(firestore, COLLECTION),
+            where('foo.bar', 'array-contains', 123),
+            where('foo.bar', 'array-contains', 123),
+          );
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('Queries only support a single array-contains filter');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if value is not defined', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(collection(firestore, COLLECTION), where('foo.bar', 'array-contains'));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'value' argument expected");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if null value and no equal operator', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(collection(firestore, COLLECTION), where('foo.bar', 'array-contains', null));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('You can only perform equals comparisons on null');
+          return Promise.resolve();
+        }
+      });
+
+      it('allows null to be used with equal operator', function () {
+        const { collection, query, where } = firestoreModular;
+        query(collection(firestore, COLLECTION), where('foo.bar', '==', null));
+      });
+
+      it('allows null to be used with not equal operator', function () {
+        const { collection, query, where } = firestoreModular;
+        query(collection(firestore, COLLECTION), where('foo.bar', '!=', null));
+      });
+
+      it('allows inequality on the same path', function () {
+        const { collection, query, where, FieldPath } = firestoreModular;
+        query(
+          collection(firestore, COLLECTION),
+          where('foo.bar', '>', 123),
+          where(new FieldPath('foo', 'bar'), '>', 1234),
+        );
+      });
+
+      it('throws if in query with no array value', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(collection(firestore, COLLECTION), where('foo.bar', 'in', '123'));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('A non-empty array is required');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if array-contains-any query with no array value', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(collection(firestore, COLLECTION), where('foo.bar', 'array-contains-any', '123'));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('A non-empty array is required');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if in query array length is greater than 30', function () {
+        const { collection, query, where } = firestoreModular;
+        const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
+
+        try {
+          query(collection(firestore, COLLECTION), where('foo.bar', 'in', queryArray));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('maximum of 30 elements in the value');
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if query has multiple array-contains-any filter', function () {
+        const { collection, query, where } = firestoreModular;
+        try {
+          query(
+            collection(firestore, COLLECTION),
+            where('foo.bar', 'array-contains-any', [1]),
+            where('foo.bar', 'array-contains-any', [2]),
+          );
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "You cannot use more than one 'array-contains-any' filter",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      /* Queries */
+
+      it('returns with where equal filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/equal`);
+
+        const search = Date.now();
+        await Promise.all([
+          addDoc(colRef, { foo: search }),
+          addDoc(colRef, { foo: search }),
+          addDoc(colRef, { foo: search + 1234 }),
+        ]);
+
+        const snapshot = await getDocs(query(colRef, where('foo', '==', search)));
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.eql(search);
+        });
+      });
+
+      it('returns with where greater than filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/greater`);
+
+        const search = Date.now();
+        await Promise.all([
+          addDoc(colRef, { foo: search - 1234 }),
+          addDoc(colRef, { foo: search }),
+          addDoc(colRef, { foo: search + 1234 }),
+          addDoc(colRef, { foo: search + 1234 }),
+        ]);
+
+        const snapshot = await getDocs(query(colRef, where('foo', '>', search)));
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.eql(search + 1234);
+        });
+      });
+
+      it('returns with where greater than or equal filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/greaterequal`);
+
+        const search = Date.now();
+        await Promise.all([
+          addDoc(colRef, { foo: search - 1234 }),
+          addDoc(colRef, { foo: search }),
+          addDoc(colRef, { foo: search + 1234 }),
+          addDoc(colRef, { foo: search + 1234 }),
+        ]);
+
+        const snapshot = await getDocs(query(colRef, where('foo', '>=', search)));
+
+        snapshot.size.should.eql(3);
+        snapshot.forEach(s => {
+          s.data().foo.should.be.aboveOrEqual(search);
+        });
+      });
+
+      it('returns with where less than filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/less`);
+
+        const search = -Date.now();
+        await Promise.all([
+          addDoc(colRef, { foo: search + -1234 }),
+          addDoc(colRef, { foo: search + -1234 }),
+          addDoc(colRef, { foo: search }),
+        ]);
+
+        const snapshot = await getDocs(query(colRef, where('foo', '<', search)));
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.be.below(search);
+        });
+      });
+
+      it('returns with where less than or equal filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/lessequal`);
+
+        const search = -Date.now();
+        await Promise.all([
+          addDoc(colRef, { foo: search + -1234 }),
+          addDoc(colRef, { foo: search + -1234 }),
+          addDoc(colRef, { foo: search }),
+          addDoc(colRef, { foo: search + 1234 }),
+        ]);
+
+        const snapshot = await getDocs(query(colRef, where('foo', '<=', search)));
+
+        snapshot.size.should.eql(3);
+        snapshot.forEach(s => {
+          s.data().foo.should.be.belowOrEqual(search);
+        });
+      });
+
+      it('returns when combining greater than and lesser than on the same nested field', async function () {
+        const { collection, doc, setDoc, query, where, orderBy, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/greaterandless`);
+
+        await Promise.all([
+          setDoc(doc(colRef, 'doc1'), { foo: { bar: 1 } }),
+          setDoc(doc(colRef, 'doc2'), { foo: { bar: 2 } }),
+          setDoc(doc(colRef, 'doc3'), { foo: { bar: 3 } }),
+        ]);
+
+        const snapshot = await getDocs(
+          query(colRef, where('foo.bar', '>', 1), where('foo.bar', '<', 3), orderBy('foo.bar')),
+        );
+
+        snapshot.size.should.eql(1);
+      });
+
+      it('returns when combining greater than and lesser than on the same nested field using FieldPath', async function () {
+        const { collection, doc, setDoc, query, where, getDocs, orderBy, FieldPath } =
+          firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/greaterandless`);
+
+        await Promise.all([
+          setDoc(doc(colRef, 'doc1'), { foo: { bar: 1 } }),
+          setDoc(doc(colRef, 'doc2'), { foo: { bar: 2 } }),
+          setDoc(doc(colRef, 'doc3'), { foo: { bar: 3 } }),
+        ]);
+
+        const snapshot = await getDocs(
+          query(
+            colRef,
+            where(new FieldPath('foo', 'bar'), '>', 1),
+            where(new FieldPath('foo', 'bar'), '<', 3),
+            orderBy(new FieldPath('foo', 'bar')),
+          ),
+        );
+
+        snapshot.size.should.eql(1);
+      });
+
+      it('returns with where array-contains filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/array-contains`);
+
+        const match = Date.now();
+        await Promise.all([
+          addDoc(colRef, { foo: [1, '2', match] }),
+          addDoc(colRef, { foo: [1, '2', match.toString()] }),
+          addDoc(colRef, { foo: [1, '2', match.toString()] }),
+        ]);
+
+        const snapshot = await getDocs(
+          query(colRef, where('foo', 'array-contains', match.toString())),
+        );
+        const expected = [1, '2', match.toString()];
+
+        snapshot.size.should.eql(2);
+        snapshot.forEach(s => {
+          s.data().foo.should.eql(jet.contextify(expected));
+        });
+      });
+
+      it('returns with in filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(firestore, `${COLLECTION}/filter/in${Date.now() + ''}`);
+
+        await Promise.all([
+          addDoc(colRef, { status: 'Ordered' }),
+          addDoc(colRef, { status: 'Ready to Ship' }),
+          addDoc(colRef, { status: 'Ready to Ship' }),
+          addDoc(colRef, { status: 'Incomplete' }),
+        ]);
+
+        const expect = ['Ready to Ship', 'Ordered'];
+        const snapshot = await getDocs(query(colRef, where('status', 'in', expect)));
+        snapshot.size.should.eql(3);
+
+        snapshot.forEach(s => {
+          s.data().status.should.equalOneOf(...expect);
+        });
+      });
+
+      it('returns with array-contains-any filter', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const colRef = collection(
+          firestore,
+          `${COLLECTION}/filter/array-contains-any${Date.now() + ''}`,
+        );
+
+        await Promise.all([
+          addDoc(colRef, { category: ['Appliances', 'Housewares', 'Cooking'] }),
+          addDoc(colRef, { category: ['Appliances', 'Electronics', 'Nursery'] }),
+          addDoc(colRef, { category: ['Audio/Video', 'Electronics'] }),
+          addDoc(colRef, { category: ['Beauty'] }),
+        ]);
+
+        const expect = ['Appliances', 'Electronics'];
+        const snapshot = await getDocs(
+          query(colRef, where('category', 'array-contains-any', expect)),
+        );
+        snapshot.size.should.eql(3); // 2nd record should only be returned once
+      });
+
+      it('returns with a FieldPath', async function () {
+        const { collection, addDoc, query, where, getDocs, FieldPath } = firestoreModular;
+        const colRef = collection(
+          firestore,
+          `${COLLECTION}/filter/where-fieldpath${Date.now() + ''}`,
+        );
+        const fieldPath = new FieldPath('map', 'foo.bar@gmail.com');
+
+        await addDoc(colRef, {
+          map: {
+            'foo.bar@gmail.com': true,
+          },
+        });
+        await addDoc(colRef, {
+          map: {
+            'bar.foo@gmail.com': true,
+          },
+        });
+
+        const snapshot = await getDocs(query(colRef, where(fieldPath, '==', true)));
+        snapshot.size.should.eql(1); // 2nd record should only be returned once
+        const data = snapshot.docs[0].data();
+        should.equal(data.map['foo.bar@gmail.com'], true);
+      });
+
+      it('should throw an error if you use a FieldPath on a filter in conjunction with an orderBy() parameter that is not FieldPath', async function () {
+        const { collection, query, where, orderBy, FieldPath } = firestoreModular;
+        try {
+          query(
+            collection(firestore, COLLECTION),
+            where(FieldPath.documentId(), 'in', ['document-id']),
+            orderBy('differentOrderBy', 'desc'),
+          );
+
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'FirestoreFieldPath' cannot be used in conjunction");
+          return Promise.resolve();
+        }
+      });
+
+      it('should correctly query integer values with in operator', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const ref = collection(firestore, `${COLLECTION}/filter/int-in${Date.now() + ''}`);
+
+        await addDoc(ref, { status: 1 });
+
+        const items = [];
+        await getDocs(query(ref, where('status', 'in', [1, 2]))).then($ =>
+          $.forEach(doc => items.push(doc.data())),
+        );
+
+        items.length.should.equal(1);
+      });
+
+      it('should correctly query integer values with array-contains operator', async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const ref = collection(
+          firestore,
+          `${COLLECTION}/filter/int-array-contains${Date.now() + ''}`,
+        );
+
+        await addDoc(ref, { status: [1, 2, 3] });
+
+        const items = [];
+        await getDocs(query(ref, where('status', 'array-contains', 2))).then($ =>
+          $.forEach(doc => items.push(doc.data())),
+        );
+
+        items.length.should.equal(1);
+      });
+
+      it("should correctly retrieve data when using 'not-in' operator", async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const ref = collection(firestore, `${COLLECTION}/filter/not-in${Date.now() + ''}`);
+
+        await Promise.all([addDoc(ref, { notIn: 'here' }), addDoc(ref, { notIn: 'now' })]);
+
+        const result = await getDocs(
+          query(ref, where('notIn', 'not-in', ['here', 'there', 'everywhere'])),
+        );
+        should(result.docs.length).equal(1);
+        should(result.docs[0].data().notIn).equal('now');
+      });
+
+      it("should throw error when using 'not-in' operator twice", async function () {
+        const { collection, query, where } = firestoreModular;
+        const ref = collection(firestore, COLLECTION);
+
+        try {
+          query(ref, where('test', 'not-in', [1]), where('test', 'not-in', [2]));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("You cannot use more than one 'not-in' filter.");
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when combining 'not-in' operator with '!=' operator", async function () {
+        const { collection, query, where } = firestoreModular;
+        const ref = collection(firestore, COLLECTION);
+
+        try {
+          query(ref, where('test', 'not-in', [1]), where('test', '!=', 1));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "You cannot use 'not-in' filters with '!=' inequality filters",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when combining 'not-in' operator with 'in' operator", async function () {
+        const { collection, query, where } = firestoreModular;
+        const ref = collection(firestore, COLLECTION);
+
+        try {
+          query(ref, where('test', 'in', [2]), where('test', 'not-in', [1]));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("You cannot use 'not-in' filters with 'in' filters.");
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when combining 'not-in' operator with 'array-contains-any' operator", async function () {
+        const { collection, query, where } = firestoreModular;
+        const ref = collection(firestore, COLLECTION);
+
+        try {
+          query(ref, where('test', 'array-contains-any', [2]), where('test', 'not-in', [1]));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "You cannot use 'not-in' filters with 'array-contains-any' filters.",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it("should throw error when 'not-in' filter has a list of more than 10 items", async function () {
+        const { collection, query, where } = firestoreModular;
+        const ref = collection(firestore, COLLECTION);
+        const queryArray = Array.from({ length: 31 }, (_, i) => i + 1);
+
+        try {
+          query(ref, where('test', 'not-in', queryArray));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            'filters support a maximum of 30 elements in the value array.',
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it("should correctly retrieve data when using '!=' operator", async function () {
+        const { collection, addDoc, query, where, getDocs } = firestoreModular;
+        const ref = collection(firestore, `${COLLECTION}/filter/bang-equals${Date.now() + ''}`);
+
+        await Promise.all([addDoc(ref, { notEqual: 'here' }), addDoc(ref, { notEqual: 'now' })]);
+
+        const result = await getDocs(query(ref, where('notEqual', '!=', 'here')));
+
+        should(result.docs.length).equal(1);
+        should(result.docs[0].data().notEqual).equal('now');
+      });
+
+      it("should throw error when using '!=' operator twice ", async function () {
+        const { collection, query, where } = firestoreModular;
+        const ref = collection(firestore, COLLECTION);
+
+        try {
+          query(ref, where('test', '!=', 1), where('test', '!=', 2));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("You cannot use more than one '!=' inequality filter.");
+          return Promise.resolve();
+        }
+      });
+
+      it('should handle where clause after sort by', async function () {
+        const { collection, addDoc, query, where, orderBy, getDocs } = firestoreModular;
+        const ref = collection(firestore, `${COLLECTION}/filter/sort-by-where${Date.now() + ''}`);
+
+        await addDoc(ref, { status: 1 });
+        await addDoc(ref, { status: 2 });
+        await addDoc(ref, { status: 3 });
+
+        const items = [];
+        await getDocs(query(ref, orderBy('status', 'desc'), where('status', '<=', 2))).then($ =>
+          $.forEach(doc => items.push(doc.data())),
+        );
+
+        items.length.should.equal(2);
+        items[0].status.should.equal(2);
+        items[1].status.should.equal(1);
+      });
+    });
+  });
+});

--- a/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
@@ -1,0 +1,774 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+const NO_RULE_COLLECTION = 'no_rules';
+
+// This collection is only allowed on the second database
+const COLLECTION = 'second-database';
+const SECOND_DATABASE_ID = 'second-rnfb';
+
+describe('Second Database', function () {
+  describe('firestore.Transaction', function () {
+    describe('v8 compatibility', function () {
+      let firestore;
+
+      before(function () {
+        firestore = firebase.app().firestore(SECOND_DATABASE_ID);
+      });
+
+      it('should throw if updateFunction is not a Promise', async function () {
+        try {
+          await firestore.runTransaction(() => 123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'updateFunction' must return a Promise");
+          return Promise.resolve();
+        }
+      });
+
+      it('should return an instance of FirestoreTransaction', async function () {
+        await firestore.runTransaction(async transaction => {
+          transaction.constructor.name.should.eql('FirestoreTransaction');
+          return null;
+        });
+      });
+
+      it('should resolve with user value', async function () {
+        const expected = Date.now();
+
+        const value = await firestore.runTransaction(async () => {
+          return expected;
+        });
+
+        value.should.eql(expected);
+      });
+
+      it('should reject with user Error', async function () {
+        const message = `Error: ${Date.now()}`;
+
+        try {
+          await firestore.runTransaction(async () => {
+            throw new Error(message);
+          });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (error) {
+          error.message.should.eql(message);
+          return Promise.resolve();
+        }
+      });
+
+      it('should reject a native error', async function () {
+        const docRef = firestore.doc(`${NO_RULE_COLLECTION}/foo`);
+
+        try {
+          await firestore.runTransaction(async t => {
+            t.set(docRef, {
+              foo: 'bar',
+            });
+          });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (error) {
+          error.code.should.eql('firestore/permission-denied');
+          return Promise.resolve();
+        }
+      });
+
+      describe('transaction.get()', function () {
+        it('should throw if not providing a document reference', async function () {
+          try {
+            await firestore.runTransaction(t => {
+              return t.get(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should get a document and return a DocumentSnapshot', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/transactions/transaction/get-delete`);
+          await docRef.set({});
+
+          await firestore.runTransaction(async t => {
+            const docSnapshot = await t.get(docRef);
+            docSnapshot.constructor.name.should.eql('FirestoreDocumentSnapshot');
+            docSnapshot.exists.should.eql(true);
+            docSnapshot.id.should.eql('get-delete');
+
+            t.delete(docRef);
+          });
+        });
+      });
+
+      describe('transaction.delete()', function () {
+        it('should throw if not providing a document reference', async function () {
+          try {
+            await firestore.runTransaction(async t => {
+              t.delete(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should delete documents', async function () {
+          const docRef1 = firestore.doc(`${COLLECTION}/transactions/transaction/delete-delete1`);
+          await docRef1.set({});
+
+          const docRef2 = firestore.doc(`${COLLECTION}/transactions/transaction/delete-delete2`);
+          await docRef2.set({});
+
+          await firestore.runTransaction(async t => {
+            t.delete(docRef1);
+            t.delete(docRef2);
+          });
+
+          const snapshot1 = await docRef1.get();
+          snapshot1.exists.should.eql(false);
+
+          const snapshot2 = await docRef2.get();
+          snapshot2.exists.should.eql(false);
+        });
+      });
+
+      describe('transaction.update()', function () {
+        it('should throw if not providing a document reference', async function () {
+          try {
+            await firestore.runTransaction(async t => {
+              t.update(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should throw if update args are invalid', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/foo`);
+
+          try {
+            await firestore.runTransaction(async t => {
+              t.update(docRef, 123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql('it must be an object');
+            return Promise.resolve();
+          }
+        });
+
+        it('should update documents', async function () {
+          const value = Date.now();
+
+          const docRef1 = firestore.doc(`${COLLECTION}/transactions/transaction/delete-delete1`);
+          await docRef1.set({
+            foo: 'bar',
+            bar: 'baz',
+          });
+
+          const docRef2 = firestore.doc(`${COLLECTION}/transactions/transaction/delete-delete2`);
+          await docRef2.set({
+            foo: 'bar',
+            bar: 'baz',
+          });
+
+          await firestore.runTransaction(async t => {
+            t.update(docRef1, {
+              bar: value,
+            });
+            t.update(docRef2, 'bar', value);
+          });
+
+          const expected = {
+            foo: 'bar',
+            bar: value,
+          };
+
+          const snapshot1 = await docRef1.get();
+          snapshot1.exists.should.eql(true);
+          snapshot1.data().should.eql(jet.contextify(expected));
+
+          const snapshot2 = await docRef2.get();
+          snapshot2.exists.should.eql(true);
+          snapshot2.data().should.eql(jet.contextify(expected));
+        });
+      });
+
+      describe('transaction.set()', function () {
+        it('should throw if not providing a document reference', async function () {
+          try {
+            await firestore.runTransaction(async t => {
+              t.set(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should throw if set data is invalid', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/foo`);
+
+          try {
+            await firestore.runTransaction(async t => {
+              t.set(docRef, 123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'data' must be an object.");
+            return Promise.resolve();
+          }
+        });
+
+        it('should throw if set options are invalid', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/foo`);
+
+          try {
+            await firestore.runTransaction(async t => {
+              t.set(
+                docRef,
+                {},
+                {
+                  merge: true,
+                  mergeFields: [],
+                },
+              );
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql(
+              "'options' must not contain both 'merge' & 'mergeFields'",
+            );
+            return Promise.resolve();
+          }
+        });
+
+        it('should set data', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/transactions/transaction/set`);
+          await docRef.set({
+            foo: 'bar',
+          });
+          const expected = {
+            foo: 'baz',
+          };
+
+          await firestore.runTransaction(async t => {
+            t.set(docRef, expected);
+          });
+
+          const snapshot = await docRef.get();
+          snapshot.data().should.eql(jet.contextify(expected));
+        });
+
+        it('should set data with merge', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/transactions/transaction/set-merge`);
+          await docRef.set({
+            foo: 'bar',
+            bar: 'baz',
+          });
+          const expected = {
+            foo: 'bar',
+            bar: 'foo',
+          };
+
+          await firestore.runTransaction(async t => {
+            t.set(
+              docRef,
+              {
+                bar: 'foo',
+              },
+              {
+                merge: true,
+              },
+            );
+          });
+
+          const snapshot = await docRef.get();
+          snapshot.data().should.eql(jet.contextify(expected));
+        });
+
+        it('should set data with merge fields', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/transactions/transaction/set-mergefields`);
+          await docRef.set({
+            foo: 'bar',
+            bar: 'baz',
+            baz: 'ben',
+          });
+          const expected = {
+            foo: 'bar',
+            bar: 'foo',
+            baz: 'foo',
+          };
+
+          await firestore.runTransaction(async t => {
+            t.set(
+              docRef,
+              {
+                bar: 'foo',
+                baz: 'foo',
+              },
+              {
+                mergeFields: ['bar', new firebase.firestore.FieldPath('baz')],
+              },
+            );
+          });
+
+          const snapshot = await docRef.get();
+          snapshot.data().should.eql(jet.contextify(expected));
+        });
+
+        it('should roll back any updates that failed', async function () {
+          const docRef = firestore.doc(`${COLLECTION}/transactions/transaction/rollback`);
+
+          await docRef.set({
+            turn: 0,
+          });
+
+          const prop1 = 'prop1';
+          const prop2 = 'prop2';
+          const turn = 0;
+          const errorMessage = 'turn cannot exceed 1';
+
+          const createTransaction = prop => {
+            return firestore.runTransaction(async transaction => {
+              const doc = await transaction.get(docRef);
+              const data = doc.data();
+
+              if (data.turn !== turn) {
+                throw new Error(errorMessage);
+              }
+
+              const update = {
+                turn: turn + 1,
+                [prop]: 1,
+              };
+
+              transaction.update(docRef, update);
+            });
+          };
+
+          const promises = [createTransaction(prop1), createTransaction(prop2)];
+
+          try {
+            await Promise.all(promises);
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql(errorMessage);
+          }
+          const result = await docRef.get();
+          should(result.data()).not.have.properties([prop1, prop2]);
+        });
+      });
+    });
+
+    describe('modular', function () {
+      let firestore;
+
+      before(function () {
+        const { getFirestore } = firestoreModular;
+        firestore = getFirestore(null, SECOND_DATABASE_ID);
+      });
+
+      it('should throw if updateFunction is not a Promise', async function () {
+        const { runTransaction } = firestoreModular;
+
+        try {
+          await runTransaction(firestore, () => 123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'updateFunction' must return a Promise");
+          return Promise.resolve();
+        }
+      });
+
+      it('should return an instance of FirestoreTransaction', async function () {
+        const { runTransaction } = firestoreModular;
+        await runTransaction(firestore, async transaction => {
+          transaction.constructor.name.should.eql('FirestoreTransaction');
+          return null;
+        });
+      });
+
+      it('should resolve with user value', async function () {
+        const { runTransaction } = firestoreModular;
+        const expected = Date.now();
+
+        const value = await runTransaction(firestore, async () => {
+          return expected;
+        });
+
+        value.should.eql(expected);
+      });
+
+      it('should reject with user Error', async function () {
+        const { runTransaction } = firestoreModular;
+        const message = `Error: ${Date.now()}`;
+
+        try {
+          await runTransaction(firestore, async () => {
+            throw new Error(message);
+          });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (error) {
+          error.message.should.eql(message);
+          return Promise.resolve();
+        }
+      });
+
+      it('should reject a native error', async function () {
+        const { runTransaction, doc } = firestoreModular;
+        const db = firestore;
+        const docRef = doc(db, `${NO_RULE_COLLECTION}/foo`);
+
+        try {
+          await runTransaction(db, async t => {
+            t.set(docRef, {
+              foo: 'bar',
+            });
+          });
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (error) {
+          error.code.should.eql('firestore/permission-denied');
+          return Promise.resolve();
+        }
+      });
+
+      describe('transaction.get()', function () {
+        it('should throw if not providing a document reference', async function () {
+          const { runTransaction } = firestoreModular;
+          try {
+            await runTransaction(firestore, t => {
+              return t.get(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should get a document and return a DocumentSnapshot', async function () {
+          const { runTransaction, doc, setDoc } = firestoreModular;
+          const db = firestore;
+          const docRef = doc(db, `${COLLECTION}/transactions/transaction/get-delete`);
+          await setDoc(docRef, {});
+
+          await runTransaction(db, async t => {
+            const docSnapshot = await t.get(docRef);
+            docSnapshot.constructor.name.should.eql('FirestoreDocumentSnapshot');
+            docSnapshot.exists.should.eql(true);
+            docSnapshot.id.should.eql('get-delete');
+
+            t.delete(docRef);
+          });
+        });
+      });
+
+      describe('transaction.delete()', function () {
+        it('should throw if not providing a document reference', async function () {
+          const { runTransaction } = firestoreModular;
+          try {
+            await runTransaction(firestore, async t => {
+              t.delete(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should delete documents', async function () {
+          const { runTransaction, doc, setDoc, getDoc } = firestoreModular;
+          const db = firestore;
+          const docRef1 = doc(db, `${COLLECTION}/transactions/transaction/delete-delete1`);
+          await setDoc(docRef1, {});
+
+          const docRef2 = doc(db, `${COLLECTION}/transactions/transaction/delete-delete2`);
+          await setDoc(docRef2, {});
+
+          await runTransaction(db, async t => {
+            t.delete(docRef1);
+            t.delete(docRef2);
+          });
+
+          const snapshot1 = await getDoc(docRef1);
+          snapshot1.exists.should.eql(false);
+
+          const snapshot2 = await getDoc(docRef2);
+          snapshot2.exists.should.eql(false);
+        });
+      });
+
+      describe('transaction.update()', function () {
+        it('should throw if not providing a document reference', async function () {
+          const { runTransaction } = firestoreModular;
+          try {
+            await runTransaction(firestore, async t => {
+              t.update(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should throw if update args are invalid', async function () {
+          const { runTransaction, doc } = firestoreModular;
+          const db = firestore;
+          const docRef = doc(db, `${COLLECTION}/foo`);
+
+          try {
+            await runTransaction(db, async t => {
+              t.update(docRef, 123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql('it must be an object');
+            return Promise.resolve();
+          }
+        });
+
+        it('should update documents', async function () {
+          const { runTransaction, doc, setDoc, getDoc } = firestoreModular;
+          const db = firestore;
+          const value = Date.now();
+
+          const docRef1 = doc(db, `${COLLECTION}/transactions/transaction/delete-delete1`);
+          await setDoc(docRef1, {
+            foo: 'bar',
+            bar: 'baz',
+          });
+
+          const docRef2 = doc(db, `${COLLECTION}/transactions/transaction/delete-delete2`);
+          await setDoc(docRef2, {
+            foo: 'bar',
+            bar: 'baz',
+          });
+
+          await runTransaction(db, async t => {
+            t.update(docRef1, {
+              bar: value,
+            });
+            t.update(docRef2, 'bar', value);
+          });
+
+          const expected = {
+            foo: 'bar',
+            bar: value,
+          };
+
+          const snapshot1 = await getDoc(docRef1);
+          snapshot1.exists.should.eql(true);
+          snapshot1.data().should.eql(jet.contextify(expected));
+
+          const snapshot2 = await getDoc(docRef2);
+          snapshot2.exists.should.eql(true);
+          snapshot2.data().should.eql(jet.contextify(expected));
+        });
+      });
+
+      describe('transaction.set()', function () {
+        it('should throw if not providing a document reference', async function () {
+          const { runTransaction } = firestoreModular;
+          try {
+            await runTransaction(firestore, async t => {
+              t.set(123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'documentRef' expected a DocumentReference");
+            return Promise.resolve();
+          }
+        });
+
+        it('should throw if set data is invalid', async function () {
+          const { runTransaction, doc } = firestoreModular;
+          const db = firestore;
+          const docRef = doc(db, `${COLLECTION}/foo`);
+
+          try {
+            await runTransaction(db, async t => {
+              t.set(docRef, 123);
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql("'data' must be an object.");
+            return Promise.resolve();
+          }
+        });
+
+        it('should throw if set options are invalid', async function () {
+          const { runTransaction, doc } = firestoreModular;
+          const db = firestore;
+          const docRef = doc(db, `${COLLECTION}/foo`);
+
+          try {
+            await runTransaction(db, async t => {
+              t.set(
+                docRef,
+                {},
+                {
+                  merge: true,
+                  mergeFields: [],
+                },
+              );
+            });
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql(
+              "'options' must not contain both 'merge' & 'mergeFields'",
+            );
+            return Promise.resolve();
+          }
+        });
+
+        it('should set data', async function () {
+          const { runTransaction, doc, getDoc, setDoc } = firestoreModular;
+          const db = firestore;
+          const docRef = doc(db, `${COLLECTION}/transactions/transaction/set`);
+          await setDoc(docRef, {
+            foo: 'bar',
+          });
+          const expected = {
+            foo: 'baz',
+          };
+
+          await runTransaction(db, async t => {
+            t.set(docRef, expected);
+          });
+
+          const snapshot = await getDoc(docRef);
+          snapshot.data().should.eql(jet.contextify(expected));
+        });
+
+        it('should set data with merge', async function () {
+          const { runTransaction, doc, getDoc, setDoc } = firestoreModular;
+          const db = firestore;
+          const docRef = doc(db, `${COLLECTION}/transactions/transaction/set-merge`);
+          await setDoc(docRef, {
+            foo: 'bar',
+            bar: 'baz',
+          });
+          const expected = {
+            foo: 'bar',
+            bar: 'foo',
+          };
+
+          await runTransaction(db, async t => {
+            t.set(
+              docRef,
+              {
+                bar: 'foo',
+              },
+              {
+                merge: true,
+              },
+            );
+          });
+
+          const snapshot = await getDoc(docRef);
+          snapshot.data().should.eql(jet.contextify(expected));
+        });
+
+        it('should set data with merge fields', async function () {
+          const { runTransaction, doc, getDoc, setDoc } = firestoreModular;
+          const db = firestore;
+
+          const docRef = doc(db, `${COLLECTION}/transactions/transaction/set-mergefields`);
+          await setDoc(docRef, {
+            foo: 'bar',
+            bar: 'baz',
+            baz: 'ben',
+          });
+          const expected = {
+            foo: 'bar',
+            bar: 'foo',
+            baz: 'foo',
+          };
+
+          await runTransaction(db, async t => {
+            t.set(
+              docRef,
+              {
+                bar: 'foo',
+                baz: 'foo',
+              },
+              {
+                mergeFields: ['bar', new firebase.firestore.FieldPath('baz')],
+              },
+            );
+          });
+
+          const snapshot = await getDoc(docRef);
+          snapshot.data().should.eql(jet.contextify(expected));
+        });
+
+        it('should roll back any updates that failed', async function () {
+          const { runTransaction, doc, getDoc, setDoc } = firestoreModular;
+          const db = firestore;
+
+          const docRef = doc(db, `${COLLECTION}/transactions/transaction/rollback`);
+
+          await setDoc(docRef, {
+            turn: 0,
+          });
+
+          const prop1 = 'prop1';
+          const prop2 = 'prop2';
+          const turn = 0;
+          const errorMessage = 'turn cannot exceed 1';
+
+          const createTransaction = prop => {
+            return runTransaction(db, async transaction => {
+              const doc = await transaction.get(docRef);
+              const data = doc.data();
+
+              if (data.turn !== turn) {
+                throw new Error(errorMessage);
+              }
+
+              const update = {
+                turn: turn + 1,
+                [prop]: 1,
+              };
+
+              transaction.update(docRef, update);
+            });
+          };
+
+          const promises = [createTransaction(prop1), createTransaction(prop2)];
+
+          try {
+            await Promise.all(promises);
+            return Promise.reject(new Error('Did not throw an Error.'));
+          } catch (error) {
+            error.message.should.containEql(errorMessage);
+          }
+          const result = await getDoc(docRef);
+          should(result.data()).not.have.properties([prop1, prop2]);
+        });
+      });
+    });
+  });
+});

--- a/packages/firestore/e2e/SecondDatabase/second.onSnapshot.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.onSnapshot.e2e.js
@@ -77,7 +77,6 @@ describe('Second Database', function () {
         await Utils.spyToBeCalledOnceAsync(callback);
 
         callback.should.be.calledOnce();
-        console.log('ssss', callback.args[0][0]);
 
         callback.args[0][1].code.should.containEql('firestore/permission-denied');
         should.equal(callback.args[0][0], null);

--- a/packages/firestore/e2e/SecondDatabase/second.onSnapshot.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.onSnapshot.e2e.js
@@ -1,0 +1,697 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const { wipe } = require('../helpers');
+
+const NO_RULE_COLLECTION = 'no_rules';
+
+// This collection is only allowed on the second database
+const COLLECTION = 'second-database';
+const SECOND_DATABASE_ID = 'second-rnfb';
+
+describe('Second Database', function () {
+  describe('firestore().collection().onSnapshot()', function () {
+    describe('v8 compatibility', function () {
+      let firestore;
+
+      before(function () {
+        firestore = firebase.app().firestore(SECOND_DATABASE_ID);
+      });
+
+      beforeEach(async function () {
+        return await wipe(false, SECOND_DATABASE_ID);
+      });
+
+      it('throws if no arguments are provided', function () {
+        try {
+          firestore.collection(COLLECTION).onSnapshot();
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('expected at least one argument');
+          return Promise.resolve();
+        }
+      });
+
+      it('returns an unsubscribe function', function () {
+        const unsub = firestore.collection(`${COLLECTION}/foo/bar1`).onSnapshot(() => {});
+
+        unsub.should.be.a.Function();
+        unsub();
+      });
+
+      it('accepts a single callback function with snapshot', async function () {
+        if (Platform.other) {
+          return;
+        }
+        const callback = sinon.spy();
+        const unsub = firestore.collection(`${COLLECTION}/foo/bar2`).onSnapshot(callback);
+
+        await Utils.spyToBeCalledOnceAsync(callback);
+
+        callback.should.be.calledOnce();
+        callback.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+        should.equal(callback.args[0][1], null);
+        unsub();
+      });
+
+      it('accepts a single callback function with Error', async function () {
+        if (Platform.other) {
+          return;
+        }
+        const callback = sinon.spy();
+        const unsub = firestore.collection(NO_RULE_COLLECTION).onSnapshot(callback);
+
+        await Utils.spyToBeCalledOnceAsync(callback);
+
+        callback.should.be.calledOnce();
+        console.log('ssss', callback.args[0][0]);
+
+        callback.args[0][1].code.should.containEql('firestore/permission-denied');
+        should.equal(callback.args[0][0], null);
+        unsub();
+      });
+
+      describe('multiple callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls onNext when successful', async function () {
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = firestore.collection(`${COLLECTION}/foo/bar3`).onSnapshot(onNext, onError);
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls onError with Error', async function () {
+          if (Platform.other) {
+            return;
+          }
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = firestore.collection(NO_RULE_COLLECTION).onSnapshot(onNext, onError);
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      describe('objects of callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls next when successful', async function () {
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = firestore.collection(`${COLLECTION}/foo/bar4`).onSnapshot({
+            next: onNext,
+            error: onError,
+          });
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls error with Error', async function () {
+          if (Platform.other) {
+            return;
+          }
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = firestore.collection(NO_RULE_COLLECTION).onSnapshot({
+            next: onNext,
+            error: onError,
+          });
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      describe('SnapshotListenerOptions + callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls callback with snapshot when successful', async function () {
+          const callback = sinon.spy();
+          const unsub = firestore.collection(`${COLLECTION}/foo/bar5`).onSnapshot(
+            {
+              includeMetadataChanges: false,
+            },
+            callback,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(callback);
+
+          callback.should.be.calledOnce();
+          callback.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(callback.args[0][1], null);
+          unsub();
+        });
+
+        it('calls callback with Error', async function () {
+          const callback = sinon.spy();
+          const unsub = firestore.collection(NO_RULE_COLLECTION).onSnapshot(
+            {
+              includeMetadataChanges: false,
+            },
+            callback,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(callback);
+
+          callback.should.be.calledOnce();
+          callback.args[0][1].code.should.containEql('firestore/permission-denied');
+          should.equal(callback.args[0][0], null);
+          unsub();
+        });
+
+        it('calls next with snapshot when successful', async function () {
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const colRef = firestore
+            // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+            // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+            .collection(`${COLLECTION}/${Utils.randString(12, '#aA')}/next-with-snapshot`);
+          const unsub = colRef.onSnapshot(
+            {
+              includeMetadataChanges: false,
+            },
+            onNext,
+            onError,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls error with Error', async function () {
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = firestore.collection(NO_RULE_COLLECTION).onSnapshot(
+            {
+              includeMetadataChanges: false,
+            },
+            onNext,
+            onError,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      describe('SnapshotListenerOptions + object of callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls next with snapshot when successful', async function () {
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = firestore.collection(`${COLLECTION}/foo/bar7`).onSnapshot(
+            {
+              includeMetadataChanges: false,
+            },
+            {
+              next: onNext,
+              error: onError,
+            },
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls error with Error', async function () {
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = firestore.collection(NO_RULE_COLLECTION).onSnapshot(
+            {
+              includeMetadataChanges: false,
+            },
+            {
+              next: onNext,
+              error: onError,
+            },
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      it('throws if SnapshotListenerOptions is invalid', function () {
+        try {
+          firestore.collection(NO_RULE_COLLECTION).onSnapshot({
+            includeMetadataChanges: 123,
+          });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "'options' SnapshotOptions.includeMetadataChanges must be a boolean value",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if next callback is invalid', function () {
+        try {
+          firestore.collection(NO_RULE_COLLECTION).onSnapshot({
+            next: 'foo',
+          });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'observer.next' or 'onNext' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if error callback is invalid', function () {
+        try {
+          firestore.collection(NO_RULE_COLLECTION).onSnapshot({
+            error: 'foo',
+          });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'observer.error' or 'onError' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      // FIXME test disabled due to flakiness in CI E2E tests.
+      // Registered 4 of 3 expected calls once (!?), 3 of 2 expected calls once.
+      it('unsubscribes from further updates', async function () {
+        if (Platform.other) {
+          return;
+        }
+        const callback = sinon.spy();
+
+        const collection = firestore
+          // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+          // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+          .collection(`${COLLECTION}/${Utils.randString(12, '#aA')}/unsubscribe-updates`);
+
+        const unsub = collection.onSnapshot(callback);
+        await Utils.sleep(2000);
+        await collection.add({});
+        await collection.add({});
+        unsub();
+        await Utils.sleep(2000);
+        await collection.add({});
+        await Utils.sleep(2000);
+        callback.should.be.callCount(3);
+      });
+    });
+
+    describe('modular', function () {
+      let firestore;
+
+      before(function () {
+        const { getFirestore } = firestoreModular;
+        firestore = getFirestore(null, SECOND_DATABASE_ID);
+      });
+
+      beforeEach(async function () {
+        return await wipe(false, SECOND_DATABASE_ID);
+      });
+
+      it('throws if no arguments are provided', function () {
+        const { collection, onSnapshot } = firestoreModular;
+        try {
+          onSnapshot(collection(firestore, COLLECTION));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('expected at least one argument');
+          return Promise.resolve();
+        }
+      });
+
+      it('returns an unsubscribe function', function () {
+        const { collection, onSnapshot } = firestoreModular;
+        const unsub = onSnapshot(collection(firestore, `${COLLECTION}/foo/bar1`), () => {});
+
+        unsub.should.be.a.Function();
+        unsub();
+      });
+
+      it('accepts a single callback function with snapshot', async function () {
+        if (Platform.other) {
+          return;
+        }
+        const { collection, onSnapshot } = firestoreModular;
+        const callback = sinon.spy();
+        const unsub = onSnapshot(collection(firestore, `${COLLECTION}/foo/bar2`), callback);
+
+        await Utils.spyToBeCalledOnceAsync(callback);
+
+        callback.should.be.calledOnce();
+        callback.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+        should.equal(callback.args[0][1], null);
+        unsub();
+      });
+
+      describe('multiple callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls onNext when successful', async function () {
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = onSnapshot(
+            collection(firestore, `${COLLECTION}/foo/bar3`),
+            onNext,
+            onError,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls onError with Error', async function () {
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = onSnapshot(collection(firestore, NO_RULE_COLLECTION), onNext, onError);
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      describe('objects of callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls next when successful', async function () {
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = onSnapshot(collection(firestore, `${COLLECTION}/foo/bar4`), {
+            next: onNext,
+            error: onError,
+          });
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls error with Error', async function () {
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = onSnapshot(collection(firestore, NO_RULE_COLLECTION), {
+            next: onNext,
+            error: onError,
+          });
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      describe('SnapshotListenerOptions + callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls callback with snapshot when successful', async function () {
+          const { collection, onSnapshot } = firestoreModular;
+          const callback = sinon.spy();
+          const unsub = onSnapshot(
+            collection(firestore, `${COLLECTION}/foo/bar5`),
+            {
+              includeMetadataChanges: false,
+            },
+            callback,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(callback);
+
+          callback.should.be.calledOnce();
+          callback.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(callback.args[0][1], null);
+          unsub();
+        });
+
+        it('calls next with snapshot when successful', async function () {
+          if (Platform.other) {
+            return;
+          }
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const colRef = collection(
+            firestore,
+            // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+            // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+            `${COLLECTION}/${Utils.randString(12, '#aA')}/next-with-snapshot`,
+          );
+          const unsub = onSnapshot(
+            colRef,
+            {
+              includeMetadataChanges: false,
+            },
+            onNext,
+            onError,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls error with Error', async function () {
+          if (Platform.other) {
+            return;
+          }
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = onSnapshot(
+            collection(firestore, NO_RULE_COLLECTION),
+            {
+              includeMetadataChanges: false,
+            },
+            onNext,
+            onError,
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      describe('SnapshotListenerOptions + object of callbacks', function () {
+        if (Platform.other) {
+          return;
+        }
+
+        it('calls next with snapshot when successful', async function () {
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = onSnapshot(
+            collection(firestore, `${COLLECTION}/foo/bar7`),
+            {
+              includeMetadataChanges: false,
+            },
+            {
+              next: onNext,
+              error: onError,
+            },
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onNext);
+
+          onNext.should.be.calledOnce();
+          onError.should.be.callCount(0);
+          onNext.args[0][0].constructor.name.should.eql('FirestoreQuerySnapshot');
+          should.equal(onNext.args[0][1], undefined);
+          unsub();
+        });
+
+        it('calls error with Error', async function () {
+          const { collection, onSnapshot } = firestoreModular;
+          const onNext = sinon.spy();
+          const onError = sinon.spy();
+          const unsub = onSnapshot(
+            collection(firestore, NO_RULE_COLLECTION),
+            {
+              includeMetadataChanges: false,
+            },
+            {
+              next: onNext,
+              error: onError,
+            },
+          );
+
+          await Utils.spyToBeCalledOnceAsync(onError);
+
+          onError.should.be.calledOnce();
+          onNext.should.be.callCount(0);
+          onError.args[0][0].code.should.containEql('firestore/permission-denied');
+          should.equal(onError.args[0][1], undefined);
+          unsub();
+        });
+      });
+
+      it('throws if SnapshotListenerOptions is invalid', function () {
+        const { collection, onSnapshot } = firestoreModular;
+        try {
+          onSnapshot(collection(firestore, NO_RULE_COLLECTION), {
+            includeMetadataChanges: 123,
+          });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            "'options' SnapshotOptions.includeMetadataChanges must be a boolean value",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if next callback is invalid', function () {
+        const { collection, onSnapshot } = firestoreModular;
+        try {
+          onSnapshot(collection(firestore, NO_RULE_COLLECTION), {
+            next: 'foo',
+          });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'observer.next' or 'onNext' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      it('throws if error callback is invalid', function () {
+        const { collection, onSnapshot } = firestoreModular;
+        try {
+          onSnapshot(collection(firestore, NO_RULE_COLLECTION), {
+            error: 'foo',
+          });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql("'observer.error' or 'onError' expected a function");
+          return Promise.resolve();
+        }
+      });
+
+      // FIXME test disabled due to flakiness in CI E2E tests.
+      // Registered 4 of 3 expected calls once (!?), 3 of 2 expected calls once.
+      it('unsubscribes from further updates', async function () {
+        if (Platform.other) {
+          return;
+        }
+        const { collection, onSnapshot, addDoc } = firestoreModular;
+        const callback = sinon.spy();
+
+        const collectionRef = collection(
+          firestore,
+          // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+          // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+          `${COLLECTION}/${Utils.randString(12, '#aA')}/unsubscribe-updates`,
+        );
+
+        const unsub = onSnapshot(collectionRef, callback);
+        await Utils.sleep(2000);
+        await addDoc(collectionRef, {});
+        await addDoc(collectionRef, {});
+        unsub();
+        await Utils.sleep(2000);
+        await addDoc(collectionRef, {});
+        await Utils.sleep(2000);
+        callback.should.be.callCount(3);
+      });
+    });
+  });
+});

--- a/packages/firestore/e2e/SecondDatabase/second.where.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.where.e2e.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-const { wipe } = require('./helpers');
+const { wipe } = require('../helpers');
 
 // This collection is only allowed on the second database
 const COLLECTION = 'second-database';
@@ -22,17 +22,17 @@ const SECOND_DATABASE_ID = 'second-rnfb';
 
 describe('Second Database', function () {
   describe('firestore().collection().where()', function () {
-    let firestore;
-
-    before(function () {
-      firestore = firebase.app().firestore(SECOND_DATABASE_ID);
-    });
-
-    beforeEach(async function () {
-      return await wipe(false, SECOND_DATABASE_ID);
-    });
-
     describe('v8 compatibility', function () {
+      let firestore;
+
+      before(function () {
+        firestore = firebase.app().firestore(SECOND_DATABASE_ID);
+      });
+
+      beforeEach(async function () {
+        return await wipe(false, SECOND_DATABASE_ID);
+      });
+
       it('throws if fieldPath is invalid', function () {
         try {
           firestore.collection(COLLECTION).where(123);
@@ -539,6 +539,10 @@ describe('Second Database', function () {
       before(function () {
         const { getFirestore } = firestoreModular;
         firestore = getFirestore(null, SECOND_DATABASE_ID);
+      });
+
+      beforeEach(async function () {
+        return await wipe(false, SECOND_DATABASE_ID);
       });
 
       it('throws if fieldPath is invalid', function () {

--- a/packages/firestore/e2e/helpers.js
+++ b/packages/firestore/e2e/helpers.js
@@ -18,7 +18,7 @@ const { getE2eTestProject, getE2eEmulatorHost } = require('../../app/e2e/helpers
  *
  */
 
-exports.wipe = async function wipe(debug = false) {
+exports.wipe = async function wipe(debug = false, databaseId = '(default)') {
   const deleteOptions = {
     method: 'DELETE',
     headers: {
@@ -27,7 +27,7 @@ exports.wipe = async function wipe(debug = false) {
     },
     port: 8080,
     host: getE2eEmulatorHost(),
-    path: '/emulator/v1/projects/' + getE2eTestProject() + '/databases/(default)/documents',
+    path: '/emulator/v1/projects/' + getE2eTestProject() + `/databases/${databaseId}/documents`,
   };
 
   try {

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -169,6 +169,7 @@ RCT_EXPORT_METHOD(namedQueryGet
                                                             options:options];
                   FIRFirestoreSource source = [self getSource:getOptions];
                   [self handleQueryGet:firebaseApp
+                            databaseId:databaseId
                         firestoreQuery:firestoreQuery
                                 source:source
                                resolve:resolve
@@ -237,6 +238,7 @@ RCT_EXPORT_METHOD(collectionGet
                                                                              options:options];
   FIRFirestoreSource source = [self getSource:getOptions];
   [self handleQueryGet:firebaseApp
+            databaseId:databaseId
         firestoreQuery:firestoreQuery
                 source:source
                resolve:resolve
@@ -281,6 +283,7 @@ RCT_EXPORT_METHOD(collectionGet
 }
 
 - (void)handleQueryGet:(FIRApp *)firebaseApp
+            databaseId:(NSString *)databaseId
         firestoreQuery:(RNFBFirestoreQuery *)firestoreQuery
                 source:(FIRFirestoreSource)source
                resolve:(RCTPromiseResolveBlock)resolve
@@ -297,7 +300,8 @@ RCT_EXPORT_METHOD(collectionGet
                           [RNFBFirestoreSerialize querySnapshotToDictionary:@"get"
                                                                    snapshot:snapshot
                                                      includeMetadataChanges:false
-                                                                    appName:appName];
+                                                                    appName:appName
+                                                                 databaseId:databaseId];
                       resolve(serialized);
                     }
                   }];
@@ -313,7 +317,8 @@ RCT_EXPORT_METHOD(collectionGet
       [RNFBFirestoreSerialize querySnapshotToDictionary:@"onSnapshot"
                                                snapshot:snapshot
                                  includeMetadataChanges:includeMetadataChanges
-                                                appName:appName];
+                                                appName:appName
+                                             databaseId:databaseId];
   [[RNFBRCTEventEmitter shared]
       sendEventWithName:RNFB_FIRESTORE_COLLECTION_SYNC
                    body:@{

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -63,6 +63,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(namedQueryOnSnapshot
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)name
                   : (NSString *)type
                   : (NSArray *)filters
@@ -74,8 +75,8 @@ RCT_EXPORT_METHOD(namedQueryOnSnapshot
     return;
   }
 
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
-  [[FIRFirestore firestore] getQueryNamed:name
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  [firestore getQueryNamed:name
                                completion:^(FIRQuery *query) {
                                  if (query == nil) {
                                    [self sendSnapshotError:firebaseApp
@@ -99,6 +100,7 @@ RCT_EXPORT_METHOD(namedQueryOnSnapshot
 
 RCT_EXPORT_METHOD(collectionOnSnapshot
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (NSString *)type
                   : (NSArray *)filters
@@ -110,7 +112,7 @@ RCT_EXPORT_METHOD(collectionOnSnapshot
     return;
   }
 
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
 
   RNFBFirestoreQuery *firestoreQuery = [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
@@ -124,7 +126,7 @@ RCT_EXPORT_METHOD(collectionOnSnapshot
               listenerOptions:listenerOptions];
 }
 
-RCT_EXPORT_METHOD(collectionOffSnapshot : (FIRApp *)firebaseApp : (nonnull NSNumber *)listenerId) {
+RCT_EXPORT_METHOD(collectionOffSnapshot : (FIRApp *)firebaseApp: (NSString *) databaseId : (nonnull NSNumber *)listenerId) {
   id<FIRListenerRegistration> listener = collectionSnapshotListeners[listenerId];
   if (listener) {
     [listener remove];
@@ -134,6 +136,7 @@ RCT_EXPORT_METHOD(collectionOffSnapshot : (FIRApp *)firebaseApp : (nonnull NSNum
 
 RCT_EXPORT_METHOD(namedQueryGet
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)name
                   : (NSString *)type
                   : (NSArray *)filters
@@ -142,8 +145,8 @@ RCT_EXPORT_METHOD(namedQueryGet
                   : (NSDictionary *)getOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
-  [[FIRFirestore firestore]
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  [firestore
       getQueryNamed:name
          completion:^(FIRQuery *query) {
            if (query == nil) {
@@ -167,6 +170,7 @@ RCT_EXPORT_METHOD(namedQueryGet
 
 RCT_EXPORT_METHOD(collectionCount
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (NSString *)type
                   : (NSArray *)filters
@@ -174,7 +178,7 @@ RCT_EXPORT_METHOD(collectionCount
                   : (NSDictionary *)options
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
   RNFBFirestoreQuery *firestoreQuery = [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
                                                                                query:query
@@ -204,6 +208,7 @@ RCT_EXPORT_METHOD(collectionCount
 
 RCT_EXPORT_METHOD(collectionGet
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (NSString *)type
                   : (NSArray *)filters
@@ -212,7 +217,7 @@ RCT_EXPORT_METHOD(collectionGet
                   : (NSDictionary *)getOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
 
   RNFBFirestoreQuery *firestoreQuery = [[RNFBFirestoreQuery alloc] initWithModifiers:firestore

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -63,7 +63,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(namedQueryOnSnapshot
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)name
                   : (NSString *)type
                   : (NSArray *)filters
@@ -75,34 +75,35 @@ RCT_EXPORT_METHOD(namedQueryOnSnapshot
     return;
   }
 
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   [firestore getQueryNamed:name
-                               completion:^(FIRQuery *query) {
-                                 if (query == nil) {
-                                   [self sendSnapshotError:firebaseApp
-                                                databaseId:databaseId
-                                                listenerId:listenerId
-                                                     error:nil];
-                                   return;
-                                 }
+                completion:^(FIRQuery *query) {
+                  if (query == nil) {
+                    [self sendSnapshotError:firebaseApp
+                                 databaseId:databaseId
+                                 listenerId:listenerId
+                                      error:nil];
+                    return;
+                  }
 
-                                 RNFBFirestoreQuery *firestoreQuery =
-                                     [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
-                                                                             query:query
-                                                                           filters:filters
-                                                                            orders:orders
-                                                                           options:options];
-                                 [self handleQueryOnSnapshot:firebaseApp
-                                                  databaseId:databaseId
-                                              firestoreQuery:firestoreQuery
-                                                  listenerId:listenerId
-                                             listenerOptions:listenerOptions];
-                               }];
+                  RNFBFirestoreQuery *firestoreQuery =
+                      [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
+                                                              query:query
+                                                            filters:filters
+                                                             orders:orders
+                                                            options:options];
+                  [self handleQueryOnSnapshot:firebaseApp
+                                   databaseId:databaseId
+                               firestoreQuery:firestoreQuery
+                                   listenerId:listenerId
+                              listenerOptions:listenerOptions];
+                }];
 }
 
 RCT_EXPORT_METHOD(collectionOnSnapshot
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (NSString *)type
                   : (NSArray *)filters
@@ -114,7 +115,8 @@ RCT_EXPORT_METHOD(collectionOnSnapshot
     return;
   }
 
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
 
   RNFBFirestoreQuery *firestoreQuery = [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
@@ -129,7 +131,10 @@ RCT_EXPORT_METHOD(collectionOnSnapshot
               listenerOptions:listenerOptions];
 }
 
-RCT_EXPORT_METHOD(collectionOffSnapshot : (FIRApp *)firebaseApp: (NSString *) databaseId : (nonnull NSNumber *)listenerId) {
+RCT_EXPORT_METHOD(collectionOffSnapshot
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)databaseId
+                  : (nonnull NSNumber *)listenerId) {
   id<FIRListenerRegistration> listener = collectionSnapshotListeners[listenerId];
   if (listener) {
     [listener remove];
@@ -139,7 +144,7 @@ RCT_EXPORT_METHOD(collectionOffSnapshot : (FIRApp *)firebaseApp: (NSString *) da
 
 RCT_EXPORT_METHOD(namedQueryGet
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)name
                   : (NSString *)type
                   : (NSArray *)filters
@@ -148,32 +153,32 @@ RCT_EXPORT_METHOD(namedQueryGet
                   : (NSDictionary *)getOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
-  [firestore
-      getQueryNamed:name
-         completion:^(FIRQuery *query) {
-           if (query == nil) {
-             return [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:nil];
-           }
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
+  [firestore getQueryNamed:name
+                completion:^(FIRQuery *query) {
+                  if (query == nil) {
+                    return [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:nil];
+                  }
 
-           RNFBFirestoreQuery *firestoreQuery =
-               [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
-                                                       query:query
-                                                     filters:filters
-                                                      orders:orders
-                                                     options:options];
-           FIRFirestoreSource source = [self getSource:getOptions];
-           [self handleQueryGet:firebaseApp
-                 firestoreQuery:firestoreQuery
-                         source:source
-                        resolve:resolve
-                         reject:reject];
-         }];
+                  RNFBFirestoreQuery *firestoreQuery =
+                      [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
+                                                              query:query
+                                                            filters:filters
+                                                             orders:orders
+                                                            options:options];
+                  FIRFirestoreSource source = [self getSource:getOptions];
+                  [self handleQueryGet:firebaseApp
+                        firestoreQuery:firestoreQuery
+                                source:source
+                               resolve:resolve
+                                reject:reject];
+                }];
 }
 
 RCT_EXPORT_METHOD(collectionCount
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (NSString *)type
                   : (NSArray *)filters
@@ -181,7 +186,8 @@ RCT_EXPORT_METHOD(collectionCount
                   : (NSDictionary *)options
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
   RNFBFirestoreQuery *firestoreQuery = [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
                                                                                query:query
@@ -211,7 +217,7 @@ RCT_EXPORT_METHOD(collectionCount
 
 RCT_EXPORT_METHOD(collectionGet
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (NSString *)type
                   : (NSArray *)filters
@@ -220,7 +226,8 @@ RCT_EXPORT_METHOD(collectionGet
                   : (NSDictionary *)getOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
 
   RNFBFirestoreQuery *firestoreQuery = [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
@@ -237,7 +244,7 @@ RCT_EXPORT_METHOD(collectionGet
 }
 
 - (void)handleQueryOnSnapshot:(FIRApp *)firebaseApp
-               databaseId: (NSString *) databaseId
+                   databaseId:(NSString *)databaseId
                firestoreQuery:(RNFBFirestoreQuery *)firestoreQuery
                    listenerId:(nonnull NSNumber *)listenerId
               listenerOptions:(NSDictionary *)listenerOptions {
@@ -254,7 +261,10 @@ RCT_EXPORT_METHOD(collectionGet
         [listener remove];
         [collectionSnapshotListeners removeObjectForKey:listenerId];
       }
-      [weakSelf sendSnapshotError:firebaseApp databaseId:databaseId listenerId:listenerId error:error];
+      [weakSelf sendSnapshotError:firebaseApp
+                       databaseId:databaseId
+                       listenerId:listenerId
+                            error:error];
     } else {
       [weakSelf sendSnapshotEvent:firebaseApp
                        databaseId:databaseId
@@ -294,7 +304,7 @@ RCT_EXPORT_METHOD(collectionGet
 }
 
 - (void)sendSnapshotEvent:(FIRApp *)firApp
-               databaseId: (NSString *) databaseId
+                databaseId:(NSString *)databaseId
                 listenerId:(nonnull NSNumber *)listenerId
                   snapshot:(FIRQuerySnapshot *)snapshot
     includeMetadataChanges:(BOOL)includeMetadataChanges {
@@ -308,7 +318,7 @@ RCT_EXPORT_METHOD(collectionGet
       sendEventWithName:RNFB_FIRESTORE_COLLECTION_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
-                     @"databaseId": databaseId,
+                     @"databaseId" : databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"snapshot" : serialized,
@@ -317,7 +327,7 @@ RCT_EXPORT_METHOD(collectionGet
 }
 
 - (void)sendSnapshotError:(FIRApp *)firApp
-               databaseId: (NSString *) databaseId
+               databaseId:(NSString *)databaseId
                listenerId:(nonnull NSNumber *)listenerId
                     error:(NSError *)error {
   NSArray *codeAndMessage = [RNFBFirestoreCommon getCodeAndMessage:error];
@@ -325,7 +335,7 @@ RCT_EXPORT_METHOD(collectionGet
       sendEventWithName:RNFB_FIRESTORE_COLLECTION_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
-                     @"databaseId": databaseId,
+                     @"databaseId" : databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"error" : @{

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -80,6 +80,7 @@ RCT_EXPORT_METHOD(namedQueryOnSnapshot
                                completion:^(FIRQuery *query) {
                                  if (query == nil) {
                                    [self sendSnapshotError:firebaseApp
+                                                databaseId:databaseId
                                                 listenerId:listenerId
                                                      error:nil];
                                    return;
@@ -92,6 +93,7 @@ RCT_EXPORT_METHOD(namedQueryOnSnapshot
                                                                             orders:orders
                                                                            options:options];
                                  [self handleQueryOnSnapshot:firebaseApp
+                                                  databaseId:databaseId
                                               firestoreQuery:firestoreQuery
                                                   listenerId:listenerId
                                              listenerOptions:listenerOptions];
@@ -121,6 +123,7 @@ RCT_EXPORT_METHOD(collectionOnSnapshot
                                                                               orders:orders
                                                                              options:options];
   [self handleQueryOnSnapshot:firebaseApp
+                   databaseId:databaseId
                firestoreQuery:firestoreQuery
                    listenerId:listenerId
               listenerOptions:listenerOptions];
@@ -234,6 +237,7 @@ RCT_EXPORT_METHOD(collectionGet
 }
 
 - (void)handleQueryOnSnapshot:(FIRApp *)firebaseApp
+               databaseId: (NSString *) databaseId
                firestoreQuery:(RNFBFirestoreQuery *)firestoreQuery
                    listenerId:(nonnull NSNumber *)listenerId
               listenerOptions:(NSDictionary *)listenerOptions {
@@ -250,9 +254,10 @@ RCT_EXPORT_METHOD(collectionGet
         [listener remove];
         [collectionSnapshotListeners removeObjectForKey:listenerId];
       }
-      [weakSelf sendSnapshotError:firebaseApp listenerId:listenerId error:error];
+      [weakSelf sendSnapshotError:firebaseApp databaseId:databaseId listenerId:listenerId error:error];
     } else {
       [weakSelf sendSnapshotEvent:firebaseApp
+                       databaseId:databaseId
                        listenerId:listenerId
                          snapshot:snapshot
            includeMetadataChanges:includeMetadataChanges];
@@ -289,6 +294,7 @@ RCT_EXPORT_METHOD(collectionGet
 }
 
 - (void)sendSnapshotEvent:(FIRApp *)firApp
+               databaseId: (NSString *) databaseId
                 listenerId:(nonnull NSNumber *)listenerId
                   snapshot:(FIRQuerySnapshot *)snapshot
     includeMetadataChanges:(BOOL)includeMetadataChanges {
@@ -302,6 +308,7 @@ RCT_EXPORT_METHOD(collectionGet
       sendEventWithName:RNFB_FIRESTORE_COLLECTION_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
+                     @"databaseId": databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"snapshot" : serialized,
@@ -310,6 +317,7 @@ RCT_EXPORT_METHOD(collectionGet
 }
 
 - (void)sendSnapshotError:(FIRApp *)firApp
+               databaseId: (NSString *) databaseId
                listenerId:(nonnull NSNumber *)listenerId
                     error:(NSError *)error {
   NSArray *codeAndMessage = [RNFBFirestoreCommon getCodeAndMessage:error];
@@ -317,6 +325,7 @@ RCT_EXPORT_METHOD(collectionGet
       sendEventWithName:RNFB_FIRESTORE_COLLECTION_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
+                     @"databaseId": databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"error" : @{

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
@@ -23,9 +23,11 @@
 
 + (dispatch_queue_t)getFirestoreQueue;
 
-+ (FIRFirestore *)getFirestoreForApp:(FIRApp *)firebaseApp;
++ (FIRFirestore *)getFirestoreForApp:(FIRApp *)firebaseApp databaseId:(NSString *)databaseId;
 
-+ (void)setFirestoreSettings:(FIRFirestore *)firestore appName:(NSString *)appName;
++ (NSString *)createFirestoreKeyWithAppName:(NSString *)appName databaseId:(NSString *)databaseId;
+
++ (void)setFirestoreSettings:(FIRFirestore *)firestore appName:(NSString *)appName databaseId:(NSString *)databaseId;
 
 + (FIRDocumentReference *)getDocumentForFirestore:(FIRFirestore *)firestore path:(NSString *)path;
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
@@ -27,7 +27,9 @@
 
 + (NSString *)createFirestoreKeyWithAppName:(NSString *)appName databaseId:(NSString *)databaseId;
 
-+ (void)setFirestoreSettings:(FIRFirestore *)firestore appName:(NSString *)appName databaseId:(NSString *)databaseId;
++ (void)setFirestoreSettings:(FIRFirestore *)firestore
+                     appName:(NSString *)appName
+                  databaseId:(NSString *)databaseId;
 
 + (FIRDocumentReference *)getDocumentForFirestore:(FIRFirestore *)firestore path:(NSString *)path;
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
@@ -29,24 +29,28 @@ NSString *const FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR =
 NSMutableDictionary *instanceCache;
 
 @implementation RNFBFirestoreCommon
-+ (FIRFirestore *)getFirestoreForApp:(FIRApp *)app {
++ (FIRFirestore *)getFirestoreForApp:(FIRApp *)app databaseId:(NSString *) databaseId {
   if (instanceCache == nil) {
     instanceCache = [[NSMutableDictionary alloc] init];
   }
-
-  FIRFirestore *cachedInstance = instanceCache[[app name]];
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:[app name] databaseId: databaseId];
+  FIRFirestore *cachedInstance = instanceCache[firestoreKey];
 
   if (cachedInstance) {
     return cachedInstance;
   }
 
-  FIRFirestore *instance = [FIRFirestore firestoreForApp:app];
+  FIRFirestore *instance = [FIRFirestore firestoreForApp:app database:databaseId];
 
-  [self setFirestoreSettings:instance appName:[RNFBSharedUtils getAppJavaScriptName:app.name]];
+  [self setFirestoreSettings:instance appName:[RNFBSharedUtils getAppJavaScriptName:app.name] databaseId:databaseId];
 
   instanceCache[[app name]] = instance;
 
   return instance;
+}
+
++ (NSString *)createFirestoreKeyWithAppName:(NSString *)appName databaseId:(NSString *)databaseId {
+    return [NSString stringWithFormat:@"%@:%@", appName, databaseId];
 }
 
 + (dispatch_queue_t)getFirestoreQueue {
@@ -59,13 +63,15 @@ NSMutableDictionary *instanceCache;
   return firestoreQueue;
 }
 
-+ (void)setFirestoreSettings:(FIRFirestore *)firestore appName:(NSString *)appName {
++ (void)setFirestoreSettings:(FIRFirestore *)firestore appName:(NSString *)appName databaseId:(NSString *)databaseId {
   FIRFirestoreSettings *firestoreSettings = [[FIRFirestoreSettings alloc] init];
   RNFBPreferences *preferences = [RNFBPreferences shared];
 
   firestoreSettings.dispatchQueue = [self getFirestoreQueue];
+  
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
 
-  NSString *cacheKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_CACHE_SIZE, appName];
+  NSString *cacheKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_CACHE_SIZE, firestoreKey];
   NSInteger size = [preferences getIntegerValue:cacheKey defaultValue:0];
 
   if (size == -1) {
@@ -76,16 +82,16 @@ NSMutableDictionary *instanceCache;
     firestoreSettings.cacheSizeBytes = size;
   }
 
-  NSString *hostKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_HOST, appName];
+  NSString *hostKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_HOST, firestoreKey];
   firestoreSettings.host = [preferences getStringValue:hostKey
                                           defaultValue:firestore.settings.host];
 
-  NSString *persistenceKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, appName];
+  NSString *persistenceKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, firestoreKey];
   firestoreSettings.persistenceEnabled =
       (BOOL)[preferences getBooleanValue:persistenceKey
                             defaultValue:firestore.settings.persistenceEnabled];
 
-  NSString *sslKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_SSL, appName];
+  NSString *sslKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_SSL, firestoreKey];
   firestoreSettings.sslEnabled =
       (BOOL)[preferences getBooleanValue:sslKey defaultValue:firestore.settings.sslEnabled];
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
@@ -29,11 +29,12 @@ NSString *const FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR =
 NSMutableDictionary *instanceCache;
 
 @implementation RNFBFirestoreCommon
-+ (FIRFirestore *)getFirestoreForApp:(FIRApp *)app databaseId:(NSString *) databaseId {
++ (FIRFirestore *)getFirestoreForApp:(FIRApp *)app databaseId:(NSString *)databaseId {
   if (instanceCache == nil) {
     instanceCache = [[NSMutableDictionary alloc] init];
   }
-  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:[app name] databaseId: databaseId];
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:[app name]
+                                                                   databaseId:databaseId];
   FIRFirestore *cachedInstance = instanceCache[firestoreKey];
 
   if (cachedInstance) {
@@ -42,7 +43,9 @@ NSMutableDictionary *instanceCache;
 
   FIRFirestore *instance = [FIRFirestore firestoreForApp:app database:databaseId];
 
-  [self setFirestoreSettings:instance appName:[RNFBSharedUtils getAppJavaScriptName:app.name] databaseId:databaseId];
+  [self setFirestoreSettings:instance
+                     appName:[RNFBSharedUtils getAppJavaScriptName:app.name]
+                  databaseId:databaseId];
 
   instanceCache[[app name]] = instance;
 
@@ -50,7 +53,7 @@ NSMutableDictionary *instanceCache;
 }
 
 + (NSString *)createFirestoreKeyWithAppName:(NSString *)appName databaseId:(NSString *)databaseId {
-    return [NSString stringWithFormat:@"%@:%@", appName, databaseId];
+  return [NSString stringWithFormat:@"%@:%@", appName, databaseId];
 }
 
 + (dispatch_queue_t)getFirestoreQueue {
@@ -63,13 +66,16 @@ NSMutableDictionary *instanceCache;
   return firestoreQueue;
 }
 
-+ (void)setFirestoreSettings:(FIRFirestore *)firestore appName:(NSString *)appName databaseId:(NSString *)databaseId {
++ (void)setFirestoreSettings:(FIRFirestore *)firestore
+                     appName:(NSString *)appName
+                  databaseId:(NSString *)databaseId {
   FIRFirestoreSettings *firestoreSettings = [[FIRFirestoreSettings alloc] init];
   RNFBPreferences *preferences = [RNFBPreferences shared];
 
   firestoreSettings.dispatchQueue = [self getFirestoreQueue];
-  
-  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
+
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                   databaseId:databaseId];
 
   NSString *cacheKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_CACHE_SIZE, firestoreKey];
   NSInteger size = [preferences getIntegerValue:cacheKey defaultValue:0];
@@ -86,7 +92,8 @@ NSMutableDictionary *instanceCache;
   firestoreSettings.host = [preferences getStringValue:hostKey
                                           defaultValue:firestore.settings.host];
 
-  NSString *persistenceKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, firestoreKey];
+  NSString *persistenceKey =
+      [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, firestoreKey];
   firestoreSettings.persistenceEnabled =
       (BOOL)[preferences getBooleanValue:persistenceKey
                             defaultValue:firestore.settings.persistenceEnabled];

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -63,7 +63,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(documentOnSnapshot
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (nonnull NSNumber *)listenerId
                   : (NSDictionary *)listenerOptions) {
@@ -71,7 +71,8 @@ RCT_EXPORT_METHOD(documentOnSnapshot
     return;
   }
 
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -83,9 +84,15 @@ RCT_EXPORT_METHOD(documentOnSnapshot
         [listener remove];
         [documentSnapshotListeners removeObjectForKey:listenerId];
       }
-      [weakSelf sendSnapshotError:firebaseApp databaseId:databaseId listenerId:listenerId error:error];
+      [weakSelf sendSnapshotError:firebaseApp
+                       databaseId:databaseId
+                       listenerId:listenerId
+                            error:error];
     } else {
-      [weakSelf sendSnapshotEvent:firebaseApp databaseId:databaseId listenerId:listenerId snapshot:snapshot];
+      [weakSelf sendSnapshotEvent:firebaseApp
+                       databaseId:databaseId
+                       listenerId:listenerId
+                         snapshot:snapshot];
     }
   };
 
@@ -100,7 +107,10 @@ RCT_EXPORT_METHOD(documentOnSnapshot
   documentSnapshotListeners[listenerId] = listener;
 }
 
-RCT_EXPORT_METHOD(documentOffSnapshot : (FIRApp *)firebaseApp : (NSString *) databaseId : (nonnull NSNumber *)listenerId) {
+RCT_EXPORT_METHOD(documentOffSnapshot
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)databaseId
+                  : (nonnull NSNumber *)listenerId) {
   id<FIRListenerRegistration> listener = documentSnapshotListeners[listenerId];
   if (listener) {
     [listener remove];
@@ -110,12 +120,13 @@ RCT_EXPORT_METHOD(documentOffSnapshot : (FIRApp *)firebaseApp : (NSString *) dat
 
 RCT_EXPORT_METHOD(documentGet
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (NSDictionary *)getOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -141,10 +152,12 @@ RCT_EXPORT_METHOD(documentGet
                                                                            error:error];
                    } else {
                      NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
-                     NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
+                     NSString *firestoreKey =
+                         [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                 databaseId:databaseId];
                      NSDictionary *serialized =
                          [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot
-                                                                      firestoreKey:firestoreKey];
+                                                                 firestoreKey:firestoreKey];
                      resolve(serialized);
                    }
                  }];
@@ -152,11 +165,12 @@ RCT_EXPORT_METHOD(documentGet
 
 RCT_EXPORT_METHOD(documentDelete
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -171,13 +185,14 @@ RCT_EXPORT_METHOD(documentDelete
 
 RCT_EXPORT_METHOD(documentSet
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (NSDictionary *)data
                   : (NSDictionary *)options
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -204,12 +219,13 @@ RCT_EXPORT_METHOD(documentSet
 
 RCT_EXPORT_METHOD(documentUpdate
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSString *)path
                   : (NSDictionary *)data
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -228,11 +244,12 @@ RCT_EXPORT_METHOD(documentUpdate
 
 RCT_EXPORT_METHOD(documentBatch
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSArray *)writes
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   FIRWriteBatch *batch = [firestore batch];
 
   for (NSDictionary *write in writes) {
@@ -270,18 +287,19 @@ RCT_EXPORT_METHOD(documentBatch
 }
 
 - (void)sendSnapshotEvent:(FIRApp *)firApp
-               databaseId: (NSString *) databaseId
+               databaseId:(NSString *)databaseId
                listenerId:(nonnull NSNumber *)listenerId
                  snapshot:(FIRDocumentSnapshot *)snapshot {
   NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firApp.name];
-  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                   databaseId:databaseId];
   NSDictionary *serialized = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot
-                                                                          firestoreKey:firestoreKey];
+                                                                     firestoreKey:firestoreKey];
   [[RNFBRCTEventEmitter shared]
       sendEventWithName:RNFB_FIRESTORE_DOCUMENT_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
-                     @"databaseId": databaseId,
+                     @"databaseId" : databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"snapshot" : serialized,
@@ -290,7 +308,7 @@ RCT_EXPORT_METHOD(documentBatch
 }
 
 - (void)sendSnapshotError:(FIRApp *)firApp
-               databaseId: (NSString *) databaseId
+               databaseId:(NSString *)databaseId
                listenerId:(nonnull NSNumber *)listenerId
                     error:(NSError *)error {
   NSArray *codeAndMessage = [RNFBFirestoreCommon getCodeAndMessage:error];
@@ -298,7 +316,7 @@ RCT_EXPORT_METHOD(documentBatch
       sendEventWithName:RNFB_FIRESTORE_DOCUMENT_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
-                     @"databaseId": databaseId,
+                     @"databaseId" : databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"error" : @{

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -83,7 +83,7 @@ RCT_EXPORT_METHOD(documentOnSnapshot
         [listener remove];
         [documentSnapshotListeners removeObjectForKey:listenerId];
       }
-      [weakSelf sendSnapshotError:firebaseApp listenerId:listenerId error:error];
+      [weakSelf sendSnapshotError:firebaseApp databaseId:databaseId listenerId:listenerId error:error];
     } else {
       [weakSelf sendSnapshotEvent:firebaseApp databaseId:databaseId listenerId:listenerId snapshot:snapshot];
     }
@@ -281,6 +281,7 @@ RCT_EXPORT_METHOD(documentBatch
       sendEventWithName:RNFB_FIRESTORE_DOCUMENT_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
+                     @"databaseId": databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"snapshot" : serialized,
@@ -289,6 +290,7 @@ RCT_EXPORT_METHOD(documentBatch
 }
 
 - (void)sendSnapshotError:(FIRApp *)firApp
+               databaseId: (NSString *) databaseId
                listenerId:(nonnull NSNumber *)listenerId
                     error:(NSError *)error {
   NSArray *codeAndMessage = [RNFBFirestoreCommon getCodeAndMessage:error];
@@ -296,6 +298,7 @@ RCT_EXPORT_METHOD(documentBatch
       sendEventWithName:RNFB_FIRESTORE_DOCUMENT_SYNC
                    body:@{
                      @"appName" : [RNFBSharedUtils getAppJavaScriptName:firApp.name],
+                     @"databaseId": databaseId,
                      @"listenerId" : listenerId,
                      @"body" : @{
                        @"error" : @{

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -63,6 +63,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(documentOnSnapshot
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (nonnull NSNumber *)listenerId
                   : (NSDictionary *)listenerOptions) {
@@ -70,7 +71,7 @@ RCT_EXPORT_METHOD(documentOnSnapshot
     return;
   }
 
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -99,7 +100,7 @@ RCT_EXPORT_METHOD(documentOnSnapshot
   documentSnapshotListeners[listenerId] = listener;
 }
 
-RCT_EXPORT_METHOD(documentOffSnapshot : (FIRApp *)firebaseApp : (nonnull NSNumber *)listenerId) {
+RCT_EXPORT_METHOD(documentOffSnapshot : (FIRApp *)firebaseApp : (NSString *) databaseId : (nonnull NSNumber *)listenerId) {
   id<FIRListenerRegistration> listener = documentSnapshotListeners[listenerId];
   if (listener) {
     [listener remove];
@@ -109,11 +110,12 @@ RCT_EXPORT_METHOD(documentOffSnapshot : (FIRApp *)firebaseApp : (nonnull NSNumbe
 
 RCT_EXPORT_METHOD(documentGet
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (NSDictionary *)getOptions
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -149,10 +151,11 @@ RCT_EXPORT_METHOD(documentGet
 
 RCT_EXPORT_METHOD(documentDelete
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -167,12 +170,13 @@ RCT_EXPORT_METHOD(documentDelete
 
 RCT_EXPORT_METHOD(documentSet
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (NSDictionary *)data
                   : (NSDictionary *)options
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -199,11 +203,12 @@ RCT_EXPORT_METHOD(documentSet
 
 RCT_EXPORT_METHOD(documentUpdate
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSString *)path
                   : (NSDictionary *)data
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRDocumentReference *documentReference = [RNFBFirestoreCommon getDocumentForFirestore:firestore
                                                                                     path:path];
 
@@ -222,10 +227,11 @@ RCT_EXPORT_METHOD(documentUpdate
 
 RCT_EXPORT_METHOD(documentBatch
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSArray *)writes
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   FIRWriteBatch *batch = [firestore batch];
 
   for (NSDictionary *write in writes) {

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -85,7 +85,7 @@ RCT_EXPORT_METHOD(documentOnSnapshot
       }
       [weakSelf sendSnapshotError:firebaseApp listenerId:listenerId error:error];
     } else {
-      [weakSelf sendSnapshotEvent:firebaseApp listenerId:listenerId snapshot:snapshot];
+      [weakSelf sendSnapshotEvent:firebaseApp databaseId:databaseId listenerId:listenerId snapshot:snapshot];
     }
   };
 
@@ -141,9 +141,10 @@ RCT_EXPORT_METHOD(documentGet
                                                                            error:error];
                    } else {
                      NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
+                     NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
                      NSDictionary *serialized =
                          [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot
-                                                                      appName:appName];
+                                                                      firestoreKey:firestoreKey];
                      resolve(serialized);
                    }
                  }];
@@ -269,11 +270,13 @@ RCT_EXPORT_METHOD(documentBatch
 }
 
 - (void)sendSnapshotEvent:(FIRApp *)firApp
+               databaseId: (NSString *) databaseId
                listenerId:(nonnull NSNumber *)listenerId
                  snapshot:(FIRDocumentSnapshot *)snapshot {
   NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firApp.name];
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
   NSDictionary *serialized = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot
-                                                                          appName:appName];
+                                                                          firestoreKey:firestoreKey];
   [[RNFBRCTEventEmitter shared]
       sendEventWithName:RNFB_FIRESTORE_DOCUMENT_SYNC
                    body:@{

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -45,9 +45,10 @@ RCT_EXPORT_METHOD(setLogLevel : (FIRLoggerLevel)loggerLevel) {
 
 RCT_EXPORT_METHOD(disableNetwork
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp]
+  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
       disableNetworkWithCompletion:^(NSError *error) {
         if (error) {
           [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
@@ -59,9 +60,10 @@ RCT_EXPORT_METHOD(disableNetwork
 
 RCT_EXPORT_METHOD(enableNetwork
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp]
+  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
       enableNetworkWithCompletion:^(NSError *error) {
         if (error) {
           [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
@@ -73,6 +75,7 @@ RCT_EXPORT_METHOD(enableNetwork
 
 RCT_EXPORT_METHOD(settings
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (NSDictionary *)settings
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
@@ -111,11 +114,12 @@ RCT_EXPORT_METHOD(settings
 
 RCT_EXPORT_METHOD(loadBundle
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (nonnull NSString *)bundle
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   NSData *bundleData = [bundle dataUsingEncoding:NSUTF8StringEncoding];
-  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp]
+  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
       loadBundle:bundleData
       completion:^(FIRLoadBundleTaskProgress *progress, NSError *error) {
         if (error) {
@@ -128,9 +132,10 @@ RCT_EXPORT_METHOD(loadBundle
 
 RCT_EXPORT_METHOD(clearPersistence
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp]
+  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
       clearPersistenceWithCompletion:^(NSError *error) {
         if (error) {
           [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
@@ -142,13 +147,14 @@ RCT_EXPORT_METHOD(clearPersistence
 
 RCT_EXPORT_METHOD(useEmulator
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (nonnull NSString *)host
                   : (NSInteger)port) {
   if (emulatorConfigs == nil) {
     emulatorConfigs = [[NSMutableDictionary alloc] init];
   }
   if (!emulatorConfigs[firebaseApp.name]) {
-    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
     [firestore useEmulatorWithHost:host port:port];
     emulatorConfigs[firebaseApp.name] = @YES;
 
@@ -161,9 +167,10 @@ RCT_EXPORT_METHOD(useEmulator
 
 RCT_EXPORT_METHOD(waitForPendingWrites
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp]
+  [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
       waitForPendingWritesWithCompletion:^(NSError *error) {
         if (error) {
           [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
@@ -175,9 +182,10 @@ RCT_EXPORT_METHOD(waitForPendingWrites
 
 RCT_EXPORT_METHOD(terminate
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *instance = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+  FIRFirestore *instance = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
 
   [instance terminateWithCompletion:^(NSError *error) {
     if (error) {

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -154,10 +154,12 @@ RCT_EXPORT_METHOD(useEmulator
   if (emulatorConfigs == nil) {
     emulatorConfigs = [[NSMutableDictionary alloc] init];
   }
-  if (!emulatorConfigs[firebaseApp.name]) {
+  
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:firebaseApp.name databaseId: databaseId];
+  if (!emulatorConfigs[firestoreKey]) {
     FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
     [firestore useEmulatorWithHost:host port:port];
-    emulatorConfigs[firebaseApp.name] = @YES;
+    emulatorConfigs[firestoreKey] = @YES;
 
     // It is not sufficient to just use emulator. You have toggle SSL off too.
     FIRFirestoreSettings *settings = firestore.settings;

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -80,32 +80,33 @@ RCT_EXPORT_METHOD(settings
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId:databaseId];
 
   if (settings[@"cacheSizeBytes"]) {
-    NSString *cacheKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_CACHE_SIZE, appName];
+    NSString *cacheKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_CACHE_SIZE, firestoreKey];
     [[RNFBPreferences shared] setIntegerValue:cacheKey
                                  integerValue:[settings[@"cacheSizeBytes"] integerValue]];
   }
 
   if (settings[@"host"]) {
-    NSString *hostKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_HOST, appName];
+    NSString *hostKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_HOST, firestoreKey];
     [[RNFBPreferences shared] setStringValue:hostKey stringValue:settings[@"host"]];
   }
 
   if (settings[@"persistence"]) {
-    NSString *persistenceKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, appName];
+    NSString *persistenceKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, firestoreKey];
     [[RNFBPreferences shared] setBooleanValue:persistenceKey
                                     boolValue:[settings[@"persistence"] boolValue]];
   }
 
   if (settings[@"ssl"]) {
-    NSString *sslKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_SSL, appName];
+    NSString *sslKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_SSL, firestoreKey];
     [[RNFBPreferences shared] setBooleanValue:sslKey boolValue:[settings[@"ssl"] boolValue]];
   }
 
   if (settings[@"serverTimestampBehavior"]) {
     NSString *key =
-        [NSString stringWithFormat:@"%@_%@", FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR, appName];
+        [NSString stringWithFormat:@"%@_%@", FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR, firestoreKey];
     [[RNFBPreferences shared] setStringValue:key stringValue:settings[@"serverTimestampBehavior"]];
   }
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -199,7 +199,9 @@ RCT_EXPORT_METHOD(terminate
     if (error) {
       [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
     } else {
-      [instanceCache removeObjectForKey:[firebaseApp name]];
+      NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:firebaseApp.name
+                                                                       databaseId:databaseId];
+      [instanceCache removeObjectForKey:firestoreKey];
       resolve(nil);
     }
   }];

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -45,7 +45,7 @@ RCT_EXPORT_METHOD(setLogLevel : (FIRLoggerLevel)loggerLevel) {
 
 RCT_EXPORT_METHOD(disableNetwork
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
@@ -60,7 +60,7 @@ RCT_EXPORT_METHOD(disableNetwork
 
 RCT_EXPORT_METHOD(enableNetwork
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
@@ -75,12 +75,13 @@ RCT_EXPORT_METHOD(enableNetwork
 
 RCT_EXPORT_METHOD(settings
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (NSDictionary *)settings
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
-  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId:databaseId];
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                   databaseId:databaseId];
 
   if (settings[@"cacheSizeBytes"]) {
     NSString *cacheKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_CACHE_SIZE, firestoreKey];
@@ -94,7 +95,8 @@ RCT_EXPORT_METHOD(settings
   }
 
   if (settings[@"persistence"]) {
-    NSString *persistenceKey = [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, firestoreKey];
+    NSString *persistenceKey =
+        [NSString stringWithFormat:@"%@_%@", FIRESTORE_PERSISTENCE, firestoreKey];
     [[RNFBPreferences shared] setBooleanValue:persistenceKey
                                     boolValue:[settings[@"persistence"] boolValue]];
   }
@@ -115,7 +117,7 @@ RCT_EXPORT_METHOD(settings
 
 RCT_EXPORT_METHOD(loadBundle
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (nonnull NSString *)bundle
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
@@ -133,7 +135,7 @@ RCT_EXPORT_METHOD(loadBundle
 
 RCT_EXPORT_METHOD(clearPersistence
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
@@ -148,16 +150,18 @@ RCT_EXPORT_METHOD(clearPersistence
 
 RCT_EXPORT_METHOD(useEmulator
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (nonnull NSString *)host
                   : (NSInteger)port) {
   if (emulatorConfigs == nil) {
     emulatorConfigs = [[NSMutableDictionary alloc] init];
   }
-  
-  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:firebaseApp.name databaseId: databaseId];
+
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:firebaseApp.name
+                                                                   databaseId:databaseId];
   if (!emulatorConfigs[firestoreKey]) {
-    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                           databaseId:databaseId];
     [firestore useEmulatorWithHost:host port:port];
     emulatorConfigs[firestoreKey] = @YES;
 
@@ -170,7 +174,7 @@ RCT_EXPORT_METHOD(useEmulator
 
 RCT_EXPORT_METHOD(waitForPendingWrites
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
   [[RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId]
@@ -185,10 +189,11 @@ RCT_EXPORT_METHOD(waitForPendingWrites
 
 RCT_EXPORT_METHOD(terminate
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  FIRFirestore *instance = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+  FIRFirestore *instance = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                        databaseId:databaseId];
 
   [instance terminateWithCompletion:^(NSError *error) {
     if (error) {

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
@@ -24,14 +24,16 @@
 + (NSDictionary *)querySnapshotToDictionary:(NSString *)source
                                    snapshot:(FIRQuerySnapshot *)snapshot
                      includeMetadataChanges:(BOOL)includeMetadataChanges
-                                    appName:(NSString *)appName;
+                                    appName:(NSString *)appName
+                                 databaseId:(NSString *)databaseId;
 
 + (NSDictionary *)documentChangeToDictionary:(FIRDocumentChange *)documentChange
                             isMetadataChange:(BOOL)isMetadataChange
-                                     appName:(NSString *)appName;
+                                     appName:(NSString *)appName
+                                  databaseId:(NSString *)databaseId;
 
 + (NSDictionary *)documentSnapshotToDictionary:(FIRDocumentSnapshot *)snapshot
-                                  firestoreKey:(NSString *)appName;
+                                  firestoreKey:(NSString *)firestoreKey;
 
 + (NSDictionary *)serializeDictionary:(NSDictionary *)dictionary;
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
@@ -31,7 +31,7 @@
                                      appName:(NSString *)appName;
 
 + (NSDictionary *)documentSnapshotToDictionary:(FIRDocumentSnapshot *)snapshot
-                                       appName:(NSString *)appName;
+                                       firestoreKey:(NSString *)appName;
 
 + (NSDictionary *)serializeDictionary:(NSDictionary *)dictionary;
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
@@ -31,7 +31,7 @@
                                      appName:(NSString *)appName;
 
 + (NSDictionary *)documentSnapshotToDictionary:(FIRDocumentSnapshot *)snapshot
-                                       firestoreKey:(NSString *)appName;
+                                  firestoreKey:(NSString *)appName;
 
 + (NSDictionary *)serializeDictionary:(NSDictionary *)dictionary;
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
@@ -65,7 +65,8 @@ enum TYPE_MAP {
 + (NSDictionary *)querySnapshotToDictionary:(NSString *)source
                                    snapshot:(FIRQuerySnapshot *)snapshot
                      includeMetadataChanges:(BOOL)includeMetadataChanges
-                                    appName:(NSString *)appName {
+                                    appName:(NSString *)appName
+                                 databaseId:(NSString *)databaseId {
   NSMutableArray *metadata = [[NSMutableArray alloc] init];
   NSMutableDictionary *snapshotMap = [[NSMutableDictionary alloc] init];
 
@@ -84,7 +85,8 @@ enum TYPE_MAP {
     for (FIRDocumentChange *documentChange in documentChangesList) {
       [changes addObject:[self documentChangeToDictionary:documentChange
                                          isMetadataChange:false
-                                                  appName:appName]];
+                                                  appName:appName
+                                               databaseId:databaseId]];
     }
   } else {
     // If listening to metadata changes, get the changes list with document changes array.
@@ -119,16 +121,19 @@ enum TYPE_MAP {
 
       [changes addObject:[self documentChangeToDictionary:documentMetadataChange
                                          isMetadataChange:isMetadataChange
-                                                  appName:appName]];
+                                                  appName:appName
+                                               databaseId:databaseId]];
     }
   }
 
   snapshotMap[KEY_CHANGES] = changes;
-
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                   databaseId:databaseId];
   // set documents
   NSMutableArray *documents = [[NSMutableArray alloc] init];
   for (FIRDocumentSnapshot *documentSnapshot in documentSnapshots) {
-    [documents addObject:[self documentSnapshotToDictionary:documentSnapshot firestoreKey:appName]];
+    [documents addObject:[self documentSnapshotToDictionary:documentSnapshot
+                                               firestoreKey:firestoreKey]];
   }
   snapshotMap[KEY_DOCUMENTS] = documents;
 
@@ -143,7 +148,8 @@ enum TYPE_MAP {
 
 + (NSDictionary *)documentChangeToDictionary:(FIRDocumentChange *)documentChange
                             isMetadataChange:(BOOL)isMetadataChange
-                                     appName:(NSString *)appName {
+                                     appName:(NSString *)appName
+                                  databaseId:(NSString *)databaseId {
   NSMutableDictionary *changeMap = [[NSMutableDictionary alloc] init];
   changeMap[@"isMetadataChange"] = @(isMetadataChange);
 
@@ -154,9 +160,10 @@ enum TYPE_MAP {
   } else {
     changeMap[KEY_DOC_CHANGE_TYPE] = CHANGE_REMOVED;
   }
-
+  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                   databaseId:databaseId];
   changeMap[KEY_DOC_CHANGE_DOCUMENT] = [self documentSnapshotToDictionary:documentChange.document
-                                                             firestoreKey:appName];
+                                                             firestoreKey:firestoreKey];
 
   // Note the Firestore C++ SDK here returns a maxed UInt that is != NSUIntegerMax, so we make one
   // ourselves so we can convert to -1 for JS land

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
@@ -156,7 +156,7 @@ enum TYPE_MAP {
   }
 
   changeMap[KEY_DOC_CHANGE_DOCUMENT] = [self documentSnapshotToDictionary:documentChange.document
-                                                                  firestoreKey:appName];
+                                                             firestoreKey:appName];
 
   // Note the Firestore C++ SDK here returns a maxed UInt that is != NSUIntegerMax, so we make one
   // ourselves so we can convert to -1 for JS land
@@ -180,7 +180,7 @@ enum TYPE_MAP {
 
 // Native DocumentSnapshot -> NSDictionary (for JS)
 + (NSDictionary *)documentSnapshotToDictionary:(FIRDocumentSnapshot *)snapshot
-                                       firestoreKey:(NSString *)firestoreKey {
+                                  firestoreKey:(NSString *)firestoreKey {
   NSMutableArray *metadata = [[NSMutableArray alloc] init];
   NSMutableDictionary *documentMap = [[NSMutableDictionary alloc] init];
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
@@ -128,7 +128,7 @@ enum TYPE_MAP {
   // set documents
   NSMutableArray *documents = [[NSMutableArray alloc] init];
   for (FIRDocumentSnapshot *documentSnapshot in documentSnapshots) {
-    [documents addObject:[self documentSnapshotToDictionary:documentSnapshot appName:appName]];
+    [documents addObject:[self documentSnapshotToDictionary:documentSnapshot firestoreKey:appName]];
   }
   snapshotMap[KEY_DOCUMENTS] = documents;
 
@@ -156,7 +156,7 @@ enum TYPE_MAP {
   }
 
   changeMap[KEY_DOC_CHANGE_DOCUMENT] = [self documentSnapshotToDictionary:documentChange.document
-                                                                  appName:appName];
+                                                                  firestoreKey:appName];
 
   // Note the Firestore C++ SDK here returns a maxed UInt that is != NSUIntegerMax, so we make one
   // ourselves so we can convert to -1 for JS land
@@ -180,7 +180,7 @@ enum TYPE_MAP {
 
 // Native DocumentSnapshot -> NSDictionary (for JS)
 + (NSDictionary *)documentSnapshotToDictionary:(FIRDocumentSnapshot *)snapshot
-                                       appName:(NSString *)appName {
+                                       firestoreKey:(NSString *)firestoreKey {
   NSMutableArray *metadata = [[NSMutableArray alloc] init];
   NSMutableDictionary *documentMap = [[NSMutableDictionary alloc] init];
 
@@ -194,7 +194,7 @@ enum TYPE_MAP {
 
   if (snapshot.exists) {
     NSString *key =
-        [NSString stringWithFormat:@"%@_%@", FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR, appName];
+        [NSString stringWithFormat:@"%@_%@", FIRESTORE_SERVER_TIMESTAMP_BEHAVIOR, firestoreKey];
     NSString *behavior = [[RNFBPreferences shared] getStringValue:key defaultValue:@"none"];
 
     FIRServerTimestampBehavior serverTimestampBehavior;

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -61,6 +61,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(transactionGetDocument
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (nonnull NSNumber *)transactionId
                   : (NSString *)path
                   : (RCTPromiseResolveBlock)resolve
@@ -75,7 +76,7 @@ RCT_EXPORT_METHOD(transactionGetDocument
 
     NSError *error = nil;
     FIRTransaction *transaction = [transactionState valueForKey:@"transaction"];
-    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
     FIRDocumentReference *ref = [RNFBFirestoreCommon getDocumentForFirestore:firestore path:path];
     FIRDocumentSnapshot *snapshot = [transaction getDocument:ref error:&error];
 
@@ -96,7 +97,7 @@ RCT_EXPORT_METHOD(transactionGetDocument
   }
 }
 
-RCT_EXPORT_METHOD(transactionDispose : (FIRApp *)firebaseApp : (nonnull NSNumber *)transactionId) {
+RCT_EXPORT_METHOD(transactionDispose : (FIRApp *)firebaseApp : (NSString *) databaseId : (nonnull NSNumber *)transactionId) {
   @synchronized(transactions[[transactionId stringValue]]) {
     NSMutableDictionary *transactionState = transactions[[transactionId stringValue]];
 
@@ -112,6 +113,7 @@ RCT_EXPORT_METHOD(transactionDispose : (FIRApp *)firebaseApp : (nonnull NSNumber
 
 RCT_EXPORT_METHOD(transactionApplyBuffer
                   : (FIRApp *)firebaseApp
+                  : (NSString *) databaseId
                   : (nonnull NSNumber *)transactionId
                   : (NSArray *)commandBuffer) {
   @synchronized(transactions[[transactionId stringValue]]) {
@@ -128,8 +130,8 @@ RCT_EXPORT_METHOD(transactionApplyBuffer
   }
 }
 
-RCT_EXPORT_METHOD(transactionBegin : (FIRApp *)firebaseApp : (nonnull NSNumber *)transactionId) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp];
+RCT_EXPORT_METHOD(transactionBegin : (FIRApp *)firebaseApp : (NSString *) databaseId : (nonnull NSNumber *)transactionId) {
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
   __block BOOL aborted = false;
   __block NSMutableDictionary *transactionState = [NSMutableDictionary new];
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -61,7 +61,7 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(transactionGetDocument
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (nonnull NSNumber *)transactionId
                   : (NSString *)path
                   : (RCTPromiseResolveBlock)resolve
@@ -76,7 +76,8 @@ RCT_EXPORT_METHOD(transactionGetDocument
 
     NSError *error = nil;
     FIRTransaction *transaction = [transactionState valueForKey:@"transaction"];
-    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+    FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                           databaseId:databaseId];
     FIRDocumentReference *ref = [RNFBFirestoreCommon getDocumentForFirestore:firestore path:path];
     FIRDocumentSnapshot *snapshot = [transaction getDocument:ref error:&error];
 
@@ -84,9 +85,10 @@ RCT_EXPORT_METHOD(transactionGetDocument
       [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
     } else {
       NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
-      NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
-      NSDictionary *snapshotDict = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot
-                                                                                firestoreKey:firestoreKey];
+      NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                       databaseId:databaseId];
+      NSDictionary *snapshotDict =
+          [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot firestoreKey:firestoreKey];
       NSString *snapshotPath = snapshotDict[@"path"];
 
       if (snapshotPath == nil) {
@@ -98,7 +100,10 @@ RCT_EXPORT_METHOD(transactionGetDocument
   }
 }
 
-RCT_EXPORT_METHOD(transactionDispose : (FIRApp *)firebaseApp : (NSString *) databaseId : (nonnull NSNumber *)transactionId) {
+RCT_EXPORT_METHOD(transactionDispose
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)databaseId
+                  : (nonnull NSNumber *)transactionId) {
   @synchronized(transactions[[transactionId stringValue]]) {
     NSMutableDictionary *transactionState = transactions[[transactionId stringValue]];
 
@@ -114,7 +119,7 @@ RCT_EXPORT_METHOD(transactionDispose : (FIRApp *)firebaseApp : (NSString *) data
 
 RCT_EXPORT_METHOD(transactionApplyBuffer
                   : (FIRApp *)firebaseApp
-                  : (NSString *) databaseId
+                  : (NSString *)databaseId
                   : (nonnull NSNumber *)transactionId
                   : (NSArray *)commandBuffer) {
   @synchronized(transactions[[transactionId stringValue]]) {
@@ -131,8 +136,12 @@ RCT_EXPORT_METHOD(transactionApplyBuffer
   }
 }
 
-RCT_EXPORT_METHOD(transactionBegin : (FIRApp *)firebaseApp : (NSString *) databaseId : (nonnull NSNumber *)transactionId) {
-  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp databaseId:databaseId];
+RCT_EXPORT_METHOD(transactionBegin
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)databaseId
+                  : (nonnull NSNumber *)transactionId) {
+  FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
+                                                         databaseId:databaseId];
   __block BOOL aborted = false;
   __block NSMutableDictionary *transactionState = [NSMutableDictionary new];
 
@@ -156,7 +165,7 @@ RCT_EXPORT_METHOD(transactionBegin : (FIRApp *)firebaseApp : (NSString *) databa
                          body:@{
                            @"listenerId" : transactionId,
                            @"appName" : [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name],
-                           @"databaseId": databaseId,
+                           @"databaseId" : databaseId,
                            @"body" : eventMap,
                          }];
       });
@@ -245,7 +254,7 @@ RCT_EXPORT_METHOD(transactionBegin : (FIRApp *)firebaseApp : (NSString *) databa
                          body:@{
                            @"listenerId" : transactionId,
                            @"appName" : [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name],
-                           @"databaseId": databaseId,
+                           @"databaseId" : databaseId,
                            @"body" : eventMap,
                          }];
       }

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -156,6 +156,7 @@ RCT_EXPORT_METHOD(transactionBegin : (FIRApp *)firebaseApp : (NSString *) databa
                          body:@{
                            @"listenerId" : transactionId,
                            @"appName" : [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name],
+                           @"databaseId": databaseId,
                            @"body" : eventMap,
                          }];
       });
@@ -244,6 +245,7 @@ RCT_EXPORT_METHOD(transactionBegin : (FIRApp *)firebaseApp : (NSString *) databa
                          body:@{
                            @"listenerId" : transactionId,
                            @"appName" : [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name],
+                           @"databaseId": databaseId,
                            @"body" : eventMap,
                          }];
       }

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -84,8 +84,9 @@ RCT_EXPORT_METHOD(transactionGetDocument
       [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
     } else {
       NSString *appName = [RNFBSharedUtils getAppJavaScriptName:firebaseApp.name];
+      NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName databaseId: databaseId];
       NSDictionary *snapshotDict = [RNFBFirestoreSerialize documentSnapshotToDictionary:snapshot
-                                                                                appName:appName];
+                                                                                firestoreKey:firestoreKey];
       NSString *snapshotPath = snapshotDict[@"path"];
 
       if (snapshotPath == nil) {

--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -2367,7 +2367,7 @@ declare module '@react-native-firebase/app' {
       >;
     }
     interface FirebaseApp {
-      firestore(): FirebaseFirestoreTypes.Module;
+      firestore(databaseId?: string): FirebaseFirestoreTypes.Module;
     }
   }
 }

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -57,8 +57,13 @@ const nativeEvents = [
 ];
 
 class FirebaseFirestoreModule extends FirebaseModule {
-  constructor(app, config) {
+  constructor(app, config, databaseId) {
     super(app, config);
+    if (isString(databaseId) || databaseId === undefined) {
+      this._customUrlOrRegion = databaseId || '(default)';
+    } else if (!isString(databaseId)) {
+      throw new Error('firebase.app().storage(*) bucket url must be a string');
+    }
     this._referencePath = new FirestorePath();
     this._transactionHandler = new FirestoreTransactionHandler(this);
 
@@ -372,7 +377,7 @@ export default createModuleNamespace({
   nativeModuleName,
   nativeEvents,
   hasMultiAppSupport: true,
-  hasCustomUrlOrRegionSupport: false,
+  hasCustomUrlOrRegionSupport: true,
   ModuleClass: FirebaseFirestoreModule,
 });
 

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -62,7 +62,7 @@ class FirebaseFirestoreModule extends FirebaseModule {
     if (isString(databaseId) || databaseId === undefined) {
       this._customUrlOrRegion = databaseId || '(default)';
     } else if (!isString(databaseId)) {
-      throw new Error('firebase.app().storage(*) bucket url must be a string');
+      throw new Error('firebase.app().firestore(*) database ID must be a string');
     }
     this._referencePath = new FirestorePath();
     this._transactionHandler = new FirestoreTransactionHandler(this);
@@ -85,6 +85,10 @@ class FirebaseFirestoreModule extends FirebaseModule {
     this._settings = {
       ignoreUndefinedProperties: false,
     };
+  }
+  // We override the FirebaseModule's `eventNameForApp()` method to include the customUrlOrRegion
+  eventNameForApp(...args) {
+    return `${this.app.name}-${this._customUrlOrRegion}-${args.join('-')}`;
   }
 
   batch() {

--- a/packages/firestore/lib/modular/index.d.ts
+++ b/packages/firestore/lib/modular/index.d.ts
@@ -118,6 +118,18 @@ export declare function getFirestore(app: FirebaseApp): Firestore;
 export function getFirestore(app?: FirebaseApp): Firestore;
 
 /**
+ * Returns the existing default {@link Firestore} instance that is associated with the
+ * provided {@link @firebase/app#FirebaseApp} and database ID. If no instance exists, initializes a new
+ * instance with default settings.
+ *
+ * @param app - The {@link @firebase/app#FirebaseApp} instance that the returned {@link Firestore}
+ * instance is associated with.
+ * @param databaseId - The ID of the Firestore database to use. If not provided, the default database is used.
+ * @returns The {@link Firestore}
+ */
+export declare function getFirestore(app?: FirebaseApp, databaseId?: string): Firestore;
+
+/**
  * Gets a `DocumentReference` instance that refers to the document at the
  * specified absolute path.
  *

--- a/packages/firestore/lib/modular/index.js
+++ b/packages/firestore/lib/modular/index.js
@@ -15,14 +15,22 @@ import { firebase } from '../index';
 
 /**
  * @param {FirebaseApp?} app
+ * @param {String?} databaseId
  * @returns {Firestore}
  */
-export function getFirestore(app) {
+export function getFirestore(app, databaseId) {
   if (app) {
-    return firebase.firestore(app);
+    if (databaseId) {
+      return firebase.app(app.name).firestore(databaseId);
+    } else {
+      return firebase.app(app.name).firestore();
+    }
+  }
+  if (databaseId) {
+    return firebase.app().firestore(databaseId);
   }
 
-  return firebase.firestore();
+  return firebase.app().firestore();
 }
 
 /**

--- a/packages/firestore/lib/web/RNFBFirestoreModule.js
+++ b/packages/firestore/lib/web/RNFBFirestoreModule.js
@@ -68,19 +68,24 @@ function getCachedAppInstance(appName) {
   return (appInstances[appName] ??= getApp(appName));
 }
 
+function createFirestoreKey(appName, databaseId) {
+  return `${appName}:${databaseId}`;
+}
+
 // Returns a cached Firestore instance.
-function getCachedFirestoreInstance(appName) {
-  let instance = firestoreInstances[appName];
+function getCachedFirestoreInstance(appName, databaseId) {
+  const firestoreKey = createFirestoreKey(appName, databaseId);
+  let instance = firestoreInstances[firestoreKey];
   if (!instance) {
-    instance = getFirestore(getCachedAppInstance(appName));
-    if (emulatorForApp[appName]) {
+    instance = getFirestore(getCachedAppInstance(appName), databaseId);
+    if (emulatorForApp[firestoreKey]) {
       connectFirestoreEmulator(
         instance,
-        emulatorForApp[appName].host,
-        emulatorForApp[appName].port,
+        emulatorForApp[firestoreKey].host,
+        emulatorForApp[firestoreKey].port,
       );
     }
-    firestoreInstances[appName] = instance;
+    firestoreInstances[firestoreKey] = instance;
   }
   return instance;
 }
@@ -126,27 +131,30 @@ export default {
   /**
    * Use the Firestore emulator.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} host - The emulator host.
    * @param {number} port - The emulator port.
    * @returns {Promise<null>} An empty promise.
    */
-  useEmulator(appName, host, port) {
+  useEmulator(appName, databaseId, host, port) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       connectFirestoreEmulator(firestore, host, port);
-      emulatorForApp[appName] = { host, port };
+      const firestoreKey = createFirestoreKey(appName, databaseId);
+      emulatorForApp[firestoreKey] = { host, port };
     });
   },
 
   /**
    * Initializes a Firestore instance with settings.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {object} settings - The Firestore settings.
    * @returns {Promise<null>} An empty promise.
    */
-  settings(appName, settings) {
+  settings(appName, databaseId, settings) {
     return guard(() => {
-      const instance = initializeFirestore(getCachedAppInstance(appName), settings);
+      const instance = initializeFirestore(getCachedAppInstance(appName), settings, databaseId);
       firestoreInstances[appName] = instance;
     });
   },
@@ -154,11 +162,12 @@ export default {
   /**
    * Terminates a Firestore instance.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @returns {Promise<null>} An empty promise.
    */
-  terminate(appName) {
+  terminate(appName, databaseId) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       await terminate(firestore);
       return null;
     });
@@ -184,6 +193,7 @@ export default {
   /**
    * Get a collection count from Firestore.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} path - The collection path.
    * @param {string} type - The collection type (e.g. collectionGroup).
    * @param {object[]} filters - The collection filters.
@@ -191,9 +201,9 @@ export default {
    * @param {object} options - The collection options.
    * @returns {Promise<object>} The collection count object.
    */
-  collectionCount(appName, path, type, filters, orders, options) {
+  collectionCount(appName, databaseId, path, type, filters, orders, options) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const queryRef =
         type === 'collectionGroup' ? collectionGroup(firestore, path) : collection(firestore, path);
       const query = buildQuery(queryRef, filters, orders, options);
@@ -208,6 +218,7 @@ export default {
   /**
    * Get a collection from Firestore.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} path - The collection path.
    * @param {string} type - The collection type (e.g. collectionGroup).
    * @param {object[]} filters - The collection filters.
@@ -216,7 +227,7 @@ export default {
    * @param {object} getOptions - The get options.
    * @returns {Promise<object>} The collection object.
    */
-  collectionGet(appName, path, type, filters, orders, options, getOptions) {
+  collectionGet(appName, databaseId, path, type, filters, orders, options, getOptions) {
     if (getOptions && getOptions.source === 'cache') {
       return rejectWithCodeAndMessage(
         'unsupported',
@@ -225,7 +236,7 @@ export default {
     }
 
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const queryRef =
         type === 'collectionGroup' ? collectionGroup(firestore, path) : collection(firestore, path);
       const query = buildQuery(queryRef, filters, orders, options);
@@ -246,11 +257,12 @@ export default {
   /**
    * Get a document from Firestore.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} path - The document path.
    * @param {object} getOptions - The get options.
    * @returns {Promise<object>} The document object.
    */
-  documentGet(appName, path, getOptions) {
+  documentGet(appName, databaseId, path, getOptions) {
     return guard(async () => {
       if (getOptions && getOptions.source === 'cache') {
         return rejectWithCodeAndMessage(
@@ -259,7 +271,7 @@ export default {
         );
       }
 
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const ref = doc(firestore, path);
       const snapshot = await getDoc(ref);
       return documentSnapshotToObject(snapshot);
@@ -269,12 +281,13 @@ export default {
   /**
    * Delete a document from Firestore.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} path - The document path.
    * @returns {Promise<null>} An empty promise.
    */
-  documentDelete(appName, path) {
+  documentDelete(appName, databaseId, path) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const ref = doc(firestore, path);
       await deleteDoc(ref);
       return null;
@@ -284,14 +297,15 @@ export default {
   /**
    * Set a document in Firestore.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} path - The document path.
    * @param {object} data - The document data.
    * @param {object} options - The set options.
    * @returns {Promise<null>} An empty promise.
    */
-  documentSet(appName, path, data, options) {
+  documentSet(appName, databaseId, path, data, options) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const ref = doc(firestore, path);
       const setOptions = {};
       if ('merge' in options) {
@@ -306,13 +320,14 @@ export default {
   /**
    * Update a document in Firestore.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} path - The document path.
    * @param {object} data - The document data.
    * @returns {Promise<null>} An empty promise.
    */
-  documentUpdate(appName, path, data) {
+  documentUpdate(appName, databaseId, path, data) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const ref = doc(firestore, path);
       await updateDoc(ref, readableToObject(firestore, data));
     });
@@ -321,11 +336,12 @@ export default {
   /**
    * Batch write documents in Firestore.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {object[]} writes - The document writes in write batches format.
    */
-  documentBatch(appName, writes) {
+  documentBatch(appName, databaseId, writes) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const batch = writeBatch(firestore);
       const writesArray = parseDocumentBatches(firestore, writes);
 
@@ -360,11 +376,12 @@ export default {
   /**
    * Get a document from a Firestore transaction.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} transactionId - The transaction id.
    * @param {string} path - The document path.
    * @returns {Promise<object>} The document object.
    */
-  transactionGetDocument(appName, transactionId, path) {
+  transactionGetDocument(appName, databaseId, transactionId, path) {
     if (!transactionHandler[transactionId]) {
       return rejectWithCodeAndMessage(
         'internal-error',
@@ -373,7 +390,7 @@ export default {
     }
 
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
       const docRef = doc(firestore, path);
       const tsx = transactionHandler[transactionId];
       const snapshot = await tsx.get(docRef);
@@ -384,9 +401,10 @@ export default {
   /**
    * Dispose a transaction instance.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} transactionId - The transaction id.
    */
-  transactionDispose(appName, transactionId) {
+  transactionDispose(appName, databaseId, transactionId) {
     // There's no abort method in the JS SDK, so we just remove the transaction handler.
     delete transactionHandler[transactionId];
   },
@@ -394,10 +412,11 @@ export default {
   /**
    * Applies a buffer of commands to a Firestore transaction.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} transactionId - The transaction id.
    * @param {object[]} commandBuffer - The readable array of buffer commands.
    */
-  transactionApplyBuffer(appName, transactionId, commandBuffer) {
+  transactionApplyBuffer(appName, databaseId, transactionId, commandBuffer) {
     if (transactionHandler[transactionId]) {
       transactionBuffer[transactionId] = commandBuffer;
     }
@@ -406,12 +425,13 @@ export default {
   /**
    * Begins a Firestore transaction.
    * @param {string} appName - The app name.
+   * @param {string} databaseId - The database ID.
    * @param {string} transactionId - The transaction id.
    * @returns {Promise<null>} An empty promise.
    */
-  transactionBegin(appName, transactionId) {
+  transactionBegin(appName, databaseId, transactionId) {
     return guard(async () => {
-      const firestore = getCachedFirestoreInstance(appName);
+      const firestore = getCachedFirestoreInstance(appName, databaseId);
 
       try {
         await runTransaction(firestore, async tsx => {
@@ -421,6 +441,7 @@ export default {
             eventName: 'firestore_transaction_event',
             body: { type: 'update' },
             appName,
+            databaseId,
             listenerId: transactionId,
           });
 
@@ -468,6 +489,7 @@ export default {
           eventName: 'firestore_transaction_event',
           body: { type: 'complete' },
           appName,
+          databaseId,
           listenerId: transactionId,
         });
       } catch (e) {
@@ -475,6 +497,7 @@ export default {
           eventName: 'firestore_transaction_event',
           body: { type: 'error', error: getWebError(e) },
           appName,
+          databaseId,
           listenerId: transactionId,
         });
       }

--- a/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
+++ b/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
@@ -281,7 +281,8 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
    * @link https://firebase.google.com/docs/reference/js/firebase.storage.Storage#useEmulator
    */
   @ReactMethod
-  public void useEmulator(String appName, String host, int port, String bucketUrl, Promise promise) {
+  public void useEmulator(
+      String appName, String host, int port, String bucketUrl, Promise promise) {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
 
     FirebaseStorage firebaseStorage = FirebaseStorage.getInstance(firebaseApp, bucketUrl);

--- a/tests/app.js
+++ b/tests/app.js
@@ -81,6 +81,7 @@ function loadTests(_) {
         firebase.auth().useEmulator('http://localhost:9099');
       if (platformSupportedModules.includes('firestore')) {
         firebase.firestore().useEmulator('localhost', 8080);
+        firebase.app().firestore('second-rnfb').useEmulator('localhost', 8080);
         // Firestore caches documents locally (a great feature!) and that confounds tests
         // as data from previous runs pollutes following runs until re-install the app. Clear it.
         if (!Platform.other) {

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1326,76 +1326,78 @@ PODS:
     - React-logger (= 0.73.4)
     - React-perflogger (= 0.73.4)
   - RecaptchaInterop (100.0.0)
+  - RNCAsyncStorage (1.24.0):
+    - React-Core
   - RNDeviceInfo (11.1.0):
     - React-Core
-  - RNFBAnalytics (20.1.0):
+  - RNFBAnalytics (20.3.0):
     - Firebase/Analytics (= 10.29.0)
     - GoogleAppMeasurementOnDeviceConversion (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (20.1.0):
+  - RNFBApp (20.3.0):
     - Firebase/CoreOnly (= 10.29.0)
     - React-Core
-  - RNFBAppCheck (20.1.0):
+  - RNFBAppCheck (20.3.0):
     - Firebase/AppCheck (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (20.1.0):
+  - RNFBAppDistribution (20.3.0):
     - Firebase/AppDistribution (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (20.1.0):
+  - RNFBAuth (20.3.0):
     - Firebase/Auth (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (20.1.0):
+  - RNFBCrashlytics (20.3.0):
     - Firebase/Crashlytics (= 10.29.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (20.1.0):
+  - RNFBDatabase (20.3.0):
     - Firebase/Database (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (20.1.0):
+  - RNFBDynamicLinks (20.3.0):
     - Firebase/DynamicLinks (= 10.29.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (20.1.0):
+  - RNFBFirestore (20.3.0):
     - Firebase/Firestore (= 10.29.0)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (20.1.0):
+  - RNFBFunctions (20.3.0):
     - Firebase/Functions (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (20.1.0):
+  - RNFBInAppMessaging (20.3.0):
     - Firebase/InAppMessaging (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (20.1.0):
+  - RNFBInstallations (20.3.0):
     - Firebase/Installations (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (20.1.0):
+  - RNFBMessaging (20.3.0):
     - Firebase/Messaging (= 10.29.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (20.1.0):
+  - RNFBML (20.3.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (20.1.0):
+  - RNFBPerf (20.3.0):
     - Firebase/Performance (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (20.1.0):
+  - RNFBRemoteConfig (20.3.0):
     - Firebase/RemoteConfig (= 10.29.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (20.1.0):
+  - RNFBStorage (20.3.0):
     - Firebase/Storage (= 10.29.0)
     - React-Core
     - RNFBApp
@@ -1454,6 +1456,7 @@ DEPENDENCIES:
   - React-runtimescheduler (from `../node_modules/react-native/ReactCommon/react/renderer/runtimescheduler`)
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - "RNFBAnalytics (from `../node_modules/@react-native-firebase/analytics`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
@@ -1621,6 +1624,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/utils"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
   RNFBAnalytics:
@@ -1758,26 +1763,27 @@ SPEC CHECKSUMS:
   React-utils: 21a798438d45e70ed9c2e2fe0894ee32ba7b7c5b
   ReactCommon: dcc65c813041388dead6c8b477444757425ce961
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
+  RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
   RNDeviceInfo: b899ce37a403a4dea52b7cb85e16e49c04a5b88e
-  RNFBAnalytics: 8aa2c79f8ced7036e14907e6ae86f9f55bd1cf49
-  RNFBApp: 94776f5e68f403793b86b91dc6a22ac6f03cf51f
-  RNFBAppCheck: 920940691bdd352b023c091a07d867d2ef968abe
-  RNFBAppDistribution: 50c6178315a8ac419cdbf09e2b3657c80ad9b80d
-  RNFBAuth: 76bde6ea67e2d6a1c250867f35bcd7c21e9a914c
-  RNFBCrashlytics: a63b5d5d9e02589fe8a3a59c4805bde4b9261972
-  RNFBDatabase: 6448909a9f07d2b2f6c39f6765fd0d125ce378e9
-  RNFBDynamicLinks: 4e181c96ad07a4d310aedcd37d3030aad9859c23
-  RNFBFirestore: 54a9a3dacaa311bc1016d8c22a2acdc0009260bc
-  RNFBFunctions: 8392e6225e2cccf0022cea05cdf3122787de86b8
-  RNFBInAppMessaging: 4ea54b07b8aa30c252508f3683ca2dee36c0e74b
-  RNFBInstallations: eb59cb11bdc16c13feddfd9ad0c8c02a652287cc
-  RNFBMessaging: ee80027da5c5eba48109c5066dc568fb98f9c27d
-  RNFBML: 617f875def61029d0c4632af07bde4be4c76bff0
-  RNFBPerf: 1853af83b06f70099c30baeae84de22d1fce55c2
-  RNFBRemoteConfig: 68b8f0a65dcb7c06af92a2b4c7cc674703019ccf
-  RNFBStorage: a569fc000b2ff3befeb2aa7d2c6455ca0c21da7c
+  RNFBAnalytics: 921cce283e56e0775b10708bd1856eb5d44011ef
+  RNFBApp: a7aff07a7f212149539fce51a1326c6d208b03ad
+  RNFBAppCheck: 2463063b94cf3178e0398175636bcc3766f4f98e
+  RNFBAppDistribution: 35f4080726886e005c9af0097ebcc624bfca8aad
+  RNFBAuth: 3ed676e60d0ca3b2c71023240658e1f02bc752d7
+  RNFBCrashlytics: 0194114803bf2984cf241fd79198a14c575b317e
+  RNFBDatabase: d46a1d1cbcf3769179deaed11e74753999e6f3a1
+  RNFBDynamicLinks: 5c83930d0ba2478501e1e330322f1ef57059720d
+  RNFBFirestore: 2c8d40c5a28007d6a3d183e21141e2fedf7f6d41
+  RNFBFunctions: bb2c9cf33f64efddf8852d1077e599436f99fa9c
+  RNFBInAppMessaging: 8f2cb9ebfbd83c1923e44822ddd585aebd20c71d
+  RNFBInstallations: e4ba9770162024c6471d3ce3c9cfe5690207e041
+  RNFBMessaging: f1fdc7ac62df96e3c8362d516caaf84fab69085d
+  RNFBML: e4045427926875c7a469332f1e75fd96999d8202
+  RNFBPerf: 818dc56dee8203dbdf5ab2bef2675a62c0df2978
+  RNFBRemoteConfig: 3d9c04beffe742f407d89d2b295a02420df4d2e8
+  RNFBStorage: 5c67f0b3d55ef904b87ad7826ce0d588c2e028fb
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 1b901a6d6eeba4e8a2e8f308f708691cdb5db312
+  Yoga: 64cd2a583ead952b0315d5135bf39e053ae9be70
 
 PODFILE CHECKSUM: 95dd7da90f1ff7fdc1017f409737e31d23b1c46a
 


### PR DESCRIPTION
### Description

- Used [existing code](https://github.com/invertase/firestore-ios-sdk-frameworks/actions/runs/10284797497/job/28461600238) to allow firestore to accept an argument (i.e databaseId).
- Update index.d.ts & modular/index.d.ts type files.
- Prepend databaseId to every native method call alongside appName for Firestore
- Updated macOS code to match.
- Tested 2nd database by creating 3 new test files based on the following existing test files:
	- [Transaction.e2e.js](https://github.com/invertase/react-native-firebase/blob/main/packages/firestore/e2e/Transaction.e2e.js) 
	- [onSnapshot.e2e.js](https://github.com/invertase/react-native-firebase/blob/main/packages/firestore/e2e/Query/onSnapshot.e2e.js)
	- [where.e2e.js](https://github.com/invertase/react-native-firebase/blob/main/packages/firestore/e2e/Query/where.e2e.js)
	- I'm happy to add more if you think it is appropriate.


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
