### PR TITLE
feat: Add initial tvOS support to some firebase packages

### DIFF
--- a/packages/app-check/RNFBAppCheck.podspec
+++ b/packages/app-check/RNFBAppCheck.podspec
@@ -10,6 +10,7 @@ if coreVersionDetected != coreVersionRequired
 end
 firebase_ios_target = appPackage['sdkVersions']['ios']['iosTarget']
 firebase_macos_target = appPackage['sdkVersions']['ios']['macosTarget']
+firebase_tvos_target = appPackage['sdkVersions']['ios']['tvosTarget']
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAppCheck"
@@ -25,6 +26,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = firebase_ios_target
   s.macos.deployment_target = firebase_macos_target
+  s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -4,6 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 firebase_sdk_version = package['sdkVersions']['ios']['firebase']
 firebase_ios_target = package['sdkVersions']['ios']['iosTarget']
 firebase_macos_target = package['sdkVersions']['ios']['macosTarget']
+firebase_tvos_target = package['sdkVersions']['ios']['tvosTarget']
 
 Pod::Spec.new do |s|
   s.name                = "RNFBApp"
@@ -19,6 +20,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = firebase_ios_target
   s.macos.deployment_target = firebase_macos_target
+  s.tvos.deployment_target = firebase_tvos_target
   s.cocoapods_version   = '>= 1.12.0'
   s.source_files        = "ios/**/*.{h,m}"
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,7 +76,8 @@
     "ios": {
       "firebase": "11.4.0",
       "iosTarget": "13.0",
-      "macosTarget": "10.15"
+      "macosTarget": "10.15",
+      "tvosTarget": "12.0"
     },
     "android": {
       "minSdk": 21,

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -10,6 +10,7 @@ if coreVersionDetected != coreVersionRequired
 end
 firebase_ios_target = appPackage['sdkVersions']['ios']['iosTarget']
 firebase_macos_target = appPackage['sdkVersions']['ios']['macosTarget']
+firebase_tvos_target = appPackage['sdkVersions']['ios']['tvosTarget']
 
 Pod::Spec.new do |s|
   s.name                = "RNFBAuth"
@@ -25,6 +26,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = firebase_ios_target
   s.macos.deployment_target = firebase_macos_target
+  s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -55,8 +55,10 @@ static __strong NSMutableDictionary *idTokenHandlers;
 static __strong NSMutableDictionary *emulatorConfigs;
 // Used for caching credentials between method calls.
 static __strong NSMutableDictionary<NSString *, FIRAuthCredential *> *credentials;
+#if !TARGET_OS_TV
 static __strong NSMutableDictionary<NSString *, FIRMultiFactorResolver *> *cachedResolver;
 static __strong NSMutableDictionary<NSString *, FIRMultiFactorSession *> *cachedSessions;
+#endif
 
 @implementation RNFBAuthModule
 #pragma mark -
@@ -76,8 +78,10 @@ RCT_EXPORT_MODULE();
     idTokenHandlers = [[NSMutableDictionary alloc] init];
     emulatorConfigs = [[NSMutableDictionary alloc] init];
     credentials = [[NSMutableDictionary alloc] init];
+#if !TARGET_OS_TV
     cachedResolver = [[NSMutableDictionary alloc] init];
     cachedSessions = [[NSMutableDictionary alloc] init];
+#endif
   });
   return self;
 }
@@ -103,8 +107,10 @@ RCT_EXPORT_MODULE();
   [idTokenHandlers removeAllObjects];
 
   [credentials removeAllObjects];
+#if !TARGET_OS_TV
   [cachedResolver removeAllObjects];
   [cachedSessions removeAllObjects];
+#endif
 }
 
 #pragma mark -
@@ -415,6 +421,7 @@ RCT_EXPORT_METHOD(updatePassword
   }
 }
 
+#if !TARGET_OS_TV
 RCT_EXPORT_METHOD(updatePhoneNumber
                   : (FIRApp *)firebaseApp
                   : (NSString *)provider
@@ -455,6 +462,7 @@ RCT_EXPORT_METHOD(updatePhoneNumber
     [self promiseNoUser:resolve rejecter:reject isError:YES];
   }
 }
