### PR TITLE
feat(remote-config): Added getJson and asJson method

### DIFF
--- a/docs/remote-config/usage/index.md
+++ b/docs/remote-config/usage/index.md
@@ -118,6 +118,12 @@ if (awesomeNewFeature.asNumber() === 5) {
 if (awesomeNewFeature.asBoolean() === true) {
   enableAwesomeNewFeature();
 }
+// resolves value to object
+// if the value is not a valid JSON string, the value will be an null
+const awesomeFeatureConfig = awesomeNewFeature.asJson();
+if (awesomeFeatureConfig && awesomeFeatureConfig.enabled === true) {
+  enableAwesomeNewFeature();
+}
 ```
 
 The API also provides a `getAll` method to read all parameters at once rather than by key:

--- a/packages/remote-config/__tests__/remote-config.test.ts
+++ b/packages/remote-config/__tests__/remote-config.test.ts
@@ -27,6 +27,7 @@ import {
   getBoolean,
   getNumber,
   getString,
+  getJson,
   getValue,
   setLogLevel,
   isSupported,
@@ -167,6 +168,10 @@ describe('remoteConfig()', function () {
 
     it('`getString` function is properly exposed to end user', function () {
       expect(getString).toBeDefined();
+    });
+
+    it('`getJson` function is properly exposed to end user', function () {
+      expect(getJson).toBeDefined();
     });
 
     it('`getValue` function is properly exposed to end user', function () {

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -189,6 +189,17 @@ describe('remoteConfig()', function () {
         });
       });
 
+      describe('getValue().asJson()', function () {
+        it('returns the value as a JSON object', function () {
+          const config = firebase.remoteConfig().getAll();
+
+          config.locale.asJson().should.deepEqual({
+            countryCode: "DE",
+            languageCode: "de"
+          });
+        });
+      });
+
       describe('getValue().asNumber()', function () {
         it('returns the value as a number if it can be evaluated as a number', function () {
           const config = firebase.remoteConfig().getAll();
@@ -262,15 +273,20 @@ describe('remoteConfig()', function () {
         const config = firebase.remoteConfig().getAll();
 
         config.should.be.a.Object();
-        config.should.have.keys('bool', 'string', 'number');
+        config.should.have.keys('bool', 'string', 'number', 'locale');
 
         const boolValue = config.bool.asBoolean();
         const stringValue = config.string.asString();
         const numberValue = config.number.asNumber();
+        const jsonValue = config.locale.asJson();
 
         boolValue.should.be.equal(true);
         stringValue.should.be.equal('invertase');
         numberValue.should.be.equal(1337);
+        jsonValue.should.be.deepEqual({
+          countryCode: "DE",
+          languageCode: "de"
+        });
       });
     });
 
@@ -470,6 +486,10 @@ describe('remoteConfig()', function () {
         config.float.getSource().should.equal('remote');
         config.prefix_1.asNumber().should.equal(1);
         config.prefix_1.getSource().should.equal('remote');
+        config.locale.asJson().should.deepEqual({
+          countryCode: "DE",
+          languageCode: "de"
+        });
       });
     });
 
@@ -591,6 +611,23 @@ describe('remoteConfig()', function () {
           unknownKey.should.equal(0);
         });
       });
+
+      describe('getValue().asJson()', function () {
+        it('returns the value as a JSON object', function () {
+          const { getRemoteConfig, getValue } = remoteConfigModular;
+          const remoteConfig = getRemoteConfig();
+
+          const config = getValue(remoteConfig, 'locale').asJson();
+
+          config.should.deepEqual({
+            countryCode: "DE",
+            languageCode: "de"
+          });
+
+        });
+      });
+
+          
 
       describe('getValue().getSource()', function () {
         it('returns the correct source as default or remote', async function () {

--- a/packages/remote-config/lib/RemoteConfigValue.js
+++ b/packages/remote-config/lib/RemoteConfigValue.js
@@ -53,7 +53,7 @@ export default class ConfigValue {
     try {
       return JSON.parse(this._value);
     } catch (error) {
-      console.warn('RemoteConfig Error, Error parsing value as JSON:', error);
+      console.warn('Firebase RemoteConfig: Error parsing value as JSON:', error);
       return null;
     }
   }

--- a/packages/remote-config/lib/RemoteConfigValue.js
+++ b/packages/remote-config/lib/RemoteConfigValue.js
@@ -45,6 +45,19 @@ export default class ConfigValue {
     return this._value;
   }
 
+  asJson() {
+    if (this._source === 'static') {
+      return null;
+    }
+
+    try {
+      return JSON.parse(this._value);
+    } catch (error) {
+      console.warn('RemoteConfig Error, Error parsing value as JSON:', error);
+      return null;
+    }
+  }
+
   getSource() {
     return this._source;
   }

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -231,6 +231,18 @@ export namespace FirebaseRemoteConfigTypes {
      * ```
      */
     asString(): string;
+    /**
+     * The returned value.
+     * 
+     * #### Example
+     * 
+     * ```js
+     * const configValue = firebase.remoteConfig().getValue('config');
+     * console.log('Config: ', configValue.asJson());
+     * ```
+     * 
+     */
+    asJson(): object | null;
   }
 
   /**
@@ -525,6 +537,20 @@ export namespace FirebaseRemoteConfigTypes {
      * @param key A key used to retrieve a specific value.
      */
     getNumber(key: string): number;
