### PR TITLE
fix: forward port a bunch of deprecations / fix android hot reload

### DIFF
--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckModule.java
@@ -100,8 +100,8 @@ public class ReactNativeFirebaseAppCheckModule extends ReactNativeFirebaseModule
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
     Log.d(TAG, "instance-destroyed");
 
     Iterator appCheckListenerIterator = mAppCheckListeners.entrySet().iterator();

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/RCTConvertFirebase.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/RCTConvertFirebase.java
@@ -98,7 +98,7 @@ public class RCTConvertFirebase {
 
     if (appConfig.hasKey("automaticDataCollectionEnabled")) {
       firebaseApp.setDataCollectionDefaultEnabled(
-          appConfig.getBoolean("automaticDataCollectionEnabled"));
+          Boolean.valueOf(appConfig.getBoolean("automaticDataCollectionEnabled")));
     }
 
     if (appConfig.hasKey("automaticResourceManagement")) {

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseModule.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseModule.java
@@ -92,9 +92,26 @@ public class ReactNativeFirebaseModule extends ReactContextBaseJavaModule
     return executorService.getTransactionalExecutor(identifier);
   }
 
-  @Override
-  @CallSuper
+
+  // This is no longer called as of react-native 0.74 and is only here for
+  // compatibility with older versions. It delegates to thew new `invalidate`
+  // method, which all modules should implement now
+  // Remove this method when minimum supported react-native is 0.74
+  /** @noinspection removal*/
+  @SuppressWarnings({"deprecation", "removal"})
+  @Deprecated
   public void onCatalystInstanceDestroy() {
+    // This should call the child class invalidate, which will then call super.invalidate,
+    // and everything will work correctly up and down the inheritance hierarchy to shut down
+    invalidate();
+  }
+
+  // This should have an @Override annotation but we cannot do
+  // that until our minimum supported react-native version is 0.74, since the
+  // method did not exist before then
+  @CallSuper
+  public void invalidate() {
+    super.invalidate();
     executorService.shutdown();
   }
 

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/SharedUtils.java
@@ -17,6 +17,7 @@ package io.invertase.firebase.common;
  *
  */
 
+import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.graphics.Point;
@@ -181,6 +182,7 @@ public class SharedUtils {
     return false;
   }
 
