### PR TITLE
chore(core): deprecation warning for v8 API ahead of future major release

### DIFF
--- a/packages/app/__tests__/app.test.ts
+++ b/packages/app/__tests__/app.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
 
-import {
+import firebase, {
   deleteApp,
   registerVersion,
   onLog,
@@ -38,6 +38,59 @@ describe('App', function () {
 
     it('`setLogLevel` function is properly exposed to end user', function () {
       expect(setLogLevel).toBeDefined();
+    });
+  });
+
+  describe('test `console.warn` is called for RNFB v8 API & not called for v9 API', function () {
+    it('deleteApp', function () {
+      const firebaseApp = firebase.app();
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // @ts-ignore test
+      jest.spyOn(firebaseApp, '_deleteApp').mockImplementation(() => Promise.resolve(null));
+      // we don't need to test this because we call underlying deleteApp directly
+      // deleteApp(firebaseApp);
+
+      firebaseApp.delete();
+      // Check that console.warn was called for v8 method call
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      // Restore the original console.warn
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('getApps', function () {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // Check that console.warn was not called for v9 method call
+      getApps();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      // Check that console.warn was called for v8 method call
+      firebase.apps;
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      // Restore the original console.warn
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('getApp', function () {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // Check that console.warn was not called for v9 method call
+      getApp();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      // Check that console.warn was called for v8 method call
+      firebase.app();
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      // Restore the original console.warn
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('setLogLevel', function () {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      // Check that console.warn was not called for v9 method call
+      setLogLevel('debug');
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      // Check that console.warn was called for v8 method call
+      firebase.setLogLevel('debug');
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      // Restore the original console.warn
+      consoleWarnSpy.mockRestore();
     });
   });
 });

--- a/packages/app/__tests__/app.test.ts
+++ b/packages/app/__tests__/app.test.ts
@@ -92,5 +92,27 @@ describe('App', function () {
       // Restore the original console.warn
       consoleWarnSpy.mockRestore();
     });
+
+    it('FirebaseApp.toString()', function () {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const app = firebase.app();
+      app.toString();
+      // Check that console.warn was called for deprecated method call
+      firebase.setLogLevel('debug');
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      // Restore the original console.warn
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('FirebaseApp.extendApp()', function () {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const app = firebase.app();
+      // To overcome type assertion
+      (app as any).extendApp({ some: 'property' });
+      // Check that console.warn was called for deprecated method call
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      // Restore the original console.warn
+      consoleWarnSpy.mockRestore();
+    });
   });
 });

--- a/packages/app/__tests__/app.test.ts
+++ b/packages/app/__tests__/app.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-
+import { checkV9Deprecation } from '../lib/common/unitTestUtils';
 import firebase, {
   deleteApp,
   registerVersion,
@@ -9,16 +9,6 @@ import firebase, {
   getApp,
   setLogLevel,
 } from '../lib';
-
-// this could be extracted to some test utils location
-const checkV9Deprecation = (modularFunction: () => void, nonModularFunction: () => void) => {
-  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-  modularFunction();
-  expect(consoleWarnSpy).not.toHaveBeenCalled();
-  nonModularFunction();
-  expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-  consoleWarnSpy.mockRestore();
-};
 
 describe('App', function () {
   describe('modular', function () {

--- a/packages/app/lib/FirebaseApp.js
+++ b/packages/app/lib/FirebaseApp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-
+import { isNotModularCall } from '@react-native-firebase/app/lib/common';
 import { getAppModule } from './internal/registry/nativeModule';
 
 export default class FirebaseApp {
@@ -61,16 +61,34 @@ export default class FirebaseApp {
   }
 
   extendApp(extendedProps) {
+    if (isNotModularCall(arguments)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API.',
+      );
+    }
     this._checkDestroyed();
     Object.assign(this, extendedProps);
   }
 
   delete() {
+    if (isNotModularCall(arguments)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `deleteApp()` instead.',
+      );
+    }
     this._checkDestroyed();
     return this._deleteApp();
   }
 
   toString() {
+    if (isNotModularCall(arguments)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API.',
+      );
+    }
     return this.name;
   }
 }

--- a/packages/app/lib/FirebaseApp.js
+++ b/packages/app/lib/FirebaseApp.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { isNotModularCall } from '@react-native-firebase/app/lib/common';
+import { warnIfNotModularCall } from '@react-native-firebase/app/lib/common';
 import { getAppModule } from './internal/registry/nativeModule';
 
 export default class FirebaseApp {
@@ -61,33 +61,21 @@ export default class FirebaseApp {
   }
 
   extendApp(extendedProps) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API.',
-    );
-
+    // this method has no modular alternative, send true for param 'noAlternative'
+    warnIfNotModularCall(arguments, '', true);
     this._checkDestroyed();
     Object.assign(this, extendedProps);
   }
 
   delete() {
-    if (isNotModularCall(arguments)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `deleteApp()` instead.',
-      );
-    }
+    warnIfNotModularCall(arguments, 'deleteApp()');
     this._checkDestroyed();
     return this._deleteApp();
   }
 
   toString() {
-    if (isNotModularCall(arguments)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API.',
-      );
-    }
+    // this method has no modular alternative, send true for param 'noAlternative'
+    warnIfNotModularCall(arguments, '', true);
     return this.name;
   }
 }

--- a/packages/app/lib/FirebaseApp.js
+++ b/packages/app/lib/FirebaseApp.js
@@ -61,12 +61,11 @@ export default class FirebaseApp {
   }
 
   extendApp(extendedProps) {
-    if (isNotModularCall(arguments)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API.',
-      );
-    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API.',
+    );
+
     this._checkDestroyed();
     Object.assign(this, extendedProps);
   }

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -105,11 +105,20 @@ export function tryJSONStringify(data) {
 
 export const MODULAR_DEPRECATION_ARG = 'react-native-firebase-modular-method-call';
 
-export function isNotModularCall(args) {
+export function warnIfNotModularCall(args, replacementMethodName, noAlternative) {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === MODULAR_DEPRECATION_ARG) {
-      return false;
+      return;
     }
   }
-  return true;
+  let message =
+    'This v8 method is deprecated and will be removed in the next major release ' +
+    'as part of move to match Firebase Web modular v9 SDK API.';
+
+  if (!noAlternative) {
+    message += ` Please use \`${replacementMethodName}\` instead.`;
+  }
+
+  // eslint-disable-next-line no-console
+  console.warn(message);
 }

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -102,3 +102,14 @@ export function tryJSONStringify(data) {
     return null;
   }
 }
