### PR TITLE
Fix typo in docstring

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1477,7 +1477,7 @@ export namespace FirebaseAuthTypes {
      * await firebase.auth().currentUser.updatePassword('654321');
      * ```
      *
-     * > This will Promise reject is the user is anonymous.
+     * > This will Promise reject if the user is anonymous.
      *
      * @error auth/weak-password Thrown if the password is not strong enough.
      * @error auth/requires-recent-login Thrown if the user's last sign-in time does not meet the security threshold.
@@ -1502,7 +1502,7 @@ export namespace FirebaseAuthTypes {
      * await firebase.auth().currentUser.updatePhoneNumber(credential);
      * ```
      *
-     * > This will Promise reject is the user is anonymous.
+     * > This will Promise reject if the user is anonymous.
      *
      * @error auth/invalid-verification-code Thrown if the verification code of the credential is not valid.
      * @error auth/invalid-verification-id Thrown if the verification ID of the credential is not valid.


### PR DESCRIPTION
### Description

Fixing a small typo in two doc strings, correcting `is` to `if`
### Related issues
None
### Release Summary
Fixed small typo in doc strings

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - *No code changes made*
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

*There are no code changes in this PR, only changes to two comments*


:fire:
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
