### PR TITLE
fix(auth, iOS): Expo plugin: skip expo-router for auth URLs

### DIFF
--- a/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
+++ b/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
@@ -1,0 +1,325 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Config Plugin iOS Tests - openUrlFix munges AppDelegate correctly - AppDelegate_bare_sdk43.m 1`] = `
+"// This AppDelegate template is used in Expo SDK 43
+// It is (nearly) identical to the pure template used when
+// creating a bare React Native app (without Expo)
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+  if (rootViewBackgroundColor != nil) {
+    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+ #endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }
+// @generated end @react-native-firebase/auth-openURL
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+@end
+"
+`;
+
+exports[`Config Plugin iOS Tests - openUrlFix munges AppDelegate correctly - AppDelegate_sdk44.m 1`] = `
+"// This AppDelegate prebuild template is used in Expo SDK 44+
+// It has the RCTBridge to be created by Expo ReactDelegate
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+ #endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }
+// @generated end @react-native-firebase/auth-openURL
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+@end
+"
+`;
+
+exports[`Config Plugin iOS Tests - openUrlFix munges AppDelegate correctly - AppDelegate_sdk45.mm 1`] = `
+"// RN 0.68.1, Expo SDK 45 template
+// The main difference between this and the SDK 44 one is that this is
+// using React Native 0.68 and is written in Objective-C++
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#import <React/RCTAppSetupUtils.h>
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <React/RCTFabricSurfaceHostingProxyRootView.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <react/config/ReactNativeConfig.h>
+
+@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+  RCTTurboModuleManager *_turboModuleManager;
+  RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
+  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
+  facebook::react::ContextContainer::Shared _contextContainer;
+}
+@end
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  RCTAppSetupPrepareApp(application);
+
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+
+#if RCT_NEW_ARCH_ENABLED
+  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+  _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
+  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
+  bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
+#endif
+
+  UIView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }
+// @generated end @react-native-firebase/auth-openURL
+  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  BOOL result = [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
+}
+
+#if RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                             delegate:self
+                                                            jsInvoker:bridge.jsCallInvoker];
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#endif
+
+@end
+"
+`;

--- a/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
+++ b/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
@@ -323,3 +323,28 @@ exports[`Config Plugin iOS Tests - openUrlFix munges AppDelegate correctly - App
 @end
 "
 `;
+
+exports[`Config Plugin iOS Tests - openUrlFix must match positiveTemplateCases[0] 1`] = `
+"- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }
+// @generated end @react-native-firebase/auth-openURL
+	int x=3;"
+`;
+
+exports[`Config Plugin iOS Tests - openUrlFix must match positiveTemplateCases[3] 1`] = `
+"  - ( BOOL ) application : ( UIApplication*	)   application openURL : ( NSURL*) url   options :  (  NSDictionary < UIApplicationOpenURLOptionsKey , id > *)	options
+
+{
+
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }
+// @generated end @react-native-firebase/auth-openURL
+"
+`;

--- a/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_urlTypes.test.ts.snap
+++ b/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_urlTypes.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Config Plugin iOS Tests adds url types to the Info.plist 1`] = `
+exports[`Config Plugin iOS Tests - urlTypes adds url types to the Info.plist 1`] = `
 {
   "CFBundleURLTypes": [
     {

--- a/packages/auth/plugin/__tests__/fixtures/AppDelegate_bare_sdk43.m
+++ b/packages/auth/plugin/__tests__/fixtures/AppDelegate_bare_sdk43.m
@@ -1,0 +1,86 @@
+// This AppDelegate template is used in Expo SDK 43
+// It is (nearly) identical to the pure template used when
+// creating a bare React Native app (without Expo)
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+  if (rootViewBackgroundColor != nil) {
+    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+ #endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+@end

--- a/packages/auth/plugin/__tests__/fixtures/AppDelegate_fallback.m
+++ b/packages/auth/plugin/__tests__/fixtures/AppDelegate_fallback.m
@@ -1,0 +1,46 @@
+// This AppDelegate template is modified to have RCTBridge
+// created in some non-standard way or not created at all.
+// This should trigger the fallback regex in iOS AppDelegate Expo plugin.
+
+// some parts omitted to be short
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+
+// The generated code should appear above ^^^
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  // the line below is malfolmed not to be matched by the Expo plugin regex
+  // RCTBridge* briddge = [RCTBridge new];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:briddge moduleName:@"main" initialProperties:nil];
+  id rootViewBackgroundColor = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTRootViewBackgroundColor"];
+  if (rootViewBackgroundColor != nil) {
+    rootView.backgroundColor = [RCTConvert UIColor:rootViewBackgroundColor];
+  } else {
+    rootView.backgroundColor = [UIColor whiteColor];
+  }
+
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+@end

--- a/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk42.m
+++ b/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk42.m
@@ -1,0 +1,102 @@
+// This AppDelegate prebuild template is used in Expo SDK 42 and older
+// It expects the old react-native-unimodules architecture (UM* prefix)
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+
+#import <UMCore/UMModuleRegistry.h>
+#import <UMReactNativeAdapter/UMNativeModulesProxy.h>
+#import <UMReactNativeAdapter/UMModuleRegistryAdapter.h>
+#import <EXSplashScreen/EXSplashScreenService.h>
+#import <UMCore/UMModuleRegistryProvider.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@interface AppDelegate () <RCTBridgeDelegate>
+
+@property (nonatomic, strong) UMModuleRegistryAdapter *moduleRegistryAdapter;
+@property (nonatomic, strong) NSDictionary *launchOptions;
+
+@end
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  self.moduleRegistryAdapter = [[UMModuleRegistryAdapter alloc] initWithModuleRegistryProvider:[[UMModuleRegistryProvider alloc] init]];
+  self.launchOptions = launchOptions;
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  #ifdef DEBUG
+    [self initializeReactNativeApp];
+  #else
+    EXUpdatesAppController *controller = [EXUpdatesAppController sharedInstance];
+    controller.delegate = self;
+    [controller startAndShowLaunchScreen:self.window];
+  #endif
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (RCTBridge *)initializeReactNativeApp
+{
+  RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:self.launchOptions];
+  RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
+
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  return bridge;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  NSArray<id<RCTBridgeModule>> *extraModules = [_moduleRegistryAdapter extraModulesForBridge:bridge];
+  // If you'd like to export some custom RCTBridgeModules that are not Expo modules, add them here!
+  return extraModules;
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+  return [[EXUpdatesAppController sharedInstance] launchAssetUrl];
+ #endif
+}
+
+- (void)appController:(EXUpdatesAppController *)appController didStartWithSuccess:(BOOL)success {
+  appController.bridge = [self initializeReactNativeApp];
+  EXSplashScreenService *splashScreenService = (EXSplashScreenService *)[UMModuleRegistryProvider getSingletonModuleForClass:[EXSplashScreenService class]];
+  [splashScreenService showSplashScreenFor:self.window.rootViewController];
+}
+
+@end

--- a/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk44.m
+++ b/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk44.m
@@ -1,0 +1,79 @@
+// This AppDelegate prebuild template is used in Expo SDK 44+
+// It has the RCTBridge to be created by Expo ReactDelegate
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+#import <FlipperKit/FlipperClient.h>
+#import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+#import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+#import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+#import <FlipperKitReactPlugin/FlipperKitReactPlugin.h>
+
+static void InitializeFlipper(UIApplication *application) {
+  FlipperClient *client = [FlipperClient sharedClient];
+  SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+  [client addPlugin:[[FlipperKitLayoutPlugin alloc] initWithRootNode:application withDescriptorMapper:layoutDescriptorMapper]];
+  [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]];
+  [client addPlugin:[FlipperKitReactPlugin new]];
+  [client addPlugin:[[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+  [client start];
+}
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+#if defined(FB_SONARKIT_ENABLED) && __has_include(<FlipperKit/FlipperClient.h>)
+  InitializeFlipper(application);
+#endif
+  
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+  RCTRootView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+ }
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge {
+ #ifdef DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index" fallbackResource:nil];
+ #else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+ #endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  return [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  return [RCTLinkingManager application:application
+                   continueUserActivity:userActivity
+                     restorationHandler:restorationHandler];
+}
+
+@end

--- a/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk45.mm
+++ b/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk45.mm
@@ -1,0 +1,129 @@
+// RN 0.68.1, Expo SDK 45 template
+// The main difference between this and the SDK 44 one is that this is
+// using React Native 0.68 and is written in Objective-C++
+
+#import "AppDelegate.h"
+
+#import <React/RCTBridge.h>
+#import <React/RCTBundleURLProvider.h>
+#import <React/RCTRootView.h>
+#import <React/RCTLinkingManager.h>
+#import <React/RCTConvert.h>
+
+#import <React/RCTAppSetupUtils.h>
+
+#if RCT_NEW_ARCH_ENABLED
+#import <React/CoreModulesPlugins.h>
+#import <React/RCTCxxBridgeDelegate.h>
+#import <React/RCTFabricSurfaceHostingProxyRootView.h>
+#import <React/RCTSurfacePresenter.h>
+#import <React/RCTSurfacePresenterBridgeAdapter.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+
+#import <react/config/ReactNativeConfig.h>
+
+@interface AppDelegate () <RCTCxxBridgeDelegate, RCTTurboModuleManagerDelegate> {
+  RCTTurboModuleManager *_turboModuleManager;
+  RCTSurfacePresenterBridgeAdapter *_bridgeAdapter;
+  std::shared_ptr<const facebook::react::ReactNativeConfig> _reactNativeConfig;
+  facebook::react::ContextContainer::Shared _contextContainer;
+}
+@end
+#endif
+
+@implementation AppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  RCTAppSetupPrepareApp(application);
+
+  RCTBridge *bridge = [self.reactDelegate createBridgeWithDelegate:self launchOptions:launchOptions];
+
+#if RCT_NEW_ARCH_ENABLED
+  _contextContainer = std::make_shared<facebook::react::ContextContainer const>();
+  _reactNativeConfig = std::make_shared<facebook::react::EmptyReactNativeConfig const>();
+  _contextContainer->insert("ReactNativeConfig", _reactNativeConfig);
+  _bridgeAdapter = [[RCTSurfacePresenterBridgeAdapter alloc] initWithBridge:bridge contextContainer:_contextContainer];
+  bridge.surfacePresenter = _bridgeAdapter.surfacePresenter;
+#endif
+
+  UIView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
+
+  rootView.backgroundColor = [UIColor whiteColor];
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [self.reactDelegate createRootViewController];
+  rootViewController.view = rootView;
+  self.window.rootViewController = rootViewController;
+  [self.window makeKeyAndVisible];
+
+  [super application:application didFinishLaunchingWithOptions:launchOptions];
+
+  return YES;
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  // If you'd like to export some custom RCTBridgeModules, add them here!
+  return @[];
+}
+
+- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
+{
+#if DEBUG
+  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index"];
+#else
+  return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+#endif
+}
+
+// Linking API
+- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  return [super application:application openURL:url options:options] || [RCTLinkingManager application:application openURL:url options:options];
+}
+
+// Universal Links
+- (BOOL)application:(UIApplication *)application continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+  BOOL result = [RCTLinkingManager application:application continueUserActivity:userActivity restorationHandler:restorationHandler];
+  return [super application:application continueUserActivity:userActivity restorationHandler:restorationHandler] || result;
+}
+
+#if RCT_NEW_ARCH_ENABLED
+
+#pragma mark - RCTCxxBridgeDelegate
+
+- (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
+{
+  _turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                             delegate:self
+                                                            jsInvoker:bridge.jsCallInvoker];
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, _turboModuleManager);
+}
+
+#pragma mark RCTTurboModuleManagerDelegate
+
+- (Class)getModuleClassFromName:(const char *)name
+{
+  return RCTCoreModulesClassProvider(name);
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+{
+  return nullptr;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
+                                                     initParams:
+                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return nullptr;
+}
+
+- (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
+{
+  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+}
+
+#endif
+
+@end

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { WarningAggregator } from '@expo/config-plugins';
 import type { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
 import {
   shouldApplyIosOpenUrlFix,
@@ -218,10 +219,11 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
         modRawConfig: { name: 'TestName', slug: 'TestSlug' },
       };
       const props = undefined;
-      const spy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const spy = jest.spyOn(WarningAggregator, 'addWarningIOS');
       const result = withOpenUrlFixForAppDelegate({ config, props });
       expect(result.modResults.contents).toBe(appDelegate);
       expect(spy).toHaveBeenCalledWith(
+        '@react-native-firebase/auth',
         "Skipping iOS openURL fix because no 'openURL' method was found",
       );
     });

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -1,5 +1,7 @@
+import fs from 'fs/promises';
+import path from 'path';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { shouldApplyIosOpenUrlFix } from '../src/ios/openUrlFix';
+import { shouldApplyIosOpenUrlFix, modifyObjcAppDelegate } from '../src/ios/openUrlFix';
 import type { ExpoConfigPluginEntry } from '../src/ios/openUrlFix';
 
 describe('Config Plugin iOS Tests - openUrlFix', () => {
@@ -152,4 +154,22 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
       ).toBe(true);
     }
   });
