### PR TITLE
test: update cli package used for patch generation

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -74,7 +74,7 @@ jobs:
           done
           ls -la $HOME/packages/
           cd $HOME
-          npx react-native init template --skip-install --skip-git-init
+          npx @react-native-community/cli init template --skip-install --skip-git-init
           cd template
           yarn
           yarn add patch-package --dev


### PR DESCRIPTION
### Description

Noticed on latest PR that the patch-package generation failed, due to a deprecation

`npx react-native init` deprecated, `npx @react-native-community/cli init` current

### Release Summary

One conventional commit, rebase merge should be fine, will not trigger a release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Very difficult to test workflows.

This should either work though, or will at worst need a slight tweak and a force-push with the tweak to accept the temp install of the package non-interactively

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
