### PR TITLE
fix: adopt firebase-ios-sdk 11.7.0 / firebase-android-sdk 33.7.0

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   ios:
     name: iOS
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
     # TODO matrix across APIs, at least 11 and 15 (lowest to highest)
     timeout-minutes: 60
     env:

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   other:
     name: Other
-    runs-on: macos-14-xlarge
+    runs-on: macos-15-xlarge
     timeout-minutes: 100
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/index.md
+++ b/docs/index.md
@@ -316,7 +316,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "33.5.1"
+        bom           : "33.7.0"
       ],
     ],
   ])
@@ -331,7 +331,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '11.5.0'
+$FirebaseSDKVersion = '11.7.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "11.5.0",
+      "firebase": "11.7.0",
       "iosTarget": "13.0",
       "macosTarget": "10.15",
       "tvosTarget": "13.0"
@@ -82,7 +82,7 @@
       "minSdk": 21,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "33.5.1",
+      "firebase": "33.7.0",
       "firebaseCrashlyticsGradle": "3.0.2",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.2",


### PR DESCRIPTION
### Description

Standard SDK updates for the native SDKs, if CI passes I'll assume they're good

I haven't seen problems with them as I build test them in make-demo.sh anyway

### Related issues

This may fix user-reported StoreKit2 in-app-purchase logging discussed here:

- #8077

Additionally this switches our apple CI to use `macos-15-xlarge` vs previous `macos-14-xlarge` to avoid a toolchain installation issue on the macos-14 runners:

- https://github.com/actions/runner-images/issues/11335


### Release Summary

single conventional commit all ready for rebase + release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

local build testing looked good

CI will chew on it and render a verdict

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
