### PR TITLE
fix(ios, sdk): constrain transitive dependencies more tightly

### DIFF
--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -45,13 +45,13 @@ Pod::Spec.new do |s|
       raise "Firebase/AnalyticsWithoutAdIdSupport requires firebase-ios-sdk 7.11.0 or greater."
     end
 
-    s.dependency          'Firebase/AnalyticsWithoutAdIdSupport', firebase_sdk_version
+    s.dependency          'Firebase/AnalyticsWithoutAdIdSupport', "<= #{firebase_sdk_version}"
   else
     if !defined?($RNFirebaseAnalyticsWithoutAdIdSupport)
       Pod::UI.puts "#{s.name}: Using default Firebase/Analytics with Ad Ids. May require App Tracking Transparency. Not allowed for Kids apps."
       Pod::UI.puts "#{s.name}: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids."
     end
-    s.dependency          'Firebase/Analytics', firebase_sdk_version
+    s.dependency          'Firebase/Analytics', "<= #{firebase_sdk_version}"
 
     # Special pod for on-device conversion
     if defined?($RNFirebaseAnalyticsEnableAdSupport) && ($RNFirebaseAnalyticsEnableAdSupport == true)
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
       raise "GoogleAppMeasurementOnDeviceConversion requires firebase-ios-sdk 9.0.0 or greater."
     end
 
-    s.dependency          'GoogleAppMeasurementOnDeviceConversion', firebase_sdk_version
+    s.dependency          'GoogleAppMeasurementOnDeviceConversion', "<= #{firebase_sdk_version}"
   end
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/app-check/RNFBAppCheck.podspec
+++ b/packages/app-check/RNFBAppCheck.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/AppCheck', firebase_sdk_version
+  s.dependency          'Firebase/AppCheck', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/app-distribution/RNFBAppDistribution.podspec
+++ b/packages/app-distribution/RNFBAppDistribution.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/AppDistribution', firebase_sdk_version
+  s.dependency          'Firebase/AppDistribution', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
+  s.dependency          'Firebase/CoreOnly', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Auth', firebase_sdk_version
+  s.dependency          'Firebase/Auth', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -38,8 +38,8 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Crashlytics', firebase_sdk_version
-  s.dependency          'FirebaseCoreExtension'
+  s.dependency          'Firebase/Crashlytics', "<= #{firebase_sdk_version}"
+  s.dependency          'FirebaseCoreExtension', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Database', firebase_sdk_version
+  s.dependency          'Firebase/Database', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/dynamic-links/RNFBDynamicLinks.podspec
+++ b/packages/dynamic-links/RNFBDynamicLinks.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/DynamicLinks', firebase_sdk_version
+  s.dependency          'Firebase/DynamicLinks', "<= #{firebase_sdk_version}"
   s.dependency          'GoogleUtilities/AppDelegateSwizzler'
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Firestore', firebase_sdk_version
+  s.dependency          'Firebase/Firestore', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Functions', firebase_sdk_version
+  s.dependency          'Firebase/Functions', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
+  s.dependency          'Firebase/InAppMessaging', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/installations/RNFBInstallations.podspec
+++ b/packages/installations/RNFBInstallations.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Installations', firebase_sdk_version
+  s.dependency          'Firebase/Installations', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -38,8 +38,8 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Messaging', firebase_sdk_version
-  s.dependency          'FirebaseCoreExtension'
+  s.dependency          'Firebase/Messaging', "<= #{firebase_sdk_version}"
+  s.dependency          'FirebaseCoreExtension', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Performance', firebase_sdk_version
+  s.dependency          'Firebase/Performance', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/RemoteConfig', firebase_sdk_version
+  s.dependency          'Firebase/RemoteConfig', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Storage', firebase_sdk_version
+  s.dependency          'Firebase/Storage', "<= #{firebase_sdk_version}"
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - AppCheckCore (11.1.0):
+  - AppCheckCore (11.2.0):
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
@@ -55,7 +55,7 @@ PODS:
   - Firebase/Storage (11.3.0):
     - Firebase/CoreOnly
     - FirebaseStorage (~> 11.3.0)
