### PR TITLE
feat(app-distribution): add Expo config plugin for App Distribution

### DIFF
--- a/docs/app-distribution/usage/index.md
+++ b/docs/app-distribution/usage/index.md
@@ -24,7 +24,7 @@ cd ios/ && pod install
 
 ## Add the App Distribution Plugin
 
-> This module does not handle Expo config plugins yet but does require a native integration similar to the perf module. If you want to add support for Expo to the App Distribution module we would welcome a PR!
+> If you're using Expo, make sure to add the `@react-native-firebase/app-distribution` config plugin to your `app.json` or `app.config.js`. It handles the below installation steps for you. For instructions on how to do that, view the [Expo](/#expo) installation section.
 
 On Android, you need to install the Google App Distribution Plugin.
 

--- a/packages/app-distribution/app.plugin.js
+++ b/packages/app-distribution/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build');

--- a/packages/app-distribution/package.json
+++ b/packages/app-distribution/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "build": "genversion --semi lib/version.js",
     "build:clean": "rimraf android/build && rimraf ios/build",
-    "prepare": "yarn run build"
+    "build:plugin": "rimraf plugin/build && tsc --build plugin",
+    "lint:plugin": "eslint plugin/src/*",
+    "prepare": "yarn run build && yarn run build:plugin"
   },
   "repository": {
     "type": "git",
@@ -22,7 +24,16 @@
     "app-distribution"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "21.6.2"
+    "@react-native-firebase/app": "21.6.2",
+    "expo": ">=47.0.0"
+  },
+  "devDependencies": {
+    "expo": "^50.0.21"
+  },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/app-distribution/plugin/__tests__/README.md
+++ b/packages/app-distribution/plugin/__tests__/README.md
@@ -1,0 +1,1 @@
+Please see the `packages/app/plugin/__tests__/README.md`.

--- a/packages/app-distribution/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/app-distribution/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -1,0 +1,167 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`App distribution Plugin Android Tests applies app distribution classpath to project build.gradle 1`] = `
+"// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = "29.0.3"
+        minSdkVersion = 21
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:5.0.0'
+        classpath("com.android.tools.build:gradle:4.1.0")
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url("$rootDir/../node_modules/react-native/android")
+        }
+        maven {
+            // Android JSC is installed from npm
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
+
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
+    }
+}
+"
+`;
+
+exports[`App distribution Plugin Android Tests applies app distribution plugin to app/build.gradle 1`] = `
+"/* Example build.gradle file from https://github.com/expo/expo/blob/6ab0274b5cb9a9c223e0d453787a522b438b4fcb/templates/expo-template-bare-minimum/android/app/build.gradle */
+
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/expo-constants/scripts/get-app-config-android.gradle"
+apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
+
+def enableSeparateBuildPerCPUArchitecture = false
+
+def enableProguardInReleaseBuilds = false
+
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.helloworld"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:\${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:\${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:\${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+
+apply plugin: 'com.google.firebase.appdistribution'"
+`;

