### PR TITLE
feat(ios): add notification service extension target for image support in notifications

### DIFF
--- a/packages/messaging/plugin/src/index.ts
+++ b/packages/messaging/plugin/src/index.ts
@@ -1,16 +1,27 @@
-import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
+import { ConfigPlugin, createRunOncePlugin } from '@expo/config-plugins';
 import { withExpoPluginFirebaseNotification } from './android';
+import {
+  withAppEnvironment,
+  withNotificationServiceExtension,
+  withRNFirebaseXcodeProject,
+} from './ios';
+import { PluginProps, withEasManagedCredentials } from './ios/setupNotificationServiceExtension';
 
 /**
  * A config plugin for configuring `@react-native-firebase/app`
  */
-const withRnFirebaseApp: ConfigPlugin = config => {
-  return withPlugins(config, [
-    // iOS
+const withRnFirebaseApp: ConfigPlugin<PluginProps> = (config, props) => {
+  // iOS
+  if (props.installNSE) {
+    config = withAppEnvironment(config, props);
+    config = withNotificationServiceExtension(config, props);
+    config = withRNFirebaseXcodeProject(config, props);
+    config = withEasManagedCredentials(config, props);
+  }
 
-    // Android
-    withExpoPluginFirebaseNotification,
-  ]);
+  // Android
+  config = withExpoPluginFirebaseNotification(config);
+  return config;
 };
 
 const pak = require('@react-native-firebase/messaging/package.json');

--- a/packages/messaging/plugin/src/ios/constants.ts
+++ b/packages/messaging/plugin/src/ios/constants.ts
@@ -1,0 +1,27 @@
+export const IPHONEOS_DEPLOYMENT_TARGET = '11.0';
+export const TARGETED_DEVICE_FAMILY = `"1,2"`;
+
+export const NSE_PODFILE_SNIPPET = `
+target 'RNFirebaseNotificationServiceExtension' do
+  use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
+  pod 'GoogleUtilities'
+  pod 'Firebase/Messaging'
+end
+`;
+
+export const NSE_PODFILE_REGEX = /target 'RNFirebaseNotificationServiceExtension'/;
+
+export const GROUP_IDENTIFIER_TEMPLATE_REGEX = /{{GROUP_IDENTIFIER}}/gm;
+export const BUNDLE_SHORT_VERSION_TEMPLATE_REGEX = /{{BUNDLE_SHORT_VERSION}}/gm;
+export const BUNDLE_VERSION_TEMPLATE_REGEX = /{{BUNDLE_VERSION}}/gm;
+
+export const DEFAULT_BUNDLE_VERSION = '1';
+export const DEFAULT_BUNDLE_SHORT_VERSION = '1.0';
+
+export const NSE_TARGET_NAME = 'RNFirebaseNotificationServiceExtension';
+export const NSE_SOURCE_FILE = 'NotificationService.m';
+export const NSE_EXT_FILES = [
+  'NotificationService.h',
+  `${NSE_TARGET_NAME}.entitlements`,
+  `${NSE_TARGET_NAME}-Info.plist`,
+];

--- a/packages/messaging/plugin/src/ios/fsutils.ts
+++ b/packages/messaging/plugin/src/ios/fsutils.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs';
+
+export async function readFile(path: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    fs.readFile(path, 'utf8', (err, data) => {
+      if (err || !data) {
+        // eslint-disable-next-line no-console
+        console.error("Couldn't read file:" + path);
+        reject(err);
+        return;
+      }
+      resolve(data);
+    });
+  });
+}
+
+export async function writeFile(path: string, contents: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    fs.writeFile(path, contents, 'utf8', err => {
+      if (err) {
+        // eslint-disable-next-line no-console
+        console.error("Couldn't write file:" + path);
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function copyFile(path1: string, path2: string): Promise<void> {
+  const fileContents = await readFile(path1);
+  await writeFile(path2, fileContents);
+}
+
+export function dirExists(path: string): boolean {
+  return fs.existsSync(path);
+}

--- a/packages/messaging/plugin/src/ios/index.ts
+++ b/packages/messaging/plugin/src/ios/index.ts
@@ -1,0 +1,13 @@
+import {
+  withNotificationServiceExtension,
+  withRNFirebaseXcodeProject,
+  withAppEnvironment,
+  withEasManagedCredentials,
+} from './setupNotificationServiceExtension';
+
+export {
+  withNotificationServiceExtension,
+  withRNFirebaseXcodeProject,
+  withAppEnvironment,
+  withEasManagedCredentials,
+};

--- a/packages/messaging/plugin/src/ios/serviceExtensionFiles/NotificationService.h
+++ b/packages/messaging/plugin/src/ios/serviceExtensionFiles/NotificationService.h
@@ -1,0 +1,5 @@
+#import <UserNotifications/UserNotifications.h>
+
+@interface NotificationService : UNNotificationServiceExtension
+
+@end

--- a/packages/messaging/plugin/src/ios/serviceExtensionFiles/NotificationService.m
+++ b/packages/messaging/plugin/src/ios/serviceExtensionFiles/NotificationService.m
@@ -1,0 +1,25 @@
+#import "NotificationService.h"
+#import "FirebaseMessaging.h"
+
+@interface NotificationService ()
+
+@property (nonatomic, strong) void (^contentHandler)(UNNotificationContent *contentToDeliver);
+@property (nonatomic, strong) UNNotificationRequest *receivedRequest;
+@property (nonatomic, strong) UNMutableNotificationContent *bestAttemptContent;
+
+@end
+
+@implementation NotificationService
+
+- (void)didReceiveNotificationRequest:(UNNotificationRequest *)request withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler {
+    self.contentHandler = contentHandler;
+    self.bestAttemptContent = [request.content mutableCopy];
+
+    [[FIRMessaging extensionHelper] populateNotificationContent:self.bestAttemptContent withContentHandler:contentHandler];  
+}
+
+- (void)serviceExtensionTimeWillExpire {
+    self.contentHandler(self.bestAttemptContent);
+}
+
+@end

--- a/packages/messaging/plugin/src/ios/serviceExtensionFiles/RNFirebaseNotificationServiceExtension-Info.plist
+++ b/packages/messaging/plugin/src/ios/serviceExtensionFiles/RNFirebaseNotificationServiceExtension-Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>RNFirebaseNotificationServiceExtension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>{{BUNDLE_SHORT_VERSION}}</string>
+	<key>CFBundleVersion</key>
+	<string>{{BUNDLE_VERSION}}</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.usernotifications.service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>NotificationService</string>
+	</dict>
+</dict>
+</plist>

--- a/packages/messaging/plugin/src/ios/serviceExtensionFiles/RNFirebaseNotificationServiceExtension.entitlements
+++ b/packages/messaging/plugin/src/ios/serviceExtensionFiles/RNFirebaseNotificationServiceExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>{{GROUP_IDENTIFIER}}</string>
+	</array>
+</dict>
+</plist>

--- a/packages/messaging/plugin/src/ios/setupNotificationServiceExtension.ts
+++ b/packages/messaging/plugin/src/ios/setupNotificationServiceExtension.ts
@@ -1,0 +1,266 @@
+import * as path from 'path';
+import {
+  ConfigPlugin,
+  withDangerousMod,
+  withEntitlementsPlist,
+  withXcodeProject,
+} from '@expo/config-plugins';
+import * as fs from 'fs';
+import { copyFile, readFile, writeFile } from './fsutils';
+import {
+  BUNDLE_SHORT_VERSION_TEMPLATE_REGEX,
+  BUNDLE_VERSION_TEMPLATE_REGEX,
+  DEFAULT_BUNDLE_SHORT_VERSION,
+  DEFAULT_BUNDLE_VERSION,
+  GROUP_IDENTIFIER_TEMPLATE_REGEX,
+  IPHONEOS_DEPLOYMENT_TARGET,
+  NSE_EXT_FILES,
+  NSE_PODFILE_REGEX,
+  NSE_PODFILE_SNIPPET,
+  NSE_SOURCE_FILE,
+  NSE_TARGET_NAME,
+  TARGETED_DEVICE_FAMILY,
+} from './constants';
+import { ExpoConfig } from '@expo/config-types';
+import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
+export type PluginProps = {
+  installNSE?: boolean;
+  /**
+   * (required) Used to configure APNs environment entitlement. "development" or "production"
+   */
+  mode: Mode;
+
+  /**
+   * (optional) Used to configure Apple Team ID. You can find your Apple Team ID by running expo credentials:manager e.g: "91SW8A37CR"
+   */
+  devTeam?: string;
+
+  /**
+   * (optional) Target IPHONEOS_DEPLOYMENT_TARGET value to be used when adding the iOS NSE. A deployment target is nothing more than
+   * the minimum version of the operating system the application can run on. This value should match the value in your Podfile e.g: "12.0".
+   */
+  iPhoneDeploymentTarget?: string;
+};
+
+export enum Mode {
+  Dev = 'development',
+  Prod = 'production',
+}
+
+const entitlementsFileName = `RNFirebaseNotificationServiceExtension.entitlements`;
+const plistFileName = `RNFirebaseNotificationServiceExtension-Info.plist`;
+
+async function updateNSEEntitlements(nsePath: string, groupIdentifier: string): Promise<void> {
+  const entitlementsFilePath = `${nsePath}/${entitlementsFileName}`;
+  let entitlementsFile = await readFile(entitlementsFilePath);
+  entitlementsFile = entitlementsFile.replace(GROUP_IDENTIFIER_TEMPLATE_REGEX, groupIdentifier);
+  await writeFile(entitlementsFilePath, entitlementsFile);
+}
+
+async function updateNSEBundleVersion(nsePath: string, version: string): Promise<void> {
+  const plistFilePath = `${nsePath}/${plistFileName}`;
+  let plistFile = await readFile(plistFilePath);
+  plistFile = plistFile.replace(BUNDLE_VERSION_TEMPLATE_REGEX, version);
+  await writeFile(plistFilePath, plistFile);
+}
+
+async function updateNSEBundleShortVersion(nsePath: string, version: string): Promise<void> {
+  const plistFilePath = `${nsePath}/${plistFileName}`;
+  let plistFile = await readFile(plistFilePath);
+  plistFile = plistFile.replace(BUNDLE_SHORT_VERSION_TEMPLATE_REGEX, version);
+  await writeFile(plistFilePath, plistFile);
+}
+
+async function updatePodfile(iosPath: string): Promise<void> {
+  const podfile = await readFile(`${iosPath}/Podfile`);
+  const matches = podfile.match(NSE_PODFILE_REGEX);
+
+  if (matches) {
+    // eslint-disable-next-line no-console
+    console.log(
+      'RNFirebaseNotificationServiceExtension target already added to Podfile. Skipping...',
+    );
+  } else {
+    fs.appendFile(`${iosPath}/Podfile`, NSE_PODFILE_SNIPPET, err => {
+      if (err) {
+        // eslint-disable-next-line no-console
+        console.error('Error writing to Podfile');
+      }
+    });
+  }
+
+  const result = mergeContents({
+    src: await readFile(`${iosPath}/Podfile`),
+    tag: '@react-native-firebase/messaging',
+    newSrc: `  pod 'GoogleUtilities'\n  pod 'Firebase/Messaging'`,
+    comment: '#',
+    anchor: 'use_native_modules!',
+    offset: 0,
+  })
+  writeFile(`${iosPath}/Podfile`, result.contents);
+}
+
+function getEasManagedCredentialsConfigExtra(config: ExpoConfig): { [k: string]: any } {
+  return {
+    ...config.extra,
+    eas: {
+      ...config.extra?.eas,
+      build: {
+        ...config.extra?.eas?.build,
+        experimental: {
+          ...config.extra?.eas?.build?.experimental,
+          ios: {
+            ...config.extra?.eas?.build?.experimental?.ios,
+            appExtensions: [
+              ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
+              {
+                // keep in sync with native changes in NSE
+                targetName: NSE_TARGET_NAME,
+                bundleIdentifier: `${config?.ios?.bundleIdentifier}.${NSE_TARGET_NAME}`,
+                entitlements: {
+                  'com.apple.security.application-groups': [
+                    `group.${config?.ios?.bundleIdentifier}.rnfirebase`,
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+export const withEasManagedCredentials: ConfigPlugin<PluginProps> = config => {
+  config.extra = getEasManagedCredentialsConfigExtra(config as ExpoConfig);
+  return config;
+};
+
+export const withAppEnvironment: ConfigPlugin<PluginProps> = (config, props) => {
+  return withEntitlementsPlist(config, newConfig => {
+    if (props?.mode == null) {
+      throw new Error(`
+        Missing required "mode" key in your app.json or app.config.js file for "@react-native-firebase/messaging".
+        "mode" can be either "development" or "production".
+        `);
+    }
+    newConfig.modResults['aps-environment'] = props.mode;
+    return newConfig;
+  });
+};
+
+export const withRNFirebaseXcodeProject: ConfigPlugin<PluginProps> = (config, props) => {
+  return withXcodeProject(config, newConfig => {
+    const xcodeProject = newConfig.modResults;
+
+    if (!!xcodeProject.pbxTargetByName(NSE_TARGET_NAME)) {
+      // eslint-disable-next-line no-console
+      console.log(`${NSE_TARGET_NAME} already exists in project. Skipping...`);
+      return newConfig;
+    }
+
+    // Create new PBXGroup for the extension
+    const extGroup = xcodeProject.addPbxGroup(
+      [...NSE_EXT_FILES, NSE_SOURCE_FILE],
+      NSE_TARGET_NAME,
+      NSE_TARGET_NAME,
+    );
+
+    // Add the new PBXGroup to the top level group. This makes the
+    // files / folder appear in the file explorer in Xcode.
+    const groups = xcodeProject.hash.project.objects['PBXGroup'];
+    // biome-ignore lint/complexity/noForEach: <explanation>
+    Object.keys(groups).forEach(key => {
+      if (
+        typeof groups[key] === 'object' &&
+        groups[key].name === undefined &&
+        groups[key].path === undefined
+      ) {
+        xcodeProject.addToPbxGroup(extGroup.uuid, key);
+      }
+    });
+
+    // WORK AROUND for codeProject.addTarget BUG
+    // Xcode projects don't contain these if there is only one target
+    // An upstream fix should be made to the code referenced in this link:
+    //   - https://github.com/apache/cordova-node-xcode/blob/8b98cabc5978359db88dc9ff2d4c015cba40f150/lib/pbxProject.js#L860
+    const projObjects = xcodeProject.hash.project.objects;
+    projObjects['PBXTargetDependency'] = projObjects['PBXTargetDependency'] || {};
+    projObjects['PBXContainerItemProxy'] = projObjects['PBXTargetDependency'] || {};
+
+    // Add the NSE target
+    // This adds PBXTargetDependency and PBXContainerItemProxy for you
+    const nseTarget = xcodeProject.addTarget(
+      NSE_TARGET_NAME,
+      'app_extension',
+      NSE_TARGET_NAME,
+      `${config.ios?.bundleIdentifier}.${NSE_TARGET_NAME}`,
+    );
+
+    // Add build phases to the new target
+    xcodeProject.addBuildPhase(
+      ['NotificationService.m'],
+      'PBXSourcesBuildPhase',
+      'Sources',
+      nseTarget.uuid,
+    );
+    xcodeProject.addBuildPhase([], 'PBXResourcesBuildPhase', 'Resources', nseTarget.uuid);
+
+    xcodeProject.addBuildPhase([], 'PBXFrameworksBuildPhase', 'Frameworks', nseTarget.uuid);
+
+    // Edit the Deployment info of the new Target, only IphoneOS and Targeted Device Family
+    // However, can be more
+    const configurations = xcodeProject.pbxXCBuildConfigurationSection();
+    for (const key in configurations) {
+      if (
+        typeof configurations[key].buildSettings !== 'undefined' &&
+        configurations[key].buildSettings.PRODUCT_NAME === `"${NSE_TARGET_NAME}"`
+      ) {
+        const buildSettingsObj = configurations[key].buildSettings;
+        buildSettingsObj.DEVELOPMENT_TEAM = props?.devTeam;
+        buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET =
+          props?.iPhoneDeploymentTarget ?? IPHONEOS_DEPLOYMENT_TARGET;
+        buildSettingsObj.IPHONEOS_DEPLOYMENT_TARGET = IPHONEOS_DEPLOYMENT_TARGET;
+        buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
+        buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${NSE_TARGET_NAME}/${NSE_TARGET_NAME}.entitlements`;
+        buildSettingsObj.CODE_SIGN_STYLE = 'Automatic';
+      }
+    }
+
+    xcodeProject.addTargetAttribute('DevelopmentTeam', props?.devTeam, nseTarget);
+    xcodeProject.addTargetAttribute('DevelopmentTeam', props?.devTeam);
+
+    return newConfig;
+  });
+};
+
+export const withNotificationServiceExtension: ConfigPlugin<PluginProps> = config => {
+  const pluginDir = require.resolve('@react-native-firebase/messaging/package.json');
+  const sourceDir = path.join(pluginDir, '../plugin/src/ios/serviceExtensionFiles/');
+
+  return withDangerousMod(config, [
+    'ios',
+    async config => {
+      const iosPath = path.join(config.modRequest.projectRoot, 'ios');
+      await updatePodfile(iosPath);
+      fs.mkdirSync(`${iosPath}/${NSE_TARGET_NAME}`, { recursive: true });
+
+      for (let i = 0; i < NSE_EXT_FILES.length; i++) {
+        const extFile = NSE_EXT_FILES[i];
+        const targetFile = `${iosPath}/${NSE_TARGET_NAME}/${extFile}`;
+        await copyFile(`${sourceDir}${extFile}`, targetFile);
+      }
+
+      const sourcePath = `${sourceDir}${NSE_SOURCE_FILE}`;
+      const targetFile = `${iosPath}/${NSE_TARGET_NAME}/${NSE_SOURCE_FILE}`;
+      await copyFile(`${sourcePath}`, targetFile);
+
+      const nsePath = `${iosPath}/${NSE_TARGET_NAME}`;
+      await updateNSEEntitlements(nsePath, `group.${config.ios?.bundleIdentifier}.rnfirebase`);
+      await updateNSEBundleVersion(nsePath, config.ios?.buildNumber ?? DEFAULT_BUNDLE_VERSION);
+      await updateNSEBundleShortVersion(nsePath, config?.version ?? DEFAULT_BUNDLE_SHORT_VERSION);
+
+      return config;
+    },
+  ]);
+};


### PR DESCRIPTION
### Description

It was impossible to add image support in notifications on iOS. I added the notification service extension to the expo plugin of messaging package. The code might have issues with style and convention. I didn't have the chance to read the other packages and code of conduct. Also I didn't updated tests and docs. So it's not ready to merge but it functions correctly. I use this code in my project with patch-package so even it's not merged it can help someone maybe.

If you give feedback and address the issues with the pull request, I would be happy to contribute to the pull request until it's merged.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

🔥 