### PR TITLE
fix(dynamic-links): pass dynamic links into getInitialLink()

### DIFF
--- a/packages/dynamic-links/lib/modular/index.d.ts
+++ b/packages/dynamic-links/lib/modular/index.d.ts
@@ -80,7 +80,9 @@ export declare function buildShortLink(
  * }
  * ```
  */
-export declare function getInitialLink(): Promise<FirebaseDynamicLinksTypes.DynamicLink | null>;
+export declare function getInitialLink(
+  dynamicLinks: FirebaseDynamicLinks,
+): Promise<FirebaseDynamicLinksTypes.DynamicLink | null>;
 
 /**
  * Subscribe to Dynamic Link open events while the app is still running.

--- a/packages/dynamic-links/type-test.ts
+++ b/packages/dynamic-links/type-test.ts
@@ -1,4 +1,4 @@
-import firebase from '.';
+import firebase, { getInitialLink } from '.';
 
 console.log(firebase.default().getInitialLink);
 
@@ -38,3 +38,6 @@ console.log(
 );
 
 console.log(firebase.dynamicLinks.ShortLinkType.SHORT);
+
+
+getInitialLink(firebase.dynamicLinks());


### PR DESCRIPTION
### Description

Addresses issue raised by user here: https://github.com/invertase/react-native-firebase/discussions/8311#discussioncomment-12114750
### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
