### PR TITLE
feat(remote-config): support for custom signals

### DIFF
--- a/packages/remote-config/__tests__/remote-config.test.ts
+++ b/packages/remote-config/__tests__/remote-config.test.ts
@@ -39,6 +39,7 @@ import {
   setDefaults,
   setDefaultsFromResource,
   onConfigUpdated,
+  setCustomSignals,
 } from '../lib';
 
 describe('remoteConfig()', function () {
@@ -215,6 +216,10 @@ describe('remoteConfig()', function () {
 
     it('`onConfigUpdated` function is properly exposed to end user', function () {
       expect(onConfigUpdated).toBeDefined();
+    });
+
+    it('`setCustomSignals` function is properly exposed to end user', function () {
+      expect(setCustomSignals).toBeDefined();
     });
   });
 });

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -256,9 +256,9 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
-  public void setCustomSignals(String appName, ReadableMap setCustomSignals, Promise promise) {
+  public void setCustomSignals(String appName, ReadableMap customSignals, Promise promise) {
     module
-      .setCustomSignals(appName, setCustomSignals.toHashMap())
+      .setCustomSignals(appName, customSignals.toHashMap())
       .addOnCompleteListener(
         task -> {
           if (task.isSuccessful()) {

--- a/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
+++ b/packages/remote-config/android/src/reactnative/java/io/invertase/firebase/config/ReactNativeFirebaseConfigModule.java
@@ -255,6 +255,20 @@ public class ReactNativeFirebaseConfigModule extends ReactNativeFirebaseModule {
     }
   }
 
+  @ReactMethod
+  public void setCustomSignals(String appName, ReadableMap setCustomSignals, Promise promise) {
+    module
+      .setCustomSignals(appName, setCustomSignals.toHashMap())
+      .addOnCompleteListener(
+        task -> {
+          if (task.isSuccessful()) {
+            promise.resolve(resultWithConstants(task.getResult()));
+          } else {
+            rejectPromiseWithExceptionMap(promise, task.getException());
+          }
+        });
+  }
+
   private WritableMap resultWithConstants(Object result) {
     Map<String, Object> responseMap = new HashMap<>(2);
     responseMap.put("result", result);

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -983,13 +983,16 @@ describe('remoteConfig()', function () {
         ];
 
         for (const signals of invalidSignals) {
-          await should(setCustomSignals(remoteConfig, signals))
-            .be.rejectedWith(Error)
-            .and.have.property('message')
-            .that.includes(
+          try {
+            await setCustomSignals(remoteConfig, signals);
+            throw new Error('Expected setCustomSignals to throw an error');
+          } catch (error) {
+            error.message.should.containEql(
               'firebase.remoteConfig().setCustomSignals(): Invalid type for custom signal',
             );
+          }
         }
+        return Promise.resolve();
       });
     });
   });

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -954,5 +954,43 @@ describe('remoteConfig()', function () {
         // console.log('checking listener functionality across javascript layer reload');
       });
     });
+
+    describe('setCustomSignals()', function () {
+      it('should resolve with valid signal value; `string`, `number` or `null`', async function () {
+        const { setCustomSignals, getRemoteConfig } = remoteConfigModular;
+        const remoteConfig = getRemoteConfig(firebase.app());
+        // native SDKs just ignore invalid key/values (e.g. too long) and just log warning
+        const signals = {
+          string: 'string',
+          number: 123,
+          double: 123.456,
+          null: null,
+        };
+
+        const result = await setCustomSignals(remoteConfig, signals);
+        should(result).equal(null);
+      });
+
+      it('should reject with invalid signal value', async function () {
+        const { setCustomSignals, getRemoteConfig } = remoteConfigModular;
+        const remoteConfig = getRemoteConfig(firebase.app());
+
+        const invalidSignals = [
+          { signal1: true },
+          { signal1: [1, 2, 3] },
+          { signal1: { key: 'value' } },
+          { signal1: false },
+        ];
+
+        for (const signals of invalidSignals) {
+          await should(setCustomSignals(remoteConfig, signals))
+            .be.rejectedWith(Error)
+            .and.have.property('message')
+            .that.includes(
+              'firebase.remoteConfig().setCustomSignals(): Invalid type for custom signal',
+            );
+        }
+      });
+    });
   });
 });

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -305,6 +305,23 @@ RCT_EXPORT_METHOD(removeConfigUpdateRegistration : (FIRApp *)firebaseApp) {
   }
 }
 