--- a/packages/app-distribution/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/app-distribution/plugin/__tests__/androidPlugin.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { applyPlugin } from '../src/android/applyPlugin';
+import { setBuildscriptDependency } from '../src/android/buildscriptDependency';
+
+describe('App distribution Plugin Android Tests', function () {
+  let appBuildGradle: string;
+  let projectBuildGradle: string;
+
+  beforeAll(async function () {
+    projectBuildGradle = await fs.readFile(
+      path.resolve(__dirname, './fixtures/project_build.gradle'),
+      { encoding: 'utf-8' },
+    );
+
+    appBuildGradle = await fs.readFile(path.resolve(__dirname, './fixtures/app_build.gradle'), {
+      encoding: 'utf-8',
+    });
+  });
+
+  it('applies app distribution classpath to project build.gradle', async function () {
+    const result = setBuildscriptDependency(projectBuildGradle);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('applies app distribution plugin to app/build.gradle', async function () {
+    const result = applyPlugin(appBuildGradle);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/app-distribution/plugin/__tests__/fixtures/app_build.gradle
+++ b/packages/app-distribution/plugin/__tests__/fixtures/app_build.gradle
@@ -1,0 +1,118 @@
+/* Example build.gradle file from https://github.com/expo/expo/blob/6ab0274b5cb9a9c223e0d453787a522b438b4fcb/templates/expo-template-bare-minimum/android/app/build.gradle */
+
+apply plugin: "com.android.application"
+
+import com.android.build.OutputFile
+
+
+project.ext.react = [
+    enableHermes: false
+]
+
+apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
+apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/expo-constants/scripts/get-app-config-android.gradle"
+apply from: "../../node_modules/expo-updates/scripts/create-manifest-android.gradle"
+
+def enableSeparateBuildPerCPUArchitecture = false
+
+def enableProguardInReleaseBuilds = false
+
+def jscFlavor = 'org.webkit:android-jsc:+'
+
+def enableHermes = project.ext.react.get("enableHermes", false);
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    defaultConfig {
+        applicationId "com.helloworld"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+    }
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    signingConfigs {
+        debug {
+            storeFile file('debug.keystore')
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
+    }
+    buildTypes {
+        debug {
+            signingConfig signingConfigs.debug
+        }
+        release {
+            // Caution! In production, you need to generate your own keystore file.
+            // see https://reactnative.dev/docs/signed-apk-android.
+            signingConfig signingConfigs.debug
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+        }
+    }
+
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            // For each separate APK per architecture, set a unique version code as described here:
+            // https://developer.android.com/studio/build/configure-apk-splits.html
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug, universal-release variants
+                output.versionCodeOverride =
+                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            }
+
+        }
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: "libs", include: ["*.jar"])
+    //noinspection GradleDynamicVersion
+    implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+      exclude group:'com.facebook.fbjni'
+    }
+    debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+        exclude group:'com.squareup.okhttp3', module:'okhttp'
+    }
+    debugImplementation("com.facebook.flipper:flipper-fresco-plugin:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.flipper'
+    }
+    addUnimodulesDependencies()
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermes-engine/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
+}
+
+// Run this once to be able to run the application with BUCK
+// puts all compile dependencies into folder libs for BUCK to use
+task copyDownloadableDepsToLibs(type: Copy) {
+    from configurations.compile
+    into 'libs'
+}
+
+apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)

--- a/packages/app-distribution/plugin/__tests__/fixtures/project_build.gradle
+++ b/packages/app-distribution/plugin/__tests__/fixtures/project_build.gradle
@@ -1,0 +1,38 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    ext {
+        buildToolsVersion = "29.0.3"
+        minSdkVersion = 21
+        compileSdkVersion = 30
+        targetSdkVersion = 30
+    }
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:4.1.0")
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
+    }
+}
+
+allprojects {
+    repositories {
+        mavenLocal()
+        maven {
+            // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+            url("$rootDir/../node_modules/react-native/android")
+        }
+        maven {
+            // Android JSC is installed from npm
+            url("$rootDir/../node_modules/jsc-android/dist")
+        }
+
+        google()
+        jcenter()
+        maven { url 'https://www.jitpack.io' }
+    }
+}

--- a/packages/app-distribution/plugin/src/android/applyPlugin.ts
+++ b/packages/app-distribution/plugin/src/android/applyPlugin.ts
@@ -1,0 +1,29 @@
+import { ConfigPlugin, WarningAggregator, withAppBuildGradle } from '@expo/config-plugins';
+import { appDistributionMonitoringPlugin } from './constants';
+
+/**
+ * Update `app/build.gradle` by applying app-distribution monitoring plugin
+ */
+export const withApplyappDistributionPlugin: ConfigPlugin = config => {
+  return withAppBuildGradle(config, config => {
+    if (config.modResults.language === 'groovy') {
+      config.modResults.contents = applyPlugin(config.modResults.contents);
+    } else {
+      WarningAggregator.addWarningAndroid(
+        'react-native-firebase-app-distribution',
+        `Cannot automatically configure app build.gradle if it's not groovy`,
+      );
+    }
+    return config;
+  });
+};
+
+export function applyPlugin(appBuildGradle: string) {
+  const appDistributionPattern = new RegExp(
+    `apply\\s+plugin:\\s+['"]${appDistributionMonitoringPlugin}['"]`,
+  );
+  if (!appBuildGradle.match(appDistributionPattern)) {
+    appBuildGradle += `\napply plugin: '${appDistributionMonitoringPlugin}'`;
+  }
+  return appBuildGradle;
+}

