### PR TITLE
fix(firestore, ios): account for filters in getAggregateFromServer with collection groups

### DIFF
--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -679,11 +679,11 @@ describe('Firestore', function () {
       firestore1.settings({ persistence: true });
       const indexManager = firestore1.persistentCacheIndexManager();
       expect(indexManager).toBeDefined();
-      expect(indexManager.constructor.name).toEqual('FirestorePersistentCacheIndexManager');
+      expect(indexManager!.constructor.name).toEqual('FirestorePersistentCacheIndexManager');
 
-      expect(indexManager.enableIndexAutoCreation).toBeInstanceOf(Function);
-      expect(indexManager.disableIndexAutoCreation).toBeInstanceOf(Function);
-      expect(indexManager.deleteAllIndexes).toBeInstanceOf(Function);
+      expect(indexManager!.enableIndexAutoCreation).toBeInstanceOf(Function);
+      expect(indexManager!.disableIndexAutoCreation).toBeInstanceOf(Function);
+      expect(indexManager!.deleteAllIndexes).toBeInstanceOf(Function);
 
       const firestore2 = firebase.firestore();
       firestore2.settings({ persistence: false });

--- a/packages/firestore/e2e/Aggregate/AggregateQuery.e2e.js
+++ b/packages/firestore/e2e/Aggregate/AggregateQuery.e2e.js
@@ -563,5 +563,51 @@ describe('getAggregateFromServer()', function () {
         data.averageBaz.should.eql(-0.19999999999999998);
       });
     });
+
+    describe('collectionGroup()', function () {
+
+      it('test count, sum, average with collectionGroup', async function () {
+        const {
+          getAggregateFromServer,
+          doc,
+          setDoc,
+          collection,
+          getFirestore,
+          count,
+          average,
+          collectionGroup,
+          sum,
+          FieldPath,
+        } = firestoreModular;
+        const firestore = getFirestore();
+
+
+        const colRef = collection(firestore,  'collectionGroup');
+
+        await Promise.all([
+          setDoc(doc(colRef, 'one'), { docId: "123", status: "paid", amount: 100, }),
+          setDoc(doc(colRef, 'two'), { docId: "123", status: "paid", amount: 200, }),
+          setDoc(doc(colRef, 'three'), { docId: "123", status: "unpaid", amount: 400 }),
+        ]);
+
+        const query = collectionGroup(firestore, 'collectionGroup')
+        .where("docId", '==', "123")
+        .where("status", '==', "paid");
+
+        const aggregateSpec = {
+          countCollection: count(),
+          averageAmount: average(new FieldPath('amount')),
+          sumAmount: sum(new FieldPath('amount')),
+        };
+
+        const result = await getAggregateFromServer(query, aggregateSpec);
+
+        const data = result.data();
+
+        data.countCollection.should.eql(2);
+        data.averageAmount.should.eql(150);
+        data.sumAmount.should.eql(300);
+      });
+    })
   });
 });

--- a/packages/firestore/e2e/Aggregate/AggregateQuery.e2e.js
+++ b/packages/firestore/e2e/Aggregate/AggregateQuery.e2e.js
@@ -565,7 +565,6 @@ describe('getAggregateFromServer()', function () {
     });
 
     describe('collectionGroup()', function () {
-
       it('test count, sum, average with collectionGroup', async function () {
         const {
           getAggregateFromServer,
@@ -581,18 +580,17 @@ describe('getAggregateFromServer()', function () {
         } = firestoreModular;
         const firestore = getFirestore();
 
-
-        const colRef = collection(firestore,  'collectionGroup');
+        const colRef = collection(firestore, 'collectionGroup');
 
         await Promise.all([
-          setDoc(doc(colRef, 'one'), { docId: "123", status: "paid", amount: 100, }),
-          setDoc(doc(colRef, 'two'), { docId: "123", status: "paid", amount: 200, }),
-          setDoc(doc(colRef, 'three'), { docId: "123", status: "unpaid", amount: 400 }),
+          setDoc(doc(colRef, 'one'), { docId: '123', status: 'paid', amount: 100 }),
+          setDoc(doc(colRef, 'two'), { docId: '123', status: 'paid', amount: 200 }),
+          setDoc(doc(colRef, 'three'), { docId: '123', status: 'unpaid', amount: 400 }),
         ]);
 
         const query = collectionGroup(firestore, 'collectionGroup')
-        .where("docId", '==', "123")
-        .where("status", '==', "paid");
+          .where('docId', '==', '123')
+          .where('status', '==', 'paid');
 
         const aggregateSpec = {
           countCollection: count(),
@@ -608,6 +606,6 @@ describe('getAggregateFromServer()', function () {
         data.averageAmount.should.eql(150);
         data.sumAmount.should.eql(300);
       });
-    })
+    });
   });
 });

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -229,7 +229,7 @@ RCT_EXPORT_METHOD(aggregateQuery
                   : (RCTPromiseRejectBlock)reject) {
   FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
                                                          databaseId:databaseId];
