### PR TITLE
fix: the init calls for modular should use modular getApp()

### DIFF
--- a/packages/analytics/lib/modular/index.js
+++ b/packages/analytics/lib/modular/index.js
@@ -1,4 +1,4 @@
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
@@ -48,9 +48,9 @@ import { firebase } from '..';
  */
 export function getAnalytics(app) {
   if (app) {
-    return firebase.app(app.name).analytics();
+    return getApp(app.name).analytics();
   }
-  return firebase.app().analytics();
+  return getApp().analytics();
 }
 
 /**
@@ -61,7 +61,7 @@ export function getAnalytics(app) {
  */
 // eslint-disable-next-line
 export function initializeAnalytics(app, options) {
-  return firebase.app(app.name).analytics();
+  return getApp(app.name).analytics();
 }
 
 /**

--- a/packages/app-check/lib/modular/index.js
+++ b/packages/app-check/lib/modular/index.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 import { MODULAR_DEPRECATION_ARG } from '../../../app/lib/common';
 import CustomProvider from '../ReactNativeFirebaseAppCheckProvider';
 
@@ -36,13 +36,13 @@ import CustomProvider from '../ReactNativeFirebaseAppCheckProvider';
  */
 export async function initializeAppCheck(app, options) {
   if (app) {
-    const appCheck = firebase.app(app.name).appCheck();
+    const appCheck = getApp(app.name).appCheck();
     await appCheck.initializeAppCheck.call(appCheck, options, MODULAR_DEPRECATION_ARG);
-    return { app: firebase.app(app.name) };
+    return { app: getApp(app.name) };
   }
-  const appCheck = firebase.app().appCheck();
+  const appCheck = getApp().appCheck();
   await appCheck.initializeAppCheck.call(appCheck, options, MODULAR_DEPRECATION_ARG);
-  return { app: firebase.app() };
+  return { app: getApp() };
 }
 
 /**

--- a/packages/app-distribution/lib/modular/index.js
+++ b/packages/app-distribution/lib/modular/index.js
@@ -1,4 +1,4 @@
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import("..").FirebaseApp} FirebaseApp
@@ -12,9 +12,9 @@ import { firebase } from '..';
  */
 export function getAppDistribution(app) {
   if (app) {
-    return firebase.appDistribution(app);
+    return getApp(app.name).appDistribution(app);
   }
-  return firebase.appDistribution();
+  return getApp().appDistribution();
 }
 
 /**

--- a/packages/auth/lib/modular/index.js
+++ b/packages/auth/lib/modular/index.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import('@firebase/app-types').FirebaseApp} FirebaseApp
@@ -47,9 +47,9 @@ import { firebase } from '..';
  */
 export function getAuth(app) {
   if (app) {
-    return firebase.app(app.name).auth();
+    return getApp(app.name).auth();
   }
-  return firebase.app().auth();
+  return getApp().auth();
 }
 
 /**
@@ -60,9 +60,9 @@ export function getAuth(app) {
  */
 export function initializeAuth(app, deps) {
   if (app) {
-    return firebase.app(app.name).auth();
+    return getApp(app.name).auth();
   }
-  return firebase.app().auth();
+  return getApp().auth();
 }
 
 /**

--- a/packages/crashlytics/lib/modular/index.js
+++ b/packages/crashlytics/lib/modular/index.js
@@ -1,5 +1,5 @@
+import { getApp } from '@react-native-firebase/app';
 import { MODULAR_DEPRECATION_ARG } from '@react-native-firebase/app/lib/common';
-import { firebase } from '..';
 
 /**
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
@@ -16,7 +16,7 @@ import { firebase } from '..';
  * @returns {FirebaseCrashlytics}
  */
 export function getCrashlytics() {
-  return firebase.crashlytics();
+  return getApp().crashlytics();
 }
 
 /**

--- a/packages/database/lib/modular/index.js
+++ b/packages/database/lib/modular/index.js
@@ -1,4 +1,4 @@
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import("..").FirebaseApp} FirebaseApp
@@ -12,10 +12,10 @@ import { firebase } from '..';
  */
 export function getDatabase(app, url) {
   if (app) {
-    return firebase.app(app.name).database(url);
+    return getApp(app.name).database(url);
   }
 
-  return firebase.app().database(url);
+  return getApp().database(url);
 }
 
 /**

--- a/packages/dynamic-links/lib/modular/index.js
+++ b/packages/dynamic-links/lib/modular/index.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import("..").FirebaseApp} FirebaseApp
@@ -32,7 +32,7 @@ export { ShortLinkType } from '..';
  * @returns {FirebaseDynamicLinks}
  */
 export function getDynamicLinks() {
-  return firebase.dynamicLinks();
+  return getApp().dynamicLinks();
 }
 
 /**

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -15,6 +15,7 @@ import {
   CheckV9DeprecationFunction,
 } from '../../app/lib/common/unitTestUtils';
 
+import { getApp } from '../../app/lib/modular';
 import firestore, {
   firebase,
   connectFirestoreEmulator,
@@ -895,10 +896,9 @@ describe('Firestore', function () {
 
       it('firestore.settings()', function () {
         const firestore = getFirestore();
-        const app = firebase.app();
         firestoreRefV9Deprecation(
           // no equivalent settings method for firebase-js-sdk
-          () => initializeFirestore(app, {}),
+          () => initializeFirestore(getApp(), {}),
           () => firestore.settings({}),
           'settings',
         );

--- a/packages/firestore/lib/modular/index.js
+++ b/packages/firestore/lib/modular/index.js
@@ -12,7 +12,7 @@
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
  */
 
