### PR TITLE
fix: do not ship unit tests in released packages

### DIFF
--- a/packages/analytics/.npmignore
+++ b/packages/analytics/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/app-check/.npmignore
+++ b/packages/app-check/.npmignore
@@ -63,4 +63,5 @@ android/.settings
 *.coverage.json
 .circleci
 .eslintignore
+type-test.ts
 __tests__

--- a/packages/app-check/.npmignore
+++ b/packages/app-check/.npmignore
@@ -63,3 +63,4 @@ android/.settings
 *.coverage.json
 .circleci
 .eslintignore
+__tests__

--- a/packages/app-distribution/.npmignore
+++ b/packages/app-distribution/.npmignore
@@ -63,4 +63,5 @@ android/.settings
 *.coverage.json
 .circleci
 .eslintignore
+type-test.ts
 __tests__

--- a/packages/app-distribution/.npmignore
+++ b/packages/app-distribution/.npmignore
@@ -63,3 +63,4 @@ android/.settings
 *.coverage.json
 .circleci
 .eslintignore
+__tests__

--- a/packages/app/.npmignore
+++ b/packages/app/.npmignore
@@ -67,3 +67,4 @@ android/.settings
 .eslintignore
 type-test.ts
 scripts
+__tests__

--- a/packages/auth/.npmignore
+++ b/packages/auth/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/crashlytics/.npmignore
+++ b/packages/crashlytics/.npmignore
@@ -67,3 +67,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/database/.npmignore
+++ b/packages/database/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/dynamic-links/.npmignore
+++ b/packages/dynamic-links/.npmignore
@@ -64,4 +64,5 @@ android/.settings
 .circleci
 .eslintignore
 test-types.ts
+type-test.ts
 __tests__

--- a/packages/dynamic-links/.npmignore
+++ b/packages/dynamic-links/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 test-types.ts
+__tests__

--- a/packages/firestore/.npmignore
+++ b/packages/firestore/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/functions/.npmignore
+++ b/packages/functions/.npmignore
@@ -64,5 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
-
 __tests__

--- a/packages/in-app-messaging/.npmignore
+++ b/packages/in-app-messaging/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/installations/.npmignore
+++ b/packages/installations/.npmignore
@@ -63,4 +63,5 @@ android/.settings
 *.coverage.json
 .circleci
 .eslintignore
+type-test.ts
 __tests__

--- a/packages/installations/.npmignore
+++ b/packages/installations/.npmignore
@@ -63,3 +63,4 @@ android/.settings
 *.coverage.json
 .circleci
 .eslintignore
+__tests__

--- a/packages/messaging/.npmignore
+++ b/packages/messaging/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/ml/.npmignore
+++ b/packages/ml/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/perf/.npmignore
+++ b/packages/perf/.npmignore
@@ -67,5 +67,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
-
 __tests__

--- a/packages/remote-config/.npmignore
+++ b/packages/remote-config/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__

--- a/packages/storage/.npmignore
+++ b/packages/storage/.npmignore
@@ -64,3 +64,4 @@ android/.settings
 .circleci
 .eslintignore
 type-test.ts
+__tests__


### PR DESCRIPTION
### Description

While test-integrating the patch set from #8307 I noticed that the patches were huge!

The functional change was miniscule though.

On investigation I discovered the patchset was huge because the unit test changes I made were showing up as diffs, because we have been shipping unit tests with our released packages for everything but functions and one other.

I made sure `__tests__` was in `.npmignore` for all the packages (including a commit I tacked on the vertexai PR #8236) so those aren't shipped anymore and won't show up in package diffs when generating patch-package sets

While test-integrating this patch and auditing the resulting node_modules package contents I noticed 4 of the packages still shipped types tests as well. Added a second commit that ignores those

### Related issues

Noticed in 
- #8307 

### Release Summary

single conventional commit, but I did set it as a "fix" which will trigger a release since it affects the release artifacts

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The patch-package set for this should result in removing the __tests__ directories when applied while testing it

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
