### PR TITLE
fix(app): add misconfiguration warning for missing native module

### DIFF
--- a/packages/app/lib/internal/RNFBNativeEventEmitter.js
+++ b/packages/app/lib/internal/RNFBNativeEventEmitter.js
@@ -20,7 +20,13 @@ import { getReactNativeModule } from './nativeModule';
 
 class RNFBNativeEventEmitter extends NativeEventEmitter {
   constructor() {
-    super(getReactNativeModule('RNFBAppModule'));
+    const RNFBAppModule = getReactNativeModule('RNFBAppModule');
+    if (!RNFBAppModule) {
+      throw new Error(
+        'Native module RNFBAppModule not found. Re-check module install, linking, configuration, build and install steps.',
+      );
+    }
+    super(RNFBAppModule);
     this.ready = false;
   }
 


### PR DESCRIPTION
### Description

This case comes up frequently and adds to support load when an error message could provide a pointer

### Related issues

Related discussion https://github.com/invertase/react-native-firebase/discussions/8102


### Release Summary

Single conventional commit, rebase merge should work

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Make sure e2e still runs - the event emitter is used everywhere so that will cover it in the normal case


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
