### PR TITLE
fix(firestore, ios): remove nanopb transitive dep from podspec

### DIFF
--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -39,10 +39,6 @@ Pod::Spec.new do |s|
   # Firebase dependencies
   s.dependency          'Firebase/Firestore', firebase_sdk_version
 
-  # required until firestore-ios-sdk-frameworks is updated, otherwise users of that distribution will have compile failures
-  # see https://github.com/invertase/firestore-ios-sdk-frameworks/issues/59
-  s.dependency          'nanopb', '>= 2.30908.0', '< 2.30910.0'
-
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"
     s.static_framework = $RNFirebaseAsStaticFramework


### PR DESCRIPTION
### Description

Upstream firestore-ios-sdk-frameworks issue is fixed and the Firestore binary distribution now directly depends on nanopb as it should, so we should remove the workaround here.

This tangentially fixes compile of InAppMessaging which was specifying a mutually exclusive nanopb version range

### Related issues

No related issue, noticed it while checking rnfbdemo repo for compile on Xcode 16

### Release Summary

the commit is a single conventional commit and a rebase-merge should work, generating a successful release later

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

rnfbdemo compile tests this to make sure it works, it appears to work fine

https://github.com/mikehardy/rnfbdemo/blob/main/make-demo.sh

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
