### PR TITLE
feat(messaging, android): add priority + originalPriority to RemoteMessage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -576,3 +576,6 @@ website/public
 !**/.yarn/releases
 !**/.yarn/sdks
 !**/.yarn/versions
+
+# Typescript items
+*.tsbuildinfo

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingSerializer.java
@@ -21,6 +21,8 @@ public class ReactNativeFirebaseMessagingSerializer {
   private static final String KEY_ERROR = "error";
   private static final String KEY_TO = "to";
   private static final String KEY_TTL = "ttl";
+  private static final String KEY_PRIORITY = "priority";
+  private static final String KEY_ORIGINAL_PRIORITY = "originalPriority";
   private static final String EVENT_MESSAGE_SENT = "messaging_message_sent";
   private static final String EVENT_MESSAGES_DELETED = "messaging_message_deleted";
   private static final String EVENT_MESSAGE_RECEIVED = "messaging_message_received";
@@ -99,6 +101,8 @@ public class ReactNativeFirebaseMessagingSerializer {
     messageMap.putMap(KEY_DATA, dataMap);
     messageMap.putDouble(KEY_TTL, remoteMessage.getTtl());
     messageMap.putDouble(KEY_SENT_TIME, remoteMessage.getSentTime());
+    messageMap.putInt(KEY_PRIORITY, remoteMessage.getPriority());
+    messageMap.putInt(KEY_ORIGINAL_PRIORITY, remoteMessage.getOriginalPriority());
 
     if (remoteMessage.getNotification() != null) {
       messageMap.putMap(

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -147,6 +147,46 @@ export namespace FirebaseMessagingTypes {
      * Options for features provided by the FCM SDK for Web.
      */
     fcmOptions: FcmOptions;
+
+    /**
+     * Priority - android-specific, undefined on non-android platforms, default PRIORITY_UNKNOWN
+     */
+    priority?: MessagePriority;
+
+    /**
+     * Original priority - android-specific, undefined on non-android platforms, default PRIORITY_UNKNOWN
+     */
+    originalPriority?: MessagePriority;
+  }
+
+  /**
+   * Represents the priority of a RemoteMessage
+   *
+   * Note: this is an android-specific property of RemoteMessages
+   *
+   * See https://github.com/firebase/firebase-android-sdk/blob/b6d01070d246b74f02c42da5691f99f52763e48b/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java#L57-L64
+   *
+   * Example:
+   *
+   * ```js
+   * firebase.messaging.MessagePriority.PRIORITY_NORMAL;
+   * ```
+   */
+  export enum MessagePriority {
+    /**
+     * Unknown priority, this will be returned as the default on non-android platforms
+     */
+    PRIORITY_UNKNOWN = 0,
+
+    /**
+     * High priority - Activities may start foreground services if they receive high priority messages
+     */
+    PRIORITY_HIGH = 1,
+
+    /**
+     * Normal priority - Activities have restrictions and may only perform unobtrusive actions on receipt
+     */
+    PRIORITY_NORMAL = 2,
   }
 
   /**


### PR DESCRIPTION
### Description

messages may be sent as high priority but downgraded to normal priority on
delivery and it is very important for applications to know this

if a priority is downgraded from high to normal, the application may not
start foreground services and the app will crash if a foreground start is
attempted

These are android-specific types not present on web, so I followed the pattern of other non-web typescript types by making them optional / warned they could be undefined

The two properties:

https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage#getPriority()
https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage#getOriginalPriority()

The java IntDef that drives the typescript enum definition:

https://github.com/firebase/firebase-android-sdk/blob/b6d01070d246b74f02c42da5691f99f52763e48b/firebase-messaging/src/main/java/com/google/firebase/messaging/RemoteMessage.java#L57-L64

### Related issues

Related:

- https://github.com/invertase/notifee/issues/470

### Release Summary

Two conventional commits that should trigger semantic release correctly if this PR is rebase-merged

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
