### PR TITLE
fix(crashlytics, ios): dependencies init param removed upstream in v11+

### DIFF
--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
@@ -134,7 +134,6 @@ NSString *const KEY_CRASHLYTICS_JAVASCRIPT_EXCEPTION_HANDLER_CHAINING_ENABLED =
   FIRComponent *crashlyticsInitProvider =
       [FIRComponent componentWithProtocol:@protocol(RNFBCrashlyticsInitProviderProtocol)
                       instantiationTiming:FIRInstantiationTimingEagerInDefaultApp
-                             dependencies:@[]  // note this will go away in firebase-ios-sdk v11+
                             creationBlock:creationBlock];
 
   return @[ crashlyticsInitProvider ];


### PR DESCRIPTION

### Description

firebase-ios-sdk v11+ removed one of the parameters from their component initialization API, we must remove it here to use firebase-ios-sdk v11+

### Related issues

The fix for the Xcode build failures on Xcode 16+ require using firebase-ios-sdk v11+, which requires this:

- #8020 

### Release Summary

This is a conventional commit so should be possible to rebase merge

**NOTE THAT package.json needs firebase bumped to 11.2.0 as a commit before this one works - however, that is not a breaking change, if you bump package.json to 11.2.0 for firebase-ios-sdk, and merge this PR plus #8021 then react-native-firebase appears to work fine**

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No **not by itself but must be issued with bump to firebase-ios-sdk v11**



### Test Plan

tested in https://github.com/mikehardy/rnfbdemo/blob/main/make-demo.sh with a patch, a bump to firebase-ios-sdk and a patch from #8021 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
