### PR TITLE
feat(crashlytics, ios): add native helper log / setCustomValue methods

### DIFF
--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.h
@@ -22,4 +22,8 @@
 
 + (void)recordNativeError:(NSError *)error;
 
++ (void)log:(nonnull NSString *)msg;
+
++ (void)setCustomValue:(nullable id)value forKey:(nonnull NSString *)key;
+
 @end

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.m
@@ -25,4 +25,12 @@
   [[FIRCrashlytics crashlytics] recordError:error];
 }
 
++ (void)log:(nonnull NSString *)msg {
+  [[FIRCrashlytics crashlytics] log:msg];
+}
+
++ (void)setCustomValue:(nullable id)value forKey:(nonnull NSString *)key {
+  [[FIRCrashlytics crashlytics] setCustomValue:value forKey:key];
+}
+
 @end


### PR DESCRIPTION
### Description

user request, useful for "brownfield" apps that have custom native code and want to use crashlytics native methods from their own native code

### Related issues

Fixes:
- Fixes #8093

### Release Summary

one conventional commit, rebase merge

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

native helper methods don't have tests, compiling correctly (which it does) should be adequate as it simply copies the previous method that has reports of user success, and does nothing but copy the SDK method signature then delegate to the SDK

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
