### PR TITLE
feat(app): Support AppDelegate.swift in @react-native-firebase/app on Expo

### DIFF
--- a/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -481,3 +481,41 @@ exports[`Config Plugin iOS Tests works with AppDelegate.mm (RN 0.68+) 1`] = `
 @end
 "
 `;
+
+exports[`Config Plugin iOS Tests works with Swift AppDelegate (RN 0.77+) 1`] = `
+"import UIKit
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+import FirebaseCore
+
+@main
+class AppDelegate: RCTAppDelegate {
+  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+// @generated begin @react-native-firebase/app-didFinishLaunchingWithOptions - expo prebuild (DO NOT MODIFY) sync-10e8520570672fd76b2403b7e1e27f5198a6349a
+FirebaseApp.configure()
+// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions
+    self.moduleName = "HelloWorld"
+    self.dependencyProvider = RCTAppDependencyProvider()
+
+    // You can add your custom initial props in the dictionary below.
+    // They will be passed down to the ViewController used by React Native.
+    self.initialProps = [:]
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
+    self.bundleURL()
+  }
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#else
+    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}
+"
+`;

--- a/packages/app/plugin/__tests__/fixtures/AppDelegate_sdk45.swift
+++ b/packages/app/plugin/__tests__/fixtures/AppDelegate_sdk45.swift
@@ -1,0 +1,30 @@
+import UIKit
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+
+@main
+class AppDelegate: RCTAppDelegate {
+  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    self.moduleName = "HelloWorld"
+    self.dependencyProvider = RCTAppDependencyProvider()
+
+    // You can add your custom initial props in the dictionary below.
+    // They will be passed down to the ViewController used by React Native.
+    self.initialProps = [:]
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  override func sourceURL(for bridge: RCTBridge) -> URL? {
+    self.bundleURL()
+  }
+
+  override func bundleURL() -> URL? {
+#if DEBUG
+    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
+#else
+    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+}

--- a/packages/app/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/app/plugin/__tests__/iosPlugin.test.ts
@@ -4,7 +4,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-import { modifyAppDelegateAsync, modifyObjcAppDelegate } from '../src/ios/appDelegate';
+import { modifyAppDelegateAsync, modifyObjcAppDelegate, modifySwiftAppDelegate } from '../src/ios/appDelegate';
 
 describe('Config Plugin iOS Tests', function () {
   beforeEach(function () {
@@ -74,17 +74,12 @@ describe('Config Plugin iOS Tests', function () {
     );
   });
 
-  it("doesn't support Swift AppDelegate", async function () {
-    jest.spyOn(fs, 'writeFile').mockImplementation(async () => {});
-
-    const appDelegateFileInfo: AppDelegateProjectFile = {
-      path: '.',
-      language: 'swift',
-      contents: 'some dummy content',
-    };
-
-    await expect(modifyAppDelegateAsync(appDelegateFileInfo)).rejects.toThrow();
-    expect(fs.writeFile).not.toHaveBeenCalled();
+  it("works with Swift AppDelegate (RN 0.77+)", async function () {
+    const appDelegate = await fs.readFile(path.join(__dirname, './fixtures/AppDelegate_sdk45.swift'), {
+      encoding: 'utf8',
+    });
+    const result = modifySwiftAppDelegate(appDelegate);
+    expect(result).toMatchSnapshot();
   });
 
   it('does not add the firebase import multiple times', async function () {

--- a/packages/app/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/app/plugin/__tests__/iosPlugin.test.ts
@@ -4,7 +4,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-import { modifyAppDelegateAsync, modifyObjcAppDelegate, modifySwiftAppDelegate } from '../src/ios/appDelegate';
+import {
+  modifyAppDelegateAsync,
+  modifyObjcAppDelegate,
+  modifySwiftAppDelegate,
+} from '../src/ios/appDelegate';
 
 describe('Config Plugin iOS Tests', function () {
   beforeEach(function () {
@@ -74,10 +78,13 @@ describe('Config Plugin iOS Tests', function () {
     );
   });
 
-  it("works with Swift AppDelegate (RN 0.77+)", async function () {
-    const appDelegate = await fs.readFile(path.join(__dirname, './fixtures/AppDelegate_sdk45.swift'), {
-      encoding: 'utf8',
-    });
+  it('works with Swift AppDelegate (RN 0.77+)', async function () {
+    const appDelegate = await fs.readFile(
+      path.join(__dirname, './fixtures/AppDelegate_sdk45.swift'),
+      {
+        encoding: 'utf8',
+      },
+    );
     const result = modifySwiftAppDelegate(appDelegate);
     expect(result).toMatchSnapshot();
   });

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -73,9 +73,6 @@ export function modifySwiftAppDelegate(contents: string): string {
   const methodInvocationLineMatcher =
   /(?:self\.moduleName\s*=\s*"([^"]*)")/g;
 
-  const fallbackInvocationLineMatcher =
-    /\s*override\s+func\s+application\(_ application:\s*UIApplication,\s*didFinishLaunchingWithOptions\s+launchOptions:.+\s*\{/g;
-
   // Add import
   if (!contents.includes('import FirebaseCore')) {
     contents = contents.replace(
@@ -91,8 +88,7 @@ import FirebaseCore`,
   }
 
   if (
-    !methodInvocationLineMatcher.test(contents) &&
-    !fallbackInvocationLineMatcher.test(contents)
+    !methodInvocationLineMatcher.test(contents)
   ) {
     WarningAggregator.addWarningIOS(
       '@react-native-firebase/app',
@@ -102,27 +98,14 @@ import FirebaseCore`,
   }
 
   // Add invocation
-  try {
-    return mergeContents({
-      tag: '@react-native-firebase/app-didFinishLaunchingWithOptions',
-      src: contents,
-      newSrc: methodInvocationBlock,
-      anchor: methodInvocationLineMatcher,
-      offset: 0, // new line will be inserted right above matched anchor
-      comment: '//',
-    }).contents;
-  } catch (_: any) {
-    // we fallback to another regex if the first one fails
-    return mergeContents({
-      tag: '@react-native-firebase/app-didFinishLaunchingWithOptions-fallback',
-      src: contents,
-      newSrc: methodInvocationBlock,
-      anchor: fallbackInvocationLineMatcher,
-      // new line will be inserted right below matched anchor
-      offset: 1,
-      comment: '//',
-    }).contents;
-  }
+  return mergeContents({
+    tag: '@react-native-firebase/app-didFinishLaunchingWithOptions',
+    src: contents,
+    newSrc: methodInvocationBlock,
+    anchor: methodInvocationLineMatcher,
+    offset: 0, // new line will be inserted right above matched anchor
+    comment: '//',
+  }).contents;
 }
 
 export async function modifyAppDelegateAsync(appDelegateFileInfo: AppDelegateProjectFile) {

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -70,8 +70,7 @@ export function modifyObjcAppDelegate(contents: string): string {
 
 export function modifySwiftAppDelegate(contents: string): string {
   const methodInvocationBlock = `FirebaseApp.configure()`;
-  const methodInvocationLineMatcher =
-  /(?:self\.moduleName\s*=\s*"([^"]*)")/g;
+  const methodInvocationLineMatcher = /(?:self\.moduleName\s*=\s*"([^"]*)")/g;
 
   // Add import
   if (!contents.includes('import FirebaseCore')) {
@@ -87,9 +86,7 @@ import FirebaseCore`,
     return contents;
   }
 
-  if (
-    !methodInvocationLineMatcher.test(contents)
-  ) {
+  if (!methodInvocationLineMatcher.test(contents)) {
     WarningAggregator.addWarningIOS(
       '@react-native-firebase/app',
       'Unable to determine correct Firebase insertion point in AppDelegate.swift. Skipping Firebase addition.',
@@ -123,7 +120,8 @@ export async function modifyAppDelegateAsync(appDelegateFileInfo: AppDelegatePro
       newContents = modifySwiftAppDelegate(contents);
       break;
     }
-    default: throw new Error(`Cannot add Firebase code to AppDelegate of language "${language}"`);
+    default:
+      throw new Error(`Cannot add Firebase code to AppDelegate of language "${language}"`);
   }
 
   await fs.promises.writeFile(path, newContents);


### PR DESCRIPTION
- **Support Swift in expo plugin for @react-native-firebase/app**
- **Remove fallback tester as we have no example code that would require it currently**
- **Add tests for swift appdelegate**

### Description

RN 0.77 uses swift, so for this package to continue working in Expo we now need to patch an AppDelegate.swift file

### Release Summary

Apply necessary patches for Expo to work on RN 0.77

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