+RCT_EXPORT_METHOD(setCustomSignals
+                  : (FIRApp *)firebaseApp
+                  : (NSDictionary *)customSignals
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] setCustomSignals:customSignals
+                    withCompletion:^(NSError *_Nullable error) {
+                      if (error != nil) {
+                        [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
+                      } else {
+                        resolve(nil);
+                      }
+                    }];
+
+  resolve([self resultWithConstants:[NSNull null] firebaseApp:firebaseApp]);
+}
+
 #pragma mark -
 #pragma mark Internal Helper Methods
 

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -310,14 +310,15 @@ RCT_EXPORT_METHOD(setCustomSignals
                   : (NSDictionary *)customSignals
                   : (RCTPromiseResolveBlock)resolve
                   : (RCTPromiseRejectBlock)reject) {
-  [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] setCustomSignals:customSignals
-                    withCompletion:^(NSError *_Nullable error) {
-                      if (error != nil) {
-                        [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
-                      } else {
-                        resolve(nil);
-                      }
-                    }];
+  [[FIRRemoteConfig remoteConfigWithApp:firebaseApp]
+      setCustomSignals:customSignals
+        withCompletion:^(NSError *_Nullable error) {
+          if (error != nil) {
+            [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
+          } else {
+            resolve(nil);
+          }
+        }];
 
   resolve([self resultWithConstants:[NSNull null] firebaseApp:firebaseApp]);
 }

--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -206,3 +206,24 @@ export function onConfigUpdated(
   remoteConfig: RemoteConfig,
   callback: (config: ConfigValues) => void,
 ): () => void;
+
+/**
+ * Defines the type for representing custom signals and their values.
+ * The values in CustomSignals must be one of the following types: string, number, or null.
+ */
+
+export interface CustomSignals {
+  [key: string]: string | number | null;
+}
+
+/**
+ * Sets the custom signals for the app instance.
+ * @param {RemoteConfig} remoteConfig - RemoteConfig instance
+ * @param {CustomSignals} customSignals - CustomSignals
+ * @returns {Promise<void>}
+ */
+
+export declare function setCustomSignals(
+  remoteConfig: RemoteConfig,
+  customSignals: CustomSignals,
+): Promise<void>;

--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -210,7 +210,9 @@ export function onConfigUpdated(
 /**
  * Defines the type for representing custom signals and their values.
  * The values in CustomSignals must be one of the following types: string, number, or null.
- */
+  * There are additional limitations on key and value length, for a full description see https://firebase.google.com/docs/remote-config/parameters?template_type=client#custom_signal_conditions
+  * Failing to stay within these limitations will result in a silent API failure with only a warning in device logs
+  */
 
 export interface CustomSignals {
   [key: string]: string | number | null;

--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -210,9 +210,9 @@ export function onConfigUpdated(
 /**
  * Defines the type for representing custom signals and their values.
  * The values in CustomSignals must be one of the following types: string, number, or null.
-  * There are additional limitations on key and value length, for a full description see https://firebase.google.com/docs/remote-config/parameters?template_type=client#custom_signal_conditions
-  * Failing to stay within these limitations will result in a silent API failure with only a warning in device logs
-  */
+ * There are additional limitations on key and value length, for a full description see https://firebase.google.com/docs/remote-config/parameters?template_type=client#custom_signal_conditions
+ * Failing to stay within these limitations will result in a silent API failure with only a warning in device logs
+ */
 
 export interface CustomSignals {
   [key: string]: string | number | null;

--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -252,6 +252,12 @@ export function onConfigUpdated(remoteConfig, callback) {
  * @returns {Promise<void>}
  */
 export function setCustomSignals(remoteConfig, customSignals) {
+  for (const [key, value] of Object.entries(customSignals)) {
+    if (typeof value !== 'string' && typeof value !== 'number' && value !== null) {
+      throw new Error(
+        `firebase.remoteConfig().setCustomSignals(): Invalid type for custom signal '${key}': ${typeof value}. Expected 'string', 'number', or 'null'.`,
+      );
+    }
+  }
   return remoteConfig.native.setCustomSignals(customSignals);
 }
-

--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -251,7 +251,7 @@ export function onConfigUpdated(remoteConfig, callback) {
  * @param {CustomSignals} customSignals - CustomSignals
  * @returns {Promise<void>}
  */
-export function setCustomSignals(remoteConfig, customSignals) {
+export async function setCustomSignals(remoteConfig, customSignals) {
   for (const [key, value] of Object.entries(customSignals)) {
     if (typeof value !== 'string' && typeof value !== 'number' && value !== null) {
       throw new Error(
@@ -259,5 +259,5 @@ export function setCustomSignals(remoteConfig, customSignals) {
       );
     }
   }
-  return remoteConfig.native.setCustomSignals(customSignals);
+  return remoteConfig._promiseWithConstants(remoteConfig.native.setCustomSignals(customSignals));
 }

--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -26,6 +26,7 @@ import { firebase } from '..';
  * @typedef {import('..').FirebaseRemoteConfigTypes.ConfigValues} ConfigValues
  * @typedef {import('..').FirebaseRemoteConfigTypes.LastFetchStatusType} LastFetchStatusType
  * @typedef {import('..').FirebaseRemoteConfigTypes.RemoteConfigLogLevel} RemoteConfigLogLevel
+ * @typedef {import('.').CustomSignals} CustomSignals
  */
 
 /**
@@ -243,3 +244,14 @@ export function setDefaultsFromResource(remoteConfig, resourceName) {
 export function onConfigUpdated(remoteConfig, callback) {
   return remoteConfig.onConfigUpdated(callback);
 }
+
+/**
+ * Sets the custom signals for the app instance.
+ * @param {RemoteConfig} remoteConfig - RemoteConfig instance
+ * @param {CustomSignals} customSignals - CustomSignals
+ * @returns {Promise<void>}
+ */
+export function setCustomSignals(remoteConfig, customSignals) {
+  return remoteConfig.native.setCustomSignals(customSignals);
+}
+

--- a/packages/remote-config/lib/web/RNFBConfigModule.js
+++ b/packages/remote-config/lib/web/RNFBConfigModule.js
@@ -7,6 +7,7 @@ import {
   fetchConfig,
   getAll,
   makeIDBAvailable,
+  setCustomSignals,
 } from '@react-native-firebase/app/lib/internal/web/firebaseRemoteConfig';
 import { guard } from '@react-native-firebase/app/lib/internal/web/utils';
 
@@ -110,6 +111,13 @@ export default {
     return guard(async () => {
       defaultConfigForInstance[appName] = defaults;
       const remoteConfig = getRemoteConfigInstanceForApp(appName);
+      return resultAndConstants(remoteConfig, null);
+    });
+  },
+  setCustomSignals(appName, customSignals) {
+    return guard(async () => {
+      const remoteConfig = getRemoteConfigInstanceForApp(appName);
+      await setCustomSignals(remoteConfig, customSignals);
       return resultAndConstants(remoteConfig, null);
     });
   },


### PR DESCRIPTION
### Description

- Support is for modular only.
- There are discrepancies between native SDKs. iOS will throw if you pass in wrong type (a dictionary is passed in as CustomSignals), I can't see any incorrect type handling on JS (although you ought to get TS warning if incorrect type I think), and android enforces a CustomSignal type which only allows long, double, string and null values. Therefore, we throw exception early if not number, string or null to keep some form of consistency.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
