### PR TITLE
fix: correct type for setBackgroundMessageHandler

### DIFF
--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -200,7 +200,7 @@ import messaging from '@react-native-firebase/messaging';
 import App from './App';
 
 // Register background handler
-messaging().setBackgroundMessageHandler(async remoteMessage => {
+messaging().setBackgroundMessageHandler(remoteMessage => {
   console.log('Message handled in the background!', remoteMessage);
 });
 
@@ -289,7 +289,7 @@ import { AppRegistry } from 'react-native';
 import messaging from '@react-native-firebase/messaging';
 
 // Handle background messages using setBackgroundMessageHandler
-messaging().setBackgroundMessageHandler(async remoteMessage => {
+messaging().setBackgroundMessageHandler(remoteMessage => {
   console.log('Message handled in the background!', remoteMessage);
 });
 

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -1066,7 +1066,7 @@ export namespace FirebaseMessagingTypes {
      * ```
      *
      */
-    setBackgroundMessageHandler(handler: (message: RemoteMessage) => Promise<any>): void;
+    setBackgroundMessageHandler(handler: (message: RemoteMessage) => any): void;
 
     /**
      * Set a handler function which is called when the `${App Name} notifications settings`

--- a/packages/messaging/lib/modular/index.d.ts
+++ b/packages/messaging/lib/modular/index.d.ts
@@ -227,7 +227,7 @@ export function onSendError(
  */
 export function setBackgroundMessageHandler(
   messaging: Messaging,
-  handler: (message: FirebaseMessagingTypes.RemoteMessage) => Promise<any>,
+  handler: (message: FirebaseMessagingTypes.RemoteMessage) => any,
 ): void;
 
 /**


### PR DESCRIPTION
The `async` breaks the https://typescript-eslint.io/rules/require-await/ rule. Even in the examples, you do not need to `await  remoteMessage`