### PR TITLE
fix(crashlytics): avoid deprecation warning during correct API usage

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,21 @@
 import * as ReactNative from 'react-native';
 import { jest } from '@jest/globals';
 
+// Avoid log pollution with emulator URL remap messages during testing
+// eslint-disable-next-line no-console
+const logOrig = console.log;
+const logWithRemapMessageRemoved = (message?: any, ...optionalParams: any[]): void => {
+  if (
+    // Make sure it is a string before attempting to filter it out
+    (typeof message !== 'string' && !(message instanceof String)) ||
+    !message.includes('android_bypass_emulator_url_remap')
+  ) {
+    logOrig(message, ...optionalParams);
+  }
+};
+// eslint-disable-next-line no-console
+console.log = logWithRemapMessageRemoved;
+
 jest.doMock('react-native', () => {
   // @ts-ignore - react-native empty bridge config so native modules at least default init
   global.__fbBatchedBridgeConfig = {};

--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, xit } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, xit } from '@jest/globals';
 
 import {
   firebase,
@@ -60,6 +60,16 @@ import {
 
 describe('Analytics', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.analytics).toBeDefined();

--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -102,591 +102,593 @@ describe('Analytics', function () {
         return Promise.resolve();
       }
     });
-  });
 
-  it('errors if milliseconds not a number', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setSessionTimeoutDuration('123')).toThrowError(
-      "'milliseconds' expected a number value",
-    );
-  });
-
-  it('throws if none string none null values', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setUserId(123)).toThrowError("'id' expected a string value");
-  });
-
-  it('throws if name is not a string', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setUserProperty(1337, 'invertase')).toThrowError(
-      "'name' expected a string value",
-    );
-  });
-
-  it('throws if value is invalid', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setUserProperty('invertase3', 33.3333)).toThrowError(
-      "'value' expected a string value",
-    );
-  });
-
-  it('throws if properties is not an object', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setUserProperties(1337)).toThrowError(
-      "'properties' expected an object of key/value pairs",
-    );
-  });
-
-  it('throws if property value is invalid', function () {
-    const props = {
-      test: '123',
-      foo: {
-        bar: 'baz',
-      },
-    };
-    // @ts-ignore test
-    expect(() => firebase.analytics().setUserProperties(props)).toThrowError(
-      "'properties' value for parameter 'foo' is invalid",
-    );
-  });
-
-  it('throws if value is a number', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setUserProperties({ invertase1: 123 })).toThrowError(
-      "'properties' value for parameter 'invertase1' is invalid, expected a string.",
-    );
-  });
-
-  it('throws if consentSettings is not an object', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setConsent(1337)).toThrowError(
-      'The supplied arg must be an object of key/values.',
-    );
-  });
-
-  it('throws if consentSettings is invalid', function () {
-    const consentSettings = {
-      ad_storage: true,
-      foo: {
-        bar: 'baz',
-      },
-    };
-    // @ts-ignore test
-    expect(() => firebase.analytics().setConsent(consentSettings)).toThrowError(
-      "'consentSettings' value for parameter 'foo' is invalid, expected a boolean.",
-    );
-  });
-
-  it('throws if one value of consentSettings is a number', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().setConsent({ ad_storage: 123 })).toThrowError(
-      "'consentSettings' value for parameter 'ad_storage' is invalid, expected a boolean.",
-    );
-  });
-
-  it('errors when no parameters are set', function () {
-    // @ts-ignore test
-    expect(() => firebase.analytics().logSearch()).toThrowError(
-      'The supplied arg must be an object of key/values',
-    );
-  });
-
-  describe('logEvent()', function () {
-    it('errors if name is not a string', function () {
+    it('errors if milliseconds not a number', function () {
       // @ts-ignore test
-      expect(() => firebase.analytics().logEvent(123)).toThrowError(
-        "firebase.analytics().logEvent(*) 'name' expected a string value.",
+      expect(() => firebase.analytics().setSessionTimeoutDuration('123')).toThrowError(
+        "'milliseconds' expected a number value",
       );
     });
 
-    it('errors if params is not an object', function () {
+    it('throws if none string none null values', function () {
       // @ts-ignore test
-      expect(() => firebase.analytics().logEvent('invertase_event', 'foobar')).toThrowError(
-        "firebase.analytics().logEvent(_, *) 'params' expected an object value.",
+      expect(() => firebase.analytics().setUserId(123)).toThrowError(
+        "'id' expected a string value",
       );
     });
 
-    it('errors on using a reserved name', function () {
-      expect(() => firebase.analytics().logEvent('session_start')).toThrowError(
-        "firebase.analytics().logEvent(*) 'name' the event name 'session_start' is reserved and can not be used.",
+    it('throws if name is not a string', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().setUserProperty(1337, 'invertase')).toThrowError(
+        "'name' expected a string value",
       );
     });
 
-    it('errors if name not alphanumeric', function () {
-      expect(() => firebase.analytics().logEvent('!@£$%^&*')).toThrowError(
-        "firebase.analytics().logEvent(*) 'name' invalid event name '!@£$%^&*'. Names should contain 1 to 40 alphanumeric characters or underscores.",
+    it('throws if value is invalid', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().setUserProperty('invertase3', 33.3333)).toThrowError(
+        "'value' expected a string value",
       );
     });
 
-    describe('logScreenView()', function () {
-      it('errors if param is not an object', function () {
+    it('throws if properties is not an object', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().setUserProperties(1337)).toThrowError(
+        "'properties' expected an object of key/value pairs",
+      );
+    });
+
+    it('throws if property value is invalid', function () {
+      const props = {
+        test: '123',
+        foo: {
+          bar: 'baz',
+        },
+      };
+      // @ts-ignore test
+      expect(() => firebase.analytics().setUserProperties(props)).toThrowError(
+        "'properties' value for parameter 'foo' is invalid",
+      );
+    });
+
+    it('throws if value is a number', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().setUserProperties({ invertase1: 123 })).toThrowError(
+        "'properties' value for parameter 'invertase1' is invalid, expected a string.",
+      );
+    });
+
+    it('throws if consentSettings is not an object', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().setConsent(1337)).toThrowError(
+        'The supplied arg must be an object of key/values.',
+      );
+    });
+
+    it('throws if consentSettings is invalid', function () {
+      const consentSettings = {
+        ad_storage: true,
+        foo: {
+          bar: 'baz',
+        },
+      };
+      // @ts-ignore test
+      expect(() => firebase.analytics().setConsent(consentSettings)).toThrowError(
+        "'consentSettings' value for parameter 'foo' is invalid, expected a boolean.",
+      );
+    });
+
+    it('throws if one value of consentSettings is a number', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().setConsent({ ad_storage: 123 })).toThrowError(
+        "'consentSettings' value for parameter 'ad_storage' is invalid, expected a boolean.",
+      );
+    });
+
+    it('errors when no parameters are set', function () {
+      // @ts-ignore test
+      expect(() => firebase.analytics().logSearch()).toThrowError(
+        'The supplied arg must be an object of key/values',
+      );
+    });
+
+    describe('logEvent()', function () {
+      it('errors if name is not a string', function () {
         // @ts-ignore test
-        expect(() => firebase.analytics().logScreenView(123)).toThrowError(
-          'firebase.analytics().logScreenView(*):',
+        expect(() => firebase.analytics().logEvent(123)).toThrowError(
+          "firebase.analytics().logEvent(*) 'name' expected a string value.",
         );
       });
 
-      it('accepts arbitrary custom event parameters while rejecting defined parameters with wrong types', function () {
-        expect(() => firebase.analytics().logScreenView({ foo: 'bar' })).not.toThrow();
-        expect(() =>
+      it('errors if params is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logEvent('invertase_event', 'foobar')).toThrowError(
+          "firebase.analytics().logEvent(_, *) 'params' expected an object value.",
+        );
+      });
+
+      it('errors on using a reserved name', function () {
+        expect(() => firebase.analytics().logEvent('session_start')).toThrowError(
+          "firebase.analytics().logEvent(*) 'name' the event name 'session_start' is reserved and can not be used.",
+        );
+      });
+
+      it('errors if name not alphanumeric', function () {
+        expect(() => firebase.analytics().logEvent('!@£$%^&*')).toThrowError(
+          "firebase.analytics().logEvent(*) 'name' invalid event name '!@£$%^&*'. Names should contain 1 to 40 alphanumeric characters or underscores.",
+        );
+      });
+
+      describe('logScreenView()', function () {
+        it('errors if param is not an object', function () {
           // @ts-ignore test
-          firebase.analytics().logScreenView({ screen_name: 123, foo: 'bar' }),
-        ).toThrowError('firebase.analytics().logScreenView(*):');
+          expect(() => firebase.analytics().logScreenView(123)).toThrowError(
+            'firebase.analytics().logScreenView(*):',
+          );
+        });
+
+        it('accepts arbitrary custom event parameters while rejecting defined parameters with wrong types', function () {
+          expect(() => firebase.analytics().logScreenView({ foo: 'bar' })).not.toThrow();
+          expect(() =>
+            // @ts-ignore test
+            firebase.analytics().logScreenView({ screen_name: 123, foo: 'bar' }),
+          ).toThrowError('firebase.analytics().logScreenView(*):');
+        });
+      });
+
+      describe('logAddPaymentInfo()', function () {
+        it('errors if param is not an object', function () {
+          // @ts-ignore test
+          expect(() => firebase.analytics().logAddPaymentInfo(123)).toThrowError(
+            'firebase.analytics().logAddPaymentInfo(*):',
+          );
+        });
+
+        it('errors when compound values are not set', function () {
+          expect(() =>
+            firebase.analytics().logAddPaymentInfo({
+              value: 123,
+            }),
+          ).toThrowError('firebase.analytics().logAddPaymentInfo(*):');
+        });
       });
     });
 
-    describe('logAddPaymentInfo()', function () {
+    describe('setDefaultEventParameters()', function () {
+      it('errors if params is not a object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().setDefaultEventParameters('123')).toThrowError(
+          "firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value when it is defined.",
+        );
+      });
+    });
+
+    describe('logAddToCart()', function () {
       it('errors if param is not an object', function () {
         // @ts-ignore test
-        expect(() => firebase.analytics().logAddPaymentInfo(123)).toThrowError(
-          'firebase.analytics().logAddPaymentInfo(*):',
+        expect(() => firebase.analytics().logAddToCart(123)).toThrowError(
+          'firebase.analytics().logAddToCart(*):',
         );
       });
 
       it('errors when compound values are not set', function () {
         expect(() =>
-          firebase.analytics().logAddPaymentInfo({
+          firebase.analytics().logAddToCart({
             value: 123,
           }),
-        ).toThrowError('firebase.analytics().logAddPaymentInfo(*):');
+        ).toThrowError('firebase.analytics().logAddToCart(*):');
       });
     });
-  });
 
-  describe('setDefaultEventParameters()', function () {
-    it('errors if params is not a object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().setDefaultEventParameters('123')).toThrowError(
-        "firebase.analytics().setDefaultEventParameters(*) 'params' expected an object value when it is defined.",
-      );
-    });
-  });
+    describe('logAddShippingInfo()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logAddShippingInfo(123)).toThrowError(
+          'firebase.analytics().logAddShippingInfo(*):',
+        );
+      });
 
-  describe('logAddToCart()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logAddToCart(123)).toThrowError(
-        'firebase.analytics().logAddToCart(*):',
-      );
-    });
-
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logAddToCart({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logAddToCart(*):');
-    });
-  });
-
-  describe('logAddShippingInfo()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logAddShippingInfo(123)).toThrowError(
-        'firebase.analytics().logAddShippingInfo(*):',
-      );
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logAddShippingInfo({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logAddShippingInfo(*):');
+      });
     });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logAddShippingInfo({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logAddShippingInfo(*):');
-    });
-  });
+    describe('logAddToWishlist()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logAddToWishlist(123)).toThrowError(
+          'firebase.analytics().logAddToWishlist(*):',
+        );
+      });
 
