### PR TITLE
fix(auth, types): instantiating OAuthProvider returns OAuthProvider

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -112,13 +112,13 @@ export namespace FirebaseAuthTypes {
   /**
    * Interface that represents an OAuth provider. Implemented by other providers.
    */
-  export interface OAuthProvider {
+  export interface OAuthProvider extends AuthProvider {
     /**
      * The provider ID of the provider.
      * @param providerId
      */
     // eslint-disable-next-line @typescript-eslint/no-misused-new
-    new (providerId: string): AuthProvider;
+    new (providerId: string): OAuthProvider;
     /**
      * Creates a new `AuthCredential`.
      *


### PR DESCRIPTION
### Description

previously 'new' on OAuthProvider returned AuthProvider which had none of the necessary OAuthProvider interface methods

Our types stray pretty far from firebase-js-sdk here, they do not allow you to `new` an OAuthProvider, however, their OAuthProvider does participate in a type inheritance chain that goes to BaseOAuthProvider, to FederatedAuthProvider which implements AuthProvider. So this change at least brings us slightly more into harmony

https://github.com/firebase/firebase-js-sdk/blob/144bc370942f1bdd00f482b40df2581e7ed83a0a/packages/auth/src/core/providers/oauth.ts#L63-L65

### Related issues

Discussed
- https://github.com/invertase/react-native-firebase/discussions/8230

### Release Summary

single conventional commit


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