+
+  const appDelegateFixtures = [
+    'AppDelegate_sdk42.m',
+    'AppDelegate_bare_sdk43.m',
+    'AppDelegate_sdk44.m',
+    'AppDelegate_fallback.m',
+    'AppDelegate_sdk45.mm',
+  ];
+  appDelegateFixtures.forEach(fixtureName => {
+    it(`munges AppDelegate correctly - ${fixtureName}`, async () => {
+      const appDelegate = await readFixtureAsText(fixtureName);
+      const result = modifyObjcAppDelegate(appDelegate);
+      expect(result).toMatchSnapshot();
+    });
+  });
 });
+
+const readFixtureAsText = async (filepath: string): Promise<string> =>
+  fs.readFile(path.join(__dirname, 'fixtures', filepath), { encoding: 'utf8' });

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { shouldApplyIosOpenUrlFix } from '../src/ios/openUrlFix';
+import type { ExpoConfigPluginEntry } from '../src/ios/openUrlFix';
+
+describe('Config Plugin iOS Tests - openUrlFix', () => {
+  beforeEach(function () {
+    jest.resetAllMocks();
+  });
+
+  it('is disabled by default', async () => {
+    const config = {
+      name: 'TestName',
+      slug: 'TestSlug',
+    };
+
+    expect(
+      shouldApplyIosOpenUrlFix({
+        config,
+        props: {},
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldApplyIosOpenUrlFix({
+        config,
+        props: {
+          ios: {},
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldApplyIosOpenUrlFix({
+        config,
+        props: {
+          ios: {
+            captchaOpenUrlFix: undefined,
+          },
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldApplyIosOpenUrlFix({
+        config,
+        props: {
+          ios: {
+            captchaOpenUrlFix: 'default',
+          },
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldApplyIosOpenUrlFix({
+        config,
+        props: {
+          ios: {
+            captchaOpenUrlFix: false,
+          },
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldApplyIosOpenUrlFix({
+        config,
+        props: {
+          ios: {
+            captchaOpenUrlFix: true,
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('is enabled by default when expo-router is found', async () => {
+    const cases: ExpoConfigPluginEntry[] = ['expo-router', ['expo-router'], ['expo-router', {}]];
+
+    for (const routerPluginEntry of cases) {
+      const plugins: ExpoConfigPluginEntry[] = [
+        'something',
+        [],
+        ['something-else', { foo: 'bar' }],
+        routerPluginEntry,
+      ];
+
+      const config = {
+        name: 'TestName',
+        slug: 'TestSlug',
+        plugins,
+      };
+
+      expect(
+        shouldApplyIosOpenUrlFix({
+          config,
+          props: {},
+        }),
+      ).toBe(true);
+
+      expect(
+        shouldApplyIosOpenUrlFix({
+          config,
+          props: {
+            ios: {},
+          },
+        }),
+      ).toBe(true);
+
+      expect(
+        shouldApplyIosOpenUrlFix({
+          config,
+          props: {
+            ios: {
+              captchaOpenUrlFix: undefined,
+            },
+          },
+        }),
+      ).toBe(true);
+
+      expect(
+        shouldApplyIosOpenUrlFix({
+          config,
+          props: {
+            ios: {
+              captchaOpenUrlFix: 'default',
+            },
+          },
+        }),
+      ).toBe(true);
+
+      expect(
+        shouldApplyIosOpenUrlFix({
+          config,
+          props: {
+            ios: {
+              captchaOpenUrlFix: false,
+            },
+          },
+        }),
+      ).toBe(false);
+
+      expect(
+        shouldApplyIosOpenUrlFix({
+          config,
+          props: {
+            ios: {
+              captchaOpenUrlFix: true,
+            },
+          },
+        }),
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -178,18 +178,29 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
     ).toThrow("Unexpected value for 'captchaOpenUrlFix' config option");
   });
 
-  const appDelegateFixtures = [
-    'AppDelegate_sdk42.m',
+  const appDelegateFixturesPatch = [
     'AppDelegate_bare_sdk43.m',
     'AppDelegate_sdk44.m',
-    'AppDelegate_fallback.m',
     'AppDelegate_sdk45.mm',
   ];
-  appDelegateFixtures.forEach(fixtureName => {
+  appDelegateFixturesPatch.forEach(fixtureName => {
     it(`munges AppDelegate correctly - ${fixtureName}`, async () => {
       const appDelegate = await readFixtureAsText(fixtureName);
       const result = modifyObjcAppDelegate(appDelegate);
       expect(result).toMatchSnapshot();
+    });
+  });
+
+  const appDelegateFixturesNoop = ['AppDelegate_sdk42.m', 'AppDelegate_fallback.m'];
+  appDelegateFixturesNoop.forEach(fixtureName => {
+    it(`skips AppDelegate without openURL - ${fixtureName}`, async () => {
+      const appDelegate = await readFixtureAsText(fixtureName);
+      const spy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const result = modifyObjcAppDelegate(appDelegate);
+      expect(result).toBe(null);
+      expect(spy).toHaveBeenCalledWith(
+        "Skipping iOS openURL fix for captcha because no 'openURL' method was found",
+      );
     });
   });
 });

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -18,6 +18,12 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
     expect(
       shouldApplyIosOpenUrlFix({
         config,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldApplyIosOpenUrlFix({
+        config,
         props: {},
       }),
     ).toBe(false);
@@ -153,6 +159,23 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
         }),
       ).toBe(true);
     }
+  });
+
+  it('throws an error for invalid config', () => {
+    expect(() =>
+      shouldApplyIosOpenUrlFix({
+        config: {
+          name: 'TestName',
+          slug: 'TestSlug',
+        },
+        props: {
+          ios: {
+            // @ts-ignore testing invalid argument
+            captchaOpenUrlFix: Math.PI,
+          },
+        },
+      }),
+    ).toThrow("Unexpected value for 'captchaOpenUrlFix' config option");
   });
 
   const appDelegateFixtures = [

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -199,6 +199,31 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
       const result = modifyObjcAppDelegate(appDelegate);
       expect(result).toMatchSnapshot();
     });
+
+    it(`prints warning message when configured to default and AppDelegate is modified`, async () => {
+      const fixturePath = path.join(__dirname, 'fixtures', fixtureName);
+      const appDelegate = await fs.readFile(fixturePath, { encoding: 'utf-8' });
+      const config = {
+        name: 'TestName',
+        slug: 'TestSlug',
+        modRequest: { projectRoot: path.join(__dirname, 'fixtures') } as any,
+        modResults: {
+          path: fixturePath,
+          language: 'objc',
+          contents: appDelegate,
+        } as AppDelegateProjectFile,
+        modRawConfig: { name: 'TestName', slug: 'TestSlug' },
+      };
+      const props = undefined;
+      const spy = jest
+        .spyOn(WarningAggregator, 'addWarningIOS')
+        .mockImplementation(() => undefined);
+      withOpenUrlFixForAppDelegate({ config, props });
+      expect(spy).toHaveBeenCalledWith(
+        '@react-native-firebase/auth',
+        'modifying iOS AppDelegate openURL method to ignore firebaseauth reCAPTCHA redirect URLs',
+      );
+    });
   });
 
   const appDelegateFixturesNoop = ['AppDelegate_sdk42.m', 'AppDelegate_fallback.m'];
@@ -219,7 +244,9 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
         modRawConfig: { name: 'TestName', slug: 'TestSlug' },
       };
       const props = undefined;
-      const spy = jest.spyOn(WarningAggregator, 'addWarningIOS');
+      const spy = jest
+        .spyOn(WarningAggregator, 'addWarningIOS')
+        .mockImplementation(() => undefined);
       const result = withOpenUrlFixForAppDelegate({ config, props });
       expect(result.modResults.contents).toBe(appDelegate);
       expect(spy).toHaveBeenCalledWith(

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -190,7 +190,8 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
   ];
   appDelegateFixturesPatch.forEach(fixtureName => {
     it(`munges AppDelegate correctly - ${fixtureName}`, async () => {
-      const appDelegate = await readFixtureAsText(fixtureName);
+      const fixturePath = path.join(__dirname, 'fixtures', fixtureName);
+      const appDelegate = await fs.readFile(fixturePath, { encoding: 'utf-8' });
       const result = modifyObjcAppDelegate(appDelegate);
       expect(result).toMatchSnapshot();
     });
@@ -247,6 +248,3 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
     });
   });
 });
-
-const readFixtureAsText = async (filepath: string): Promise<string> =>
-  fs.readFile(path.join(__dirname, 'fixtures', filepath), { encoding: 'utf8' });

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -6,6 +6,7 @@ import {
   shouldApplyIosOpenUrlFix,
   modifyObjcAppDelegate,
   withOpenUrlFixForAppDelegate,
+  ensureFirebaseSwizzlingIsEnabled,
   appDelegateOpenUrlInsertionPointAfter,
   multiline_appDelegateOpenUrlInsertionPointAfter,
 } from '../src/ios/openUrlFix';
@@ -286,5 +287,28 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
     it(`must not match negativeTemplateCases[${caseIdx}]`, () => {
       expect(appDelegateOpenUrlInsertionPointAfter.test(snippet)).toBe(false);
     });
+  });
+
+  it(`rejects projects with swizzling disabled`, () => {
+    const config = {
+      name: 'TestName',
+      slug: 'TestSlug',
+      plugins: ['expo-router'],
+      modRequest: { projectRoot: path.join(__dirname, 'fixtures') } as any,
+      modResults: {
+        path: path.join(__dirname, 'fixtures', '/path/to/Info.plist'),
+        language: 'plist',
+        contents: '',
+      },
+      modRawConfig: { name: 'TestName', slug: 'TestSlug' },
+      ios: {
+        infoPlist: {
+          FirebaseAppDelegateProxyEnabled: false,
+        },
+      },
+    };
+    expect(() => ensureFirebaseSwizzlingIsEnabled(config)).toThrow(
+      'Your app has disabled swizzling by setting FirebaseAppDelegateProxyEnabled=false in its Info.plist.',
+    );
   });
 });

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -5,7 +5,7 @@ import type { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Path
 import {
   shouldApplyIosOpenUrlFix,
   modifyObjcAppDelegate,
-  withOpenUrlFixForCaptcha,
+  withOpenUrlFixForAppDelegate,
   appDelegateOpenUrlInsertionPointAfter,
   multiline_appDelegateOpenUrlInsertionPointAfter,
 } from '../src/ios/openUrlFix';
@@ -218,7 +218,7 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
       };
       const props = undefined;
       const spy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
-      const result = withOpenUrlFixForCaptcha({ config, props });
+      const result = withOpenUrlFixForAppDelegate({ config, props });
       expect(result.modResults.contents).toBe(appDelegate);
       expect(spy).toHaveBeenCalledWith(
         "Skipping iOS openURL fix because no 'openURL' method was found",
@@ -244,7 +244,7 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
           captchaOpenUrlFix: true,
         },
       };
-      expect(() => withOpenUrlFixForCaptcha({ config, props })).toThrow(
+      expect(() => withOpenUrlFixForAppDelegate({ config, props })).toThrow(
         "Failed to apply iOS openURL fix because no 'openURL' method was found",
       );
     });

--- a/packages/auth/plugin/__tests__/iosPlugin_urlTypes.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_urlTypes.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { setUrlTypesForCaptcha } from '../src/ios/urlTypes';
 
-describe('Config Plugin iOS Tests', () => {
+describe('Config Plugin iOS Tests - urlTypes', () => {
   beforeEach(function () {
     jest.resetAllMocks();
   });

--- a/packages/auth/plugin/src/index.ts
+++ b/packages/auth/plugin/src/index.ts
@@ -1,6 +1,6 @@
 import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
 
-import { withIosCaptchaUrlTypes } from './ios';
+import { withIosCaptchaUrlTypes, withIosCaptchaOpenUrlFix } from './ios';
 
 /**
  * A config plugin for configuring `@react-native-firebase/auth`
@@ -9,6 +9,7 @@ const withRnFirebaseAuth: ConfigPlugin = config => {
   return withPlugins(config, [
     // iOS
     withIosCaptchaUrlTypes,
+    withIosCaptchaOpenUrlFix,
   ]);
 };
 

--- a/packages/auth/plugin/src/index.ts
+++ b/packages/auth/plugin/src/index.ts
@@ -1,15 +1,16 @@
 import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
 
 import { withIosCaptchaUrlTypes, withIosCaptchaOpenUrlFix } from './ios';
+import { PluginConfigType } from './pluginConfig';
 
 /**
  * A config plugin for configuring `@react-native-firebase/auth`
  */
-const withRnFirebaseAuth: ConfigPlugin = config => {
+const withRnFirebaseAuth: ConfigPlugin<PluginConfigType> = (config, props) => {
   return withPlugins(config, [
     // iOS
-    withIosCaptchaUrlTypes,
-    withIosCaptchaOpenUrlFix,
+    [withIosCaptchaUrlTypes, props],
+    [withIosCaptchaOpenUrlFix, props],
   ]);
 };
 

--- a/packages/auth/plugin/src/ios/index.ts
+++ b/packages/auth/plugin/src/ios/index.ts
@@ -1,3 +1,4 @@
 import { withIosCaptchaUrlTypes } from './urlTypes';
+import { withIosCaptchaOpenUrlFix } from './openUrlFix';
 
-export { withIosCaptchaUrlTypes };
+export { withIosCaptchaUrlTypes, withIosCaptchaOpenUrlFix };

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -8,6 +8,10 @@ export const withIosCaptchaOpenUrlFix: ConfigPlugin<PluginConfigType> = (
   config: ExpoConfig,
   props?: PluginConfigType,
 ) => {
+  if (!shouldApplyIosOpenUrlFix({ config, props })) {
+    return config;
+  }
+
   return withAppDelegate(config, config => {
     return withOpenUrlFixForCaptcha({ config, props });
   });
@@ -41,10 +45,6 @@ export function withOpenUrlFixForCaptcha({
   props?: PluginConfigType;
 }) {
   const { language, contents } = config.modResults;
-
-  if (!shouldApplyIosOpenUrlFix({ config, props })) {
-    return config;
-  }
 
   if (['objc', 'objcpp'].includes(language)) {
     const newContents = modifyObjcAppDelegate(contents);

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -3,6 +3,7 @@ import {
   withAppDelegate,
   withInfoPlist,
   ExportedConfigWithProps,
+  WarningAggregator,
 } from '@expo/config-plugins';
 import type { ExpoConfig } from '@expo/config/build/Config.types';
 import type { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
@@ -66,8 +67,10 @@ export function withOpenUrlFixForAppDelegate({
       if (props?.ios?.captchaOpenUrlFix === true) {
         throw new Error("Failed to apply iOS openURL fix because no 'openURL' method was found");
       } else {
-        // eslint-disable-next-line no-console
-        console.warn("Skipping iOS openURL fix because no 'openURL' method was found");
+        WarningAggregator.addWarningIOS(
+          '@react-native-firebase/auth',
+          "Skipping iOS openURL fix because no 'openURL' method was found",
+        );
         return config;
       }
     } else {

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -36,7 +36,7 @@ export const withIosCaptchaOpenUrlFix: ConfigPlugin<PluginConfigType> = (
 
   // apply patch
   return withAppDelegate(config, config => {
-    return withOpenUrlFixForCaptcha({ config, props });
+    return withOpenUrlFixForAppDelegate({ config, props });
   });
 };
 
@@ -60,7 +60,7 @@ export function shouldApplyIosOpenUrlFix({
   }
 }
 
-export function withOpenUrlFixForCaptcha({
+export function withOpenUrlFixForAppDelegate({
   config,
   props,
 }: {

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -102,21 +102,30 @@ const skipOpenUrlForFirebaseAuthBlock: string = `\
 `;
 
 // NOTE: `mergeContents()` requires that this pattern not match newlines
-const appDelegateOpenUrlInsertionPointAfter: RegExp =
+export const appDelegateOpenUrlInsertionPointAfter: RegExp =
   /-\s*\(\s*BOOL\s*\)\s*application\s*:\s*\(\s*UIApplication\s*\*\s*\)\s*application\s+openURL\s*:\s*\(\s*NSURL\s*\*\s*\)\s*url\s+options\s*:\s*\(\s*NSDictionary\s*<\s*UIApplicationOpenURLOptionsKey\s*,\s*id\s*>\s*\*\s*\)\s*options\s*/; // 🙈
+
+export const multiline_appDelegateOpenUrlInsertionPointAfter = new RegExp(
+  appDelegateOpenUrlInsertionPointAfter.source + '\\s*{\\s*\\n',
+);
 
 // Returns AppDelegate with modification applied, or null if no change needed.
 export function modifyObjcAppDelegate(contents: string): string | null {
   const pattern = appDelegateOpenUrlInsertionPointAfter;
-  const multilinePattern = new RegExp(
-    appDelegateOpenUrlInsertionPointAfter.source + '\\s*{\\s*\\n',
-  );
+  const multilinePattern = multiline_appDelegateOpenUrlInsertionPointAfter;
   const fullMatch = contents.match(multilinePattern);
   if (!fullMatch) {
     if (contents.match(pattern)) {
       throw new Error("Failed to find insertion point; expected newline after '{'");
     } else if (contents.match(/openURL\s*:/)) {
-      throw new Error("Failed to find insertion point but detected 'openURL' method");
+      throw new Error(
+        [
+          "Failed to apply 'captchaOpenUrlFix' but detected 'openURL' method.",
+          "Please manually apply the fix to your AppDelegate's openURL method,",
+          "then update your app.config.json by configuring the '@react-native-firebase/auth' plugin",
+          'to set `captchaOpenUrlFix: false`.',
+        ].join(' '),
+      );
     } else {
       return null;
     }

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -1,0 +1,78 @@
+import { ConfigPlugin, withAppDelegate, ExportedConfigWithProps } from '@expo/config-plugins';
+import type { ExpoConfig } from '@expo/config/build/Config.types';
+import type { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
+import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
+
+export const withIosCaptchaOpenUrlFix: ConfigPlugin = config => {
+  if (isPluginEnabled(config, 'expo-router')) {
+    config = withAppDelegate(config, config => {
+      return patchOpenUrlForCaptcha({ config });
+    });
+  }
+  return config;
+};
+
+const skipOpenUrlForFirebaseAuthBlock = `\
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }\
+`;
+
+// NOTE: `mergeContents()` requires that this pattern not match newlines
+const appDelegateOpenUrlInsertionPointAfter =
+  /-\s*\(\s*BOOL\s*\)\s*application\s*:\s*\(\s*UIApplication\s*\*\s*\)\s*application\s+openURL\s*:\s*\(\s*NSURL\s*\*\s*\)\s*url\s+options\s*:\s*\(\s*NSDictionary\s*<\s*UIApplicationOpenURLOptionsKey\s*,\s*id\s*>\s*\*\s*\)\s*options\s*/; // 🙈
+
+function patchOpenUrlForCaptcha({
+  config,
+}: {
+  config: ExportedConfigWithProps<AppDelegateProjectFile>;
+}) {
+  const { contents } = config.modResults;
+  const multilineMatcher = new RegExp(
+    appDelegateOpenUrlInsertionPointAfter.source + '\\s*{\\s*\\n',
+  );
+  const fullMatch = contents.match(multilineMatcher);
+  if (!fullMatch) {
+    throw new Error("Failed to find insertion point; expected newline after '{'");
+  }
+  const fullMatchNumLines = fullMatch[0].split('\n').length;
+  const offset = fullMatchNumLines - 1;
+  if (offset < 0) {
+    throw new Error(`Failed to find insertion point; fullMatchNumLines=${fullMatchNumLines}`);
+  }
+
+  const newContents = mergeContents({
+    tag: '@react-native-firebase/auth-openURL',
+    src: contents,
+    newSrc: skipOpenUrlForFirebaseAuthBlock,
+    anchor: appDelegateOpenUrlInsertionPointAfter,
+    offset,
+    comment: '//',
+  }).contents;
+
+  const newConfig = {
+    ...config,
+    modResults: {
+      ...config.modResults,
+      contents: newContents,
+    },
+  };
+  return newConfig;
+}
+
+// Search the ExpoConfig plugins array to see if `pluginName` is present
+function isPluginEnabled(config: ExpoConfig, pluginName: string): boolean {
+  if (config.plugins === undefined) {
+    return false;
+  }
+  return config.plugins.some((plugin: string | [] | [string] | [string, any]) => {
+    if (plugin === pluginName) {
+      return true;
+    } else if (Array.isArray(plugin) && plugin.length >= 1 && plugin[0] === pluginName) {
+      return true;
+    } else {
+      return false;
+    }
+  });
+}

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -5,7 +5,7 @@ import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
 import { PluginConfigType } from '../pluginConfig';
 
 export const withIosCaptchaOpenUrlFix: ConfigPlugin<PluginConfigType> = (config, props) => {
-  if (shouldApplyIosOpenUrlFix(config, props)) {
+  if (shouldApplyIosOpenUrlFix({ config, props })) {
     config = withAppDelegate(config, config => {
       return patchOpenUrlForCaptcha({ config });
     });
@@ -14,7 +14,13 @@ export const withIosCaptchaOpenUrlFix: ConfigPlugin<PluginConfigType> = (config,
 };
 
 // Interpret the plugin config to determine whether this fix should be applied
-function shouldApplyIosOpenUrlFix(config: ExpoConfig, props: PluginConfigType): boolean {
+export function shouldApplyIosOpenUrlFix({
+  config,
+  props,
+}: {
+  config: ExpoConfig;
+  props: PluginConfigType;
+}): boolean {
   const flag = props.ios?.captchaOpenUrlFix;
   if (flag === undefined || flag === 'default') {
     // by default, apply the fix whenever 'expo-router' is detected in the same project
@@ -38,7 +44,7 @@ const skipOpenUrlForFirebaseAuthBlock = `\
 const appDelegateOpenUrlInsertionPointAfter =
   /-\s*\(\s*BOOL\s*\)\s*application\s*:\s*\(\s*UIApplication\s*\*\s*\)\s*application\s+openURL\s*:\s*\(\s*NSURL\s*\*\s*\)\s*url\s+options\s*:\s*\(\s*NSDictionary\s*<\s*UIApplicationOpenURLOptionsKey\s*,\s*id\s*>\s*\*\s*\)\s*options\s*/; // 🙈
 
-function patchOpenUrlForCaptcha({
+export function patchOpenUrlForCaptcha({
   config,
 }: {
   config: ExportedConfigWithProps<AppDelegateProjectFile>;
@@ -76,12 +82,14 @@ function patchOpenUrlForCaptcha({
   return newConfig;
 }
 
+export type ExpoConfigPluginEntry = string | [] | [string] | [string, any];
+
 // Search the ExpoConfig plugins array to see if `pluginName` is present
 function isPluginEnabled(config: ExpoConfig, pluginName: string): boolean {
   if (config.plugins === undefined) {
     return false;
   }
-  return config.plugins.some((plugin: string | [] | [string] | [string, any]) => {
+  return config.plugins.some((plugin: ExpoConfigPluginEntry) => {
     if (plugin === pluginName) {
       return true;
     } else if (Array.isArray(plugin) && plugin.length >= 1 && plugin[0] === pluginName) {

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -103,7 +103,7 @@ export const multiline_appDelegateOpenUrlInsertionPointAfter = new RegExp(
   appDelegateOpenUrlInsertionPointAfter.source + '\\s*{\\s*\\n',
 );
 
-// Returns AppDelegate with modification applied, or null if no change needed.
+// Returns contents of new AppDelegate with modification applied, or returns null if this patch is not applicable because the AppDelegate doesn't have an 'openURL' method to handle deep links.
 export function modifyObjcAppDelegate(contents: string): string | null {
   const pattern = appDelegateOpenUrlInsertionPointAfter;
   const multilinePattern = multiline_appDelegateOpenUrlInsertionPointAfter;
@@ -121,6 +121,7 @@ export function modifyObjcAppDelegate(contents: string): string | null {
         ].join(' '),
       );
     } else {
+      // openURL method was not found in AppDelegate
       return null;
     }
   }

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -36,17 +36,6 @@ export function shouldApplyIosOpenUrlFix({
   }
 }
 
-const skipOpenUrlForFirebaseAuthBlock = `\
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
-    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
-    return NO;
-  }\
-`;
-
-// NOTE: `mergeContents()` requires that this pattern not match newlines
-const appDelegateOpenUrlInsertionPointAfter =
-  /-\s*\(\s*BOOL\s*\)\s*application\s*:\s*\(\s*UIApplication\s*\*\s*\)\s*application\s+openURL\s*:\s*\(\s*NSURL\s*\*\s*\)\s*url\s+options\s*:\s*\(\s*NSDictionary\s*<\s*UIApplicationOpenURLOptionsKey\s*,\s*id\s*>\s*\*\s*\)\s*options\s*/; // 🙈
-
 export function withOpenUrlFixForCaptcha({
   config,
 }: {
@@ -68,6 +57,17 @@ export function withOpenUrlFixForCaptcha({
     throw new Error(`Don't know how to apply openUrlFix to AppDelegate of language "${language}"`);
   }
 }
+
+const skipOpenUrlForFirebaseAuthBlock: string = `\
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }\
+`;
+
+// NOTE: `mergeContents()` requires that this pattern not match newlines
+const appDelegateOpenUrlInsertionPointAfter: RegExp =
+  /-\s*\(\s*BOOL\s*\)\s*application\s*:\s*\(\s*UIApplication\s*\*\s*\)\s*application\s+openURL\s*:\s*\(\s*NSURL\s*\*\s*\)\s*url\s+options\s*:\s*\(\s*NSDictionary\s*<\s*UIApplicationOpenURLOptionsKey\s*,\s*id\s*>\s*\*\s*\)\s*options\s*/; // 🙈
 
 export function modifyObjcAppDelegate(contents: string): string {
   const multilineMatcher = new RegExp(

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -4,7 +4,10 @@ import type { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Path
 import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
 import { PluginConfigType } from '../pluginConfig';
 
-export const withIosCaptchaOpenUrlFix: ConfigPlugin<PluginConfigType> = (config, props) => {
+export const withIosCaptchaOpenUrlFix: ConfigPlugin<PluginConfigType> = (
+  config: ExpoConfig,
+  props?: PluginConfigType,
+) => {
   if (shouldApplyIosOpenUrlFix({ config, props })) {
     config = withAppDelegate(config, config => {
       return withOpenUrlFixForCaptcha({ config });
@@ -19,9 +22,9 @@ export function shouldApplyIosOpenUrlFix({
   props,
 }: {
   config: ExpoConfig;
-  props: PluginConfigType;
+  props?: PluginConfigType;
 }): boolean {
-  const flag = props.ios?.captchaOpenUrlFix;
+  const flag = props?.ios?.captchaOpenUrlFix;
   if (flag === undefined || flag === 'default') {
     // by default, apply the fix whenever 'expo-router' is detected in the same project
     return isPluginEnabled(config, 'expo-router');

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -21,17 +21,8 @@ export const withIosCaptchaOpenUrlFix: ConfigPlugin<PluginConfigType> = (
 
   // check that swizzling is enabled; otherwise patch must be customized and applied manually
   withInfoPlist(config, config => {
-    if (isFirebaseSwizzlingDisabled(config)) {
-      throw new Error(
-        [
-          'Your app has disabled swizzling by setting FirebaseAppDelegateProxyEnabled=false in its Info.plist.',
-          "Please update your app.config.json to configure the '@react-native-firebase/auth' plugin to set `captchaOpenUrlFix: false`",
-          'and see https://firebase.google.com/docs/auth/ios/phone-auth#appendix:-using-phone-sign-in-without-swizzling for instructions.',
-        ].join(' '),
-      );
-    } else {
-      return config;
-    }
+    ensureFirebaseSwizzlingIsEnabled(config);
+    return config;
   });
 
   // apply patch
@@ -165,4 +156,20 @@ function isPluginEnabled(config: ExpoConfig, pluginName: string): boolean {
 
 export function isFirebaseSwizzlingDisabled(config: ExportedConfigWithProps<InfoPlist>): boolean {
   return config.ios?.infoPlist?.['FirebaseAppDelegateProxyEnabled'] === false;
+}
+
+export function ensureFirebaseSwizzlingIsEnabled(
+  config: ExportedConfigWithProps<InfoPlist>,
+): boolean {
+  if (isFirebaseSwizzlingDisabled(config)) {
+    throw new Error(
+      [
+        'Your app has disabled swizzling by setting FirebaseAppDelegateProxyEnabled=false in its Info.plist.',
+        "Please update your app.config.json to configure the '@react-native-firebase/auth' plugin to set `captchaOpenUrlFix: false`",
+        'and see https://firebase.google.com/docs/auth/ios/phone-auth#appendix:-using-phone-sign-in-without-swizzling for instructions.',
+      ].join(' '),
+    );
+  } else {
+    return true;
+  }
 }

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -60,11 +60,12 @@ export function withOpenUrlFixForAppDelegate({
   props?: PluginConfigType;
 }) {
   const { language, contents } = config.modResults;
+  const configValue = props?.ios?.captchaOpenUrlFix || 'default';
 
   if (['objc', 'objcpp'].includes(language)) {
     const newContents = modifyObjcAppDelegate(contents);
     if (newContents === null) {
-      if (props?.ios?.captchaOpenUrlFix === true) {
+      if (configValue === true) {
         throw new Error("Failed to apply iOS openURL fix because no 'openURL' method was found");
       } else {
         WarningAggregator.addWarningIOS(
@@ -74,6 +75,12 @@ export function withOpenUrlFixForAppDelegate({
         return config;
       }
     } else {
+      if (configValue === 'default') {
+        WarningAggregator.addWarningIOS(
+          '@react-native-firebase/auth',
+          'modifying iOS AppDelegate openURL method to ignore firebaseauth reCAPTCHA redirect URLs',
+        );
+      }
       return {
         ...config,
         modResults: {

--- a/packages/auth/plugin/src/ios/urlTypes.ts
+++ b/packages/auth/plugin/src/ios/urlTypes.ts
@@ -2,29 +2,17 @@ import {
   ConfigPlugin,
   IOSConfig,
   withInfoPlist,
-  withAppDelegate,
   ExportedConfigWithProps,
 } from '@expo/config-plugins';
-import type { ExpoConfig } from '@expo/config/build/Config.types';
-import type { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
-import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
 import fs from 'fs';
 import path from 'path';
 import plist from 'plist';
 
 // does this for you: https://firebase.google.com/docs/auth/ios/phone-auth#enable-phone-number-sign-in-for-your-firebase-project
 export const withIosCaptchaUrlTypes: ConfigPlugin = config => {
-  config = withInfoPlist(config, config => {
+  return withInfoPlist(config, config => {
     return setUrlTypesForCaptcha({ config });
   });
-
-  if(isPluginEnabled(config, "expo-router")) {
-    config = withAppDelegate(config, config => {
-      return patchOpenUrlForCaptcha({ config });
-    });
-  }
-
-  return config;
 };
 
 function getReversedClientId(googleServiceFilePath: string): string {
@@ -99,65 +87,4 @@ export function setUrlTypesForCaptcha({
   addUriScheme(config, reversedClientId);
 
   return config;
-}
-
-const skipOpenUrlForFirebaseAuthBlock = `\
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
-    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
-    return NO;
-  }\
-`;
-
-// NOTE: `mergeContents()` requires that this pattern not match newlines
-const appDelegateOpenUrlInsertionPointAfter =
-  /-\s*\(\s*BOOL\s*\)\s*application\s*:\s*\(\s*UIApplication\s*\*\s*\)\s*application\s+openURL\s*:\s*\(\s*NSURL\s*\*\s*\)\s*url\s+options\s*:\s*\(\s*NSDictionary\s*<\s*UIApplicationOpenURLOptionsKey\s*,\s*id\s*>\s*\*\s*\)\s*options\s*/; // 🙈
-
-function patchOpenUrlForCaptcha({ config }: {
-  config: ExportedConfigWithProps<AppDelegateProjectFile>;
-}) {
-  const {contents} = config.modResults;
-  const multilineMatcher = new RegExp(appDelegateOpenUrlInsertionPointAfter.source + '\\s*{\\s*\\n');
-  const fullMatch = contents.match(multilineMatcher);
-  if(!fullMatch) {
-    throw new Error("Failed to find insertion point; expected newline after '{'");
-  }
-  const fullMatchNumLines = fullMatch[0].split('\n').length;
-  const offset = fullMatchNumLines - 1;
-  if(offset < 0) {
-    throw new Error(`Failed to find insertion point; fullMatchNumLines=${fullMatchNumLines}`);
-  }
-
-  const newContents = mergeContents({
-    tag: '@react-native-firebase/auth-openURL',
-    src: contents,
-    newSrc: skipOpenUrlForFirebaseAuthBlock ,
-    anchor: appDelegateOpenUrlInsertionPointAfter,
-    offset,
-    comment: '//',
-  }).contents;
-
-  const newConfig = {
-    ...config,
-    modResults: {
-      ...config.modResults,
-      contents: newContents,
-    },
-  };
-  return newConfig;
-}
-
-// Search the ExpoConfig plugins array to see if `pluginName` is present
-function isPluginEnabled(config: ExpoConfig, pluginName: string): boolean {
-  if(config.plugins === undefined) {
-    return false;
-  }
-  return config.plugins.some((plugin: string | [] | [string] | [string, any]) => {
-    if(plugin === pluginName) {
-      return true;
-    } else if(Array.isArray(plugin) && plugin.length >= 1 && plugin[0] === pluginName) {
-      return true;
-    } else {
-      return false;
-    }
-  });
 }

--- a/packages/auth/plugin/src/ios/urlTypes.ts
+++ b/packages/auth/plugin/src/ios/urlTypes.ts
@@ -7,9 +7,10 @@ import {
 import fs from 'fs';
 import path from 'path';
 import plist from 'plist';
+import { PluginConfigType } from '../pluginConfig';
 
 // does this for you: https://firebase.google.com/docs/auth/ios/phone-auth#enable-phone-number-sign-in-for-your-firebase-project
-export const withIosCaptchaUrlTypes: ConfigPlugin = config => {
+export const withIosCaptchaUrlTypes: ConfigPlugin<PluginConfigType> = (config, {}) => {
   return withInfoPlist(config, config => {
     return setUrlTypesForCaptcha({ config });
   });

--- a/packages/auth/plugin/src/ios/urlTypes.ts
+++ b/packages/auth/plugin/src/ios/urlTypes.ts
@@ -2,17 +2,24 @@ import {
   ConfigPlugin,
   IOSConfig,
   withInfoPlist,
+  withAppDelegate,
   ExportedConfigWithProps,
 } from '@expo/config-plugins';
+import type { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
+import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
 import fs from 'fs';
 import path from 'path';
 import plist from 'plist';
 
 // does this for you: https://firebase.google.com/docs/auth/ios/phone-auth#enable-phone-number-sign-in-for-your-firebase-project
 export const withIosCaptchaUrlTypes: ConfigPlugin = config => {
-  return withInfoPlist(config, config => {
+  config = withInfoPlist(config, config => {
     return setUrlTypesForCaptcha({ config });
   });
+  config = withAppDelegate(config, config => {
+    return patchOpenUrlForCaptcha({ config });
+  });
+  return config;
 };
 
 function getReversedClientId(googleServiceFilePath: string): string {
@@ -87,4 +94,49 @@ export function setUrlTypesForCaptcha({
   addUriScheme(config, reversedClientId);
 
   return config;
+}
+
+const skipOpenUrlForFirebaseAuthBlock = `\
+  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+    // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+    return NO;
+  }\
+`;
+
+// NOTE: `mergeContents()` requires that this pattern not match newlines
+const appDelegateOpenUrlInsertionPointAfter =
+  /-\s*\(\s*BOOL\s*\)\s*application\s*:\s*\(\s*UIApplication\s*\*\s*\)\s*application\s+openURL\s*:\s*\(\s*NSURL\s*\*\s*\)\s*url\s+options\s*:\s*\(\s*NSDictionary\s*<\s*UIApplicationOpenURLOptionsKey\s*,\s*id\s*>\s*\*\s*\)\s*options\s*/; // 🙈
+
+function patchOpenUrlForCaptcha({ config }: {
+  config: ExportedConfigWithProps<AppDelegateProjectFile>;
+}) {
+  const {contents} = config.modResults;
+  const multilineMatcher = new RegExp(appDelegateOpenUrlInsertionPointAfter.source + '\\s*{\\s*\\n');
+  const fullMatch = contents.match(multilineMatcher);
+  if(!fullMatch) {
+    throw new Error("Failed to find insertion point; expected newline after '{'");
+  }
+  const fullMatchNumLines = fullMatch[0].split('\n').length;
+  const offset = fullMatchNumLines - 1;
+  if(offset < 0) {
+    throw new Error(`Failed to find insertion point; fullMatchNumLines=${fullMatchNumLines}`);
+  }
+
+  const newContents = mergeContents({
+    tag: '@react-native-firebase/auth-openURL',
+    src: contents,
+    newSrc: skipOpenUrlForFirebaseAuthBlock ,
+    anchor: appDelegateOpenUrlInsertionPointAfter,
+    offset,
+    comment: '//',
+  }).contents;
+
+  const newConfig = {
+    ...config,
+    modResults: {
+      ...config.modResults,
+      contents: newContents,
+    },
+  };
+  return newConfig;
 }

--- a/packages/auth/plugin/src/ios/urlTypes.ts
+++ b/packages/auth/plugin/src/ios/urlTypes.ts
@@ -10,7 +10,7 @@ import plist from 'plist';
 import { PluginConfigType } from '../pluginConfig';
 
 // does this for you: https://firebase.google.com/docs/auth/ios/phone-auth#enable-phone-number-sign-in-for-your-firebase-project
-export const withIosCaptchaUrlTypes: ConfigPlugin<PluginConfigType> = (config, {}) => {
+export const withIosCaptchaUrlTypes: ConfigPlugin<PluginConfigType> = config => {
   return withInfoPlist(config, config => {
     return setUrlTypesForCaptcha({ config });
   });

--- a/packages/auth/plugin/src/pluginConfig.ts
+++ b/packages/auth/plugin/src/pluginConfig.ts
@@ -1,0 +1,7 @@
+export interface PluginConfigType {
+  ios?: PluginConfigTypeIos;
+}
+
+export interface PluginConfigTypeIos {
+  captchaOpenUrlFix?: undefined | boolean | 'default';
+}


### PR DESCRIPTION
### Description

*Summary*:
Fix [#7258: @react-native-firebase/auth (phone auth) + Expo Router - Redirected to appScheme://firebaseuth/link after resolving recaptcha in ios simulator](https://github.com/invertase/react-native-firebase/issues/7258)

*Problem*:
When using `@react-native-firebase/auth` and `expo-router` in the same application, the phone number login method on iOS fails in some scenarios. In particular, when Firebase uses its ReCAPTCHA verifier (e.g. when running in the iOS simulator), the application ends up navigating away from the login page to a new route `/firebaseauth/link`. 

*Cause*:
After the user has completed the captcha challenge, the WebView redirects back to the application using an iOS deep link of the form `${googleServiceJson.REVERSED_CLIENT_ID}://firebaseauth/link?${queryParams}`. This inadvertently gets handled by Expo Router, which treats it as a navigation event to a route called `/firebaseauth/link`.

The root cause of this is a bad interaction between a feature in the Firebase iOS SDK and one in Expo Router:
- Firebase uses a technique called "swizzling" to automatically intercept the `openURL` call and do its business, but then it also passes along the same `openURL` call to our application so we can handle it too.
- Our iOS app's `AppDelegate` is supposed to return `TRUE` if it can handle the provided URL, and `FALSE` if it can't.
- When using Expo Router, our AppDelegate is configured to just pass the URL along onto the router.
- However, Expo Router always answers "yes I can handle this URL" -- even if it's going to "handle" it by displaying a "Not Found" error.

This interacts badly because it's effectively like Expo Router is hijacking the call that's intended for Firebase Auth. Yet, this situation only occurs because Firebase Auth is forwarding the `openURL` call to our app even after it has already handled it.

*Solution*:
This PR automatically updates the AppDelegate's `openURL` method to not handle URLs for the hostname `"firebaseauth"`, under the assumption that it's already being handled by Firebase.

- Adds a configuration option to `@react-native-firebase/auth` Expo plugin called `captchaOpenUrlFix`.
- When `captchaOpenUrlFix` option is unset or `"default"`, automatically applies patch if `expo-router` plugin is detected in Expo config.
- Robust error handling and reporting

*TODO*:
- Documentation updates

CC: @mikehardy 
### Related issues
Fixes #7258, #7953 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [X] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

Comprehensive unit tests have been added:
- plugin configurations
- positive and negative examples of patching
- tests for each error handling condition
