### PR TITLE
fix(analytics,web): sets no-cors on analytics requests for web

### DIFF
--- a/packages/analytics/lib/web/api.js
+++ b/packages/analytics/lib/web/api.js
@@ -315,7 +315,6 @@ For example, to use React Native Async Storage:
             origin: 'firebase',
             pragma: 'no-cache',
             'sec-fetch-dest': 'empty',
-            'sec-fetch-mode': 'no-cors',
             'sec-fetch-site': 'cross-site',
             'user-agent': 'react-native-firebase',
           },

--- a/packages/analytics/lib/web/api.js
+++ b/packages/analytics/lib/web/api.js
@@ -304,6 +304,7 @@ For example, to use React Native Async Storage:
         }
         const response = await fetch(url, {
           method: 'POST',
+          mode: 'no-cors',
           headers: {
             accept: '*/*',
             'accept-encoding': 'gzip, deflate, br',


### PR DESCRIPTION
### Description

Requests to Google analytics for web aren't setting no-cors so requests are triggering CORS preflight and subsequently failing.

See the following discussion for more details: https://github.com/invertase/react-native-firebase/discussions/7982#discussioncomment-11878809

### Related issues

### Release Summary

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ x] No

### Test Plan

Tested manually in Chrome. I verified that no CORS preflight is sent and that I received an HTTP 204 response from my Google analytics request.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
