### PR TITLE
docs(app, other): add a note about dynamic initialization on other

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -245,6 +245,32 @@ If you are using the [Expo Tools](https://marketplace.visualstudio.com/items?ite
 
 ---
 
+## Other / Web
+
+If you are using the firebase-js-sdk fallback support for [web or "other" platforms](platforms#other-platforms) then you must initialize Firebase dynamically by calling [`initializeApp`](/reference/app#initializeApp).
+
+However, you only want to do this for the web platform. For non-web / native apps the "default" firebase app instance will already be configured by the native google-services.json / GoogleServices-Info.plist files as mentioned above.
+
+At some point during your application's bootstrap processes, initialize firebase like this:
+
+```javascript
+import { getApp, initializeApp } from '@react-native-firebase/app';
+
+// web requires dynamic initialization on web prior to using firebase
+if (Platform.OS === 'web') {
+  const firebaseConfig = {
+    // ... config items pasted from firebase console for your web app here
+  };
+
+  initializeApp(firebaseConfig);
+}
+
+// ...now throughout your app, use firebase APIs normally, for example:
+const firebaseApp = getApp();
+```
+
+---
+
 ## Miscellaneous
 
 ### Android Enabling Multidex


### PR DESCRIPTION
### Description

this was confusing to users because the install notes are very specific about how to do initialization with the firebase config on the native platforms, but there was no mention of the completely different style needed for "other" / web

### Related issues

- Related: #8056 

### Release Summary

conventional commits ready for rebase-merge as ever

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Just review for working, docs only at current

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
