### PR TITLE
fix(auth, ios): demonstrate test integration of upstream fix 13772

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tests:ios:test-reuse": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
     "tests:ios:test-cover": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.debug --loglevel verbose",
     "tests:ios:test-cover-reuse": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 node_modules/.bin/nyc yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
-    "tests:ios:pod:install": "cd tests && rm -f ios/Podfile.lock && rm -rf ios/ReactNativeFirebaseDemo.xcworkspace && cd ios && pod install",
+    "tests:ios:pod:install": "cd tests && rm -f ios/Podfile.lock && rm -rf ios/ReactNativeFirebaseDemo.xcworkspace && cd ios && pod install && cd Pods/FirebaseAuth && (patch --forward < ../../../patches/firebase-ios-sdk-13772.diff || true)",
     "tests:macos:build": "cd tests && yarn build:macos",
     "tests:macos:pod:install": "cd tests && rm -f macos/Podfile.lock && cd macos && pod install",
     "tests:macos:test-cover": "cd tests && npx jet --target=macos --coverage",

--- a/tests/patches/firebase-ios-sdk-13772.diff
+++ b/tests/patches/firebase-ios-sdk-13772.diff
@@ -1,0 +1,35 @@
+diff --git a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+index 444a97c1c07..84bf5ec55c9 100644
+--- a/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
++++ b/FirebaseAuth/Sources/Swift/Backend/AuthBackend.swift
+@@ -76,21 +76,19 @@ class AuthBackend {
+     return "FirebaseAuth.iOS/\(FirebaseVersion()) \(GTMFetcherStandardUserAgentString(nil))"
+   }
+ 
+-  private static var gBackendImplementation: AuthBackendImplementation?
++  private static var realRPCBackend = AuthBackendRPCImplementation()
++  private static var gBackendImplementation = realRPCBackend
+ 
+-  class func setDefaultBackendImplementationWithRPCIssuer(issuer: AuthBackendRPCIssuer?) {
+-    let defaultImplementation = AuthBackendRPCImplementation()
+-    if let issuer = issuer {
+-      defaultImplementation.rpcIssuer = issuer
+-    }
+-    gBackendImplementation = defaultImplementation
++  class func setTestRPCIssuer(issuer: AuthBackendRPCIssuer) {
++    gBackendImplementation.rpcIssuer = issuer
++  }
++
++  class func resetRPCIssuer() {
++    gBackendImplementation.rpcIssuer = realRPCBackend.rpcIssuer
+   }
+ 
+   class func implementation() -> AuthBackendImplementation {
+-    if gBackendImplementation == nil {
+-      gBackendImplementation = AuthBackendRPCImplementation()
+-    }
+-    return gBackendImplementation!
++    return gBackendImplementation
+   }
+ 
+   class func call<T: AuthRPCRequest>(with request: T) async throws -> T.Response {


### PR DESCRIPTION

This is not for merge

This is a demonstration of how to patch a source file integrated via cocoapods in a react-native context

It should handle these cases:

- no tools installed (that is, there are things like `[cocoapods-patch](https://github.com/DoubleSymmetry/cocoapods-patch)` but you have to install things, that is unwanted
- patch is already applied (using `--forward` and the `(command || true)` construction in patch call means it will silently proceed without a non-zero exit code, even if patch is already applied)

Doing something like this in your project may help you test-integrate the upstream fix to see if it stops the crashing for you

See related discussion at https://github.com/firebase/firebase-ios-sdk/issues/13761