+#endif
 
 RCT_EXPORT_METHOD(updateProfile
                   : (FIRApp *)firebaseApp
@@ -617,6 +625,7 @@ RCT_EXPORT_METHOD(signInWithProvider
     [builder setCustomParameters:provider[@"customParameters"]];
   }
 
+#if !TARGET_OS_TV
   [builder getCredentialWithUIDelegate:nil
                             completion:^(FIRAuthCredential *_Nullable credential,
                                          NSError *_Nullable error) {
@@ -647,6 +656,7 @@ RCT_EXPORT_METHOD(signInWithProvider
                                               }];
                               }
                             }];
+#endif
 }
 
 RCT_EXPORT_METHOD(confirmPasswordReset
@@ -817,6 +827,7 @@ RCT_EXPORT_METHOD(signInWithCustomToken
                  }];
 }
 
+#if !TARGET_OS_TV
 RCT_EXPORT_METHOD(signInWithPhoneNumber
                   : (FIRApp *)firebaseApp
                   : (NSString *)phoneNumber
@@ -1053,6 +1064,7 @@ RCT_EXPORT_METHOD(confirmationResultConfirm
                   }
                 }];
 }
+#endif
 
 RCT_EXPORT_METHOD(linkWithCredential
                   : (FIRApp *)firebaseApp
@@ -1122,6 +1134,7 @@ RCT_EXPORT_METHOD(linkWithProvider
     [builder setCustomParameters:provider[@"parameters"]];
   }
 
+#if !TARGET_OS_TV
   [builder getCredentialWithUIDelegate:nil
                             completion:^(FIRAuthCredential *_Nullable credential,
                                          NSError *_Nullable error) {
@@ -1151,6 +1164,7 @@ RCT_EXPORT_METHOD(linkWithProvider
                                               }];
                               }
                             }];
+#endif
 }
 
 RCT_EXPORT_METHOD(unlink
@@ -1248,7 +1262,7 @@ RCT_EXPORT_METHOD(reauthenticateWithProvider
   if (provider[@"parameters"]) {
     [builder setCustomParameters:provider[@"parameters"]];
   }
-
+#if !TARGET_OS_TV
   [builder getCredentialWithUIDelegate:nil
                             completion:^(FIRAuthCredential *_Nullable credential,
                                          NSError *_Nullable error) {
@@ -1279,6 +1293,7 @@ RCT_EXPORT_METHOD(reauthenticateWithProvider
                                                         }];
                               }
                             }];
