### PR TITLE
fix: deprecation warning / documentation / test cleanups

### DIFF
--- a/docs/migrating-to-v22.md
+++ b/docs/migrating-to-v22.md
@@ -7,10 +7,10 @@ next: /typescript
 
 # Switching off warning logs
 
-You may notice an influx of console warning logs as we continue deprecating all existing namespaced API. If you would like to switch these logs off, you may set the following global property to `true` anywhere before you initialize Firebase.
+You may notice a lot of console warning logs as we deprecate the existing namespaced API. If you would like to switch these logs off, you may set the following global property to `true` anywhere before you initialize Firebase.
 
 ```js
-globalThis.RNFB_SILENCE_V8_DEPRECATION_WARNINGS = true;
+globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
 ```
 
 # Migrating to React Native modular API

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -213,7 +213,7 @@ const mapOfDeprecationReplacements = {
   },
 };
 
-const v8deprecationMessage =
+const modularDeprecationMessage =
   'This method is deprecated (as well as all React Native Firebase namespaced API) and will be removed in the next major release ' +
   'as part of move to match Firebase Web modular SDK API. Please see migration guide for more details: https://rnfirebase.io/migrating-to-v22';
 
@@ -226,7 +226,7 @@ export function deprecationConsoleWarning(nameSpace, methodName, instanceName, i
       if (instanceMap && deprecatedMethod) {
         const message = createMessage(nameSpace, methodName, instanceName);
 
-        if (!globalThis.RNFB_SILENCE_V8_DEPRECATION_WARNINGS) {
+        if (!globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS) {
           // eslint-disable-next-line no-console
           console.warn(message);
         }
@@ -253,9 +253,9 @@ export function createMessage(
       const replacementMethodName = instance[methodName];
 
       if (replacementMethodName !== NO_REPLACEMENT) {
-        return v8deprecationMessage + ` Please use \`${replacementMethodName}\` instead.`;
+        return modularDeprecationMessage + ` Please use \`${replacementMethodName}\` instead.`;
       } else {
-        return v8deprecationMessage;
+        return modularDeprecationMessage;
       }
     }
   }
@@ -363,12 +363,12 @@ export function warnIfNotModularCall(args, replacementMethodName = '') {
     }
   }
 
-  let message = v8deprecationMessage;
+  let message = modularDeprecationMessage;
   if (replacementMethodName.length > 0) {
     message += ` Please use \`${replacementMethodName}\` instead.`;
   }
 
-  if (!globalThis.RNFB_SILENCE_V8_DEPRECATION_WARNINGS) {
+  if (!globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS) {
     // eslint-disable-next-line no-console
     console.warn(message);
   }

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -362,10 +362,8 @@ export function warnIfNotModularCall(args, replacementMethodName = '') {
       return;
     }
   }
-  let message =
-    'This v8 method is deprecated and will be removed in the next major release ' +
-    'as part of move to match Firebase Web modular v9 SDK API.';
 
+  let message = v8deprecationMessage;
   if (replacementMethodName.length > 0) {
     message += ` Please use \`${replacementMethodName}\` instead.`;
   }

--- a/packages/crashlytics/e2e/crashlytics.e2e.js
+++ b/packages/crashlytics/e2e/crashlytics.e2e.js
@@ -91,14 +91,13 @@ describe('crashlytics()', function () {
         // eslint-disable-next-line no-console
         console.warn = msg => {
           // we console.warn for deprecated API, can be removed when we move to v9
-          if (!msg.includes('v8 method is deprecated')) {
+          if (!msg.includes('method is deprecated')) {
             msg.should.containEql('expects an instance of Error');
             logged = true;
             // eslint-disable-next-line no-console
             console.warn = orig;
           }
         };
-
         firebase.crashlytics().recordError(1337);
         should.equal(logged, true);
       });
@@ -265,7 +264,7 @@ describe('crashlytics()', function () {
         // eslint-disable-next-line no-console
         console.warn = msg => {
           // we console.warn for deprecated API, can be removed when we move to v9
-          if (!msg.includes('v8 method is deprecated')) {
+          if (!msg.includes('method is deprecated')) {
             msg.should.containEql('expects an instance of Error');
             logged = true;
             // eslint-disable-next-line no-console


### PR DESCRIPTION
### Description

Two tiny commits that I will merge+release as soon as CI agrees:

- a warning message cleanup - one was changed to "modular" language, one was not, so crashlytics testing failed
- a docs and global variable name cleanup - removing "V8" in favor of "modular" for disable var

Both are aimed at using "modular" and "namespaced" exclusively in user messaging, so we don't have any "version number" confusion, since "v8" is ambiguous in a react-native-firebase context

### Related issues

None logged, but tests are failing on main currently after I merged #8279 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The PR is aimed at *fixing* tests, so if e2e passes after this, it worked

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