-import { firebase } from '../index';
+import { getApp, setLogLevel as appSetLogLevel } from '@react-native-firebase/app';
 import { isObject } from '@react-native-firebase/app/lib/common';
 import {
   FirestoreAggregateQuerySnapshot,
@@ -31,16 +31,16 @@ import { MODULAR_DEPRECATION_ARG } from '../../../app/lib/common';
 export function getFirestore(app, databaseId) {
   if (app) {
     if (databaseId) {
-      return firebase.app(app.name).firestore(databaseId);
+      return getApp(app.name).firestore(databaseId);
     } else {
-      return firebase.app(app.name).firestore();
+      return getApp(app.name).firestore();
     }
   }
   if (databaseId) {
-    return firebase.app().firestore(databaseId);
+    return getApp().firestore(databaseId);
   }
 
-  return firebase.app().firestore();
+  return getApp().firestore();
 }
 
 /**
@@ -185,7 +185,8 @@ export function waitForPendingWrites(firestore) {
  */
 export async function initializeFirestore(app, settings /* databaseId */) {
   // TODO(exaby73): implement 2nd database once it's supported
-  const firestore = firebase.firestore(app);
+  const firebase = getApp(app.name);
+  const firestore = firebase.firestore();
   await firestore.settings.call(firestore, settings, MODULAR_DEPRECATION_ARG);
   return firestore;
 }
@@ -199,7 +200,7 @@ export function connectFirestoreEmulator(firestore, host, port, options) {
  * @returns {void}
  */
 export function setLogLevel(logLevel) {
-  return firebase.firestore.setLogLevel.call(null, logLevel, MODULAR_DEPRECATION_ARG);
+  return appSetLogLevel(logLevel);
 }
 
 /**

--- a/packages/functions/lib/modular/index.js
+++ b/packages/functions/lib/modular/index.js
@@ -21,7 +21,7 @@
  * @typedef {import("@firebase/app").FirebaseApp} FirebaseApp
  */
 
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * Returns a Functions instance for the given app.
@@ -31,10 +31,10 @@ import { firebase } from '..';
  */
 export function getFunctions(app, regionOrCustomDomain) {
   if (app) {
-    return firebase.app(app.name).functions(regionOrCustomDomain);
+    return getApp(app.name).functions(regionOrCustomDomain);
   }
 
-  return firebase.app().functions(regionOrCustomDomain);
+  return getApp().functions(regionOrCustomDomain);
 }
 
 /**
@@ -46,10 +46,7 @@ export function getFunctions(app, regionOrCustomDomain) {
  * @returns {void}
  */
 export function connectFunctionsEmulator(functionsInstance, host, port) {
-  return firebase
-    .app(functionsInstance.app.name)
-    .functions(functionsInstance._customUrlOrRegion)
-    .useEmulator(host, port);
+  return functionsInstance.useEmulator(host, port);
 }
 
 /**
@@ -60,10 +57,7 @@ export function connectFunctionsEmulator(functionsInstance, host, port) {
  * @returns {HttpsCallable}
  */
 export function httpsCallable(functionsInstance, name, options) {
-  return firebase
-    .app(functionsInstance.app.name)
-    .functions(functionsInstance._customUrlOrRegion)
-    .httpsCallable(name, options);
+  return functionsInstance.httpsCallable(name, options);
 }
 
 /**
@@ -74,8 +68,5 @@ export function httpsCallable(functionsInstance, name, options) {
  * @returns {HttpsCallable}
  */
 export function httpsCallableFromUrl(functionsInstance, url, options) {
-  return firebase
-    .app(functionsInstance.app.name)
-    .functions(functionsInstance._customUrlOrRegion)
-    .httpsCallableFromUrl(url, options);
+  return functionsInstance.httpsCallableFromUrl(url, options);
 }

--- a/packages/in-app-messaging/lib/modular/index.js
+++ b/packages/in-app-messaging/lib/modular/index.js
@@ -1,4 +1,4 @@
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import("..").FirebaseApp} FirebaseApp
@@ -9,7 +9,7 @@ import { firebase } from '..';
  * @returns {FirebaseInAppMessaging}
  */
 export function getInAppMessaging() {
-  return firebase.inAppMessaging();
+  return getApp().inAppMessaging();
 }
 
 /**

--- a/packages/installations/lib/modular/index.js
+++ b/packages/installations/lib/modular/index.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import('..').FirebaseInstallationsTypes.Module} FirebaseInstallation
@@ -23,9 +23,9 @@ import { firebase } from '..';
 
 export function getInstallations(app) {
   if (app) {
-    return firebase.app(app.name).installations();
+    return getApp(app.name).installations();
   }
-  return firebase.app().installations();
+  return getApp().installations();
 }
 
 /**
@@ -33,7 +33,7 @@ export function getInstallations(app) {
  * @returns {Promise<void>}
  */
 export function deleteInstallations(installations) {
-  return firebase.app(installations.app.name).installations().delete();
+  return installations.delete();
 }
 
 /**
@@ -41,7 +41,7 @@ export function deleteInstallations(installations) {
  * @returns {Promise<string>}
  */
 export function getId(installations) {
-  return firebase.app(installations.app.name).installations().getId();
+  return installations.getId();
 }
 
 /**
@@ -50,7 +50,7 @@ export function getId(installations) {
  * @returns {Promise<string>}
  */
 export function getToken(installations, forceRefresh) {
-  return firebase.app(installations.app.name).installations().getToken(forceRefresh);
+  return installations.getToken(forceRefresh);
 }
 
 /**
@@ -58,7 +58,6 @@ export function getToken(installations, forceRefresh) {
  * @param {(string) => void} callback
  * @returns {() => void}
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function onIdChange(installations, callback) {
+export function onIdChange(_installations, _callback) {
   throw new Error('onIdChange() is unsupported by the React Native Firebase SDK.');
 }

--- a/packages/messaging/lib/modular/index.js
+++ b/packages/messaging/lib/modular/index.js
@@ -1,4 +1,4 @@
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import('..').FirebaseMessagingTypes} FirebaseMessagingTypes
@@ -19,10 +19,10 @@ import { firebase } from '..';
  */
 export function getMessaging(app) {
   if (app) {
-    return firebase.app(app.name).messaging();
+    return getApp(app.name).messaging();
   }
 
-  return firebase.app().messaging();
+  return getApp().messaging();
 }
 
 /**

--- a/packages/ml/lib/modular/index.js
+++ b/packages/ml/lib/modular/index.js
@@ -1,4 +1,4 @@
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
@@ -11,7 +11,7 @@ import { firebase } from '..';
  */
 export function getML(app) {
   if (app) {
-    return firebase.ml(app);
+    return getApp(app).ml();
   }
-  return firebase.ml();
+  return getApp().ml();
 }

--- a/packages/perf/lib/modular/index.js
+++ b/packages/perf/lib/modular/index.js
@@ -24,7 +24,7 @@
  */
 
 import { isBoolean } from '@react-native-firebase/app/lib/common';
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * Returns a Performance instance for the given app.
@@ -33,10 +33,10 @@ import { firebase } from '..';
  */
 export function getPerformance(app) {
   if (app) {
-    return firebase.app(app.name).perf();
+    return getApp(app.name).perf();
   }
 
-  return firebase.app().perf();
+  return getApp().perf();
 }
 
 /**
@@ -46,7 +46,7 @@ export function getPerformance(app) {
  * @returns {Performance}
  */
 export async function initializePerformance(app, settings) {
-  const perf = firebase.app(app.name).perf();
+  const perf = getApp(app.name).perf();
 
   if (settings && isBoolean(settings.dataCollectionEnabled)) {
     await perf.setPerformanceCollectionEnabled(settings.dataCollectionEnabled);

--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -15,7 +15,7 @@
  *
  */
 
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
@@ -35,10 +35,10 @@ import { firebase } from '..';
  */
 export function getRemoteConfig(app) {
   if (app) {
-    return firebase.app(app.name).remoteConfig();
+    return getApp(app.name).remoteConfig();
   }
 
-  return firebase.app().remoteConfig();
+  return getApp().remoteConfig();
 }
 
 /**

--- a/packages/storage/lib/modular/index.js
+++ b/packages/storage/lib/modular/index.js
@@ -28,7 +28,7 @@
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
  */
 
-import { firebase } from '..';
+import { getApp } from '@react-native-firebase/app';
 
 /**
  * Returns a Storage instance for the given app.
@@ -39,17 +39,17 @@ import { firebase } from '..';
 export function getStorage(app, bucketUrl) {
   if (app) {
     if (bucketUrl != null) {
-      return firebase.app(app.name).storage(bucketUrl);
+      return getApp(app.name).storage(bucketUrl);
     }
 
-    return firebase.app(app.name).storage();
+    return getApp(app.name).storage();
   }
 
   if (bucketUrl != null) {
-    return firebase.app().storage(bucketUrl);
+    return getApp().storage(bucketUrl);
   }
 
-  return firebase.app().storage();
+  return getApp().storage();
 }
 
 /**


### PR DESCRIPTION
### Description

Use modular `getApp` (and app `setLogLevel` in firestore...) calls from the modular module code, otherwise they recursively trigger the deprecation warning, implying you can never quiet *all* deprecation warnings even with full migration to modular APIs

That's the whole change. These module inits are exercised everywhere since they are fundamental to modular method usage, so it is a fundamental change but also well-tested in CI

### Related issues

Comment on related migration issue:

- https://github.com/invertase/react-native-firebase/issues/8282#issuecomment-2645818363

### Release Summary

one conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I verified this style of init works in-situ in rnfbdemo while reproducing the error

I also examined the relevant e2e tests - the modular ones exercise this pretty well so if they work, then this new style of chaining should work as well

Finally, I'll take the patches from the patch-package patch generator workflow and integrate them into a local rnfbdemo ("clean") app running locally and make sure that the user issue is no longer reproduced but that the APIs do work in general

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