+#endif
 }
 
 RCT_EXPORT_METHOD(fetchSignInMethodsForEmail
@@ -1375,10 +1390,12 @@ RCT_EXPORT_METHOD(useEmulator
   } else if ([provider compare:@"github.com" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIRGitHubAuthProvider credentialWithToken:authToken];
   } else if ([provider compare:@"phone" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
+#if !TARGET_OS_TV
     DLog(@"using app credGen: %@", firebaseApp.name) credential =
         [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
             credentialWithVerificationID:authToken
                         verificationCode:authTokenSecret];
+#endif
   } else if ([provider compare:@"oauth" options:NSCaseInsensitiveSearch] == NSOrderedSame) {
     credential = [FIROAuthProvider credentialWithProviderID:@"oauth"
                                                     IDToken:authToken
@@ -1423,6 +1440,7 @@ RCT_EXPORT_METHOD(useEmulator
   }
 }
 
+#if !TARGET_OS_TV
 - (NSDictionary *)multiFactorResolverToDict:(FIRMultiFactorResolver *)resolver {
   // Temporarily store the non-serializable session for later
   NSString *sessionHash = [NSString stringWithFormat:@"%@", @([resolver.session hash])];
@@ -1433,6 +1451,7 @@ RCT_EXPORT_METHOD(useEmulator
     @"auth" : resolver.auth
   };
 }
+#endif
 
 - (NSString *)getJSFactorId:(NSString *)factorId {
   if ([factorId isEqualToString:@"1"]) {
@@ -1542,7 +1561,9 @@ RCT_EXPORT_METHOD(useEmulator
     authCredentialDict = [self authCredentialToDict:authCredential];
   }
 
+
   NSDictionary *resolverDict = nil;
+#if !TARGET_OS_TV
   if ([error userInfo][FIRAuthErrorUserInfoMultiFactorResolverKey] != nil) {
     FIRMultiFactorResolver *resolver = error.userInfo[FIRAuthErrorUserInfoMultiFactorResolverKey];
     resolverDict = [self multiFactorResolverToDict:resolver];
@@ -1550,6 +1571,7 @@ RCT_EXPORT_METHOD(useEmulator
     NSString *sessionKey = [NSString stringWithFormat:@"%@", @([resolver.session hash])];
     cachedResolver[sessionKey] = resolver;
   }
+#endif
 
   return @{
     @"code" : code,
@@ -1696,11 +1718,14 @@ RCT_EXPORT_METHOD(useEmulator
     @"refreshToken" : user.refreshToken,
     @"tenantId" : user.tenantID ? (id)user.tenantID : [NSNull null],
     keyUid : user.uid,
+#if !TARGET_OS_TV
     @"multiFactor" :
         @{@"enrolledFactors" : [self convertMultiFactorData:user.multiFactor.enrolledFactors]}
+#endif
   };
 }
 
+#if !TARGET_OS_TV
 - (NSArray<NSMutableDictionary *> *)convertMultiFactorData:(NSArray<FIRMultiFactorInfo *> *)hints {
   NSMutableArray *enrolledFactors = [NSMutableArray array];
 
@@ -1720,6 +1745,7 @@ RCT_EXPORT_METHOD(useEmulator
   }
   return enrolledFactors;
 }
+#endif
 
 - (NSDictionary *)authCredentialToDict:(FIRAuthCredential *)authCredential {
   NSString *authCredentialHash = [NSString stringWithFormat:@"%@", @([authCredential hash])];

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -10,6 +10,7 @@ if coreVersionDetected != coreVersionRequired
 end
 firebase_ios_target = appPackage['sdkVersions']['ios']['iosTarget']
 firebase_macos_target = appPackage['sdkVersions']['ios']['macosTarget']
+firebase_tvos_target = appPackage['sdkVersions']['ios']['tvosTarget']
 
 Pod::Spec.new do |s|
   s.name                = "RNFBFirestore"
@@ -25,6 +26,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = firebase_ios_target
   s.macos.deployment_target = firebase_macos_target
+  s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -10,6 +10,7 @@ if coreVersionDetected != coreVersionRequired
 end
 firebase_ios_target = appPackage['sdkVersions']['ios']['iosTarget']
 firebase_macos_target = appPackage['sdkVersions']['ios']['macosTarget']
+firebase_tvos_target = appPackage['sdkVersions']['ios']['tvosTarget']
 
 Pod::Spec.new do |s|
   s.name                = "RNFBFunctions"
@@ -25,6 +26,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = firebase_ios_target
   s.macos.deployment_target = firebase_macos_target
+  s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -10,6 +10,7 @@ if coreVersionDetected != coreVersionRequired
 end
 firebase_ios_target = appPackage['sdkVersions']['ios']['iosTarget']
 firebase_macos_target = appPackage['sdkVersions']['ios']['macosTarget']
+firebase_tvos_target = appPackage['sdkVersions']['ios']['tvosTarget']
 
 Pod::Spec.new do |s|
   s.name                = "RNFBStorage"
@@ -25,6 +26,7 @@ Pod::Spec.new do |s|
   s.social_media_url    = 'http://twitter.com/invertaseio'
   s.ios.deployment_target = firebase_ios_target
   s.macos.deployment_target = firebase_macos_target
+  s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
   # React Native dependencies


### PR DESCRIPTION
Adds compatibility with tvOS (using [react-native-tvos](https://github.com/react-native-tvos/react-native-tvos)) for RNFirebase packages: app, auth, firestore, functions, storage and app check

### Description

Two main changes:

 - Updates the podspec files of packages to add tvOS deployment targets.
 - Updates `RNFBAuthModule.m` to only remove incompatible tvOS APIs

This allows running the updated Firebase packages on tvOS.

### Related issues

Not aware of an open issue but discussion here:
https://github.com/invertase/react-native-firebase/discussions/5722#discussioncomment-11125191

### Release Summary

Adds compatibility with tvOS (using [react-native-tvos](https://github.com/react-native-tvos/react-native-tvos)) for RNFirebase packages: app, auth, firestore, functions, storage and app check

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS` (well sort of, `tvOS`)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

Not sure how to add a test plan for this change.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