--- a/packages/app-distribution/plugin/src/android/buildscriptDependency.ts
+++ b/packages/app-distribution/plugin/src/android/buildscriptDependency.ts
@@ -1,0 +1,33 @@
+import { ConfigPlugin, WarningAggregator, withProjectBuildGradle } from '@expo/config-plugins';
+
+import { appDistributionMonitoringClassPath, appDistributionMonitoringVersion } from './constants';
+
+/**
+ * Update `<project>/build.gradle` by adding app-distribution dependency to buildscript
+ */
+export const withBuildscriptDependency: ConfigPlugin = config => {
+  return withProjectBuildGradle(config, config => {
+    if (config.modResults.language === 'groovy') {
+      config.modResults.contents = setBuildscriptDependency(config.modResults.contents);
+    } else {
+      WarningAggregator.addWarningAndroid(
+        'react-native-firebase-app-distribution',
+        `Cannot automatically configure project build.gradle if it's not groovy`,
+      );
+    }
+    return config;
+  });
+};
+
+export function setBuildscriptDependency(buildGradle: string) {
+  // TODO: Find a more stable solution for this
+  if (!buildGradle.includes(appDistributionMonitoringClassPath)) {
+    return buildGradle.replace(
+      /dependencies\s?{/,
+      `dependencies {
+        classpath '${appDistributionMonitoringClassPath}:${appDistributionMonitoringVersion}'`,
+    );
+  }
+
+  return buildGradle;
+}

--- a/packages/app-distribution/plugin/src/android/constants.ts
+++ b/packages/app-distribution/plugin/src/android/constants.ts
@@ -1,0 +1,7 @@
+const appPackageJson = require('@react-native-firebase/app/package.json');
+
+export const appDistributionMonitoringClassPath =
+  'com.google.firebase:firebase-appdistribution-gradle';
+export const appDistributionMonitoringPlugin = 'com.google.firebase.appdistribution';
+export const appDistributionMonitoringVersion =
+  appPackageJson.sdkVersions.android.firebaseAppDistributionGradle;

--- a/packages/app-distribution/plugin/src/android/index.ts
+++ b/packages/app-distribution/plugin/src/android/index.ts
@@ -1,0 +1,4 @@
+import { withApplyappDistributionPlugin } from './applyPlugin';
+import { withBuildscriptDependency } from './buildscriptDependency';
+
+export { withBuildscriptDependency, withApplyappDistributionPlugin };

--- a/packages/app-distribution/plugin/src/index.ts
+++ b/packages/app-distribution/plugin/src/index.ts
@@ -1,0 +1,13 @@
+import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withApplyappDistributionPlugin, withBuildscriptDependency } from './android';
+
+/**
+ * A config plugin for configuring `@react-native-firebase/app-distribution`
+ */
+const withRnFirebaseAppDistribution: ConfigPlugin = config => {
+  return withPlugins(config, [withBuildscriptDependency, withApplyappDistributionPlugin]);
+};
+
+const pak = require('@react-native-firebase/app-distribution/package.json');
+export default createRunOncePlugin(withRnFirebaseAppDistribution, pak.name, pak.version);

--- a/packages/app-distribution/plugin/tsconfig.json
+++ b/packages/app-distribution/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node-lts/tsconfig",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["./src"]
+}

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -86,7 +86,8 @@
       "firebaseCrashlyticsGradle": "3.0.2",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.2",
-      "playServicesAuth": "21.2.0"
+      "playServicesAuth": "21.2.0",
+      "firebaseAppDistributionGradle": "5.0.0"
     }
   }
 }

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -81,7 +81,7 @@ PODS:
     - FirebaseCore (= 11.5)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAppCheckInterop (11.5.0)
+  - FirebaseAppCheckInterop (11.6.0)
   - FirebaseAppDistribution (11.5.0-beta):
     - FirebaseCore (= 11.5)
     - FirebaseInstallations (~> 11.0)
@@ -96,7 +96,7 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (11.5.0)
+  - FirebaseAuthInterop (11.6.0)
   - FirebaseCore (11.5.0):
     - FirebaseCoreInternal (= 11.5)
     - GoogleUtilities/Environment (~> 8.0)
@@ -172,7 +172,7 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseMessagingInterop (11.5.0)
+  - FirebaseMessagingInterop (11.6.0)
   - FirebasePerformance (11.5.0):
     - FirebaseCore (= 11.5)
     - FirebaseInstallations (~> 11.0)
@@ -191,7 +191,7 @@ PODS:
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.5.0)
+  - FirebaseRemoteConfigInterop (11.6.0)
   - FirebaseSessions (11.5.0):
     - FirebaseCore (= 11.5)
     - FirebaseCoreExtension (= 11.5)
@@ -1437,73 +1437,73 @@ PODS:
     - React-Core
   - RNDeviceInfo (13.0.0):
     - React-Core
