### PR TITLE
fix(messaging, types): export correct module types

### DIFF
--- a/packages/messaging/lib/modular/index.d.ts
+++ b/packages/messaging/lib/modular/index.d.ts
@@ -1,7 +1,7 @@
 import { FirebaseMessagingTypes } from '..';
 import { ReactNativeFirebase } from '@react-native-firebase/app';
 
-import Messaging = FirebaseStorageTypes.Module;
+import Messaging = FirebaseMessagingTypes.Module;
 import FirebaseApp = ReactNativeFirebase.FirebaseApp;
 
 export const AuthorizationStatus = FirebaseMessagingTypes.AuthorizationStatus;


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->
Wrong type for messaging module in the modular types.
### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
Import the `getMessaging` function.
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
