### PR TITLE
feat(app, sdk): allow env var override of firebase-ios-sdk value

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -305,7 +305,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '11.4.0'
+$FirebaseSDKVersion = '11.5.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -267,10 +267,10 @@ React Native Firebase internally sets the versions of the native SDKs which each
 is tested against a fixed set of SDK versions (e.g. Firebase SDKs), allowing us to be confident that every feature the
 library supports is working as expected.
 
-Sometimes it's required to change these versions to play nicely with other React Native libraries; therefore we allow
+Sometimes it's required to change these versions to play nicely with other React Native libraries or to work around temporary build failures; therefore we allow
 manually overriding these native SDK versions.
 
-> Using your own SDK versions is generally not recommended as it can lead to breaking changes in your application. Proceed with caution.
+> Using your own SDK versions is not recommended and not supported as it can lead to unexpected build failures when new react-native-firebase versions are released that expect to use new SDK versions. Proceed with caution and remove these overrides as soon as possible when no longer needed.
 
 #### Android
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -310,6 +310,8 @@ $FirebaseSDKVersion = '11.5.0'
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.
 
+Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=11.5.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=11.5.0 yarn expo prebuild --clean`
+
 ### Increasing Android build memory
 
 As you add more Firebase modules, there is an incredible demand placed on the Android build system, and the default memory

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -27,6 +27,11 @@ Pod::Spec.new do |s|
   # React Native dependencies
   s.dependency          'React-Core'
 
+  if (ENV.include?('FIREBASE_SDK_VERSION'))
+    Pod::UI.puts "#{s.name}: Found Firebase SDK version in environment '#{ENV['FIREBASE_SDK_VERSION']}'"
+    $FirebaseSDKVersion = ENV['FIREBASE_SDK_VERSION']
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion


### PR DESCRIPTION
### Description


When there are build breaks like happened with firebase-ios-sdk 11.4.1, people need to override the firebase-ios-sdk value, but it is not easy to do in a managed / no-native-code environment like Expo where you cannot easily modify the Podfile

It easy to send an environment variable through though, so I checked overriding it that way, and not only does it work but it is sufficient to do so in the RNFBApp.podspec alone

No config plugin needed, no dangerous Podfile mod needed

I also took the opportunity to make the risk of overriding the SDK versions much more specific, since users are still surprised by build errors when we adopt new SDK semver minors and start using the new symbols, while users with overrides don't get the new SDK and have a build error

### Related issues

- Fixes #8079 

### Release Summary

Some conventional commits, rebase-merge should do it

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


### Test Plan

In an expo app with react-native-firebase (app, and others) installed, expo-dev-client installed, run:

`yarn expo prebuild --clean`

You should see 11.5.0 pods installed by default at the time of this writing, it works just fine still, with no environment variable specified

Then do it again but with 11.4.2 specified via environment variable, see they all get switched:

```
mike@isabela:~/work/expo-random/RNFBWebTest/ios (main) % FIREBASE_SDK_VERSION=11.4.2 pod install
Using Expo modules
[Expo] Enabling modular headers for pod ExpoModulesCore
[Expo] Enabling modular headers for pod React-Core
[Expo] Enabling modular headers for pod React-RCTAppDelegate
[Expo] Enabling modular headers for pod
expo-dev-menu-interface
[Expo] Enabling modular headers for pod EXManifests
[Expo] Enabling modular headers for pod EXUpdatesInterface
[Expo] Enabling modular headers for pod expo-dev-menu
[Expo] Enabling modular headers for pod React-jsinspector
[Expo] Enabling modular headers for pod RCT-Folly
[Expo] Enabling modular headers for pod glog
[Expo] Enabling modular headers for pod React-RCTFabric
[Expo] Enabling modular headers for pod ReactCodegen
[Expo] Enabling modular headers for pod RCTRequired
[Expo] Enabling modular headers for pod RCTTypeSafety
[Expo] Enabling modular headers for pod ReactCommon
[Expo] Enabling modular headers for pod
React-NativeModulesApple
[Expo] Enabling modular headers for pod Yoga
[Expo] Enabling modular headers for pod React-Fabric
[Expo] Enabling modular headers for pod React-graphics
[Expo] Enabling modular headers for pod React-utils
[Expo] Enabling modular headers for pod React-featureflags
[Expo] Enabling modular headers for pod React-debug
[Expo] Enabling modular headers for pod React-ImageManager
[Expo] Enabling modular headers for pod React-rendererdebug
[Expo] Enabling modular headers for pod DoubleConversion
[Expo] Enabling modular headers for pod hermes-engine
[Expo] Enabling modular headers for pod expo-dev-launcher
RNFBAnalytics: Using default Firebase/Analytics with Ad Ids. May require App Tracking Transparency. Not allowed for Kids apps.
RNFBAnalytics: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids.
RNFBApp: Found Firebase SDK version in environment '11.4.2'
RNFBApp: Using user specified Firebase SDK version '11.4.2'
RNFBAppCheck: Using user specified Firebase SDK version '11.4.2'
RNFBAuth: Using user specified Firebase SDK version '11.4.2'
RNFBDatabase: Using user specified Firebase SDK version '11.4.2'
RNFBFirestore: Using user specified Firebase SDK version '11.4.2'
RNFBFunctions: Using user specified Firebase SDK version '11.4.2'
RNFBRemoteConfig: Using user specified Firebase SDK version '11.4.2'
RNFBStorage: Using user specified Firebase SDK version '11.4.2'
Found 15 modules for target `RNFBWebTest`

(lots of other stuff)


Installing Firebase 11.4.2 (was 11.5.0)
Installing FirebaseABTesting 11.4.0 (was 11.5.0)
Installing FirebaseAnalytics 11.4.0 (was 11.5.0)
Installing FirebaseAppCheck 11.4.0 (was 11.5.0)
Installing FirebaseAuth 11.4.0 (was 11.5.0)
Installing FirebaseCore 11.4.2 (was 11.5.0)
Installing FirebaseCoreExtension 11.4.1 (was 11.5.0)
Installing FirebaseDatabase 11.4.0 (was 11.5.0)
Installing FirebaseFirestore 11.4.0 (was 11.5.0)
Installing FirebaseFirestoreInternal 11.4.0 (was 11.5.0)
Installing FirebaseFunctions 11.4.0 (was 11.5.0)
Installing FirebaseInstallations 11.4.0 (was 11.5.0)
Installing FirebaseRemoteConfig 11.4.0 (was 11.5.0)
Installing FirebaseStorage 11.4.0 (was 11.5.0)
Installing GoogleAppMeasurement 11.4.0 (was 11.5.0)
Installing RNFBAnalytics 21.5.0
Installing RNFBApp 21.5.0
Installing RNFBAppCheck 21.5.0
Installing RNFBAuth 21.5.0
Installing RNFBDatabase 21.5.0
Installing RNFBFirestore 21.5.0
Installing RNFBFunctions 21.5.0
Installing RNFBRemoteConfig 21.5.0
Installing RNFBStorage 21.5.0
```

So it appears to work as expected with one little stanza in RNFBApp.podspec, and it doesn't break if no env var is specified

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
