### PR TITLE
docs: remove version_number example in ios-notification-images docs

### DIFF
--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -38,7 +38,6 @@ target 'ImageNotification' do
 end
 ```
 
-- Make sure to change the version number `VERSION_NUMBER` with the currently installed version (check your Podfile.lock)
 - Install or update your pods using `pod install` from the `ios` folder
 
 ![step-2](/assets/docs/messaging/ios-notification-images-step-2.gif)


### PR DESCRIPTION
### Description

This PR fixes an issue in the `ios-notification-images.md` doc, the doc tells to update VERSION_NUMBER but there's no version set in the example. In the gif below the image you can see the VERSION_NUMBER being set if you are fast enough.

The text:

> Make sure to change the version number VERSION_NUMBER with the currently installed version (check your Podfile.lock)

Screenshot from the gif:

![image](https://github.com/user-attachments/assets/c16bd88f-1958-4d86-b55d-89f4540bfe5d)

As per discussions, we removed the `VERSION_NUMBER` example from the docs

### Release Summary

docs: removed VERSION_NUMBER example in the `ios-notification-image.md` docs

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Follow the guide, add the version number and run `pod install`