-  describe('logAddToWishlist()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logAddToWishlist(123)).toThrowError(
-        'firebase.analytics().logAddToWishlist(*):',
-      );
-    });
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logAddToWishlist({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logAddToWishlist(*):');
+      });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logAddToWishlist({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logAddToWishlist(*):');
+      it('items accept arbitrary custom event parameters', function () {
+        expect(() =>
+          firebase.analytics().logAddToWishlist({ items: [{ foo: 'bar' }] }),
+        ).not.toThrow();
+      });
     });
 
-    it('items accept arbitrary custom event parameters', function () {
-      expect(() =>
-        firebase.analytics().logAddToWishlist({ items: [{ foo: 'bar' }] }),
-      ).not.toThrow();
-    });
-  });
+    describe('logBeginCheckout()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logBeginCheckout(123)).toThrowError(
+          'firebase.analytics().logBeginCheckout(*):',
+        );
+      });
 
-  describe('logBeginCheckout()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logBeginCheckout(123)).toThrowError(
-        'firebase.analytics().logBeginCheckout(*):',
-      );
-    });
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logBeginCheckout({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logBeginCheckout(*):');
+      });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logBeginCheckout({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logBeginCheckout(*):');
-    });
-
-    it('accepts arbitrary custom event parameters', function () {
-      expect(() =>
-        firebase.analytics().logBeginCheckout({
-          value: 123,
-          currency: 'EUR',
-          foo: 'bar',
-        }),
-      ).not.toThrow();
-    });
-  });
-
-  describe('logGenerateLead()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logGenerateLead(123)).toThrowError(
-        'firebase.analytics().logGenerateLead(*):',
-      );
+      it('accepts arbitrary custom event parameters', function () {
+        expect(() =>
+          firebase.analytics().logBeginCheckout({
+            value: 123,
+            currency: 'EUR',
+            foo: 'bar',
+          }),
+        ).not.toThrow();
+      });
     });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logGenerateLead({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logGenerateLead(*):');
-    });
-  });
+    describe('logGenerateLead()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logGenerateLead(123)).toThrowError(
+          'firebase.analytics().logGenerateLead(*):',
+        );
+      });
 
-  describe('logCampaignDetails()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logCampaignDetails(123)).toThrowError(
-        'firebase.analytics().logCampaignDetails(*):',
-      );
-    });
-  });
-
-  describe('logEarnVirtualCurrency()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logEarnVirtualCurrency(123)).toThrowError(
-        'firebase.analytics().logEarnVirtualCurrency(*):',
-      );
-    });
-  });
-
-  describe('logJoinGroup()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logJoinGroup(123)).toThrowError(
-        'firebase.analytics().logJoinGroup(*):',
-      );
-    });
-  });
-
-  describe('logLevelEnd()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logLevelEnd(123)).toThrowError(
-        'firebase.analytics().logLevelEnd(*):',
-      );
-    });
-  });
-
-  describe('logLevelStart()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logLevelStart(123)).toThrowError(
-        'firebase.analytics().logLevelStart(*):',
-      );
-    });
-  });
-
-  describe('logLevelUp()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logLevelUp(123)).toThrowError(
-        'firebase.analytics().logLevelUp(*):',
-      );
-    });
-  });
-
-  describe('logLogin()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logLogin(123)).toThrowError(
-        'firebase.analytics().logLogin(*):',
-      );
-    });
-  });
-
-  describe('logPostScore()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logPostScore(123)).toThrowError(
-        'firebase.analytics().logPostScore(*):',
-      );
-    });
-  });
-
-  describe('logSelectContent()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logSelectContent(123)).toThrowError(
-        'firebase.analytics().logSelectContent(*):',
-      );
-    });
-  });
-
-  describe('logSearch()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logSearch(123)).toThrowError(
-        'firebase.analytics().logSearch(*):',
-      );
-    });
-  });
-
-  describe('logSelectItem()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logSelectItem(123)).toThrowError(
-        'firebase.analytics().logSelectItem(*):',
-      );
-    });
-  });
-
-  describe('logSetCheckoutOption()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logSetCheckoutOption(123)).toThrowError(
-        'firebase.analytics().logSetCheckoutOption(*):',
-      );
-    });
-  });
-
-  describe('logShare()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logShare(123)).toThrowError(
-        'firebase.analytics().logShare(*):',
-      );
-    });
-  });
-
-  describe('logSignUp()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logSignUp(123)).toThrowError(
-        'firebase.analytics().logSignUp(*):',
-      );
-    });
-  });
-
-  describe('logSelectPromotion()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logSelectPromotion(123)).toThrowError(
-        'firebase.analytics().logSelectPromotion(*):',
-      );
-    });
-  });
-
-  describe('logSpendVirtualCurrency()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logSpendVirtualCurrency(123)).toThrowError(
-        'firebase.analytics().logSpendVirtualCurrency(*):',
-      );
-    });
-  });
-
-  describe('logUnlockAchievement()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logUnlockAchievement(123)).toThrowError(
-        'firebase.analytics().logUnlockAchievement(*):',
-      );
-    });
-  });
-
-  describe('logPurchase()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logPurchase(123)).toThrowError(
-        'firebase.analytics().logPurchase(*):',
-      );
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logGenerateLead({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logGenerateLead(*):');
+      });
     });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logPurchase({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logPurchase(*):');
+    describe('logCampaignDetails()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logCampaignDetails(123)).toThrowError(
+          'firebase.analytics().logCampaignDetails(*):',
+        );
+      });
     });
 
-    it('accepts arbitrary custom event parameters', function () {
-      expect(() =>
-        firebase.analytics().logPurchase({
-          value: 123,
-          currency: 'EUR',
-          foo: 'bar',
-        }),
-      ).not.toThrow();
-    });
-  });
-
-  describe('logRefund()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logRefund(123)).toThrowError(
-        'firebase.analytics().logRefund(*):',
-      );
+    describe('logEarnVirtualCurrency()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logEarnVirtualCurrency(123)).toThrowError(
+          'firebase.analytics().logEarnVirtualCurrency(*):',
+        );
+      });
     });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logRefund({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logRefund(*):');
-    });
-  });
-
-  describe('logViewCart()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logViewCart(123)).toThrowError(
-        'firebase.analytics().logViewCart(*):',
-      );
+    describe('logJoinGroup()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logJoinGroup(123)).toThrowError(
+          'firebase.analytics().logJoinGroup(*):',
+        );
+      });
     });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logViewCart({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logViewCart(*):');
-    });
-  });
-
-  describe('logViewItem()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logViewItem(123)).toThrowError(
-        'firebase.analytics().logViewItem(*):',
-      );
+    describe('logLevelEnd()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logLevelEnd(123)).toThrowError(
+          'firebase.analytics().logLevelEnd(*):',
+        );
+      });
     });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logViewItem({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logViewItem(*):');
-    });
-  });
-
-  describe('logViewItemList()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logViewItemList(123)).toThrowError(
-        'firebase.analytics().logViewItemList(*):',
-      );
-    });
-  });
-
-  describe('logRemoveFromCart()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logRemoveFromCart(123)).toThrowError(
-        'firebase.analytics().logRemoveFromCart(*):',
-      );
+    describe('logLevelStart()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logLevelStart(123)).toThrowError(
+          'firebase.analytics().logLevelStart(*):',
+        );
+      });
     });
 
-    it('errors when compound values are not set', function () {
-      expect(() =>
-        firebase.analytics().logRemoveFromCart({
-          value: 123,
-        }),
-      ).toThrowError('firebase.analytics().logRemoveFromCart(*):');
+    describe('logLevelUp()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logLevelUp(123)).toThrowError(
+          'firebase.analytics().logLevelUp(*):',
+        );
+      });
     });
-  });
 
-  describe('logViewPromotion()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logViewPromotion(123)).toThrowError(
-        'firebase.analytics().logViewPromotion(*):',
-      );
+    describe('logLogin()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logLogin(123)).toThrowError(
+          'firebase.analytics().logLogin(*):',
+        );
+      });
     });
-  });
 
-  describe('logViewSearchResults()', function () {
-    it('errors if param is not an object', function () {
-      // @ts-ignore test
-      expect(() => firebase.analytics().logViewSearchResults(123)).toThrowError(
-        'firebase.analytics().logViewSearchResults(*):',
-      );
+    describe('logPostScore()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logPostScore(123)).toThrowError(
+          'firebase.analytics().logPostScore(*):',
+        );
+      });
     });
-  });
 
-  describe('setAnalyticsCollectionEnabled()', function () {
-    it('throws if not a boolean', function () {
-      // @ts-ignore
-      expect(() => firebase.analytics().setAnalyticsCollectionEnabled('foo')).toThrowError(
-        "firebase.analytics().setAnalyticsCollectionEnabled(*) 'enabled' expected a boolean value.",
-      );
+    describe('logSelectContent()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logSelectContent(123)).toThrowError(
+          'firebase.analytics().logSelectContent(*):',
+        );
+      });
     });
-  });
 
-  describe('initiateOnDeviceConversionMeasurementWithEmailAddress()', function () {
-    it('throws if not a string', function () {
-      expect(() =>
+    describe('logSearch()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logSearch(123)).toThrowError(
+          'firebase.analytics().logSearch(*):',
+        );
+      });
+    });
+
+    describe('logSelectItem()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logSelectItem(123)).toThrowError(
+          'firebase.analytics().logSelectItem(*):',
+        );
+      });
+    });
+
+    describe('logSetCheckoutOption()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logSetCheckoutOption(123)).toThrowError(
+          'firebase.analytics().logSetCheckoutOption(*):',
+        );
+      });
+    });
+
+    describe('logShare()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logShare(123)).toThrowError(
+          'firebase.analytics().logShare(*):',
+        );
+      });
+    });
+
+    describe('logSignUp()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logSignUp(123)).toThrowError(
+          'firebase.analytics().logSignUp(*):',
+        );
+      });
+    });
+
+    describe('logSelectPromotion()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logSelectPromotion(123)).toThrowError(
+          'firebase.analytics().logSelectPromotion(*):',
+        );
+      });
+    });
+
+    describe('logSpendVirtualCurrency()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logSpendVirtualCurrency(123)).toThrowError(
+          'firebase.analytics().logSpendVirtualCurrency(*):',
+        );
+      });
+    });
+
+    describe('logUnlockAchievement()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logUnlockAchievement(123)).toThrowError(
+          'firebase.analytics().logUnlockAchievement(*):',
+        );
+      });
+    });
+
+    describe('logPurchase()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logPurchase(123)).toThrowError(
+          'firebase.analytics().logPurchase(*):',
+        );
+      });
+
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logPurchase({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logPurchase(*):');
+      });
+
+      it('accepts arbitrary custom event parameters', function () {
+        expect(() =>
+          firebase.analytics().logPurchase({
+            value: 123,
+            currency: 'EUR',
+            foo: 'bar',
+          }),
+        ).not.toThrow();
+      });
+    });
+
+    describe('logRefund()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logRefund(123)).toThrowError(
+          'firebase.analytics().logRefund(*):',
+        );
+      });
+
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logRefund({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logRefund(*):');
+      });
+    });
+
+    describe('logViewCart()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logViewCart(123)).toThrowError(
+          'firebase.analytics().logViewCart(*):',
+        );
+      });
+
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logViewCart({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logViewCart(*):');
+      });
+    });
+
+    describe('logViewItem()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logViewItem(123)).toThrowError(
+          'firebase.analytics().logViewItem(*):',
+        );
+      });
+
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logViewItem({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logViewItem(*):');
+      });
+    });
+
+    describe('logViewItemList()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logViewItemList(123)).toThrowError(
+          'firebase.analytics().logViewItemList(*):',
+        );
+      });
+    });
+
+    describe('logRemoveFromCart()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logRemoveFromCart(123)).toThrowError(
+          'firebase.analytics().logRemoveFromCart(*):',
+        );
+      });
+
+      it('errors when compound values are not set', function () {
+        expect(() =>
+          firebase.analytics().logRemoveFromCart({
+            value: 123,
+          }),
+        ).toThrowError('firebase.analytics().logRemoveFromCart(*):');
+      });
+    });
+
+    describe('logViewPromotion()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logViewPromotion(123)).toThrowError(
+          'firebase.analytics().logViewPromotion(*):',
+        );
+      });
+    });
+
+    describe('logViewSearchResults()', function () {
+      it('errors if param is not an object', function () {
+        // @ts-ignore test
+        expect(() => firebase.analytics().logViewSearchResults(123)).toThrowError(
+          'firebase.analytics().logViewSearchResults(*):',
+        );
+      });
+    });
+
+    describe('setAnalyticsCollectionEnabled()', function () {
+      it('throws if not a boolean', function () {
         // @ts-ignore
-        firebase.analytics().initiateOnDeviceConversionMeasurementWithEmailAddress(true),
-      ).toThrowError(
-        "firebase.analytics().initiateOnDeviceConversionMeasurementWithEmailAddress(*) 'emailAddress' expected a string value.",
-      );
-    });
-  });
-
-  describe('initiateOnDeviceConversionMeasurementWithHashedEmailAddress()', function () {
-    it('throws if not a string', function () {
-      expect(() =>
-        // @ts-ignore
-        firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedEmailAddress(true),
-      ).toThrowError(
-        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedEmailAddress(*) 'hashedEmailAddress' expected a string value.",
-      );
-    });
-  });
-
-  describe('initiateOnDeviceConversionMeasurementWithHashedPhoneNumber()', function () {
-    it('throws if not a string', function () {
-      expect(() =>
-        // @ts-ignore
-        firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(1234),
-      ).toThrowError(
-        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a string value.",
-      );
+        expect(() => firebase.analytics().setAnalyticsCollectionEnabled('foo')).toThrowError(
+          "firebase.analytics().setAnalyticsCollectionEnabled(*) 'enabled' expected a boolean value.",
+        );
+      });
     });
 
-    it('throws if hashed value is a phone number in E.164 format', function () {
-      expect(() =>
-        firebase
-          .analytics()
-          .initiateOnDeviceConversionMeasurementWithHashedPhoneNumber('+1234567890'),
-      ).toThrowError(
-        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a sha256-hashed value of a phone number in E.164 format.",
-      );
+    describe('initiateOnDeviceConversionMeasurementWithEmailAddress()', function () {
+      it('throws if not a string', function () {
+        expect(() =>
+          // @ts-ignore
+          firebase.analytics().initiateOnDeviceConversionMeasurementWithEmailAddress(true),
+        ).toThrowError(
+          "firebase.analytics().initiateOnDeviceConversionMeasurementWithEmailAddress(*) 'emailAddress' expected a string value.",
+        );
+      });
+    });
+
+    describe('initiateOnDeviceConversionMeasurementWithHashedEmailAddress()', function () {
+      it('throws if not a string', function () {
+        expect(() =>
+          // @ts-ignore
+          firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedEmailAddress(true),
+        ).toThrowError(
+          "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedEmailAddress(*) 'hashedEmailAddress' expected a string value.",
+        );
+      });
+    });
+
+    describe('initiateOnDeviceConversionMeasurementWithHashedPhoneNumber()', function () {
+      it('throws if not a string', function () {
+        expect(() =>
+          // @ts-ignore
+          firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(1234),
+        ).toThrowError(
+          "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a string value.",
+        );
+      });
+
+      it('throws if hashed value is a phone number in E.164 format', function () {
+        expect(() =>
+          firebase
+            .analytics()
+            .initiateOnDeviceConversionMeasurementWithHashedPhoneNumber('+1234567890'),
+        ).toThrowError(
+          "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a sha256-hashed value of a phone number in E.164 format.",
+        );
+      });
     });
   });
 

--- a/packages/app-check/__tests__/appcheck.test.ts
+++ b/packages/app-check/__tests__/appcheck.test.ts
@@ -34,11 +34,11 @@ describe('appCheck()', function () {
         'secondaryFromNative',
       );
     });
-  });
 