+
+export const MODULAR_DEPRECATION_ARG = 'react-native-firebase-modular-method-call';
+
+export function isNotModularCall(args) {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === MODULAR_DEPRECATION_ARG) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/app/lib/common/unitTestUtils.ts
+++ b/packages/app/lib/common/unitTestUtils.ts
@@ -1,0 +1,10 @@
+import { expect, jest } from '@jest/globals';
+
+export const checkV9Deprecation = (modularFunction: () => void, nonModularFunction: () => void) => {
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  modularFunction();
+  expect(consoleWarnSpy).not.toHaveBeenCalled();
+  nonModularFunction();
+  expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  consoleWarnSpy.mockRestore();
+};

--- a/packages/app/lib/internal/registry/app.js
+++ b/packages/app/lib/internal/registry/app.js
@@ -19,6 +19,7 @@ import {
   isIOS,
   isOther,
   isNull,
+  isNotModularCall,
   isObject,
   isFunction,
   isString,
@@ -84,6 +85,12 @@ export function initializeNativeApps() {
  * @param name
  */
 export function getApp(name = DEFAULT_APP_NAME) {
+  if (isNotModularCall(arguments)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `getApp()` instead.',
+    );
+  }
   if (!initializedNativeApps) {
     initializeNativeApps();
   }
@@ -100,6 +107,12 @@ export function getApp(name = DEFAULT_APP_NAME) {
  * Gets all app instances, used for `firebase.apps`
  */
 export function getApps() {
+  if (isNotModularCall(arguments)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `getApps()` instead.',
+    );
+  }
   if (!initializedNativeApps) {
     initializeNativeApps();
   }
@@ -112,6 +125,12 @@ export function getApps() {
  * @param configOrName
  */
 export function initializeApp(options = {}, configOrName) {
+  if (isNotModularCall(arguments)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `initializeApp()` instead.',
+    );
+  }
   let appConfig = configOrName;
 
   if (!isObject(configOrName) || isNull(configOrName)) {
@@ -200,6 +219,12 @@ export function initializeApp(options = {}, configOrName) {
 }
 
 export function setLogLevel(logLevel) {
+  if (isNotModularCall(arguments)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `setLogLevel()` instead.',
+    );
+  }
   if (!['error', 'warn', 'info', 'debug', 'verbose'].includes(logLevel)) {
     throw new Error('LogLevel must be one of "error", "warn", "info", "debug", "verbose"');
   }

--- a/packages/app/lib/internal/registry/app.js
+++ b/packages/app/lib/internal/registry/app.js
@@ -19,7 +19,7 @@ import {
   isIOS,
   isOther,
   isNull,
-  isNotModularCall,
+  warnIfNotModularCall,
   isObject,
   isFunction,
   isString,
@@ -85,12 +85,7 @@ export function initializeNativeApps() {
  * @param name
  */
 export function getApp(name = DEFAULT_APP_NAME) {
-  if (isNotModularCall(arguments)) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `getApp()` instead.',
-    );
-  }
+  warnIfNotModularCall(arguments, 'getApp()');
   if (!initializedNativeApps) {
     initializeNativeApps();
   }
@@ -107,12 +102,7 @@ export function getApp(name = DEFAULT_APP_NAME) {
  * Gets all app instances, used for `firebase.apps`
  */
 export function getApps() {
-  if (isNotModularCall(arguments)) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `getApps()` instead.',
-    );
-  }
+  warnIfNotModularCall(arguments, 'getApps()');
   if (!initializedNativeApps) {
     initializeNativeApps();
   }
@@ -125,12 +115,7 @@ export function getApps() {
  * @param configOrName
  */
 export function initializeApp(options = {}, configOrName) {
-  if (isNotModularCall(arguments)) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `initializeApp()` instead.',
-    );
-  }
+  warnIfNotModularCall(arguments, 'initializeApp()');
   let appConfig = configOrName;
 
   if (!isObject(configOrName) || isNull(configOrName)) {
@@ -219,12 +204,7 @@ export function initializeApp(options = {}, configOrName) {
 }
 
 export function setLogLevel(logLevel) {
-  if (isNotModularCall(arguments)) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'This v8 method is deprecated and will be removed in the next major release as part of move to match Firebase Web modular v9 SDK API. Please use `setLogLevel()` instead.',
-    );
-  }
+  warnIfNotModularCall(arguments, 'setLogLevel()');
   if (!['error', 'warn', 'info', 'debug', 'verbose'].includes(logLevel)) {
     throw new Error('LogLevel must be one of "error", "warn", "info", "debug", "verbose"');
   }

--- a/packages/app/lib/modular/index.js
+++ b/packages/app/lib/modular/index.js
@@ -1,3 +1,4 @@
+import { MODULAR_DEPRECATION_ARG } from '@react-native-firebase/app/lib/common';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {
   deleteApp as deleteAppCompat,
@@ -6,6 +7,7 @@ import {
   initializeApp as initializeAppCompat,
   setLogLevel as setLogLevelCompat,
 } from '../internal';
+import sdkVersion from '../version';
 
 /**
  * @typedef {import('..').ReactNativeFirebase.FirebaseApp} FirebaseApp
@@ -19,7 +21,7 @@ import {
  * @returns {Promise<void>}
  */
 export function deleteApp(app) {
-  return deleteAppCompat(app.name, app._nativeInitialized);
+  return deleteAppCompat.call(null, app.name, app._nativeInitialized, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -48,7 +50,7 @@ export function onLog(logCallback, options) {
  * @returns {FirebaseApp[]} - An array of all initialized Firebase apps.
  */
 export function getApps() {
-  return getAppsCompat();
+  return getAppsCompat.call(null, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -58,7 +60,7 @@ export function getApps() {
  * @returns {FirebaseApp} - The initialized Firebase app.
  */
 export function initializeApp(options, name) {
-  return initializeAppCompat(options, name);
+  return initializeAppCompat.call(null, options, name, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -67,7 +69,7 @@ export function initializeApp(options, name) {
  * @returns {FirebaseApp} - The requested Firebase app instance.
  */
 export function getApp(name) {
-  return getAppCompat(name);
+  return getAppCompat.call(null, name, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -76,5 +78,7 @@ export function getApp(name) {
  * @returns {void}
  */
 export function setLogLevel(logLevel) {
-  return setLogLevelCompat(logLevel);
+  return setLogLevelCompat.call(null, logLevel, MODULAR_DEPRECATION_ARG);
 }
+
+export const SDK_VERSION = sdkVersion;

--- a/packages/crashlytics/e2e/crashlytics.e2e.js
+++ b/packages/crashlytics/e2e/crashlytics.e2e.js
@@ -90,10 +90,13 @@ describe('crashlytics()', function () {
         let logged = false;
         // eslint-disable-next-line no-console
         console.warn = msg => {
-          msg.should.containEql('expects an instance of Error');
-          logged = true;
-          // eslint-disable-next-line no-console
-          console.warn = orig;
+          // we console.warn for deprecated API, can be removed when we move to v9
+          if (!msg.includes('v8 method is deprecated')) {
+            msg.should.containEql('expects an instance of Error');
+            logged = true;
+            // eslint-disable-next-line no-console
+            console.warn = orig;
+          }
         };
 
         firebase.crashlytics().recordError(1337);

--- a/packages/crashlytics/e2e/crashlytics.e2e.js
+++ b/packages/crashlytics/e2e/crashlytics.e2e.js
@@ -264,10 +264,13 @@ describe('crashlytics()', function () {
         let logged = false;
         // eslint-disable-next-line no-console
         console.warn = msg => {
-          msg.should.containEql('expects an instance of Error');
-          logged = true;
-          // eslint-disable-next-line no-console
-          console.warn = orig;
+          // we console.warn for deprecated API, can be removed when we move to v9
+          if (!msg.includes('v8 method is deprecated')) {
+            msg.should.containEql('expects an instance of Error');
+            logged = true;
+            // eslint-disable-next-line no-console
+            console.warn = orig;
+          }
         };
 
         recordError(getCrashlytics(), 1337);


### PR DESCRIPTION

### Description

There is also a `utils()` method on FirebaseApp: https://rnfirebase.io/reference/app#utils

Not sure whether to leave it or to remove.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
