### PR TITLE
fix(app, sdk): firebase-android-sdk 33.5.1

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -290,7 +290,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "33.4.0"
+        bom           : "33.5.1"
       ],
     ],
   ])

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -82,7 +82,7 @@
       "minSdk": 21,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "33.4.0",
+      "firebase": "33.5.1",
       "firebaseCrashlyticsGradle": "3.0.2",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.2",

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -103,7 +103,7 @@ PODS:
     - GoogleUtilities/Logger (~> 8.0)
   - FirebaseCoreExtension (11.4.0):
     - FirebaseCore (~> 11.0)
-  - FirebaseCoreInternal (11.4.0):
+  - FirebaseCoreInternal (11.4.2):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
   - FirebaseCrashlytics (11.4.0):
     - FirebaseCore (~> 11.4)
@@ -266,7 +266,7 @@ PODS:
   - hermes-engine (0.74.5):
     - hermes-engine/Pre-built (= 0.74.5)
   - hermes-engine/Pre-built (0.74.5)
-  - leveldb-library (1.22.5)
+  - leveldb-library (1.22.6)
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -1437,73 +1437,73 @@ PODS:
     - React-Core
   - RNDeviceInfo (13.0.0):
     - React-Core
-  - RNFBAnalytics (21.1.1):
+  - RNFBAnalytics (21.2.0):
     - Firebase/Analytics (<= 11.4.0)
     - GoogleAppMeasurementOnDeviceConversion (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (21.1.1):
+  - RNFBApp (21.2.0):
     - Firebase/CoreOnly (<= 11.4.0)
     - React-Core
-  - RNFBAppCheck (21.1.1):
+  - RNFBAppCheck (21.2.0):
     - Firebase/AppCheck (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (21.1.1):
+  - RNFBAppDistribution (21.2.0):
     - Firebase/AppDistribution (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.1.1):
+  - RNFBAuth (21.2.0):
     - Firebase/Auth (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.1.1):
+  - RNFBCrashlytics (21.2.0):
     - Firebase/Crashlytics (<= 11.4.0)
     - FirebaseCoreExtension (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.1.1):
+  - RNFBDatabase (21.2.0):
     - Firebase/Database (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.1.1):
+  - RNFBDynamicLinks (21.2.0):
     - Firebase/DynamicLinks (<= 11.4.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.1.1):
+  - RNFBFirestore (21.2.0):
     - Firebase/Firestore (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.1.1):
+  - RNFBFunctions (21.2.0):
     - Firebase/Functions (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.1.1):
+  - RNFBInAppMessaging (21.2.0):
     - Firebase/InAppMessaging (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.1.1):
+  - RNFBInstallations (21.2.0):
     - Firebase/Installations (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.1.1):
+  - RNFBMessaging (21.2.0):
     - Firebase/Messaging (<= 11.4.0)
     - FirebaseCoreExtension (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBML (21.1.1):
+  - RNFBML (21.2.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.1.1):
+  - RNFBPerf (21.2.0):
     - Firebase/Performance (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.1.1):
+  - RNFBRemoteConfig (21.2.0):
     - Firebase/RemoteConfig (<= 11.4.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.1.1):
+  - RNFBStorage (21.2.0):
     - Firebase/Storage (<= 11.4.0)
     - React-Core
     - RNFBApp
@@ -1806,7 +1806,7 @@ SPEC CHECKSUMS:
   FirebaseAuthInterop: 9ac948965ac13ec9d8a080f39490ddb2bda30520
   FirebaseCore: e0510f1523bc0eb21653cac00792e1e2bd6f1771
   FirebaseCoreExtension: 4445e4cd877e0790c4af33bedca61eaef27b7513
-  FirebaseCoreInternal: 5c2b016f06a96fbf20d9b443459f80427a827d7b
+  FirebaseCoreInternal: 35731192cab10797b88411be84940d2beb33a238
   FirebaseCrashlytics: 41bbdd2b514a8523cede0c217aee6ef7ecf38401
   FirebaseDatabase: ccd11f02c170076ffeeef40020cbb2f6d33e718c
   FirebaseDynamicLinks: 192110d77418357fe994f2823a7df7db3ccb15bf
@@ -1836,7 +1836,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMSessionFetcher: 923b710231ad3d6f3f0495ac1ced35421e07d9a6
   hermes-engine: 8c1577f3fdb849cbe7729c2e7b5abc4b845e88f8
-  leveldb-library: e8eadf9008a61f9e1dde3978c086d2b6d9b9dc28
+  leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
@@ -1890,26 +1890,26 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
   RNDeviceInfo: 55264dd7cc939dad6e9c231a7621311f5277f1dc
-  RNFBAnalytics: e2c82ecd2e2b8cec12773c8c9d1d24542516ce89
-  RNFBApp: 625be5f3a3e834ebbc9885f4f089f669a8d12f3a
-  RNFBAppCheck: 6e7e7073a4902a33ad3d1793abc3a603511fde13
-  RNFBAppDistribution: 1e3a6b6ae0d7743ef096b4ad521bd6e2e3274cf6
-  RNFBAuth: ca1d097e123229b0a6edec2c6809fdf007f98ea0
-  RNFBCrashlytics: ab0733fa4ba986449f379d77036ad43d46f90935
-  RNFBDatabase: 77f41497d129cff9612921cca1896a1c0f9183d7
-  RNFBDynamicLinks: 486bd382925d14e03287bc0ddbdb11e5f3a69b3d
-  RNFBFirestore: a214b5b5fb103b7259a35137c113a91a46377f6f
-  RNFBFunctions: 79fcfdde972b6e8e75719e9bc6d6025ad0698b63
-  RNFBInAppMessaging: 7bd0fe6f8b0552ce3c0ec5d11daf9a8ef03a5d64
-  RNFBInstallations: 5cca2bbc2bb4672194c1b748b53041806ff86203
-  RNFBMessaging: 33c5519f794d04ef1f3aa0ebc7b57b465f1c6f34
-  RNFBML: 6eff74c2f7990692fa528437a2306b0cec013316
-  RNFBPerf: de40e0ca35709b217ebcf5d4fdfca6bf0e58bcce
-  RNFBRemoteConfig: 1b42db29699a95c835e0aac448609b218f0ddf76
-  RNFBStorage: 0b1a3bc416e3b3484fd14a4201e2c134e3a60643
+  RNFBAnalytics: 01c492e5ee3bcdc9c73665e4ad6c8939c9645ede
+  RNFBApp: 5d3d1b9d563857c68d161a3226d9dd6d6be1a846
+  RNFBAppCheck: e17c7a221bf15e3e43184d26eaf56728481307b9
+  RNFBAppDistribution: 4ae2a712b2a7159885b13463cf15deb5f88481f9
+  RNFBAuth: 7af4d3571e58aa38b7de2ebc2704fe703120ee72
+  RNFBCrashlytics: 335b08979fa09bd44eb851d54dca346171f2529d
+  RNFBDatabase: f767fea3d07ba0178a20ec139abf7532b3b6d41f
+  RNFBDynamicLinks: fdf983c5331ac4100f8b47b5064426a06bffd927
+  RNFBFirestore: 55e3f4a5abdc5bfa05fc5c0a41bb07b74f2a27f9
+  RNFBFunctions: ba9e978852f47aa320cd68f1f2027ba5b7a27853
+  RNFBInAppMessaging: 9ee367387691732f7b61ddf4bbdb4f9aa4ac1218
+  RNFBInstallations: fdc3ae989dd830ad74f146723a2a103e644907aa
+  RNFBMessaging: 2895d9dfa1cfea663c26a1b5dfb5faf17ad096f8
+  RNFBML: ae9857c327cd6c48b827508ab4ca560cf8535ce4
+  RNFBPerf: 7aa759f1e796dea89bf8419748856d68694c512c
+  RNFBRemoteConfig: 7b55aba003a58ce9b8355af1d7edf65480c7f3c9
+  RNFBStorage: 0212beaa00576bae041f13f0769aff273d394e5b
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 33622183a85805e12703cd618b2c16bfd18bfffb
 
 PODFILE CHECKSUM: 95dd7da90f1ff7fdc1017f409737e31d23b1c46a
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.1


### PR DESCRIPTION
### Description

underlying fixes but nothing visible for / necessary from library consumers

### Related issues

Nothing logged, but:

- android updated protobuf to solve a security CVE

- the saga of FirebaseCoreExtension is what drove the iOS SDK patch releases - unfortunately we can't really do a 11.4.2 release because firestore did not actually bump except some of it's internal/transitives, so firestore-ios-sdk-frameworks won't generate a release, it will have to wait for 11.5.0

### Release Summary

a single conventional commit, rebase merge + release should do the trick

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Incorporated in my rnfbdemo build tests successfully, CI will qualify it here

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