-  // FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
+
   FIRQuery *firestoreBaseQuery = [RNFBFirestoreCommon getQueryForFirestore:firestore 
                                                                 path:path type:type];
   RNFBFirestoreQuery *firestoreQuery =

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -229,7 +229,17 @@ RCT_EXPORT_METHOD(aggregateQuery
                   : (RCTPromiseRejectBlock)reject) {
   FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
                                                          databaseId:databaseId];
-  FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
+  // FIRQuery *query = [RNFBFirestoreCommon getQueryForFirestore:firestore path:path type:type];
+  FIRQuery *firestoreBaseQuery = [RNFBFirestoreCommon getQueryForFirestore:firestore 
+                                                                path:path type:type];
+  RNFBFirestoreQuery *firestoreQuery =
+   [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
+                                         query:firestoreBaseQuery
+                                        filters:filters
+                                        orders:orders
+                                        options:options];
+  
+  FIRQuery *query = [firestoreQuery instance];
 
   NSMutableArray<FIRAggregateField *> *aggregateFields =
       [[NSMutableArray<FIRAggregateField *> alloc] init];

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -229,7 +229,7 @@ RCT_EXPORT_METHOD(aggregateQuery
                   : (RCTPromiseRejectBlock)reject) {
   FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
                                                          databaseId:databaseId];
-
+                                                         
   FIRQuery *firestoreBaseQuery = [RNFBFirestoreCommon getQueryForFirestore:firestore 
                                                                 path:path type:type];
   RNFBFirestoreQuery *firestoreQuery =

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -229,16 +229,17 @@ RCT_EXPORT_METHOD(aggregateQuery
                   : (RCTPromiseRejectBlock)reject) {
   FIRFirestore *firestore = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
                                                          databaseId:databaseId];
-                                                         
-  FIRQuery *firestoreBaseQuery = [RNFBFirestoreCommon getQueryForFirestore:firestore 
-                                                                path:path type:type];
+
+  FIRQuery *firestoreBaseQuery = [RNFBFirestoreCommon getQueryForFirestore:firestore
+                                                                      path:path
+                                                                      type:type];
   RNFBFirestoreQuery *firestoreQuery =
-   [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
-                                         query:firestoreBaseQuery
-                                        filters:filters
-                                        orders:orders
-                                        options:options];
-  
+      [[RNFBFirestoreQuery alloc] initWithModifiers:firestore
+                                              query:firestoreBaseQuery
+                                            filters:filters
+                                             orders:orders
+                                            options:options];
+
   FIRQuery *query = [firestoreQuery instance];
 
   NSMutableArray<FIRAggregateField *> *aggregateFields =

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -6,107 +6,107 @@ PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.74.5)
-  - Firebase/Analytics (11.5.0):
+  - Firebase/Analytics (11.7.0):
     - Firebase/Core