-  - RNFBAnalytics (21.4.0):
+  - RNFBAnalytics (21.6.2):
     - Firebase/Analytics (= 11.5.0)
     - GoogleAppMeasurementOnDeviceConversion (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (21.4.0):
+  - RNFBApp (21.6.2):
     - Firebase/CoreOnly (= 11.5.0)
     - React-Core
-  - RNFBAppCheck (21.4.0):
+  - RNFBAppCheck (21.6.2):
     - Firebase/AppCheck (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (21.4.0):
+  - RNFBAppDistribution (21.6.2):
     - Firebase/AppDistribution (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.4.0):
+  - RNFBAuth (21.6.2):
     - Firebase/Auth (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.4.0):
+  - RNFBCrashlytics (21.6.2):
     - Firebase/Crashlytics (= 11.5.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.4.0):
+  - RNFBDatabase (21.6.2):
     - Firebase/Database (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.4.0):
+  - RNFBDynamicLinks (21.6.2):
     - Firebase/DynamicLinks (= 11.5.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.4.0):
+  - RNFBFirestore (21.6.2):
     - Firebase/Firestore (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.4.0):
+  - RNFBFunctions (21.6.2):
     - Firebase/Functions (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.4.0):
+  - RNFBInAppMessaging (21.6.2):
     - Firebase/InAppMessaging (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.4.0):
+  - RNFBInstallations (21.6.2):
     - Firebase/Installations (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.4.0):
+  - RNFBMessaging (21.6.2):
     - Firebase/Messaging (= 11.5.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (21.4.0):
+  - RNFBML (21.6.2):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.4.0):
+  - RNFBPerf (21.6.2):
     - Firebase/Performance (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.4.0):
+  - RNFBRemoteConfig (21.6.2):
     - Firebase/RemoteConfig (= 11.5.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.4.0):
+  - RNFBStorage (21.6.2):
     - Firebase/Storage (= 11.5.0)
     - React-Core
     - RNFBApp
@@ -1800,10 +1800,10 @@ SPEC CHECKSUMS:
   FirebaseABTesting: 42403a7ffdde1904cb063b5bc2d27dd200e37ac2
   FirebaseAnalytics: 2f4a11eeb7a0e9c6fcf642d4e6aaca7fa4d38c28
   FirebaseAppCheck: 1c4adb8028cc5ec6a8d3d10f18b60293cddc45a4
-  FirebaseAppCheckInterop: d265d9f4484e7ec1c591086408840fdd383d1213
+  FirebaseAppCheckInterop: 347aa09a805219a31249b58fc956888e9fcb314b
   FirebaseAppDistribution: 0285ac7b19e5768d0ec737f444343e1e41a1b5fc
   FirebaseAuth: d8ad770642af39d1be932094be5f5230efb0ea74
-  FirebaseAuthInterop: 1219bee9b23e6ebe84c256a0d95adab53d11c331
+  FirebaseAuthInterop: a919d415797d23b7bfe195a04f322b86c65020ef
   FirebaseCore: 93abc05437f8064cd2bc0a53b768fb0bc5a1d006
   FirebaseCoreExtension: ddb2eb987f736b714d30f6386795b52c4670439e
   FirebaseCoreInternal: f47dd28ae7782e6a4738aad3106071a8fe0af604
@@ -1821,10 +1821,10 @@ SPEC CHECKSUMS:
   FirebaseInAppMessaging: de1044733441fe5735576214bb5ae0b65b96de8b
   FirebaseInstallations: d8063d302a426d114ac531cd82b1e335a0565745
   FirebaseMessaging: 9f4e42053241bd45ce8565c881bfdd9c1df2f7da
-  FirebaseMessagingInterop: c9e95011afc8750b96c9c3bfe849d79cc18be8a9
+  FirebaseMessagingInterop: d768073b71144b7bceadfec019d3dc49c743d53e
   FirebasePerformance: bd2f3c54fb768b0920bb31657e48df8d9f4e4121
   FirebaseRemoteConfig: 9c06ced90c1561c18ccfc258e2548371eb3a7137
-  FirebaseRemoteConfigInterop: 7a7aebb9342d53913a5c890efa88e289d9e5c1bc
+  FirebaseRemoteConfigInterop: e75e348953352a000331eb77caf01e424248e176
   FirebaseSessions: b252b3f91a51186188882ea8e7e1730fc1eee391
   FirebaseSharedSwift: 302ac5967857ad7e7388b15382d705b8c8d892aa
   FirebaseStorage: 4e521b5c833f0f3d488dcbde0c72044d02c59146
@@ -1890,26 +1890,26 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
   RNDeviceInfo: 55264dd7cc939dad6e9c231a7621311f5277f1dc
-  RNFBAnalytics: a6c98791bb66cc0dbe4ff2253631cd9119dd320e
-  RNFBApp: fb8295c1a9562b2b2bf0838932993105aa0a45bc
-  RNFBAppCheck: f85e038125d87e5e43b4a9cfeaaf9bbe7998f586
-  RNFBAppDistribution: ad8c59b6f87726f75beddad425c0ae16a0d48eaa
-  RNFBAuth: 7fbf741bdb782711316b0d9c97ad616c3bd0daad
-  RNFBCrashlytics: 993a383c7350234f9cfd95b41cd115137016e98f
-  RNFBDatabase: 7ca318d37a511563bb11de7a8799e37b4a7489be
-  RNFBDynamicLinks: 8f0965304cf6554326364becc05060ba3756ba2a
-  RNFBFirestore: de036cc1169e9cf3e5a674b21d258924533b1f14
-  RNFBFunctions: 9ffa6e6caa41017db50e122931871103c41d713f
-  RNFBInAppMessaging: 90ef5198a3aa99cfc127c48cbd26afaa97d32d3c
-  RNFBInstallations: 677c095e1d93b610a249ed3e9a8be0638bd4130c
-  RNFBMessaging: 34669a125c06d7ceb44877c8e3162ccb6486250d
-  RNFBML: 2d525c7fd92817a0b5de687f609f895ba0ad0fb1
-  RNFBPerf: 952a69fa03748895d7ae12ddbb95a86062e3ed1a
-  RNFBRemoteConfig: 704bd20d79f2ac2269ef36865eacf1d45998480d
-  RNFBStorage: 0d764334ff9b33ba7a516d546d157e2a4b599e06
+  RNFBAnalytics: c9dcf9dc64594e77461409517d184b2095fa91dc
+  RNFBApp: 5c187f161ac2b1c258c9c099d56bf5cfdb1f0bcb
+  RNFBAppCheck: 94c8ce0a972880b3dd1563a01e0ba3245126a9a9
+  RNFBAppDistribution: d718990bb9eb6312f74cb5c96c220042320e8946
+  RNFBAuth: dc124c8219a950dc8ca10e6410000898848253ad
+  RNFBCrashlytics: be29aaeb2245b7e6130716cf3c49e0b94e1dca3d
+  RNFBDatabase: 08d0bb1b1a0057250a5902db072859d63f409919
+  RNFBDynamicLinks: 7ab8a0254f8686276524036c4fe462445f85b0e7
+  RNFBFirestore: 5f70c6e994bd86a5d771060b9808e02ef484cc83
+  RNFBFunctions: afbc87adc8aa8c28b8f75fa29ec1f3479d529267
+  RNFBInAppMessaging: 30aae43da88362581fc81a1ad99f44e1ec268077
+  RNFBInstallations: de59d4981917bbf944ca27564de9a22a9008351d
+  RNFBMessaging: cb53c6f68f35949983ecb768589bb1c4771bea04
+  RNFBML: 93990f600cacacd8b3f952553f28b8ffcc24dcca
+  RNFBPerf: 5665a4acd86e7a6a476016c8877ee7d8f0d50a4c
+  RNFBRemoteConfig: 53076a0bd643506fde6eea7a4d5958a14b979c30
+  RNFBStorage: 382a43cee8e34a10d04ab98090dae54a2e88f8ec
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Yoga: 33622183a85805e12703cd618b2c16bfd18bfffb
 
 PODFILE CHECKSUM: ebb415306b3593b02c638dfd858de0c40942d52c
 
-COCOAPODS: 1.16.1
+COCOAPODS: 1.15.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -6219,8 +6219,14 @@ __metadata:
 "@react-native-firebase/app-distribution@npm:21.6.2, @react-native-firebase/app-distribution@workspace:packages/app-distribution":
   version: 0.0.0-use.local
   resolution: "@react-native-firebase/app-distribution@workspace:packages/app-distribution"
+  dependencies:
+    expo: "npm:^50.0.21"
   peerDependencies:
     "@react-native-firebase/app": 21.6.2
+    expo: ">=47.0.0"
+  peerDependenciesMeta:
+    expo:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

This pull request is intended to add an expo config plugin for @react-native-firebase/app-distribution which does not currently have an Expo plugin :fire:. https://rnfirebase.io/app-distribution/usage#add-the-app-distribution-plugin

### Related issues
None

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

Add Expo config plugin for App Distribution 

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
