### PR TITLE
fix:remote-config, ios): avoid double-resolve when setting custom signals

### DIFF
--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -316,11 +316,9 @@ RCT_EXPORT_METHOD(setCustomSignals
           if (error != nil) {
             [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
           } else {
-            resolve(nil);
+            resolve([self resultWithConstants:[NSNull null] firebaseApp:firebaseApp]);
           }
         }];
-
-  resolve([self resultWithConstants:[NSNull null] firebaseApp:firebaseApp]);
 }
 
 #pragma mark -


### PR DESCRIPTION

### Description

The iOS code for the new custom signals feature has multiple pathways that can resolve, leading to a redbox error on ios devices

### Related issues

PR related:
- #8274 

### Release Summary

single conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Saw the error while checking test results, fixing this removes the redbox, tests still pass

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