-  - Firebase/AppCheck (11.5.0):
+  - Firebase/AppCheck (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 11.5.0)
-  - Firebase/AppDistribution (11.5.0):
+    - FirebaseAppCheck (~> 11.7.0)
+  - Firebase/AppDistribution (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 11.5.0-beta)
-  - Firebase/Auth (11.5.0):
+    - FirebaseAppDistribution (~> 11.7.0-beta)
+  - Firebase/Auth (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 11.5.0)
-  - Firebase/Core (11.5.0):
+    - FirebaseAuth (~> 11.7.0)
+  - Firebase/Core (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 11.5.0)
-  - Firebase/CoreOnly (11.5.0):
-    - FirebaseCore (= 11.5.0)
-  - Firebase/Crashlytics (11.5.0):
+    - FirebaseAnalytics (~> 11.7.0)
+  - Firebase/CoreOnly (11.7.0):
+    - FirebaseCore (~> 11.7.0)
+  - Firebase/Crashlytics (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 11.5.0)
-  - Firebase/Database (11.5.0):
+    - FirebaseCrashlytics (~> 11.7.0)
+  - Firebase/Database (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 11.5.0)
-  - Firebase/DynamicLinks (11.5.0):
+    - FirebaseDatabase (~> 11.7.0)
+  - Firebase/DynamicLinks (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 11.5.0)
-  - Firebase/Firestore (11.5.0):
+    - FirebaseDynamicLinks (~> 11.7.0)
+  - Firebase/Firestore (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 11.5.0)
-  - Firebase/Functions (11.5.0):
+    - FirebaseFirestore (~> 11.7.0)
+  - Firebase/Functions (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 11.5.0)
-  - Firebase/InAppMessaging (11.5.0):
+    - FirebaseFunctions (~> 11.7.0)
+  - Firebase/InAppMessaging (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 11.5.0-beta)
-  - Firebase/Installations (11.5.0):
+    - FirebaseInAppMessaging (~> 11.7.0-beta)
+  - Firebase/Installations (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 11.5.0)
-  - Firebase/Messaging (11.5.0):
+    - FirebaseInstallations (~> 11.7.0)
+  - Firebase/Messaging (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 11.5.0)
-  - Firebase/Performance (11.5.0):
+    - FirebaseMessaging (~> 11.7.0)
+  - Firebase/Performance (11.7.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 11.5.0)
-  - Firebase/RemoteConfig (11.5.0):
+    - FirebasePerformance (~> 11.7.0)
+  - Firebase/RemoteConfig (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 11.5.0)
-  - Firebase/Storage (11.5.0):
+    - FirebaseRemoteConfig (~> 11.7.0)
+  - Firebase/Storage (11.7.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 11.5.0)
-  - FirebaseABTesting (11.5.0):
-    - FirebaseCore (= 11.5)
-  - FirebaseAnalytics (11.5.0):
-    - FirebaseAnalytics/AdIdSupport (= 11.5.0)
-    - FirebaseCore (= 11.5)
+    - FirebaseStorage (~> 11.7.0)
+  - FirebaseABTesting (11.7.0):
+    - FirebaseCore (~> 11.7.0)
+  - FirebaseAnalytics (11.7.0):
+    - FirebaseAnalytics/AdIdSupport (= 11.7.0)
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/AdIdSupport (11.5.0):
-    - FirebaseCore (= 11.5)
+  - FirebaseAnalytics/AdIdSupport (11.7.0):
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement (= 11.5.0)
+    - GoogleAppMeasurement (= 11.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAppCheck (11.5.0):
+  - FirebaseAppCheck (11.7.0):
     - AppCheckCore (~> 11.0)
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (= 11.5)
+    - FirebaseCore (~> 11.7.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAppCheckInterop (11.6.0)
-  - FirebaseAppDistribution (11.5.0-beta):
-    - FirebaseCore (= 11.5)
+  - FirebaseAppCheckInterop (11.7.0)
+  - FirebaseAppDistribution (11.7.0-beta):
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAuth (11.5.0):
+  - FirebaseAuth (11.7.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (= 11.5)
-    - FirebaseCoreExtension (= 11.5)
+    - FirebaseCore (~> 11.7.0)
+    - FirebaseCoreExtension (~> 11.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (11.6.0)
-  - FirebaseCore (11.5.0):
-    - FirebaseCoreInternal (= 11.5)
+  - FirebaseAuthInterop (11.7.0)
+  - FirebaseCore (11.7.0):
+    - FirebaseCoreInternal (~> 11.7.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreExtension (11.5.0):
-    - FirebaseCore (= 11.5)
-  - FirebaseCoreInternal (11.5.0):
+  - FirebaseCoreExtension (11.7.0):
+    - FirebaseCore (~> 11.7.0)
+  - FirebaseCoreInternal (11.7.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseCrashlytics (11.5.0):
-    - FirebaseCore (= 11.5)
+  - FirebaseCrashlytics (11.7.0):
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -114,22 +114,22 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseDatabase (11.5.0):
+  - FirebaseDatabase (11.7.0):
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (= 11.5)
+    - FirebaseCore (~> 11.7.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (11.5.0):
-    - FirebaseCore (= 11.5)
-  - FirebaseFirestore (11.5.0):
-    - FirebaseFirestoreBinary (= 11.5.0)
+  - FirebaseDynamicLinks (11.7.0):
+    - FirebaseCore (~> 11.7.0)
+  - FirebaseFirestore (11.7.0):
+    - FirebaseFirestoreBinary (= 11.7.0)
   - FirebaseFirestoreAbseilBinary (1.2024011602.0)
-  - FirebaseFirestoreBinary (11.5.0):
-    - FirebaseCore (= 11.5.0)
-    - FirebaseCoreExtension (= 11.5.0)
-    - FirebaseFirestoreInternalBinary (= 11.5.0)
-    - FirebaseSharedSwift (= 11.5.0)
+  - FirebaseFirestoreBinary (11.7.0):
+    - FirebaseCore (= 11.7.0)
+    - FirebaseCoreExtension (= 11.7.0)
+    - FirebaseFirestoreInternalBinary (= 11.7.0)
+    - FirebaseSharedSwift (= 11.7.0)
   - FirebaseFirestoreGRPCBoringSSLBinary (1.65.1)
   - FirebaseFirestoreGRPCCoreBinary (1.65.1):
     - FirebaseFirestoreAbseilBinary (= 1.2024011602.0)
@@ -137,34 +137,34 @@ PODS:
   - FirebaseFirestoreGRPCCPPBinary (1.65.1):
     - FirebaseFirestoreAbseilBinary (= 1.2024011602.0)
     - FirebaseFirestoreGRPCCoreBinary (= 1.65.1)
-  - FirebaseFirestoreInternalBinary (11.5.0):
-    - FirebaseCore (= 11.5.0)
+  - FirebaseFirestoreInternalBinary (11.7.0):
+    - FirebaseCore (= 11.7.0)
     - FirebaseFirestoreAbseilBinary (= 1.2024011602.0)
     - FirebaseFirestoreGRPCCPPBinary (= 1.65.1)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseFunctions (11.5.0):
+  - FirebaseFunctions (11.7.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (= 11.5)
-    - FirebaseCoreExtension (= 11.5)
+    - FirebaseCore (~> 11.7.0)
+    - FirebaseCoreExtension (~> 11.7.0)
     - FirebaseMessagingInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
-  - FirebaseInAppMessaging (11.5.0-beta):
+  - FirebaseInAppMessaging (11.7.0-beta):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (= 11.5)
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseInstallations (11.5.0):
-    - FirebaseCore (= 11.5)
+  - FirebaseInstallations (11.7.0):
+    - FirebaseCore (~> 11.7.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.5.0):
-    - FirebaseCore (= 11.5)
+  - FirebaseMessaging (11.7.0):
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -172,9 +172,9 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseMessagingInterop (11.6.0)
-  - FirebasePerformance (11.5.0):
-    - FirebaseCore (= 11.5)
+  - FirebaseMessagingInterop (11.7.0)
+  - FirebasePerformance (11.7.0):
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfig (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -183,55 +183,55 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseRemoteConfig (11.5.0):
+  - FirebaseRemoteConfig (11.7.0):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (= 11.5)
+    - FirebaseCore (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.6.0)
-  - FirebaseSessions (11.5.0):
-    - FirebaseCore (= 11.5)
-    - FirebaseCoreExtension (= 11.5)
+  - FirebaseRemoteConfigInterop (11.7.0)
+  - FirebaseSessions (11.7.0):
+    - FirebaseCore (~> 11.7.0)
+    - FirebaseCoreExtension (~> 11.7.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.5.0)
-  - FirebaseStorage (11.5.0):
+  - FirebaseSharedSwift (11.7.0)
+  - FirebaseStorage (11.7.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (= 11.5)
-    - FirebaseCoreExtension (= 11.5)
+    - FirebaseCore (~> 11.7.0)
+    - FirebaseCoreExtension (~> 11.7.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - GoogleAppMeasurement (11.5.0):
-    - GoogleAppMeasurement/AdIdSupport (= 11.5.0)
+  - GoogleAppMeasurement (11.7.0):
+    - GoogleAppMeasurement/AdIdSupport (= 11.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/AdIdSupport (11.5.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.5.0)
+  - GoogleAppMeasurement/AdIdSupport (11.7.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.7.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (11.5.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (11.7.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurementOnDeviceConversion (11.5.0)
+  - GoogleAppMeasurementOnDeviceConversion (11.7.0)
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
@@ -262,7 +262,7 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GTMSessionFetcher/Core (4.1.0)
+  - GTMSessionFetcher/Core (4.3.0)
   - hermes-engine (0.74.5):
     - hermes-engine/Pre-built (= 0.74.5)
   - hermes-engine/Pre-built (0.74.5)
@@ -1435,76 +1435,76 @@ PODS:
   - RecaptchaInterop (100.0.0)
   - RNCAsyncStorage (1.24.0):
     - React-Core
-  - RNDeviceInfo (13.0.0):
+  - RNDeviceInfo (13.2.0):
     - React-Core
-  - RNFBAnalytics (21.6.2):
-    - Firebase/Analytics (= 11.5.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 11.5.0)
-    - React-Core
-    - RNFBApp
-  - RNFBApp (21.6.2):
-    - Firebase/CoreOnly (= 11.5.0)
-    - React-Core
-  - RNFBAppCheck (21.6.2):
-    - Firebase/AppCheck (= 11.5.0)
+  - RNFBAnalytics (21.7.1):
+    - Firebase/Analytics (= 11.7.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (21.6.2):
-    - Firebase/AppDistribution (= 11.5.0)
+  - RNFBApp (21.7.1):
+    - Firebase/CoreOnly (= 11.7.0)
+    - React-Core
+  - RNFBAppCheck (21.7.1):
+    - Firebase/AppCheck (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.6.2):
-    - Firebase/Auth (= 11.5.0)
+  - RNFBAppDistribution (21.7.1):
+    - Firebase/AppDistribution (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.6.2):
-    - Firebase/Crashlytics (= 11.5.0)
+  - RNFBAuth (21.7.1):
+    - Firebase/Auth (= 11.7.0)
+    - React-Core
+    - RNFBApp
+  - RNFBCrashlytics (21.7.1):
+    - Firebase/Crashlytics (= 11.7.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.6.2):
-    - Firebase/Database (= 11.5.0)
+  - RNFBDatabase (21.7.1):
+    - Firebase/Database (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.6.2):
-    - Firebase/DynamicLinks (= 11.5.0)
+  - RNFBDynamicLinks (21.7.1):
+    - Firebase/DynamicLinks (= 11.7.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.6.2):
-    - Firebase/Firestore (= 11.5.0)
+  - RNFBFirestore (21.7.1):
+    - Firebase/Firestore (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.6.2):
-    - Firebase/Functions (= 11.5.0)
+  - RNFBFunctions (21.7.1):
+    - Firebase/Functions (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.6.2):
-    - Firebase/InAppMessaging (= 11.5.0)
+  - RNFBInAppMessaging (21.7.1):
+    - Firebase/InAppMessaging (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.6.2):
-    - Firebase/Installations (= 11.5.0)
+  - RNFBInstallations (21.7.1):
+    - Firebase/Installations (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.6.2):
-    - Firebase/Messaging (= 11.5.0)
+  - RNFBMessaging (21.7.1):
+    - Firebase/Messaging (= 11.7.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (21.6.2):
+  - RNFBML (21.7.1):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.6.2):
-    - Firebase/Performance (= 11.5.0)
+  - RNFBPerf (21.7.1):
+    - Firebase/Performance (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.6.2):
-    - Firebase/RemoteConfig (= 11.5.0)
+  - RNFBRemoteConfig (21.7.1):
+    - Firebase/RemoteConfig (= 11.7.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.6.2):
-    - Firebase/Storage (= 11.5.0)
+  - RNFBStorage (21.7.1):
+    - Firebase/Storage (= 11.7.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.7.0)
@@ -1514,7 +1514,7 @@ DEPENDENCIES:
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.5.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.7.0`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -1643,7 +1643,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.5.0
+    :tag: 11.7.0
   fmt:
     :podspec: "../node_modules/react-native/third-party-podspecs/fmt.podspec"
   glog:
@@ -1789,52 +1789,52 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.5.0
+    :tag: 11.7.0
 
 SPEC CHECKSUMS:
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   FBLazyVector: ac12dc084d1c8ec4cc4d7b3cf1b0ebda6dab85af
-  Firebase: 7a56fe4f56b5ab81b86a6822f5b8f909ae6fc7e2
-  FirebaseABTesting: 42403a7ffdde1904cb063b5bc2d27dd200e37ac2
-  FirebaseAnalytics: 2f4a11eeb7a0e9c6fcf642d4e6aaca7fa4d38c28
-  FirebaseAppCheck: 1c4adb8028cc5ec6a8d3d10f18b60293cddc45a4
-  FirebaseAppCheckInterop: 347aa09a805219a31249b58fc956888e9fcb314b
-  FirebaseAppDistribution: 0285ac7b19e5768d0ec737f444343e1e41a1b5fc
-  FirebaseAuth: d8ad770642af39d1be932094be5f5230efb0ea74
-  FirebaseAuthInterop: a919d415797d23b7bfe195a04f322b86c65020ef
-  FirebaseCore: 93abc05437f8064cd2bc0a53b768fb0bc5a1d006
-  FirebaseCoreExtension: ddb2eb987f736b714d30f6386795b52c4670439e
-  FirebaseCoreInternal: f47dd28ae7782e6a4738aad3106071a8fe0af604
-  FirebaseCrashlytics: 94c11c3bf296fde8c18f2c9f8e76bd9349227038
-  FirebaseDatabase: 49600b40ee3ecd8711bf37e6cbf3a26cf87f7297
-  FirebaseDynamicLinks: 0e4954b3d050560dfa4bf3a7e8ffe16c9a4b8280
-  FirebaseFirestore: d8e2cd8b0ec476909ec6fd0432e98947084bdea9
+  Firebase: a64bf6a8546e6eab54f1c715cd6151f39d2329f4
+  FirebaseABTesting: 08b3e19b28504632a9cd03e7a796b355c5d39b27
+  FirebaseAnalytics: bc9e565af9044ba8d6c6e4157e4edca8e5fdf7ec
+  FirebaseAppCheck: 2bd832b48faa38f7d86f902c57f78af93eae4cdc
+  FirebaseAppCheckInterop: 2376d3ec5cb4267facad4fe754ab4f301a5a519b
+  FirebaseAppDistribution: 5788e4d44db80a6a8df54247eea33208e3cb696f
+  FirebaseAuth: 77e25aa24f3e1c626c5babd3338551fc1669ee0e
+  FirebaseAuthInterop: a6973d72aa242ea88ffb6be9c9b06c65455071da
+  FirebaseCore: 3227e35f4197a924206fbcdc0349325baf4f5de4
+  FirebaseCoreExtension: 206c1b399f0d103055207c16f299b28e3dbd1949
+  FirebaseCoreInternal: d6c17dafc8dc33614733a8b52df78fcb4394c881
+  FirebaseCrashlytics: 785a73b624715bbc09a40bb56cdc3829a801cc98
+  FirebaseDatabase: b014c0068fa691dec5f4a868357e685df882cca5
+  FirebaseDynamicLinks: e81e03f6076bd02081ae6e06631797e134380a76
+  FirebaseFirestore: 61305c5ac196ec1526dde68ac132543a7749a081
   FirebaseFirestoreAbseilBinary: fa2ebd2ed02cadef5382e4f7c93f1b265c812c85
-  FirebaseFirestoreBinary: b89c49fd52faf320f81f8ecb4cdb0b077cef3014
+  FirebaseFirestoreBinary: 86eaad2ff00b789242734496029a3d08d4d86a89
   FirebaseFirestoreGRPCBoringSSLBinary: d86ebbe2adc8d15d7ebf305fff7d6358385327f8
   FirebaseFirestoreGRPCCoreBinary: 472bd808e1886a5efb2fd03dd09b98d34641a335
   FirebaseFirestoreGRPCCPPBinary: db76d83d2b7517623f8426ed7f7a17bad2478084
-  FirebaseFirestoreInternalBinary: 4e13e767203cd1d4d3e7d3b4d9862ab96d73ba66
-  FirebaseFunctions: 302356b97cd56d1d95dc9aca0ddcb0f1e0443b0c
-  FirebaseInAppMessaging: de1044733441fe5735576214bb5ae0b65b96de8b
-  FirebaseInstallations: d8063d302a426d114ac531cd82b1e335a0565745
-  FirebaseMessaging: 9f4e42053241bd45ce8565c881bfdd9c1df2f7da
-  FirebaseMessagingInterop: d768073b71144b7bceadfec019d3dc49c743d53e
-  FirebasePerformance: bd2f3c54fb768b0920bb31657e48df8d9f4e4121
-  FirebaseRemoteConfig: 9c06ced90c1561c18ccfc258e2548371eb3a7137
-  FirebaseRemoteConfigInterop: e75e348953352a000331eb77caf01e424248e176
-  FirebaseSessions: b252b3f91a51186188882ea8e7e1730fc1eee391
-  FirebaseSharedSwift: 302ac5967857ad7e7388b15382d705b8c8d892aa
-  FirebaseStorage: 4e521b5c833f0f3d488dcbde0c72044d02c59146
+  FirebaseFirestoreInternalBinary: 1850c8c72f3d7933a00a4d0bae88021df87c9e10
+  FirebaseFunctions: b7f3122ca91ced5253f16aa0418339f19434d0c7
+  FirebaseInAppMessaging: f8a9fd60f71bf98cd098c7ee347846251ab1d1bc
+  FirebaseInstallations: 9347e719c3d52d8d7b9074b2c32407dd027305e9
+  FirebaseMessaging: 00ece041b71ddb52a2862ffdee73fb6e9824bd0c
+  FirebaseMessagingInterop: b7acc94b0b65ce2df02a795b5488f698ac7d5c52
+  FirebasePerformance: 0c6fe140f24967b09a59c40c5ad54a623b740ad8
+  FirebaseRemoteConfig: aa1d4cb05ef4caad203448dfc87842de12f1ea8d
+  FirebaseRemoteConfigInterop: ca12abf9da0003efd3a476b2dff4f7a04fd31b4f
+  FirebaseSessions: 32ed7a9387ae71efe3a35a7f20f3a7292950957b
+  FirebaseSharedSwift: a45efd84d60ebbfdcdbaebc66948af3630459e62
+  FirebaseStorage: d35da127dd49edcbd07b8c07cf651a70161558b2
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
-  GoogleAppMeasurement: ee5c2d2242816773fbf79e5b0563f5355ef1c315
-  GoogleAppMeasurementOnDeviceConversion: fb2634f256d999a7b3cf0662ff0d8cb085f3bb4f
+  GoogleAppMeasurement: 0471a5b5bff51f3a91b1e76df22c952d04c63967
+  GoogleAppMeasurementOnDeviceConversion: 35ca1deeb019c506d04da8d4887f0d107d1ffca4
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  GTMSessionFetcher: 923b710231ad3d6f3f0495ac1ced35421e07d9a6
+  GTMSessionFetcher: 257ead9ba8e15a2d389d79496e02b9cc5dd0c62c
   hermes-engine: 8c1577f3fdb849cbe7729c2e7b5abc4b845e88f8
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
@@ -1889,27 +1889,27 @@ SPEC CHECKSUMS:
   ReactCommon: f79ae672224dc1e6c2d932062176883c98eebd57
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
-  RNDeviceInfo: 55264dd7cc939dad6e9c231a7621311f5277f1dc
-  RNFBAnalytics: c9dcf9dc64594e77461409517d184b2095fa91dc
-  RNFBApp: 5c187f161ac2b1c258c9c099d56bf5cfdb1f0bcb
-  RNFBAppCheck: 94c8ce0a972880b3dd1563a01e0ba3245126a9a9
-  RNFBAppDistribution: d718990bb9eb6312f74cb5c96c220042320e8946
-  RNFBAuth: dc124c8219a950dc8ca10e6410000898848253ad
-  RNFBCrashlytics: be29aaeb2245b7e6130716cf3c49e0b94e1dca3d
-  RNFBDatabase: 08d0bb1b1a0057250a5902db072859d63f409919
-  RNFBDynamicLinks: 7ab8a0254f8686276524036c4fe462445f85b0e7
-  RNFBFirestore: 5f70c6e994bd86a5d771060b9808e02ef484cc83
-  RNFBFunctions: afbc87adc8aa8c28b8f75fa29ec1f3479d529267
-  RNFBInAppMessaging: 30aae43da88362581fc81a1ad99f44e1ec268077
-  RNFBInstallations: de59d4981917bbf944ca27564de9a22a9008351d
-  RNFBMessaging: cb53c6f68f35949983ecb768589bb1c4771bea04
-  RNFBML: 93990f600cacacd8b3f952553f28b8ffcc24dcca
-  RNFBPerf: 5665a4acd86e7a6a476016c8877ee7d8f0d50a4c
-  RNFBRemoteConfig: 53076a0bd643506fde6eea7a4d5958a14b979c30
-  RNFBStorage: 382a43cee8e34a10d04ab98090dae54a2e88f8ec
+  RNDeviceInfo: 29e01d5ae94bdb5a0f6c11a4c438132545b4df80
+  RNFBAnalytics: 3da3b2921243115cccaad443be73ea54c05edabf
+  RNFBApp: 67229e8085ab427c935defad2a6c3fc57c7f656d
+  RNFBAppCheck: ec415c40a7b5ca7f05afc0d1be5b6b754c1453dd
+  RNFBAppDistribution: a533b19d91086fad7b5a82733178d7697069256b
+  RNFBAuth: 13f641fec88aee849a628b54332425b2e36f14db
+  RNFBCrashlytics: 5fa31a9936f64be7bd4efbaf05ec64f006ebd862
+  RNFBDatabase: 2f3b556768fe0d723418ba61faa67dfb7c306ef7
+  RNFBDynamicLinks: 2f4c56c026b7d7606d30960f421c26ba14266969
+  RNFBFirestore: 2e4b7bf2824bb68bce11e1036413d4ae49c16343
+  RNFBFunctions: cfdacbc234397ee1bde468c54cf7a9f6fd02a227
+  RNFBInAppMessaging: 677643d7ffbf56a4f1e8c8ea365c5199086c3b42
+  RNFBInstallations: 8166c4f0ca2e797a15a71aa3e6f26b52aa93c326
+  RNFBMessaging: e485940b19e3cff5eeb0f7f095d480576cbab505
+  RNFBML: dde37fb260bf42dacb3b5bcc387afe90bd07dde5
+  RNFBPerf: 0ac96b5a787b84eda8e70787d0be29e29c1c2e03
+  RNFBRemoteConfig: b80554e297980a005b296b548e0a1ddeb3c64b2e
+  RNFBStorage: bdbb9e04c1496de82fa7695449a9f4461ec1d0c7
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 33622183a85805e12703cd618b2c16bfd18bfffb
+  Yoga: 1ab23c1835475da69cf14e211a560e73aab24cb0
 
 PODFILE CHECKSUM: ebb415306b3593b02c638dfd858de0c40942d52c
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
### Related issues

Fixes https://github.com/invertase/react-native-firebase/issues/8253

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
