### PR TITLE
docs: Update axios-integration.md

### DIFF
--- a/docs/perf/axios-integration.md
+++ b/docs/perf/axios-integration.md
@@ -22,7 +22,7 @@ import perf from '@react-native-firebase/perf';
 
 axios.interceptors.request.use(async function (config) {
   try {
-    const httpMetric = perf().newHttpMetric(config.url, config.method);
+    const httpMetric = perf().newHttpMetric(config.url, config.method.toUpperCase());
     config.metadata = { httpMetric };
 
     // add any extra metric attributes, if required


### PR DESCRIPTION
### Description
This PR addresses an issue with the `newHttpMetric` function in the Firebase Performance Monitoring documentation. According to the documentation, when tracking HTTP request performance (e.g., using Axios), the HTTP method needs to be passed in uppercase. However, the `config.method` from Axios returns the method in lowercase, causing the following error:
```
[Error: firebase.perf().newHttpMetric(_, *) 'httpMethod' must be one of CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE.]
```
As a result, this error prevents the use of `httpMetric` in response monitoring.

The issue was resolved by adding the `toUpperCase()` method to the HTTP method before passing it to `newHttpMetric`. The documentation has been updated to reflect this requirement.

### Related issues
None

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No