+    /**
+     * Gets a config property using the key and converts to a JSON value.
+     * It will be null if the value is not a JSON value.
+     * 
+     * #### Example
+     * 
+     * ```js
+     * // JSON value of 'experiment' property
+     * const configValue = firebase.remoteConfig().getJson('experiment');
+     * ```
+     * 
+     * @param key A key used to retrieve a specific value.
+     */
+    getJson(key: string): object | null;
 
     /**
      * Deletes all activated, fetched and defaults configs and resets all Firebase Remote Config settings.

--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -242,7 +242,7 @@ export namespace FirebaseRemoteConfigTypes {
      * ```
      * 
      */
-    asJson(): object | null;
+    asJson(): object | any[] | null;
   }
 
   /**
@@ -550,7 +550,7 @@ export namespace FirebaseRemoteConfigTypes {
      * 
      * @param key A key used to retrieve a specific value.
      */
-    getJson(key: string): object | null;
+    getJson(key: string): object | any[] | null;
 
     /**
      * Deletes all activated, fetched and defaults configs and resets all Firebase Remote Config settings.

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -125,6 +125,10 @@ class FirebaseConfigModule extends FirebaseModule {
     return this.getValue(key).asString();
   }
 
+  getJson(key) {
+    return this.getValue(key).asJson();
+  }
+
   getAll() {
     const values = {};
     Object.keys(this._values).forEach(key => (values[key] = this.getValue(key)));

--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -100,7 +100,7 @@ export function getString(remoteConfig: RemoteConfig, key: string): string;
  * @param key - key for JSON object value
  * @returns {object | any[] | null}
  */
-export function getJson(remoteConfig: RemoteConfig, key: string): object | null;
+export function getJson(remoteConfig: RemoteConfig, key: string): object | any[] | null;
 
 /**
  * Gets the value for the given key

--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -98,7 +98,7 @@ export function getString(remoteConfig: RemoteConfig, key: string): string;
  * Gets the value for the given key as a JSON object.
  * @param remoteConfig - RemoteConfig instance
  * @param key - key for JSON object value
- * @returns {object | null}
+ * @returns {object | any[] | null}
  */
 export function getJson(remoteConfig: RemoteConfig, key: string): object | null;
 

--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -93,6 +93,15 @@ export function getNumber(remoteConfig: RemoteConfig, key: string): number;
  */
 export function getString(remoteConfig: RemoteConfig, key: string): string;
 
+
+/**
+ * Gets the value for the given key as a JSON object.
+ * @param remoteConfig - RemoteConfig instance
+ * @param key - key for JSON object value
+ * @returns {object | null}
+ */
+export function getJson(remoteConfig: RemoteConfig, key: string): object | null;
+
 /**
  * Gets the value for the given key
  * @param remoteConfig - RemoteConfig instance

--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -122,7 +122,7 @@ export function getString(remoteConfig, key) {
  * Gets the value for the given key as a JSON object.
  * @param {RemoteConfig} remoteConfig - RemoteConfig instance
  * @param {string} key - key for JSON object value
- * @returns {object | null}
+ * @returns {object | any[] | null}
  */
 export function getJson(remoteConfig, key) {
   return remoteConfig.getJson(key);

--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -119,6 +119,16 @@ export function getString(remoteConfig, key) {
 }
 
 /**
+ * Gets the value for the given key as a JSON object.
+ * @param {RemoteConfig} remoteConfig - RemoteConfig instance
+ * @param {string} key - key for JSON object value
+ * @returns {object | null}
+ */
+export function getJson(remoteConfig, key) {
+  return remoteConfig.getJson(key);
+}
+
+/**
  * Gets the value for the given key
  * @param {RemoteConfig} remoteConfig - RemoteConfig instance
  * @param {string} key - key for the given value


### PR DESCRIPTION
### Description

This pull request introduces an `getJson('key')` and `getValue('key').asJson()` method to the Remote Config module of `@react-native-firebase/remote-config`. Currently, Firebase allows storing data as JSON, including objects and arrays. However, this library does not provide a direct way to retrieve these values in their parsed JSON form. Users have to manually fetch the data as strings and then parse it themselves.

With the new method, users can now directly retrieve JSON-encoded values as JSON objects and arrays. This addition aligns the library with Firebase’s support for various data types and simplifies handling complex data structures. Instead of manually parsing string values, users can now obtain object and array data with a single method call, reducing complexity and improving ease of use.

### Related issues
No related issues at the moment

### Release Summary

Added `getJson('key')` and `getValue('key').asJson()` method to Remote Config to retrieve JSON-encoded values as JSON objects and arrays, aligning with Firebase's supported data types and simplifying data handling

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan


:fire: