### PR TITLE
feat: support custom firebase.json path

### DIFF
--- a/packages/app/android/firebase-json.gradle
+++ b/packages/app/android/firebase-json.gradle
@@ -4,16 +4,22 @@ import groovy.json.JsonSlurper
 
 String fileName = 'firebase.json'
 String jsonRoot = 'react-native'
+String customFirebaseJsonDir = rootProject.ext.get("react-native")["options"]["firebaseJsonDir"]
 
 File jsonFile = null
-File parentDir = rootProject.projectDir
 
-for (int i = 0; i <= 3; i++) {
-  if (parentDir == null) { break }
-  parentDir = parentDir.parentFile
-  if (parentDir != null) {
-    jsonFile = new File(parentDir, fileName)
-    if (jsonFile.exists()) { break }
+if (customFirebaseJsonDir != null) {
+  jsonFile = new File(customFirebaseJsonDir, fileName)
+} else {
+  File parentDir = rootProject.projectDir
+
+  for (int i = 0; i <= 3; i++) {
+    if (parentDir == null) { break }
+    parentDir = parentDir.parentFile
+    if (parentDir != null) {
+      jsonFile = new File(parentDir, fileName)
+      if (jsonFile.exists()) { break }
+    }
   }
 }
 


### PR DESCRIPTION
### Description
Currently, the firebase.json file is configured only when it is located in the parent directory of the Android project. However, React Native can be used in different ways, especially when integrating it into an existing native project.

In my case, I’m trying to integrate a React Native app into a brownfield native app as a submodule, so retrieving firebase.json from the upper directory always fails. I think providing an option to set a custom "firebaseJsonDir" would be very useful for people in my situation.

I add "customFirebaseJsonDir" option in same way to override firebase sdk versions and reactNativeDir. 

I would appreciate any help to add this feature on iOS too. 



### Release Summary
- Support custom firebase.json path

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


