### PR TITLE
docs: create a Swift version example of the ios-notification-images doc

### DIFF
--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -94,7 +94,7 @@ class NotificationService: UNNotificationServiceExtension {
 -            
 -            contentHandler(bestAttemptContent)
 +            Messaging.serviceExtension()
-                .populateNotificationContent(bestAttemptContent, withContentHandler: contentHandler)
++               .populateNotificationContent(bestAttemptContent, withContentHandler: contentHandler)
         }
 ```
 

--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -46,7 +46,7 @@ end
 ### Step 3 - Use the extension helper (Objective-C)
 
 > If you selected to create your extension as a Swift project, jump to the next section.
- 
+
 At this point everything should still be running normally. This is the final step which is invoking the extension helper.
 
 - From the navigator select your `ImageNotification` extension
@@ -91,7 +91,7 @@ class NotificationService: UNNotificationServiceExtension {
         if let bestAttemptContent = bestAttemptContent {
 -            // Modify the notification content here...
 -            bestAttemptContent.title = "\(bestAttemptContent.title) [modified]"
--            
+-
 -            contentHandler(bestAttemptContent)
 +            Messaging.serviceExtension()
 +               .populateNotificationContent(bestAttemptContent, withContentHandler: contentHandler)

--- a/docs/messaging/ios-notification-images.md
+++ b/docs/messaging/ios-notification-images.md
@@ -43,8 +43,10 @@ end
 
 ![step-2](/assets/docs/messaging/ios-notification-images-step-2.gif)
 
-### Step 3 - Use the extension helper
+### Step 3 - Use the extension helper (Objective-C)
 
+> If you selected to create your extension as a Swift project, jump to the next section.
+ 
 At this point everything should still be running normally. This is the final step which is invoking the extension helper.
 
 - From the navigator select your `ImageNotification` extension
@@ -67,6 +69,34 @@ At this point everything should still be running normally. This is the final ste
 ```
 
 ![step-3](/assets/docs/messaging/ios-notification-images-step-3.gif)
+
+### Step 3 - Use the extension helper (Swift)
+
+At this point everything should still be running normally. This is the final step which is invoking the extension helper.
+
+- From the navigator select your `ImageNotification` extension
+- Open the `NotificationService.swift` file
+- At the top of the file import `Firebase` right after the `NotificationService` as shown below
+
+```diff
+import UserNotifications
++ import Firebase
+
+class NotificationService: UNNotificationServiceExtension {
+```
+
+- then replace everything from line 19 to 23 with the extension helper
+
+```diff
+        if let bestAttemptContent = bestAttemptContent {
+-            // Modify the notification content here...
+-            bestAttemptContent.title = "\(bestAttemptContent.title) [modified]"
+-            
+-            contentHandler(bestAttemptContent)
++            Messaging.serviceExtension()
+                .populateNotificationContent(bestAttemptContent, withContentHandler: contentHandler)
+        }
+```
 
 ## All done
 


### PR DESCRIPTION
### Description

This PR is sort of follow up for #8184. This PR adds Swift version of the same steps described in the document so others don't have to convert the example steps manually like I did.

### Release Summary

docs: added a Swift version example of the `ios-notification-images.md` doc

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Run the steps in the doc, build the app, check that the image shows up