-  - FirebaseABTesting (11.3.0):
+  - FirebaseABTesting (11.4.0):
     - FirebaseCore (~> 11.0)
   - FirebaseAnalytics (11.3.0):
     - FirebaseAnalytics/AdIdSupport (= 11.3.0)
@@ -81,7 +81,7 @@ PODS:
     - FirebaseCore (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAppCheckInterop (11.3.0)
+  - FirebaseAppCheckInterop (11.4.0)
   - FirebaseAppDistribution (11.3.0-beta):
     - FirebaseCore (~> 11.0)
     - FirebaseInstallations (~> 11.0)
@@ -96,14 +96,14 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (~> 3.4)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (11.3.0)
+  - FirebaseAuthInterop (11.4.0)
   - FirebaseCore (11.3.0):
     - FirebaseCoreInternal (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
   - FirebaseCoreExtension (11.3.0):
     - FirebaseCore (~> 11.0)
-  - FirebaseCoreInternal (11.3.0):
+  - FirebaseCoreInternal (11.4.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
   - FirebaseCrashlytics (11.3.0):
     - FirebaseCore (~> 11.0)
@@ -172,7 +172,7 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseMessagingInterop (11.3.0)
+  - FirebaseMessagingInterop (11.4.0)
   - FirebasePerformance (11.3.0):
     - FirebaseCore (~> 11.0)
     - FirebaseInstallations (~> 11.0)
@@ -191,7 +191,7 @@ PODS:
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.3.0)
+  - FirebaseRemoteConfigInterop (11.4.0)
   - FirebaseSessions (11.3.0):
     - FirebaseCore (~> 11.0)
     - FirebaseCoreExtension (~> 11.0)
@@ -1437,74 +1437,74 @@ PODS:
     - React-Core
   - RNDeviceInfo (13.0.0):
     - React-Core
-  - RNFBAnalytics (21.0.0):
-    - Firebase/Analytics (= 11.3.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 11.3.0)
+  - RNFBAnalytics (21.1.0):
+    - Firebase/Analytics (<= 11.3.0)
+    - GoogleAppMeasurementOnDeviceConversion (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (21.0.0):
-    - Firebase/CoreOnly (= 11.3.0)
+  - RNFBApp (21.1.0):
+    - Firebase/CoreOnly (<= 11.3.0)
     - React-Core
-  - RNFBAppCheck (21.0.0):
-    - Firebase/AppCheck (= 11.3.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (21.0.0):
-    - Firebase/AppDistribution (= 11.3.0)
+  - RNFBAppCheck (21.1.0):
+    - Firebase/AppCheck (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.0.0):
-    - Firebase/Auth (= 11.3.0)
+  - RNFBAppDistribution (21.1.0):
+    - Firebase/AppDistribution (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.0.0):
-    - Firebase/Crashlytics (= 11.3.0)
-    - FirebaseCoreExtension
+  - RNFBAuth (21.1.0):
+    - Firebase/Auth (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.0.0):
-    - Firebase/Database (= 11.3.0)
+  - RNFBCrashlytics (21.1.0):
+    - Firebase/Crashlytics (<= 11.3.0)
+    - FirebaseCoreExtension (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.0.0):
-    - Firebase/DynamicLinks (= 11.3.0)
+  - RNFBDatabase (21.1.0):
+    - Firebase/Database (<= 11.3.0)
+    - React-Core
+    - RNFBApp
+  - RNFBDynamicLinks (21.1.0):
+    - Firebase/DynamicLinks (<= 11.3.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.0.0):
-    - Firebase/Firestore (= 11.3.0)
+  - RNFBFirestore (21.1.0):
+    - Firebase/Firestore (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.0.0):
-    - Firebase/Functions (= 11.3.0)
+  - RNFBFunctions (21.1.0):
+    - Firebase/Functions (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.0.0):
-    - Firebase/InAppMessaging (= 11.3.0)
+  - RNFBInAppMessaging (21.1.0):
+    - Firebase/InAppMessaging (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.0.0):
-    - Firebase/Installations (= 11.3.0)
+  - RNFBInstallations (21.1.0):
+    - Firebase/Installations (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.0.0):
-    - Firebase/Messaging (= 11.3.0)
-    - FirebaseCoreExtension
+  - RNFBMessaging (21.1.0):
+    - Firebase/Messaging (<= 11.3.0)
+    - FirebaseCoreExtension (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBML (21.0.0):
+  - RNFBML (21.1.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.0.0):
-    - Firebase/Performance (= 11.3.0)
+  - RNFBPerf (21.1.0):
+    - Firebase/Performance (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.0.0):
-    - Firebase/RemoteConfig (= 11.3.0)
+  - RNFBRemoteConfig (21.1.0):
+    - Firebase/RemoteConfig (<= 11.3.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.0.0):
-    - Firebase/Storage (= 11.3.0)
+  - RNFBStorage (21.1.0):
+    - Firebase/Storage (<= 11.3.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.7.0)
@@ -1792,21 +1792,21 @@ CHECKOUT OPTIONS:
     :tag: 11.3.0
 
 SPEC CHECKSUMS:
-  AppCheckCore: 85a8346f8b5d2f50ee1b9f55d8bcaaeafe904adb
+  AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: ac12dc084d1c8ec4cc4d7b3cf1b0ebda6dab85af
   Firebase: 5c575140761e22324806f401e38c483d58db2dec
-  FirebaseABTesting: c4559fcd2eba9f6bdaf0599e2c37ded01c343e4c
+  FirebaseABTesting: aef1719704fade00b200827e7973f352efc4caee
   FirebaseAnalytics: ce1593872635a5ebd715d0d3937fab195991ecc9
   FirebaseAppCheck: db69ee8842189d7a86366b79941da15934f99b75
-  FirebaseAppCheckInterop: 7789a8adfb09e905ce02a76540b94b059029ea81
+  FirebaseAppCheckInterop: 1b9643ae2f1ee214488caa2f8e32b7bc2f0f3735
   FirebaseAppDistribution: 630df0f6f46a8201de63016329aa4428338a777b
   FirebaseAuth: c7b82c8f3942c22629145c3f2972c33d1dc3ee6c
-  FirebaseAuthInterop: c453b7ba7c49b88b2f519bb8d2e29edf7ada4a2a
+  FirebaseAuthInterop: 9ac948965ac13ec9d8a080f39490ddb2bda30520
   FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e
   FirebaseCoreExtension: 30bb063476ef66cd46925243d64ad8b2c8ac3264
-  FirebaseCoreInternal: ac26d09a70c730e497936430af4e60fb0c68ec4e
+  FirebaseCoreInternal: 5c2b016f06a96fbf20d9b443459f80427a827d7b
   FirebaseCrashlytics: ba7b6a55dc10393f6583d87d8600d0d3ab2671d8
   FirebaseDatabase: 33b92c5a719fb0c2d7f67e86bf6bcc70d7772998
   FirebaseDynamicLinks: f370f4f98f12d595f815cfb518c8c235cc0a132c
@@ -1821,10 +1821,10 @@ SPEC CHECKSUMS:
   FirebaseInAppMessaging: 0b05d8a54b855674e307fc65740b91bfaba1ebf1
   FirebaseInstallations: 58cf94dabf1e2bb2fa87725a9be5c2249171cda0
   FirebaseMessaging: ed3f874c733f1d20e32b82a3428f6a9f01ef9270
-  FirebaseMessagingInterop: 41f840551051fa9e5516b2f572c659e03a79e00d
+  FirebaseMessagingInterop: 249006abd2ef8fbf9dae3572eb2def468a647b37
   FirebasePerformance: 83cea3aa69401248317353646d8b63cb315047c9
   FirebaseRemoteConfig: 5be2ca4f9870d475b39214210955fdaeecf7e5ca
-  FirebaseRemoteConfigInterop: c3a5c31b3c22079f41ba1dc645df889d9ce38cb9
+  FirebaseRemoteConfigInterop: e76f46ffa4d6a65e273d4dfebb6a79e588cec136
   FirebaseSessions: 655ff17f3cc1a635cbdc2d69b953878001f9e25b
   FirebaseSharedSwift: d39c2ad64a11a8d936ce25a42b00df47078bb59c
   FirebaseStorage: d011ded57cc2c5904bbba947f269db506a788ea0
@@ -1890,26 +1890,26 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
   RNDeviceInfo: 55264dd7cc939dad6e9c231a7621311f5277f1dc
-  RNFBAnalytics: 0ce4ebd2ef83400262e1b53faf0e62784eb687d9
-  RNFBApp: cf5e7a5dec1e9389da261920a953a61a29339d25
-  RNFBAppCheck: d9b2156cdc67dc4f35676750516c40de895e9809
-  RNFBAppDistribution: 0a1f9a91c2d2766305907e051471d1521d5db037
-  RNFBAuth: e21c2d028432bf9baf529e109fc9070b61f12ba4
-  RNFBCrashlytics: 12720af5a4afa8c452e2e3315803198a588ddbdd
-  RNFBDatabase: 0d891b620ca74b8f6c894440301fa4bbf1d564ca
-  RNFBDynamicLinks: d09055dcfa5658cc803bd4e57bbf67274c271109
-  RNFBFirestore: e4d639b1426bc5b0d275ae1c45e543219fb100db
-  RNFBFunctions: 233b99ecb21b8025c31788f64c3160d7eeb2d875
-  RNFBInAppMessaging: d858376d4fbba70b0123004078b54991aadb7622
-  RNFBInstallations: cab17208914a12c8067dc2b3ea6129e2e5c9fab1
-  RNFBMessaging: 1e81b8a2af929061e226a76a89a3ddc2af400046
-  RNFBML: cc6db10a7cff92bc65f796a42abcfe6885c80d4b
-  RNFBPerf: 07f89ef6a9ce88cd31237648150710b16747e523
-  RNFBRemoteConfig: bd93b90fce1912668046af382f95ab8ac81de3c7
-  RNFBStorage: 2d1365f21ce8224321f7f68e4f5d1b31860052be
+  RNFBAnalytics: ce6a2f182e236dead738834397df927b4a4eeefa
+  RNFBApp: cf26fce8879cff40a8ec758ad79c6896a061d572
+  RNFBAppCheck: 88ec77c4dbe485780cb12991e972b8e9236b1ee4
+  RNFBAppDistribution: b17a79a099e59a3a61fe4edbc04b1b405e74ec99
+  RNFBAuth: 2e32d8461e88c7755d5dc9baa16d3611868a8b3c
+  RNFBCrashlytics: 3e1032144644431e84b257dcdc962c497c79a41b
+  RNFBDatabase: b11592ebbfb50b9281af13662a3ff1747a9631a6
+  RNFBDynamicLinks: 17e7c382becdc2c4dde60441906b0c632c80c56b
+  RNFBFirestore: e2aeed6fec328b3837d6365bd97cc058b725c85c
+  RNFBFunctions: b813201c70d822a4a01608158b06558160545476
+  RNFBInAppMessaging: cc06ca580d6b0063fc3d9e2129708871e83fb43e
+  RNFBInstallations: fa3ca35778030b6c538dbdbe6140e3a91f1d9a28
+  RNFBMessaging: 79aa8dc16d2afaed725e3e326686fd571b6ea882
+  RNFBML: 2c920665f05790e4d9ea836f312aaad815edca6f
+  RNFBPerf: c92792f1eb62c160d83b5948f3b7b20c8a0cece7
+  RNFBRemoteConfig: 6d43d9200983781aeb95bd21a6adf28bca9e6a57
+  RNFBStorage: d3da3ba1759f5a862c0d29539d9a45624b3aa9f0
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 33622183a85805e12703cd618b2c16bfd18bfffb
 
-PODFILE CHECKSUM: a36a0d7dc37e28167d12c25215dd67f4737187e6
+PODFILE CHECKSUM: 95dd7da90f1ff7fdc1017f409737e31d23b1c46a
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
### Description

some were slipping out to 11.4.0 and causing compilation failures while the majority of the system was still on 11.3.0

we can't set exact versions because some pods don't version while others do (a previous issue) but we *can* set a max for compatibility reasons

### Related issues

Fixes:
- #8073 

### Release Summary

A single conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Simply being able to build (and pass the build) in CI should be a proof there was no regression

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
