### PR TITLE
fix: handle nulls correctly in react-native new architecture

### DIFF
--- a/packages/database/e2e/reference/update.e2e.js
+++ b/packages/database/e2e/reference/update.e2e.js
@@ -84,6 +84,26 @@ describe('database().ref().update()', function () {
       );
     });
 
+    it('removes property if set to `null`', async function () {
+      const value = Date.now();
+      const ref = firebase.database().ref(TEST_PATH);
+      await ref.update({
+        foo: value,
+      });
+      const snapshot = await ref.once('value');
+      snapshot.val().should.eql(
+        jet.contextify({
+          foo: value,
+        }),
+      );
+      await ref.update({
+        foo: null,
+      });
+      const snapshot2 = await ref.once('value');
+      // Removes key/value
+      should(snapshot2.val()).be.null();
+    });
+
     it('callback if function is passed', async function () {
       const value = Date.now();
       return new Promise(async resolve => {

--- a/packages/functions/e2e/functions.e2e.js
+++ b/packages/functions/e2e/functions.e2e.js
@@ -225,7 +225,7 @@ describe('functions() modular', function () {
         response.data.should.equal('array');
       });
 
-      xit('accepts object args', async function () {
+      it('accepts object args', async function () {
         const type = 'object';
         const inputData = SAMPLE_DATA[type];
         const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegionV2');
@@ -236,7 +236,7 @@ describe('functions() modular', function () {
         should.deepEqual(outputData, inputData);
       });
 
-      xit('accepts complex nested objects', async function () {
+      it('accepts complex nested objects', async function () {
         const type = 'deepObject';
         const inputData = SAMPLE_DATA[type];
         const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegionV2');
@@ -247,7 +247,7 @@ describe('functions() modular', function () {
         should.deepEqual(outputData, inputData);
       });
 
-      xit('accepts complex nested arrays', async function () {
+      it('accepts complex nested arrays', async function () {
         const type = 'deepArray';
         const inputData = SAMPLE_DATA[type];
         const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegionV2');
@@ -275,7 +275,7 @@ describe('functions() modular', function () {
         return Promise.resolve();
       });
 
-      xit('HttpsError.details -> allows returning complex data', async function () {
+      it('HttpsError.details -> allows returning complex data', async function () {
         let type = 'deepObject';
         let inputData = SAMPLE_DATA[type];
         const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegionV2');
@@ -314,7 +314,7 @@ describe('functions() modular', function () {
         return Promise.resolve();
       });
 
-      xit('HttpsError.details -> allows returning primitives', async function () {
+      it('HttpsError.details -> allows returning primitives', async function () {
         let type = 'number';
         let inputData = SAMPLE_DATA[type];
         const functionRunner = firebase.functions().httpsCallable('testFunctionDefaultRegionV2');
@@ -580,7 +580,7 @@ describe('functions() modular', function () {
         response.data.should.equal('array');
       });
 
-      xit('accepts object args', async function () {
+      it('accepts object args', async function () {
         const { getFunctions, httpsCallable } = functionsModular;
         const type = 'object';
         const inputData = SAMPLE_DATA[type];
@@ -595,7 +595,7 @@ describe('functions() modular', function () {
         should.deepEqual(outputData, inputData);
       });
 
-      xit('accepts complex nested objects', async function () {
+      it('accepts complex nested objects', async function () {
         const { getFunctions, httpsCallable } = functionsModular;
         const type = 'deepObject';
         const inputData = SAMPLE_DATA[type];
@@ -610,7 +610,7 @@ describe('functions() modular', function () {
         should.deepEqual(outputData, inputData);
       });
 
-      xit('accepts complex nested arrays', async function () {
+      it('accepts complex nested arrays', async function () {
         const { getFunctions, httpsCallable } = functionsModular;
         const type = 'deepArray';
         const inputData = SAMPLE_DATA[type];
@@ -646,7 +646,7 @@ describe('functions() modular', function () {
         return Promise.resolve();
       });
 
-      xit('HttpsError.details -> allows returning complex data', async function () {
+      it('HttpsError.details -> allows returning complex data', async function () {
         let type = 'deepObject';
         let inputData = SAMPLE_DATA[type];
         const { getFunctions, httpsCallable } = functionsModular;
@@ -689,7 +689,7 @@ describe('functions() modular', function () {
         return Promise.resolve();
       });
 
-      xit('HttpsError.details -> allows returning primitives', async function () {
+      it('HttpsError.details -> allows returning primitives', async function () {
         const { getFunctions, httpsCallable } = functionsModular;
         let type = 'number';
         let inputData = SAMPLE_DATA[type];

--- a/tests/patches/react-native+0.76.5.patch
+++ b/tests/patches/react-native+0.76.5.patch
@@ -1,0 +1,141 @@
+diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
+index ad267de..680ca63 100644
+--- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
++++ b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
+@@ -337,7 +337,7 @@ void ObjCInteropTurboModule::setInvocationArg(
+   SEL selector = selectorForType(argumentType);
+ 
+   if ([RCTConvert respondsToSelector:selector]) {
+-    id objCArg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
++    id objCArg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
+ 
+     if (objCArgType == @encode(char)) {
+       char arg = RCTConvertTo<char>(selector, objCArg);
+@@ -491,7 +491,7 @@ void ObjCInteropTurboModule::setInvocationArg(
+     }
+ 
+     RCTResponseSenderBlock arg =
+-        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
++        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
+     if (arg) {
+       [retainedObjectsForInvocation addObject:arg];
+     }
+@@ -506,7 +506,7 @@ void ObjCInteropTurboModule::setInvocationArg(
+     }
+ 
+     RCTResponseSenderBlock senderBlock =
+-        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
++        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
+     RCTResponseErrorBlock arg = ^(NSError *error) {
+       senderBlock(@[ RCTJSErrorFromNSError(error) ]);
+     };
+@@ -536,7 +536,7 @@ void ObjCInteropTurboModule::setInvocationArg(
+           runtime, errorPrefix + "JavaScript argument must be a plain object. Got " + getType(runtime, jsiArg));
+     }
+ 
+-    id arg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
++    id arg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
+ 
+     RCTManagedPointer *(*convert)(id, SEL, id) = (__typeof__(convert))objc_msgSend;
+     RCTManagedPointer *box = convert([RCTCxxConvert class], selector, arg);
+diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+index f54e175..8196ff9 100644
+--- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
++++ b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+@@ -32,6 +32,11 @@ using EventEmitterCallback = std::function<void(const std::string &, id)>;
+ namespace TurboModuleConvertUtils {
+ jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
+ id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);
++id convertJSIValueToObjCObject(
++    jsi::Runtime &runtime,
++    const jsi::Value &value,
++    std::shared_ptr<CallInvoker> jsInvoker,
++    BOOL useNSNull);
+ } // namespace TurboModuleConvertUtils
+ 
+ template <>
+diff --git a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+index 2678b19..42067c0 100644
+--- a/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
++++ b/node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+@@ -111,21 +111,27 @@ static NSString *convertJSIStringToNSString(jsi::Runtime &runtime, const jsi::St
+   return [NSString stringWithUTF8String:value.utf8(runtime).c_str()];
+ }
+ 
+-static NSArray *
+-convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value, std::shared_ptr<CallInvoker> jsInvoker)
++static NSArray *convertJSIArrayToNSArray(
++    jsi::Runtime &runtime,
++    const jsi::Array &value,
++    std::shared_ptr<CallInvoker> jsInvoker,
++    BOOL useNSNull)
+ {
+   size_t size = value.size(runtime);
+   NSMutableArray *result = [NSMutableArray new];
+   for (size_t i = 0; i < size; i++) {
+     // Insert kCFNull when it's `undefined` value to preserve the indices.
+-    [result
+-        addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i), jsInvoker) ?: (id)kCFNull];
++    id convertedObject = convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i), jsInvoker, useNSNull);
++    [result addObject:convertedObject ? convertedObject : (id)kCFNull];
+   }
+   return [result copy];
+ }
+ 
+-static NSDictionary *
+-convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value, std::shared_ptr<CallInvoker> jsInvoker)
++static NSDictionary *convertJSIObjectToNSDictionary(
++    jsi::Runtime &runtime,
++    const jsi::Object &value,
++    std::shared_ptr<CallInvoker> jsInvoker,
++    BOOL useNSNull)
+ {
+   jsi::Array propertyNames = value.getPropertyNames(runtime);
+   size_t size = propertyNames.size(runtime);
+@@ -133,7 +139,7 @@ convertJSIObjectToNSDictionary(jsi::Runtime &runtime, const jsi::Object &value,
+   for (size_t i = 0; i < size; i++) {
+     jsi::String name = propertyNames.getValueAtIndex(runtime, i).getString(runtime);
+     NSString *k = convertJSIStringToNSString(runtime, name);
+-    id v = convertJSIValueToObjCObject(runtime, value.getProperty(runtime, name), jsInvoker);
++    id v = convertJSIValueToObjCObject(runtime, value.getProperty(runtime, name), jsInvoker, useNSNull);
+     if (v) {
+       result[k] = v;
+     }
+@@ -161,9 +167,21 @@ convertJSIFunctionToCallback(jsi::Runtime &rt, jsi::Function &&function, std::sh
+ 
+ id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker)
+ {
+-  if (value.isUndefined() || value.isNull()) {
++  return convertJSIValueToObjCObject(runtime, value, jsInvoker, NO);
++}
++
++id convertJSIValueToObjCObject(
++    jsi::Runtime &runtime,
++    const jsi::Value &value,
++    std::shared_ptr<CallInvoker> jsInvoker,
++    BOOL useNSNull)
++{
++  if (value.isUndefined() || (value.isNull() && !useNSNull)) {
+     return nil;
+   }
++  if (value.isNull() && useNSNull) {
++    return [NSNull null];
++  }
+   if (value.isBool()) {
+     return @(value.getBool());
+   }
+@@ -176,12 +194,12 @@ id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, s
+   if (value.isObject()) {
+     jsi::Object o = value.getObject(runtime);
+     if (o.isArray(runtime)) {
+-      return convertJSIArrayToNSArray(runtime, o.getArray(runtime), jsInvoker);
++      return convertJSIArrayToNSArray(runtime, o.getArray(runtime), jsInvoker, useNSNull);
+     }
+     if (o.isFunction(runtime)) {
+       return convertJSIFunctionToCallback(runtime, o.getFunction(runtime), jsInvoker);
+     }
+-    return convertJSIObjectToNSDictionary(runtime, o, jsInvoker);
++    return convertJSIObjectToNSDictionary(runtime, o, jsInvoker, useNSNull);
+   }
+ 
+   throw std::runtime_error("Unsupported jsi::Value kind");


### PR DESCRIPTION
### Description

Unsure what changed between new architecture and old architecture in react-native, but it has affected how nulls are handled when we attempt to remove them, and shows up in two specific places:

1- functions, our function test is showing object differences between expected and actual, in all the cases where nulls are sent inside objects (but not in arrays!)
2- database - we can't set a null to clear an item anymore, as seen in  and probed in 


There are probably other areas that people just haven't seen yet! Like, what about setting null to clear a user id for analytics? That's supposed to work. Other areas where we send null through similar to 1 and 2 above? There are likely more so we should search once we find a pattern

### Related issues

- Fixes #8144 - this PR should close this issue once we determine how to repair
- #8146 - related, I will close that PR as I cherry-picked the test commit here

### Release Summary

None yet

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

We have test failures that expose the problem, this PR needs fresh commits now that make e2e test suite green 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