+  @SuppressLint("DiscouragedApi")
   public static int getResId(Context ctx, String resName) {
     int resourceId = ctx.getResources().getIdentifier(resName, "string", ctx.getPackageName());
 

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -123,8 +123,8 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
     Log.d(TAG, "instance-destroyed");
 
     Iterator authListenerIterator = mAuthListeners.entrySet().iterator();

--- a/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQueryModule.java
+++ b/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQueryModule.java
@@ -42,8 +42,8 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
 
     Iterator refIterator = queryMap.entrySet().iterator();
     while (refIterator.hasNext()) {

--- a/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
+++ b/packages/dynamic-links/android/src/main/java/io/invertase/firebase/dynamiclinks/ReactNativeFirebaseDynamicLinksModule.java
@@ -71,10 +71,10 @@ public class ReactNativeFirebaseDynamicLinksModule extends ReactNativeFirebaseMo
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     getReactApplicationContext().removeActivityEventListener(this);
     getReactApplicationContext().addLifecycleEventListener(this);
-    super.onCatalystInstanceDestroy();
+    super.invalidate();
   }
 
   @ReactMethod

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -42,8 +42,8 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
 
     for (int i = 0, size = collectionSnapshotListeners.size(); i < size; i++) {
       int key = collectionSnapshotListeners.keyAt(i);

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -43,8 +43,8 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
 
     for (int i = 0, size = documentSnapshotListeners.size(); i < size; i++) {
       int key = documentSnapshotListeners.keyAt(i);

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
@@ -45,7 +45,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     for (int i = 0, size = transactionHandlers.size(); i < size; i++) {
       int key = transactionHandlers.keyAt(i);
       ReactNativeFirebaseFirestoreTransactionHandler transactionHandler =
@@ -57,7 +57,7 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
     }
 
     transactionHandlers.clear();
-    super.onCatalystInstanceDestroy();
+    super.invalidate();
   }
 
   @ReactMethod

--- a/packages/perf/android/src/reactnative/java/io/invertase/firebase/perf/ReactNativeFirebasePerfModule.java
+++ b/packages/perf/android/src/reactnative/java/io/invertase/firebase/perf/ReactNativeFirebasePerfModule.java
@@ -36,8 +36,8 @@ public class ReactNativeFirebasePerfModule extends ReactNativeFirebaseModule {
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
     module.onTearDown();
   }
 

--- a/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/main/java/io/invertase/firebase/config/UniversalFirebaseConfigModule.java
@@ -19,6 +19,7 @@ package io.invertase.firebase.config;
 
 import static com.google.firebase.remoteconfig.FirebaseRemoteConfig.*;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.XmlResourceParser;
@@ -154,6 +155,7 @@ public class UniversalFirebaseConfigModule extends UniversalFirebaseModule {
     return configValuesMap;
   }
 
+  @SuppressLint("DiscouragedApi")
   private int getXmlResourceIdByName(String name) {
     String packageName = getApplicationContext().getPackageName();
     return getApplicationContext().getResources().getIdentifier(name, "xml", packageName);

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -45,8 +45,8 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
-    super.onCatalystInstanceDestroy();
+  public void invalidate() {
+    super.invalidate();
 
     Iterator<Map.Entry<String, ConfigUpdateListenerRegistration>> configRegistrationsIterator =
         mConfigUpdateRegistrations.entrySet().iterator();

--- a/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
+++ b/packages/storage/android/src/main/java/io/invertase/firebase/storage/ReactNativeFirebaseStorageModule.java
@@ -51,9 +51,9 @@ public class ReactNativeFirebaseStorageModule extends ReactNativeFirebaseModule 
   }
 
   @Override
-  public void onCatalystInstanceDestroy() {
+  public void invalidate() {
     ReactNativeFirebaseStorageTask.destroyAllTasks();
-    super.onCatalystInstanceDestroy();
+    super.invalidate();
   }
 
   /**

--- a/tests/.detoxrc.js
+++ b/tests/.detoxrc.js
@@ -23,7 +23,7 @@ module.exports = {
     'android.debug': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest lintDebug -DtestBuildType=debug && cd ..',
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest lintDebug -DtestBuildType=debug --warning-mode all && cd ..',
       reversePorts: [
         8080,
         8081,

--- a/tests/android/app/jacoco.gradle
+++ b/tests/android/app/jacoco.gradle
@@ -68,7 +68,7 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'conn
 
     reports {
         xml.required = true
-        html.destination htmlOutDir
+        html.outputLocation = htmlOutDir
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
@@ -98,7 +98,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
 
     reports {
         xml.required = true
-        html.destination htmlOutDir
+        html.outputLocation = htmlOutDir
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
@@ -123,7 +123,7 @@ task jacocoAndroidTestReport(type: JacocoReport) {
 
     reports {
         xml.required = true
-        html.destination htmlOutDir
+        html.outputLocation = htmlOutDir
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']


### PR DESCRIPTION
### Description

I noticed while attempting to reproduce #7819 that react-native-firebase was still using `onCatalystInstanceDestroy` for it's module teardown, even though that no longer exists. Fixed already in Notifee and others, but not here

This implements the new `invalidate` hook for hot reload that should be used as of react-native 0.74 but leaves the old hook in place (delegating to this new implementation) for people still on react-native <= 0.73

Also fixed a few other deprecations I was aware of while I was in there

### Related issues

Related:
- Fixes #7819 

### Release Summary

a bunch of conventional commits ready for rebase-merge, per usual

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

run the e2e app (or an app from my make-demo.sh script) and search for "instance-destroyed" if you hot-reload it - you won't see that in `adb logcat` without these changes now that e2e app is on react-native 0.74+

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