-  describe('react-native-firebase provider', function () {
-    it('correctly creates a provider instance', function () {
-      expect(firebase.appCheck().newReactNativeFirebaseAppCheckProvider()).toBeDefined();
+    describe('react-native-firebase provider', function () {
+      it('correctly creates a provider instance', function () {
+        expect(firebase.appCheck().newReactNativeFirebaseAppCheckProvider()).toBeDefined();
+      });
     });
   });
 

--- a/packages/app-check/__tests__/appcheck.test.ts
+++ b/packages/app-check/__tests__/appcheck.test.ts
@@ -7,6 +7,11 @@ import {
   CheckV9DeprecationFunction,
 } from '../../app/lib/common/unitTestUtils';
 
+// @ts-ignore
+import { MODULAR_DEPRECATION_ARG } from '../../app/lib/common';
+
+import { getApp } from '../../app/lib';
+
 import {
   firebase,
   initializeAppCheck,
@@ -102,11 +107,10 @@ describe('appCheck()', function () {
 
     describe('AppCheck', function () {
       it('appCheck.activate()', function () {
-        const app = firebase.app();
-        const appCheck = firebase.appCheck();
+        const appCheck = firebase.appCheck.call(null, getApp(), MODULAR_DEPRECATION_ARG);
         appCheckRefV9Deprecation(
           () =>
-            initializeAppCheck(app, {
+            initializeAppCheck(getApp(), {
               provider: {
                 providerOptions: {
                   android: {
@@ -122,7 +126,7 @@ describe('appCheck()', function () {
       });
 
       it('appCheck.setTokenAutoRefreshEnabled()', function () {
-        const appCheck = firebase.appCheck();
+        const appCheck = firebase.appCheck.call(null, getApp(), MODULAR_DEPRECATION_ARG);
         appCheckRefV9Deprecation(
           () => setTokenAutoRefreshEnabled(appCheck, true),
           () => appCheck.setTokenAutoRefreshEnabled(true),
@@ -131,7 +135,7 @@ describe('appCheck()', function () {
       });
 
       it('appCheck.getToken()', function () {
-        const appCheck = firebase.appCheck();
+        const appCheck = firebase.appCheck.call(null, getApp(), MODULAR_DEPRECATION_ARG);
         appCheckRefV9Deprecation(
           () => getToken(appCheck, true),
           () => appCheck.getToken(true),
@@ -140,7 +144,7 @@ describe('appCheck()', function () {
       });
 
       it('appCheck.getLimitedUseToken()', function () {
-        const appCheck = firebase.appCheck();
+        const appCheck = firebase.appCheck.call(null, getApp(), MODULAR_DEPRECATION_ARG);
         appCheckRefV9Deprecation(
           () => getLimitedUseToken(appCheck),
           () => appCheck.getLimitedUseToken(),
@@ -149,7 +153,7 @@ describe('appCheck()', function () {
       });
 
       it('appCheck.onTokenChanged()', function () {
-        const appCheck = firebase.appCheck();
+        const appCheck = firebase.appCheck.call(null, getApp(), MODULAR_DEPRECATION_ARG);
         appCheckRefV9Deprecation(
           () =>
             onTokenChanged(
@@ -169,7 +173,11 @@ describe('appCheck()', function () {
       });
 
       it('CustomProvider', function () {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
         const appCheck = firebase.appCheck;
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
         staticsRefV9Deprecation(
           () => CustomProvider,
           () => appCheck.CustomProvider,

--- a/packages/app-check/__tests__/appcheck.test.ts
+++ b/packages/app-check/__tests__/appcheck.test.ts
@@ -1,4 +1,4 @@
-import { jest, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 // @ts-ignore test
 import FirebaseModule from '../../app/lib/internal/FirebaseModule';
 
@@ -19,6 +19,16 @@ import {
 
 describe('appCheck()', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.appCheck).toBeDefined();

--- a/packages/app-distribution/__tests__/app-distribution.test.ts
+++ b/packages/app-distribution/__tests__/app-distribution.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import {
   firebase,
@@ -11,6 +11,16 @@ import {
 
 describe('appDistribution()', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.appDistribution).toBeDefined();

--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import auth, {
   firebase,
@@ -63,6 +63,16 @@ import { NativeFirebaseError } from '../../app/lib/internal';
 
 describe('Auth', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.auth).toBeDefined();

--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -68,110 +68,112 @@ describe('Auth', function () {
       expect(app.auth).toBeDefined();
       expect(app.auth().useEmulator).toBeDefined();
     });
-  });
 
-  describe('useEmulator()', function () {
-    it('useEmulator requires a string url', function () {
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => auth().useEmulator()).toThrow(
-        'firebase.auth().useEmulator() takes a non-empty string',
-      );
-      expect(() => auth().useEmulator('')).toThrow(
-        'firebase.auth().useEmulator() takes a non-empty string',
-      );
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => auth().useEmulator(123)).toThrow(
-        'firebase.auth().useEmulator() takes a non-empty string',
-      );
-    });
+    describe('useEmulator()', function () {
+      it('useEmulator requires a string url', function () {
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => auth().useEmulator()).toThrow(
+          'firebase.auth().useEmulator() takes a non-empty string',
+        );
+        expect(() => auth().useEmulator('')).toThrow(
+          'firebase.auth().useEmulator() takes a non-empty string',
+        );
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => auth().useEmulator(123)).toThrow(
+          'firebase.auth().useEmulator() takes a non-empty string',
+        );
+      });
 
-    it('useEmulator requires a well-formed url', function () {
-      // No http://
-      expect(() => auth().useEmulator('localhost:9099')).toThrow(
-        'firebase.auth().useEmulator() takes a non-empty string URL',
-      );
-      // No port
-      expect(() => auth().useEmulator('http://localhost')).toThrow(
-        'firebase.auth().useEmulator() unable to parse host and port from URL',
-      );
-    });
+      it('useEmulator requires a well-formed url', function () {
+        // No http://
+        expect(() => auth().useEmulator('localhost:9099')).toThrow(
+          'firebase.auth().useEmulator() takes a non-empty string URL',
+        );
+        // No port
+        expect(() => auth().useEmulator('http://localhost')).toThrow(
+          'firebase.auth().useEmulator() unable to parse host and port from URL',
+        );
+      });
 
-    it('useEmulator -> remaps Android loopback to host', function () {
-      const foo = auth().useEmulator('http://localhost:9099');
-      expect(foo).toEqual(['10.0.2.2', 9099]);
+      it('useEmulator -> remaps Android loopback to host', function () {
+        const foo = auth().useEmulator('http://localhost:9099');
+        expect(foo).toEqual(['10.0.2.2', 9099]);
 
-      const bar = auth().useEmulator('http://127.0.0.1:9099');
-      expect(bar).toEqual(['10.0.2.2', 9099]);
-    });
+        const bar = auth().useEmulator('http://127.0.0.1:9099');
+        expect(bar).toEqual(['10.0.2.2', 9099]);
+      });
 
-    it('useEmulator allows hyphens in the hostname', function () {
-      const result = auth().useEmulator('http://my-host:9099');
-      expect(result).toEqual(['my-host', 9099]);
-    });
-  });
-
-  describe('tenantId', function () {
-    it('should be able to set tenantId ', function () {
-      const auth = firebase.app().auth();
-      auth.setTenantId('test-id').then(() => {
-        expect(auth.tenantId).toBe('test-id');
+      it('useEmulator allows hyphens in the hostname', function () {
+        const result = auth().useEmulator('http://my-host:9099');
+        expect(result).toEqual(['my-host', 9099]);
       });
     });
 
-    it('should throw error when tenantId is a non string object ', async function () {
-      try {
-        await firebase.app().auth().setTenantId(Object());
-        return Promise.reject('It should throw an error');
-      } catch (e: any) {
-        expect(e.message).toBe("firebase.auth().setTenantId(*) expected 'tenantId' to be a string");
-        return Promise.resolve('Error catched');
-      }
-    });
-  });
+    describe('tenantId', function () {
+      it('should be able to set tenantId ', function () {
+        const auth = firebase.app().auth();
+        auth.setTenantId('test-id').then(() => {
+          expect(auth.tenantId).toBe('test-id');
+        });
+      });
 
-  describe('getMultiFactorResolver', function () {
-    it('should return null if no resolver object is found', function () {
-      const unknownError = NativeFirebaseError.fromEvent(
-        {
-          code: 'unknown',
-        },
-        'auth',
-      );
-      const actual = auth.getMultiFactorResolver(auth(), unknownError);
-      expect(actual).toBe(null);
+      it('should throw error when tenantId is a non string object ', async function () {
+        try {
+          await firebase.app().auth().setTenantId(Object());
+          return Promise.reject('It should throw an error');
+        } catch (e: any) {
+          expect(e.message).toBe(
+            "firebase.auth().setTenantId(*) expected 'tenantId' to be a string",
+          );
+          return Promise.resolve('Error catched');
+        }
+      });
     });
 
-    it('should return null if resolver object is null', function () {
-      const unknownError = NativeFirebaseError.fromEvent(
-        {
-          code: 'unknown',
-          resolver: null,
-        },
-        'auth',
-      );
-      const actual = auth.getMultiFactorResolver(firebase.app().auth(), unknownError);
-      expect(actual).toBe(null);
-    });
+    describe('getMultiFactorResolver', function () {
+      it('should return null if no resolver object is found', function () {
+        const unknownError = NativeFirebaseError.fromEvent(
+          {
+            code: 'unknown',
+          },
+          'auth',
+        );
+        const actual = auth.getMultiFactorResolver(auth(), unknownError);
+        expect(actual).toBe(null);
+      });
 
-    it('should return the resolver object if its found', function () {
-      const resolver = { session: '', hints: [] };
-      const errorWithResolver = NativeFirebaseError.fromEvent(
-        {
-          code: 'multi-factor-auth-required',
-          resolver,
-        },
-        'auth',
-      );
-      const actual = auth.getMultiFactorResolver(firebase.app().auth(), errorWithResolver);
-      // Using expect(actual).toEqual(resolver) causes unexpected errors:
-      //  You attempted to use "firebase.app('[DEFAULT]').appCheck" but this module could not be found.
-      expect(actual).not.toBeNull();
-      // @ts-ignore We know actual is not null
-      expect(actual.session).toEqual(resolver.session);
-      // @ts-ignore We know actual is not null
-      expect(actual.hints).toEqual(resolver.hints);
-      // @ts-ignore We know actual is not null
-      expect(actual._auth).not.toBeNull();
+      it('should return null if resolver object is null', function () {
+        const unknownError = NativeFirebaseError.fromEvent(
+          {
+            code: 'unknown',
+            resolver: null,
+          },
+          'auth',
+        );
+        const actual = auth.getMultiFactorResolver(firebase.app().auth(), unknownError);
+        expect(actual).toBe(null);
+      });
+
+      it('should return the resolver object if its found', function () {
+        const resolver = { session: '', hints: [] };
+        const errorWithResolver = NativeFirebaseError.fromEvent(
+          {
+            code: 'multi-factor-auth-required',
+            resolver,
+          },
+          'auth',
+        );
+        const actual = auth.getMultiFactorResolver(firebase.app().auth(), errorWithResolver);
+        // Using expect(actual).toEqual(resolver) causes unexpected errors:
+        //  You attempted to use "firebase.app('[DEFAULT]').appCheck" but this module could not be found.
+        expect(actual).not.toBeNull();
+        // @ts-ignore We know actual is not null
+        expect(actual.session).toEqual(resolver.session);
+        // @ts-ignore We know actual is not null
+        expect(actual.hints).toEqual(resolver.hints);
+        // @ts-ignore We know actual is not null
+        expect(actual._auth).not.toBeNull();
+      });
     });
   });
 

--- a/packages/crashlytics/__tests__/crashlytics.test.ts
+++ b/packages/crashlytics/__tests__/crashlytics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it, jest, beforeEach } from '@jest/globals';
 // @ts-ignore test
 import FirebaseModule from '../../app/lib/internal/FirebaseModule';
 import {
@@ -24,6 +24,16 @@ import {
 
 describe('Crashlytics', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.crashlytics).toBeDefined();

--- a/packages/crashlytics/lib/index.js
+++ b/packages/crashlytics/lib/index.js
@@ -16,12 +16,14 @@
  *
  */
 
+import { getApp } from '@react-native-firebase/app';
 import {
   isBoolean,
   isError,
   isObject,
   isString,
   isOther,
+  MODULAR_DEPRECATION_ARG,
 } from '@react-native-firebase/app/lib/common';
 import {
   createModuleNamespace,
@@ -171,5 +173,5 @@ export const firebase = getFirebaseRoot();
 
 // This will throw with 'Default App Not initialized' if the default app is not configured.
 if (!isOther) {
-  firebase.crashlytics();
+  firebase.crashlytics.call(null, getApp(), MODULAR_DEPRECATION_ARG);
 }

--- a/packages/database/__tests__/database.test.ts
+++ b/packages/database/__tests__/database.test.ts
@@ -53,40 +53,40 @@ describe('Database', function () {
       expect(app.database).toBeDefined();
       expect(app.database().useEmulator).toBeDefined();
     });
-  });
 
-  describe('useEmulator()', function () {
-    it('useEmulator requires a string host', function () {
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => database().useEmulator()).toThrow(
-        'firebase.database().useEmulator() takes a non-empty host',
-      );
-      expect(() => database().useEmulator('', -1)).toThrow(
-        'firebase.database().useEmulator() takes a non-empty host',
-      );
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => database().useEmulator(123)).toThrow(
-        'firebase.database().useEmulator() takes a non-empty host',
-      );
-    });
+    describe('useEmulator()', function () {
+      it('useEmulator requires a string host', function () {
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => database().useEmulator()).toThrow(
+          'firebase.database().useEmulator() takes a non-empty host',
+        );
+        expect(() => database().useEmulator('', -1)).toThrow(
+          'firebase.database().useEmulator() takes a non-empty host',
+        );
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => database().useEmulator(123)).toThrow(
+          'firebase.database().useEmulator() takes a non-empty host',
+        );
+      });
 
-    it('useEmulator requires a host and port', function () {
-      expect(() => database().useEmulator('', 9000)).toThrow(
-        'firebase.database().useEmulator() takes a non-empty host and port',
-      );
-      // No port
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => database().useEmulator('localhost')).toThrow(
-        'firebase.database().useEmulator() takes a non-empty host and port',
-      );
-    });
+      it('useEmulator requires a host and port', function () {
+        expect(() => database().useEmulator('', 9000)).toThrow(
+          'firebase.database().useEmulator() takes a non-empty host and port',
+        );
+        // No port
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => database().useEmulator('localhost')).toThrow(
+          'firebase.database().useEmulator() takes a non-empty host and port',
+        );
+      });
 
-    it('useEmulator -> remaps Android loopback to host', function () {
-      const foo = database().useEmulator('localhost', 9000);
-      expect(foo).toEqual(['10.0.2.2', 9000]);
+      it('useEmulator -> remaps Android loopback to host', function () {
+        const foo = database().useEmulator('localhost', 9000);
+        expect(foo).toEqual(['10.0.2.2', 9000]);
 
-      const bar = database().useEmulator('127.0.0.1', 9000);
-      expect(bar).toEqual(['10.0.2.2', 9000]);
+        const bar = database().useEmulator('127.0.0.1', 9000);
+        expect(bar).toEqual(['10.0.2.2', 9000]);
+      });
     });
   });
 

--- a/packages/database/__tests__/database.test.ts
+++ b/packages/database/__tests__/database.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import database, {
   firebase,
@@ -48,6 +48,16 @@ import database, {
 
 describe('Database', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.database).toBeDefined();

--- a/packages/database/lib/index.js
+++ b/packages/database/lib/index.js
@@ -188,12 +188,22 @@ class FirebaseDatabaseModule extends FirebaseModule {
       throw new Error('firebase.database().useEmulator() takes a non-empty host and port');
     }
     let _host = host;
-    if (isAndroid && _host) {
-      if (_host === 'localhost' || _host === '127.0.0.1') {
-        _host = '10.0.2.2';
+    const androidBypassEmulatorUrlRemap =
+      typeof this.firebaseJson.android_bypass_emulator_url_remap === 'boolean' &&
+      this.firebaseJson.android_bypass_emulator_url_remap;
+    if (!androidBypassEmulatorUrlRemap && isAndroid && _host) {
+      if (_host.startsWith('localhost')) {
+        _host = _host.replace('localhost', '10.0.2.2');
         // eslint-disable-next-line no-console
         console.log(
-          'Mapping database host to "10.0.2.2" for android emulators. Use real IP on real devices.',
+          'Mapping database host "localhost" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
+        );
+      }
+      if (_host.startsWith('127.0.0.1')) {
+        _host = _host.replace('127.0.0.1', '10.0.2.2');
+        // eslint-disable-next-line no-console
+        console.log(
+          'Mapping database host "127.0.0.1" to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
         );
       }
     }

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 // @ts-ignore test
 import { createDeprecationProxy } from '../../app/lib/common';
 // @ts-ignore test
@@ -83,6 +83,16 @@ const COLLECTION = 'firestore';
 
 describe('Firestore', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.firestore).toBeDefined();

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -153,21 +153,35 @@ describe('Firestore', function () {
       });
 
       it('throws if host is not a string', async function () {
+        // eslint-disable-next-line no-console
+        const warnOrig = console.warn;
+        // eslint-disable-next-line no-console
+        console.warn = (_: string) => {};
         try {
           // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
           await firebase.firestore().settings({ host: 123 });
           return Promise.reject(new Error('Did not throw an Error.'));
         } catch (e: any) {
           return expect(e.message).toContain("'settings.host' must be a string value");
+        } finally {
+          // eslint-disable-next-line no-console
+          console.warn = warnOrig;
         }
       });
 
       it('throws if host is an empty string', async function () {
+        // eslint-disable-next-line no-console
+        const warnOrig = console.warn;
+        // eslint-disable-next-line no-console
+        console.warn = (_: string) => {};
         try {
           await firebase.firestore().settings({ host: '' });
           return Promise.reject(new Error('Did not throw an Error.'));
         } catch (e: any) {
           return expect(e.message).toContain("'settings.host' must not be an empty string");
+        } finally {
+          // eslint-disable-next-line no-console
+          console.warn = warnOrig;
         }
       });
 

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -88,366 +88,387 @@ describe('Firestore', function () {
       expect(app.firestore).toBeDefined();
       expect(app.firestore().settings).toBeDefined();
     });
-  });
 
-  describe('batch()', function () {
-    it('returns a new WriteBatch instance', function () {
-      const instance = firebase.firestore().batch();
-      return expect(instance.constructor.name).toEqual('FirestoreWriteBatch');
-    });
-  });
-
-  describe('settings', function () {
-    it('throws if settings is not an object', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firebase.firestore().settings('foo');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings' must be an object");
-      }
+    describe('batch()', function () {
+      it('returns a new WriteBatch instance', function () {
+        const instance = firebase.firestore().batch();
+        return expect(instance.constructor.name).toEqual('FirestoreWriteBatch');
+      });
     });
 
-    it('throws if passing an incorrect setting key', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firebase.firestore().settings({ foo: 'bar' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings.foo' is not a valid settings field");
-      }
+    describe('settings', function () {
+      it('throws if settings is not an object', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firebase.firestore().settings('foo');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings' must be an object");
+        }
+      });
+
+      it('throws if passing an incorrect setting key', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firebase.firestore().settings({ foo: 'bar' });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings.foo' is not a valid settings field");
+        }
+      });
+
+      it('throws if cacheSizeBytes is not a number', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firebase.firestore().settings({ cacheSizeBytes: 'foo' });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings.cacheSizeBytes' must be a number value");
+        }
+      });
+
+      it('throws if cacheSizeBytes is less than 1MB', async function () {
+        try {
+          await firebase.firestore().settings({ cacheSizeBytes: 123 });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings.cacheSizeBytes' the minimum cache size");
+        }
+      });
+
+      it('accepts an unlimited cache size', async function () {
+        await firebase
+          .firestore()
+          .settings({ cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED });
+      });
+
+      it('throws if host is not a string', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firebase.firestore().settings({ host: 123 });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings.host' must be a string value");
+        }
+      });
+
+      it('throws if host is an empty string', async function () {
+        try {
+          await firebase.firestore().settings({ host: '' });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings.host' must not be an empty string");
+        }
+      });
+
+      it('throws if persistence is not a boolean', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firebase.firestore().settings({ persistence: 'true' });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings.persistence' must be a boolean value");
+        }
+      });
+
+      it('throws if ssl is not a boolean', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firebase.firestore().settings({ ssl: 'true' });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'settings.ssl' must be a boolean value");
+        }
+      });
+
+      it('throws if ignoreUndefinedProperties is not a boolean', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firestore().settings({ ignoreUndefinedProperties: 'bogus' });
+          return Promise.reject(new Error('Should throw'));
+        } catch (e: any) {
+          return expect(e.message).toContain("ignoreUndefinedProperties' must be a boolean value.");
+        }
+      });
+
+      it("throws if serverTimestampBehavior is not one of 'estimate', 'previous', 'none'", async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firestore().settings({ serverTimestampBehavior: 'bogus' });
+          return Promise.reject(new Error('Should throw'));
+        } catch (e: any) {
+          return expect(e.message).toContain(
+            "serverTimestampBehavior' must be one of 'estimate', 'previous', 'none'",
+          );
+        }
+      });
     });
 
-    it('throws if cacheSizeBytes is not a number', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firebase.firestore().settings({ cacheSizeBytes: 'foo' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings.cacheSizeBytes' must be a number value");
-      }
+    describe('runTransaction()', function () {
+      it('throws if updateFunction is not a function', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          await firebase.firestore().runTransaction('foo');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'updateFunction' must be a function");
+        }
+      });
     });
 
-    it('throws if cacheSizeBytes is less than 1MB', async function () {
-      try {
-        await firebase.firestore().settings({ cacheSizeBytes: 123 });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings.cacheSizeBytes' the minimum cache size");
-      }
+    describe('collectionGroup()', function () {
+      it('returns a new query instance', function () {
+        const query = firebase.firestore().collectionGroup(COLLECTION);
+        expect(query.constructor.name).toEqual('FirestoreQuery');
+      });
+
+      it('throws if id is not a string', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          firebase.firestore().collectionGroup(123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'collectionId' must be a string value");
+        }
+      });
+
+      it('throws if id is empty', async function () {
+        try {
+          firebase.firestore().collectionGroup('');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'collectionId' must be a non-empty string");
+        }
+      });
+
+      it('throws if id contains forward-slash', async function () {
+        try {
+          firebase.firestore().collectionGroup(`someCollection/bar`);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'collectionId' must not contain '/'");
+        }
+      });
     });
 
-    it('accepts an unlimited cache size', async function () {
-      await firebase
-        .firestore()
-        .settings({ cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED });
+    describe('collection()', function () {
+      it('throws if path is not a string', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          firebase.firestore().collection(123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'collectionPath' must be a string value");
+        }
+      });
+
+      it('throws if path is empty string', async function () {
+        try {
+          firebase.firestore().collection('');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'collectionPath' must be a non-empty string");
+        }
+      });
+
+      it('throws if path does not point to a collection', async function () {
+        try {
+          firebase.firestore().collection(`firestore/bar`);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'collectionPath' must point to a collection");
+        }
+      });
+
+      it('returns a new CollectionReference', async function () {
+        const collectionReference = firebase.firestore().collection('firestore');
+        expect(collectionReference.constructor.name).toEqual('FirestoreCollectionReference');
+        expect(collectionReference.path).toEqual('firestore');
+      });
     });
 
-    it('throws if host is not a string', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firebase.firestore().settings({ host: 123 });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings.host' must be a string value");
-      }
-    });
+    describe('doc()', function () {
+      it('throws if path is not a string', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          firebase.firestore().doc(123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'documentPath' must be a string value");
+        }
+      });
 
-    it('throws if host is an empty string', async function () {
-      try {
-        await firebase.firestore().settings({ host: '' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings.host' must not be an empty string");
-      }
-    });
+      it('throws if path is empty string', async function () {
+        try {
+          firebase.firestore().doc('');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'documentPath' must be a non-empty string");
+        }
+      });
 
-    it('throws if persistence is not a boolean', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firebase.firestore().settings({ persistence: 'true' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings.persistence' must be a boolean value");
-      }
-    });
+      it('throws if path does not point to a document', async function () {
+        try {
+          firebase.firestore().doc(`${COLLECTION}/bar/baz`);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'documentPath' must point to a document");
+        }
+      });
 
-    it('throws if ssl is not a boolean', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firebase.firestore().settings({ ssl: 'true' });
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'settings.ssl' must be a boolean value");
-      }
-    });
+      it('returns a new DocumentReference', async function () {
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+        expect(docRef.constructor.name).toEqual('FirestoreDocumentReference');
+        expect(docRef.path).toEqual(`${COLLECTION}/bar`);
+      });
 
-    it('throws if ignoreUndefinedProperties is not a boolean', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firestore().settings({ ignoreUndefinedProperties: 'bogus' });
-        return Promise.reject(new Error('Should throw'));
-      } catch (e: any) {
-        return expect(e.message).toContain("ignoreUndefinedProperties' must be a boolean value.");
-      }
-    });
+      it('throws when undefined value provided and ignored undefined is false', async function () {
+        await firebase.firestore().settings({ ignoreUndefinedProperties: false });
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+        try {
+          await docRef.set({
+            field1: 1,
+            field2: undefined,
+          });
 
-    it("throws if serverTimestampBehavior is not one of 'estimate', 'previous', 'none'", async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firestore().settings({ serverTimestampBehavior: 'bogus' });
-        return Promise.reject(new Error('Should throw'));
-      } catch (e: any) {
-        return expect(e.message).toContain(
-          "serverTimestampBehavior' must be one of 'estimate', 'previous', 'none'",
-        );
-      }
-    });
-  });
+          return Promise.reject(new Error('Expected set() to throw'));
+        } catch (e: any) {
+          return expect(e.message).toEqual('Unsupported field value: undefined');
+        }
+      });
 
-  describe('runTransaction()', function () {
-    it('throws if updateFunction is not a function', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        await firebase.firestore().runTransaction('foo');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'updateFunction' must be a function");
-      }
-    });
-  });
+      it('throws when nested undefined object value provided and ignored undefined is false', async function () {
+        await firebase.firestore().settings({ ignoreUndefinedProperties: false });
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+        try {
+          await docRef.set({
+            field1: 1,
+            field2: {
+              shouldNotWork: undefined,
+            },
+          });
+          return Promise.reject(new Error('Expected set() to throw'));
+        } catch (e: any) {
+          return expect(e.message).toEqual('Unsupported field value: undefined');
+        }
+      });
 
-  describe('collectionGroup()', function () {
-    it('returns a new query instance', function () {
-      const query = firebase.firestore().collectionGroup(COLLECTION);
-      expect(query.constructor.name).toEqual('FirestoreQuery');
-    });
+      it('throws when nested undefined array value provided and ignored undefined is false', async function () {
+        await firebase.firestore().settings({ ignoreUndefinedProperties: false });
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+        try {
+          await docRef.set({
+            myArray: [{ name: 'Tim', location: { state: undefined, country: 'United Kingdom' } }],
+          });
+          return Promise.reject(new Error('Expected set() to throw'));
+        } catch (e: any) {
+          return expect(e.message).toEqual('Unsupported field value: undefined');
+        }
+      });
 
-    it('throws if id is not a string', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        firebase.firestore().collectionGroup(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'collectionId' must be a string value");
-      }
-    });
-
-    it('throws if id is empty', async function () {
-      try {
-        firebase.firestore().collectionGroup('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'collectionId' must be a non-empty string");
-      }
-    });
-
-    it('throws if id contains forward-slash', async function () {
-      try {
-        firebase.firestore().collectionGroup(`someCollection/bar`);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'collectionId' must not contain '/'");
-      }
-    });
-  });
-
-  describe('collection()', function () {
-    it('throws if path is not a string', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        firebase.firestore().collection(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'collectionPath' must be a string value");
-      }
-    });
-
-    it('throws if path is empty string', async function () {
-      try {
-        firebase.firestore().collection('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'collectionPath' must be a non-empty string");
-      }
-    });
-
-    it('throws if path does not point to a collection', async function () {
-      try {
-        firebase.firestore().collection(`firestore/bar`);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'collectionPath' must point to a collection");
-      }
-    });
-
-    it('returns a new CollectionReference', async function () {
-      const collectionReference = firebase.firestore().collection('firestore');
-      expect(collectionReference.constructor.name).toEqual('FirestoreCollectionReference');
-      expect(collectionReference.path).toEqual('firestore');
-    });
-  });
-
-  describe('doc()', function () {
-    it('throws if path is not a string', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        firebase.firestore().doc(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'documentPath' must be a string value");
-      }
-    });
-
-    it('throws if path is empty string', async function () {
-      try {
-        firebase.firestore().doc('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'documentPath' must be a non-empty string");
-      }
-    });
-
-    it('throws if path does not point to a document', async function () {
-      try {
-        firebase.firestore().doc(`${COLLECTION}/bar/baz`);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'documentPath' must point to a document");
-      }
-    });
-
-    it('returns a new DocumentReference', async function () {
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      expect(docRef.constructor.name).toEqual('FirestoreDocumentReference');
-      expect(docRef.path).toEqual(`${COLLECTION}/bar`);
-    });
-
-    it('throws when undefined value provided and ignored undefined is false', async function () {
-      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      try {
+      it('does not throw when nested undefined array value provided and ignore undefined is true', async function () {
+        await firebase.firestore().settings({ ignoreUndefinedProperties: true });
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
         await docRef.set({
-          field1: 1,
-          field2: undefined,
+          myArray: [{ name: 'Tim', location: { state: undefined, country: 'United Kingdom' } }],
         });
+      });
 
-        return Promise.reject(new Error('Expected set() to throw'));
-      } catch (e: any) {
-        return expect(e.message).toEqual('Unsupported field value: undefined');
-      }
-    });
-
-    it('throws when nested undefined object value provided and ignored undefined is false', async function () {
-      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      try {
+      it('does not throw when nested undefined object value provided and ignore undefined is true', async function () {
+        await firebase.firestore().settings({ ignoreUndefinedProperties: true });
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
         await docRef.set({
           field1: 1,
           field2: {
             shouldNotWork: undefined,
           },
         });
-        return Promise.reject(new Error('Expected set() to throw'));
-      } catch (e: any) {
-        return expect(e.message).toEqual('Unsupported field value: undefined');
-      }
-    });
+      });
 
-    it('throws when nested undefined array value provided and ignored undefined is false', async function () {
-      await firebase.firestore().settings({ ignoreUndefinedProperties: false });
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      try {
+      it('does not throw when Date is provided instead of Timestamp', async function () {
+        // type BarType = {
+        //   myDate: FirebaseFirestoreTypes.Timestamp;
+        // };
+
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
         await docRef.set({
-          myArray: [{ name: 'Tim', location: { state: undefined, country: 'United Kingdom' } }],
+          myDate: new Date(),
         });
-        return Promise.reject(new Error('Expected set() to throw'));
-      } catch (e: any) {
-        return expect(e.message).toEqual('Unsupported field value: undefined');
-      }
-    });
+      });
 
-    it('does not throw when nested undefined array value provided and ignore undefined is true', async function () {
-      await firebase.firestore().settings({ ignoreUndefinedProperties: true });
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      await docRef.set({
-        myArray: [{ name: 'Tim', location: { state: undefined, country: 'United Kingdom' } }],
+      it('does not throw when serverTimestamp is provided instead of Timestamp', async function () {
+        // type BarType = {
+        //   myDate: FirebaseFirestoreTypes.Timestamp;
+        // };
+
+        const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
+        await docRef.set({
+          myDate: firestore.FieldValue.serverTimestamp(),
+        });
       });
     });
 
-    it('does not throw when nested undefined object value provided and ignore undefined is true', async function () {
-      await firebase.firestore().settings({ ignoreUndefinedProperties: true });
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      await docRef.set({
-        field1: 1,
-        field2: {
-          shouldNotWork: undefined,
-        },
+    describe('loadBundle()', function () {
+      it('throws if bundle is not a string', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          firebase.firestore().loadBundle(123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'bundle' must be a string value");
+        }
+      });
+
+      it('throws if bundle is empty string', async function () {
+        try {
+          firebase.firestore().loadBundle('');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'bundle' must be a non-empty string");
+        }
       });
     });
 
-    it('does not throw when Date is provided instead of Timestamp', async function () {
-      // type BarType = {
-      //   myDate: FirebaseFirestoreTypes.Timestamp;
-      // };
-
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      await docRef.set({
-        myDate: new Date(),
+    describe('namedQuery()', function () {
+      it('throws if queryName is not a string', async function () {
+        try {
+          // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
+          firebase.firestore().namedQuery(123);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'queryName' must be a string value");
+        }
       });
-    });
 
-    it('does not throw when serverTimestamp is provided instead of Timestamp', async function () {
-      // type BarType = {
-      //   myDate: FirebaseFirestoreTypes.Timestamp;
-      // };
-
-      const docRef = firebase.firestore().doc(`${COLLECTION}/bar`);
-      await docRef.set({
-        myDate: firestore.FieldValue.serverTimestamp(),
+      it('throws if queryName is empty string', async function () {
+        try {
+          firebase.firestore().namedQuery('');
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (e: any) {
+          return expect(e.message).toContain("'queryName' must be a non-empty string");
+        }
       });
-    });
-  });
 
-  describe('loadBundle()', function () {
-    it('throws if bundle is not a string', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        firebase.firestore().loadBundle(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'bundle' must be a string value");
-      }
-    });
+      describe('FirestorePersistentCacheIndexManager', function () {
+        it('is exposed to end user', function () {
+          const firestore1 = firebase.firestore();
+          firestore1.settings({ persistence: true });
+          const indexManager = firestore1.persistentCacheIndexManager();
+          expect(indexManager).toBeDefined();
+          expect(indexManager!.constructor.name).toEqual('FirestorePersistentCacheIndexManager');
 
-    it('throws if bundle is empty string', async function () {
-      try {
-        firebase.firestore().loadBundle('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'bundle' must be a non-empty string");
-      }
-    });
-  });
+          expect(indexManager!.enableIndexAutoCreation).toBeInstanceOf(Function);
+          expect(indexManager!.disableIndexAutoCreation).toBeInstanceOf(Function);
+          expect(indexManager!.deleteAllIndexes).toBeInstanceOf(Function);
 
-  describe('namedQuery()', function () {
-    it('throws if queryName is not a string', async function () {
-      try {
-        // @ts-ignore the type is incorrect *on purpose* to test type checking in javascript
-        firebase.firestore().namedQuery(123);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'queryName' must be a string value");
-      }
-    });
+          const firestore2 = firebase.firestore();
+          firestore2.settings({ persistence: false });
 
-    it('throws if queryName is empty string', async function () {
-      try {
-        firebase.firestore().namedQuery('');
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (e: any) {
-        return expect(e.message).toContain("'queryName' must be a non-empty string");
-      }
+          const nullIndexManager = firestore2.persistentCacheIndexManager();
+
+          expect(nullIndexManager).toBeNull();
+        });
+      });
     });
   });
 
@@ -658,8 +679,10 @@ describe('Firestore', function () {
 
     it('`getPersistentCacheIndexManager` is properly exposed to end user', function () {
       expect(getPersistentCacheIndexManager).toBeDefined();
-      const indexManager = getPersistentCacheIndexManager(firebase.firestore());
-      expect(indexManager!.constructor.name).toEqual('FirestorePersistentCacheIndexManager');
+      // FIXME there is currently no way to programmatically alter
+      //       persistence settings via modular API (FirestoreSettings.localCache ...)
+      const nullIndexManagerModular = getPersistentCacheIndexManager(getFirestore());
+      expect(nullIndexManagerModular).toBeNull();
     });
 
     it('`deleteAllPersistentCacheIndexes` is properly exposed to end user', function () {
@@ -688,30 +711,6 @@ describe('Firestore', function () {
 
     it('`sum` is properly exposed to end user', function () {
       expect(sum).toBeDefined();
-    });
-  });
-
-  describe('FirestorePersistentCacheIndexManager', function () {
-    it('is exposed to end user', function () {
-      const firestore1 = firebase.firestore();
-      firestore1.settings({ persistence: true });
-      const indexManager = firestore1.persistentCacheIndexManager();
-      expect(indexManager).toBeDefined();
-      expect(indexManager!.constructor.name).toEqual('FirestorePersistentCacheIndexManager');
-
-      expect(indexManager!.enableIndexAutoCreation).toBeInstanceOf(Function);
-      expect(indexManager!.disableIndexAutoCreation).toBeInstanceOf(Function);
-      expect(indexManager!.deleteAllIndexes).toBeInstanceOf(Function);
-
-      const firestore2 = firebase.firestore();
-      firestore2.settings({ persistence: false });
-
-      const nullIndexManager = firestore2.persistentCacheIndexManager();
-
-      expect(nullIndexManager).toBeNull();
-
-      const nullIndexManagerModular = getPersistentCacheIndexManager(firestore2);
-      expect(nullIndexManagerModular).toBeNull();
     });
   });
 

--- a/packages/functions/__tests__/functions.test.ts
+++ b/packages/functions/__tests__/functions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import functions, {
   firebase,
@@ -10,6 +10,16 @@ import functions, {
 
 describe('Cloud Functions', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.functions).toBeDefined();

--- a/packages/functions/__tests__/functions.test.ts
+++ b/packages/functions/__tests__/functions.test.ts
@@ -15,41 +15,41 @@ describe('Cloud Functions', function () {
       expect(app.functions).toBeDefined();
       expect(app.functions().httpsCallable).toBeDefined();
     });
-  });
 
-  describe('useFunctionsEmulator()', function () {
-    it('useFunctionsEmulator -> uses 10.0.2.2', function () {
-      functions().useEmulator('localhost', 5001);
+    describe('useFunctionsEmulator()', function () {
+      it('useFunctionsEmulator -> uses 10.0.2.2', function () {
+        functions().useEmulator('localhost', 5001);
 
-      // @ts-ignore
-      expect(functions()._useFunctionsEmulatorHost).toBe('10.0.2.2');
+        // @ts-ignore
+        expect(functions()._useFunctionsEmulatorHost).toBe('10.0.2.2');
 
-      functions().useEmulator('127.0.0.1', 5001);
+        functions().useEmulator('127.0.0.1', 5001);
 
-      // @ts-ignore
-      expect(functions()._useFunctionsEmulatorHost).toBe('10.0.2.2');
+        // @ts-ignore
+        expect(functions()._useFunctionsEmulatorHost).toBe('10.0.2.2');
+      });
+
+      it('prefers emulator to custom domain', function () {
+        const app = firebase.app();
+        const customUrl = 'https://test.com';
+        const functions = app.functions(customUrl);
+
+        functions.useFunctionsEmulator('http://10.0.2.2');
+
+        // @ts-ignore
+        expect(functions._useFunctionsEmulatorHost).toBe('10.0.2.2');
+      });
     });
 
-    it('prefers emulator to custom domain', function () {
-      const app = firebase.app();
-      const customUrl = 'https://test.com';
-      const functions = app.functions(customUrl);
+    describe('httpcallable()', function () {
+      it('throws an error with an incorrect timeout', function () {
+        const app = firebase.app();
 
-      functions.useFunctionsEmulator('http://10.0.2.2');
-
-      // @ts-ignore
-      expect(functions._useFunctionsEmulatorHost).toBe('10.0.2.2');
-    });
-  });
-
-  describe('httpcallable()', function () {
-    it('throws an error with an incorrect timeout', function () {
-      const app = firebase.app();
-
-      // @ts-ignore
-      expect(() => app.functions().httpsCallable('example', { timeout: 'test' })).toThrow(
-        'HttpsCallableOptions.timeout expected a Number in milliseconds',
-      );
+        // @ts-ignore
+        expect(() => app.functions().httpsCallable('example', { timeout: 'test' })).toThrow(
+          'HttpsCallableOptions.timeout expected a Number in milliseconds',
+        );
+      });
     });
   });
 

--- a/packages/in-app-messaging/__tests__/inappmessaging.test.ts
+++ b/packages/in-app-messaging/__tests__/inappmessaging.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import {
   firebase,
@@ -12,6 +12,16 @@ import {
 
 describe('in-app-messaging', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.inAppMessaging).toBeDefined();

--- a/packages/installations/__tests__/installations.test.ts
+++ b/packages/installations/__tests__/installations.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import {
   firebase,
@@ -11,6 +11,16 @@ import {
 
 describe('installations()', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.installations).toBeDefined();

--- a/packages/messaging/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/messaging/plugin/__tests__/androidPlugin.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { setFireBaseMessagingAndroidManifest } from '../src/android/setupFirebaseNotifationIcon';
 import { ExpoConfig } from '@expo/config-types';
 import expoConfigExample from './fixtures/expo-config-example';
@@ -50,14 +50,21 @@ describe('Config Plugin Android Tests', function () {
   });
 
   it('applies changes to app/src/main/AndroidManifest.xml without notification', async function () {
-    const warnSpy = jest.spyOn(console, 'warn');
+    // eslint-disable-next-line no-console
+    const warnOrig = console.warn;
+    let called = false;
+    // eslint-disable-next-line no-console
+    console.warn = (_: string) => {
+      called = true;
+    };
     const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExample));
     const manifestApplication: ManifestApplication = JSON.parse(
       JSON.stringify(manifestApplicationExample),
     );
     config.notification = undefined;
     setFireBaseMessagingAndroidManifest(config, manifestApplication);
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
+    expect(called).toBeTruthy();
+    // eslint-disable-next-line no-console
+    console.warn = warnOrig;
   });
 });

--- a/packages/ml/__tests__/ml.test.ts
+++ b/packages/ml/__tests__/ml.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import { firebase, getML } from '../lib';
 
 describe('ml()', function () {
   describe('namespace', function () {
+    beforeAll(async () => {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async () => {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.ml).toBeDefined();

--- a/packages/perf/__tests__/perf.test.ts
+++ b/packages/perf/__tests__/perf.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import perf, {
   firebase,
@@ -12,6 +12,16 @@ import perf, {
 
 describe('Performance Monitoring', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.perf).toBeDefined();

--- a/packages/perf/__tests__/perf.test.ts
+++ b/packages/perf/__tests__/perf.test.ts
@@ -17,114 +17,114 @@ describe('Performance Monitoring', function () {
       expect(app.perf).toBeDefined();
       expect(app.perf().app).toEqual(app);
     });
-  });
 
-  describe('setPerformanceCollectionEnabled', function () {
-    it('errors if not boolean', function () {
-      expect(async () => {
+    describe('setPerformanceCollectionEnabled', function () {
+      it('errors if not boolean', function () {
+        expect(async () => {
+          // @ts-ignore
+          await perf().setPerformanceCollectionEnabled();
+        }).rejects.toThrow('must be a boolean');
+      });
+    });
+
+    describe('newTrace()', function () {
+      it('returns an instance of Trace', function () {
+        const trace = perf().newTrace('invertase');
+        expect(trace.constructor.name).toEqual('Trace');
+
         // @ts-ignore
-        await perf().setPerformanceCollectionEnabled();
-      }).rejects.toThrow('must be a boolean');
+        expect(trace._identifier).toEqual('invertase');
+      });
+
+      it('errors if identifier not a string', function () {
+        try {
+          // @ts-ignore
+          perf().newTrace(1337);
+          return Promise.reject(new Error('Did not throw'));
+        } catch (e: any) {
+          expect(e.message).toEqual(
+            "firebase.perf().newTrace(*) 'identifier' must be a string with a maximum length of 100 characters.",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it('errors if identifier length > 100', function () {
+        try {
+          perf().newTrace(new Array(101).fill('i').join(''));
+          return Promise.reject(new Error('Did not throw'));
+        } catch (e: any) {
+          expect(e.message).toEqual(
+            "firebase.perf().newTrace(*) 'identifier' must be a string with a maximum length of 100 characters.",
+          );
+          return Promise.resolve();
+        }
+      });
     });
-  });
 
-  describe('newTrace()', function () {
-    it('returns an instance of Trace', function () {
-      const trace = perf().newTrace('invertase');
-      expect(trace.constructor.name).toEqual('Trace');
+    describe('newHttpMetric()', function () {
+      it('returns an instance of HttpMetric', async function () {
+        const metric = perf().newHttpMetric('https://invertase.io', 'GET');
+        expect(metric.constructor.name).toEqual('HttpMetric');
 
-      // @ts-ignore
-      expect(trace._identifier).toEqual('invertase');
-    });
-
-    it('errors if identifier not a string', function () {
-      try {
         // @ts-ignore
-        perf().newTrace(1337);
-        return Promise.reject(new Error('Did not throw'));
-      } catch (e: any) {
-        expect(e.message).toEqual(
-          "firebase.perf().newTrace(*) 'identifier' must be a string with a maximum length of 100 characters.",
-        );
-        return Promise.resolve();
-      }
-    });
+        expect(metric._url).toEqual('https://invertase.io');
 
-    it('errors if identifier length > 100', function () {
-      try {
-        perf().newTrace(new Array(101).fill('i').join(''));
-        return Promise.reject(new Error('Did not throw'));
-      } catch (e: any) {
-        expect(e.message).toEqual(
-          "firebase.perf().newTrace(*) 'identifier' must be a string with a maximum length of 100 characters.",
-        );
-        return Promise.resolve();
-      }
-    });
-  });
-
-  describe('newHttpMetric()', function () {
-    it('returns an instance of HttpMetric', async function () {
-      const metric = perf().newHttpMetric('https://invertase.io', 'GET');
-      expect(metric.constructor.name).toEqual('HttpMetric');
-
-      // @ts-ignore
-      expect(metric._url).toEqual('https://invertase.io');
-
-      // @ts-ignore
-      expect(metric._httpMethod).toEqual('GET');
-    });
-
-    it('errors if url not a string', async function () {
-      try {
         // @ts-ignore
-        perf().newHttpMetric(1337, 7331);
-        return Promise.reject(new Error('Did not throw'));
-      } catch (e: any) {
-        expect(e.message).toEqual("firebase.perf().newHttpMetric(*, _) 'url' must be a string.");
-        return Promise.resolve();
-      }
+        expect(metric._httpMethod).toEqual('GET');
+      });
+
+      it('errors if url not a string', async function () {
+        try {
+          // @ts-ignore
+          perf().newHttpMetric(1337, 7331);
+          return Promise.reject(new Error('Did not throw'));
+        } catch (e: any) {
+          expect(e.message).toEqual("firebase.perf().newHttpMetric(*, _) 'url' must be a string.");
+          return Promise.resolve();
+        }
+      });
+
+      it('errors if httpMethod not a string', async function () {
+        try {
+          // @ts-ignore
+          perf().newHttpMetric('https://invertase.io', 1337);
+          return Promise.reject(new Error('Did not throw'));
+        } catch (e: any) {
+          expect(e.message).toEqual(
+            "firebase.perf().newHttpMetric(_, *) 'httpMethod' must be one of CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE.",
+          );
+          return Promise.resolve();
+        }
+      });
+
+      it('errors if httpMethod not a valid type', async function () {
+        try {
+          // @ts-ignore
+          perf().newHttpMetric('https://invertase.io', 'FIRE');
+          return Promise.reject(new Error('Did not throw'));
+        } catch (e: any) {
+          expect(e.message).toEqual(
+            "firebase.perf().newHttpMetric(_, *) 'httpMethod' must be one of CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE.",
+          );
+          return Promise.resolve();
+        }
+      });
     });
 
-    it('errors if httpMethod not a string', async function () {
-      try {
-        // @ts-ignore
-        perf().newHttpMetric('https://invertase.io', 1337);
-        return Promise.reject(new Error('Did not throw'));
-      } catch (e: any) {
-        expect(e.message).toEqual(
-          "firebase.perf().newHttpMetric(_, *) 'httpMethod' must be one of CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE.",
-        );
-        return Promise.resolve();
-      }
-    });
-
-    it('errors if httpMethod not a valid type', async function () {
-      try {
-        // @ts-ignore
-        perf().newHttpMetric('https://invertase.io', 'FIRE');
-        return Promise.reject(new Error('Did not throw'));
-      } catch (e: any) {
-        expect(e.message).toEqual(
-          "firebase.perf().newHttpMetric(_, *) 'httpMethod' must be one of CONNECT, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE.",
-        );
-        return Promise.resolve();
-      }
-    });
-  });
-
-  describe('setPerformanceCollectionEnabled()', function () {
-    it('errors if not boolean', async function () {
-      try {
-        // @ts-ignore
-        await firebase.perf().setPerformanceCollectionEnabled();
-        return Promise.reject(new Error('Did not throw'));
-      } catch (e: any) {
-        expect(e.message).toEqual(
-          "firebase.perf().setPerformanceCollectionEnabled(*) 'enabled' must be a boolean.",
-        );
-        return Promise.resolve();
-      }
+    describe('setPerformanceCollectionEnabled()', function () {
+      it('errors if not boolean', async function () {
+        try {
+          // @ts-ignore
+          await firebase.perf().setPerformanceCollectionEnabled();
+          return Promise.reject(new Error('Did not throw'));
+        } catch (e: any) {
+          expect(e.message).toEqual(
+            "firebase.perf().setPerformanceCollectionEnabled(*) 'enabled' must be a boolean.",
+          );
+          return Promise.resolve();
+        }
+      });
     });
   });
 

--- a/packages/remote-config/__tests__/remote-config.test.ts
+++ b/packages/remote-config/__tests__/remote-config.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import {
   firebase,
@@ -43,6 +43,16 @@ import {
 
 describe('remoteConfig()', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.remoteConfig()).toBeDefined();

--- a/packages/remote-config/__tests__/remote-config.test.ts
+++ b/packages/remote-config/__tests__/remote-config.test.ts
@@ -55,80 +55,80 @@ describe('remoteConfig()', function () {
         'secondaryFromNative',
       );
     });
-  });
 
-  describe('statics', function () {
-    it('LastFetchStatus', function () {
-      expect(firebase.remoteConfig.LastFetchStatus).toBeDefined();
-      expect(firebase.remoteConfig.LastFetchStatus.FAILURE).toEqual('failure');
-      expect(firebase.remoteConfig.LastFetchStatus.SUCCESS).toEqual('success');
-      expect(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET).toEqual('no_fetch_yet');
-      expect(firebase.remoteConfig.LastFetchStatus.THROTTLED).toEqual('throttled');
+    describe('statics', function () {
+      it('LastFetchStatus', function () {
+        expect(firebase.remoteConfig.LastFetchStatus).toBeDefined();
+        expect(firebase.remoteConfig.LastFetchStatus.FAILURE).toEqual('failure');
+        expect(firebase.remoteConfig.LastFetchStatus.SUCCESS).toEqual('success');
+        expect(firebase.remoteConfig.LastFetchStatus.NO_FETCH_YET).toEqual('no_fetch_yet');
+        expect(firebase.remoteConfig.LastFetchStatus.THROTTLED).toEqual('throttled');
+      });
+
+      it('ValueSource', function () {
+        expect(firebase.remoteConfig.ValueSource).toBeDefined();
+        expect(firebase.remoteConfig.ValueSource.REMOTE).toEqual('remote');
+        expect(firebase.remoteConfig.ValueSource.STATIC).toEqual('static');
+        expect(firebase.remoteConfig.ValueSource.DEFAULT).toEqual('default');
+      });
     });
 
-    it('ValueSource', function () {
-      expect(firebase.remoteConfig.ValueSource).toBeDefined();
-      expect(firebase.remoteConfig.ValueSource.REMOTE).toEqual('remote');
-      expect(firebase.remoteConfig.ValueSource.STATIC).toEqual('static');
-      expect(firebase.remoteConfig.ValueSource.DEFAULT).toEqual('default');
-    });
-  });
-
-  describe('fetch()', function () {
-    it('it throws if expiration is not a number', function () {
-      expect(() => {
-        // @ts-ignore - incorrect argument on purpose to check validation
-        firebase.remoteConfig().fetch('foo');
-      }).toThrow('must be a number value');
-    });
-  });
-
-  describe('setConfigSettings()', function () {
-    it('it throws if arg is not an object', async function () {
-      expect(() => {
-        // @ts-ignore - incorrect argument on purpose to check validation
-        firebase.remoteConfig().setConfigSettings('not an object');
-      }).toThrow('must set an object');
+    describe('fetch()', function () {
+      it('it throws if expiration is not a number', function () {
+        expect(() => {
+          // @ts-ignore - incorrect argument on purpose to check validation
+          firebase.remoteConfig().fetch('foo');
+        }).toThrow('must be a number value');
+      });
     });
 
-    it('throws if minimumFetchIntervalMillis is not a number', async function () {
-      expect(() => {
-        // @ts-ignore - incorrect argument on purpose to check validation
-        firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 'potato' });
-      }).toThrow('must be a number type in milliseconds.');
+    describe('setConfigSettings()', function () {
+      it('it throws if arg is not an object', async function () {
+        expect(() => {
+          // @ts-ignore - incorrect argument on purpose to check validation
+          firebase.remoteConfig().setConfigSettings('not an object');
+        }).toThrow('must set an object');
+      });
+
+      it('throws if minimumFetchIntervalMillis is not a number', async function () {
+        expect(() => {
+          // @ts-ignore - incorrect argument on purpose to check validation
+          firebase.remoteConfig().setConfigSettings({ minimumFetchIntervalMillis: 'potato' });
+        }).toThrow('must be a number type in milliseconds.');
+      });
+
+      it('throws if fetchTimeMillis is not a number', function () {
+        expect(() => {
+          // @ts-ignore - incorrect argument on purpose to check validation
+          firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 'potato' });
+        }).toThrow('must be a number type in milliseconds.');
+      });
     });
 
-    it('throws if fetchTimeMillis is not a number', function () {
-      expect(() => {
-        // @ts-ignore - incorrect argument on purpose to check validation
-        firebase.remoteConfig().setConfigSettings({ fetchTimeMillis: 'potato' });
-      }).toThrow('must be a number type in milliseconds.');
+    describe('setDefaults()', function () {
+      it('it throws if defaults object not provided', function () {
+        expect(() => {
+          // @ts-ignore - incorrect argument on purpose to check validation
+          firebase.remoteConfig().setDefaults('not an object');
+        }).toThrow('must be an object.');
+      });
     });
-  });
 
-  describe('setDefaults()', function () {
-    it('it throws if defaults object not provided', function () {
-      expect(() => {
-        // @ts-ignore - incorrect argument on purpose to check validation
-        firebase.remoteConfig().setDefaults('not an object');
-      }).toThrow('must be an object.');
+    describe('setDefaultsFromResource()', function () {
+      it('throws if resourceName is not a string', function () {
+        expect(() => {
+          // @ts-ignore - incorrect argument on purpose to check validation
+          firebase.remoteConfig().setDefaultsFromResource(1337);
+        }).toThrow('must be a string value');
+      });
     });
-  });
 
-  describe('setDefaultsFromResource()', function () {
-    it('throws if resourceName is not a string', function () {
-      expect(() => {
-        // @ts-ignore - incorrect argument on purpose to check validation
-        firebase.remoteConfig().setDefaultsFromResource(1337);
-      }).toThrow('must be a string value');
-    });
-  });
-
-  describe('getAll() should not crash', function () {
-    it('should return an empty object pre-fetch, pre-defaults', function () {
-      const config = firebase.remoteConfig().getAll();
-      expect(config).toBeDefined();
-      expect(config).toEqual({});
+    describe('getAll() should not crash', function () {
+      it('should return an empty object pre-fetch, pre-defaults', function () {
+        const config = firebase.remoteConfig().getAll();
+        expect(config).toBeDefined();
+        expect(config).toEqual({});
+      });
     });
   });
 

--- a/packages/storage/__tests__/storage.test.ts
+++ b/packages/storage/__tests__/storage.test.ts
@@ -34,40 +34,40 @@ describe('Storage', function () {
       expect(app.storage).toBeDefined();
       expect(app.storage().useEmulator).toBeDefined();
     });
-  });
 
-  describe('useEmulator()', function () {
-    it('useEmulator requires a string host', function () {
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => storage().useEmulator()).toThrow(
-        'firebase.storage().useEmulator() takes a non-empty host',
-      );
-      expect(() => storage().useEmulator('', -1)).toThrow(
-        'firebase.storage().useEmulator() takes a non-empty host',
-      );
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => storage().useEmulator(123)).toThrow(
-        'firebase.storage().useEmulator() takes a non-empty host',
-      );
-    });
+    describe('useEmulator()', function () {
+      it('useEmulator requires a string host', function () {
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => storage().useEmulator()).toThrow(
+          'firebase.storage().useEmulator() takes a non-empty host',
+        );
+        expect(() => storage().useEmulator('', -1)).toThrow(
+          'firebase.storage().useEmulator() takes a non-empty host',
+        );
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => storage().useEmulator(123)).toThrow(
+          'firebase.storage().useEmulator() takes a non-empty host',
+        );
+      });
 
-    it('useEmulator requires a host and port', function () {
-      expect(() => storage().useEmulator('', 9000)).toThrow(
-        'firebase.storage().useEmulator() takes a non-empty host and port',
-      );
-      // No port
-      // @ts-ignore because we pass an invalid argument...
-      expect(() => storage().useEmulator('localhost')).toThrow(
-        'firebase.storage().useEmulator() takes a non-empty host and port',
-      );
-    });
+      it('useEmulator requires a host and port', function () {
+        expect(() => storage().useEmulator('', 9000)).toThrow(
+          'firebase.storage().useEmulator() takes a non-empty host and port',
+        );
+        // No port
+        // @ts-ignore because we pass an invalid argument...
+        expect(() => storage().useEmulator('localhost')).toThrow(
+          'firebase.storage().useEmulator() takes a non-empty host and port',
+        );
+      });
 
-    it('useEmulator -> remaps Android loopback to host', function () {
-      const foo = storage().useEmulator('localhost', 9000);
-      expect(foo).toEqual(['10.0.2.2', 9000]);
+      it('useEmulator -> remaps Android loopback to host', function () {
+        const foo = storage().useEmulator('localhost', 9000);
+        expect(foo).toEqual(['10.0.2.2', 9000]);
 
-      const bar = storage().useEmulator('127.0.0.1', 9000);
-      expect(bar).toEqual(['10.0.2.2', 9000]);
+        const bar = storage().useEmulator('127.0.0.1', 9000);
+        expect(bar).toEqual(['10.0.2.2', 9000]);
+      });
     });
   });
 

--- a/packages/storage/__tests__/storage.test.ts
+++ b/packages/storage/__tests__/storage.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals';
 
 import storage, {
   firebase,
@@ -29,6 +29,16 @@ import storage, {
 
 describe('Storage', function () {
   describe('namespace', function () {
+    beforeAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterAll(async function () {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       expect(app.storage).toBeDefined();

--- a/packages/storage/lib/index.js
+++ b/packages/storage/lib/index.js
@@ -172,7 +172,7 @@ class FirebaseStorageModule extends FirebaseModule {
         _host = '10.0.2.2';
         // eslint-disable-next-line no-console
         console.log(
-          'Mapping storage host to "10.0.2.2" for android emulators. Use real IP on real devices.',
+          'Mapping storage host to "10.0.2.2" for android emulators. Use real IP on real devices. You can bypass this behaviour with "android_bypass_emulator_url_remap" flag.',
         );
       }
     }


### PR DESCRIPTION
### Description

@lorenc-tomasz reported a deprecation message still popping up despite correct API usage in crashlytics

### Reviewer Note

Review this commit by commit or you'll go crazy.

In particular turning on "ignore whitespace" for the commit where I refactored the namespace tests to all be in namespace suite looks trivial that way but mind-boggling with whitespace showing up

### Approach

This PR takes a pretty thorough approach to silencing these since it was the second deprecation message that popped up (see #8304) - indicating it was a "class" issue, not a one-off, so we needed to be more thorough

- go through jest test setup and quiet all non-deprecation logs that we expect
   - filter out android emulator remap messages
   - ⚠️ ❗  **Realize database did not respect the emulator remap bypass flag! Repair that while there**
   - expo messaging plugin has an expected warning it explicitly tests for. Avoid printing it
- disable deprecated API warnings from tests that use namespaced API - they are expected, provide no useful signal
   - mostly accomplished by doing a before/after for all namespaced tests where we disable the warnings
   - app-check had some very specific issues to handle for API-motion reasons, handled those as one-offs

Finally the logs are very very quiet, except the specific message Tomasz mentioned! Success, mostly.

That was a crashlytics internal API call chain to a namespaced method that was unavoidable in a modular context, so I handled it with specific call using the modular context call style

### Related issues

- Fixes #8306 

### Release Summary

Bunch of commits, but all semantic-release style

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Wasn't even able to see the problem *until* I had test support. It's all backed by `yarn tests:jest`

At the end of this, if you run `yarn tests:jest` it is 💯  clean. Zero deprecation warnings or log messages of any kind.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
