### PR TITLE
fix: add deprecation strict mode, implement isEquals(snapshot, snapshot), e2e test modular ports

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -50,7 +50,7 @@ jobs:
           timeout_minutes: 3
           retry_wait_seconds: 10
           max_attempts: 3
-          command: yarn lint
+          command: yarn lint && git diff --exit-code
       - uses: actions/cache/save@v4
         name: Yarn Cache Save
         if: "${{ github.ref == 'refs/heads/main' }}"

--- a/docs/migrating-to-v22.md
+++ b/docs/migrating-to-v22.md
@@ -13,6 +13,18 @@ You may notice a lot of console warning logs as we deprecate the existing namesp
 globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
 ```
 
+# Enabling deprecation strict modes
+
+You may enable a feature for the API migration which will throw a javascript error immediately when any namespaced API usage is detected.
+
+This is useful to help you quickly locate any remaining usage of the deprecated namespace API via examination of the line numbers in the stack trace.
+
+Note that there may be modular API implementation errors within the react-native-firebase modules, this may still be useful as a troubleshooting aid when collaborating with the maintainers to correct these errors.
+
+```js
+globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE === true;
+```
+
 # Migrating to React Native modular API
 
 If you are familiar with the Firebase JS SDK, the upgrade will be a familiar process, following similar steps to [the migration guide](https://firebase.google.com/docs/web/modular-upgrade#refactor_to_the_modular_style) for firebase-js-sdk.

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -251,9 +251,12 @@ export function createMessage(
       const replacementMethodName = instance[methodName];
 
       if (replacementMethodName !== NO_REPLACEMENT) {
-        return modularDeprecationMessage + ` Please use \`${replacementMethodName}\` instead.`;
+        return (
+          modularDeprecationMessage +
+          `. Method called was \`${methodName}\`. Please use \`${replacementMethodName}\` instead.`
+        );
       } else {
-        return modularDeprecationMessage;
+        return modularDeprecationMessage + `. Method called was \`${methodName}\``;
       }
     }
   }

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -224,11 +224,9 @@ export function deprecationConsoleWarning(nameSpace, methodName, instanceName, i
       const instanceMap = moduleMap[instanceName];
       const deprecatedMethod = instanceMap[methodName];
       if (instanceMap && deprecatedMethod) {
-        const message = createMessage(nameSpace, methodName, instanceName);
-
         if (!globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS) {
           // eslint-disable-next-line no-console
-          console.warn(message);
+          console.warn(createMessage(nameSpace, methodName, instanceName));
         }
       }
     }

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -227,6 +227,10 @@ export function deprecationConsoleWarning(nameSpace, methodName, instanceName, i
         if (!globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS) {
           // eslint-disable-next-line no-console
           console.warn(createMessage(nameSpace, methodName, instanceName));
+
+          if (globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE === true) {
+            throw new Error('Deprecated API usage detected while in strict mode.');
+          }
         }
       }
     }
@@ -372,5 +376,9 @@ export function warnIfNotModularCall(args, replacementMethodName = '') {
   if (!globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS) {
     // eslint-disable-next-line no-console
     console.warn(message);
+
+    if (globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE === true) {
+      throw new Error('Deprecated API usage detected while in strict mode.');
+    }
   }
 }

--- a/packages/crashlytics/e2e/crashlytics.e2e.js
+++ b/packages/crashlytics/e2e/crashlytics.e2e.js
@@ -17,6 +17,16 @@
 
 describe('crashlytics()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('log()', function () {
       it('accepts any value', async function () {
         firebase.crashlytics().log('invertase');
@@ -251,7 +261,8 @@ describe('crashlytics()', function () {
       });
 
       it('accepts string values', async function () {
-        await firebase.crashlytics().setAttributes({ invertase: '1337' });
+        const { getCrashlytics, setAttributes } = crashlyticsModular;
+        await setAttributes(getCrashlytics(), { invertase: '1337' });
       });
     });
 
@@ -263,13 +274,10 @@ describe('crashlytics()', function () {
         let logged = false;
         // eslint-disable-next-line no-console
         console.warn = msg => {
-          // we console.warn for deprecated API, can be removed when we move to v9
-          if (!msg.includes('method is deprecated')) {
-            msg.should.containEql('expects an instance of Error');
-            logged = true;
-            // eslint-disable-next-line no-console
-            console.warn = orig;
-          }
+          msg.should.containEql('expects an instance of Error');
+          logged = true;
+          // eslint-disable-next-line no-console
+          console.warn = orig;
         };
 
         recordError(getCrashlytics(), 1337);
@@ -344,19 +352,17 @@ describe('crashlytics()', function () {
 
     describe('setCrashlyticsCollectionEnabled()', function () {
       it('false', async function () {
-        const { getCrashlytics, setCrashlyticsCollectionEnabled, isCrashlyticsCollectionEnabled } =
-          crashlyticsModular;
+        const { getCrashlytics, setCrashlyticsCollectionEnabled } = crashlyticsModular;
         const crashlytics = getCrashlytics();
         await setCrashlyticsCollectionEnabled(crashlytics, false);
-        should.equal(isCrashlyticsCollectionEnabled(crashlytics), false);
+        should.equal(crashlytics.isCrashlyticsCollectionEnabled, false);
       });
 
       it('true', async function () {
-        const { getCrashlytics, setCrashlyticsCollectionEnabled, isCrashlyticsCollectionEnabled } =
-          crashlyticsModular;
+        const { getCrashlytics, setCrashlyticsCollectionEnabled } = crashlyticsModular;
         const crashlytics = getCrashlytics();
         await setCrashlyticsCollectionEnabled(crashlytics, true);
-        should.equal(isCrashlyticsCollectionEnabled(crashlytics), true);
+        should.equal(crashlytics.isCrashlyticsCollectionEnabled, true);
       });
 
       it('errors if not boolean', async function () {

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -949,7 +949,7 @@ describe('Firestore', function () {
         collectionRefV9Deprecation(
           () => getCountFromServer(query),
           () => query.countFromServer(),
-          'count',
+          'countFromServer',
         );
       });
 

--- a/packages/firestore/e2e/Aggregate/count.e2e.js
+++ b/packages/firestore/e2e/Aggregate/count.e2e.js
@@ -22,6 +22,16 @@ describe('firestore().collection().count()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no argument provided', function () {
       try {
         firebase.firestore().collection(COLLECTION).startAt();

--- a/packages/firestore/e2e/Blob.e2e.js
+++ b/packages/firestore/e2e/Blob.e2e.js
@@ -21,6 +21,16 @@ const testBuffer = [123, 34, 104, 101, 108, 108, 111, 34, 58, 34, 119, 111, 114,
 const testBase64 = 'eyJoZWxsbyI6IndvcmxkIn0=';
 
 describe('firestore.Blob', function () {
+  beforeEach(async function beforeEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+  });
+
+  afterEach(async function afterEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+  });
+
   it('should throw if constructed manually', function () {
     try {
       new firebase.firestore.Blob();

--- a/packages/firestore/e2e/Bundle/loadBundle.e2e.js
+++ b/packages/firestore/e2e/Bundle/loadBundle.e2e.js
@@ -27,6 +27,16 @@ describe('firestore().loadBundle()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('loads the bundle contents', async function () {
       const bundle = getBundle();
       const progress = await firebase.firestore().loadBundle(bundle);

--- a/packages/firestore/e2e/Bundle/namedQuery.e2e.js
+++ b/packages/firestore/e2e/Bundle/namedQuery.e2e.js
@@ -23,7 +23,8 @@ describe('firestore().namedQuery()', function () {
 
   beforeEach(async function () {
     await wipe();
-    return await firebase.firestore().loadBundle(getBundle());
+    const { getFirestore, loadBundle } = firestoreModular;
+    return await loadBundle(getFirestore(), getBundle());
   });
 
   // FIXME named query functionality appears to have an android-only issue

--- a/packages/firestore/e2e/Bundle/namedQuery.e2e.js
+++ b/packages/firestore/e2e/Bundle/namedQuery.e2e.js
@@ -28,10 +28,20 @@ describe('firestore().namedQuery()', function () {
 
   // FIXME named query functionality appears to have an android-only issue
   // with loading and clearing and re-loading bundles. We test modular but not v8
-  // APIs since they are the future, and idsable the v8 compat APIs for now
+  // APIs since they are the future, and disable the v8 compat APIs for now
   // Still bears investigating, there could be a race condition either in our android
   // native code or in firebase-android-sdk
   xdescribe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns bundled QuerySnapshot', async function () {
       const query = firebase.firestore().namedQuery(BUNDLE_QUERY_NAME);
       const snapshot = await query.get({ source: 'cache' });

--- a/packages/firestore/e2e/CollectionReference/add.e2e.js
+++ b/packages/firestore/e2e/CollectionReference/add.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.collection().add()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if data is not an object', function () {
       try {
         firebase.firestore().collection(COLLECTION).add(123);

--- a/packages/firestore/e2e/CollectionReference/doc.e2e.js
+++ b/packages/firestore/e2e/CollectionReference/doc.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.collection().doc()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if path is not a document', function () {
       try {
         firebase.firestore().collection(COLLECTION).doc('bar/baz');

--- a/packages/firestore/e2e/CollectionReference/properties.e2e.js
+++ b/packages/firestore/e2e/CollectionReference/properties.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.collection()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns the firestore instance', function () {
       const instance = firebase.firestore().collection(COLLECTION);
       instance.firestore.app.name.should.eql('[DEFAULT]');

--- a/packages/firestore/e2e/DocumentChange.e2e.js
+++ b/packages/firestore/e2e/DocumentChange.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.DocumentChange', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('.doc -> returns a DocumentSnapshot', async function () {
       if (Platform.other) {
         return;

--- a/packages/firestore/e2e/DocumentReference/collection.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/collection.e2e.js
@@ -19,6 +19,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.doc().collection()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if path is not a string', function () {
       try {
         firebase.firestore().doc('bar/baz').collection(123);

--- a/packages/firestore/e2e/DocumentReference/delete.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/delete.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.doc().delete()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('deletes a document', async function () {
       const ref = firebase.firestore().doc(`${COLLECTION}/deleteme`);
       await ref.set({ foo: 'bar' });

--- a/packages/firestore/e2e/DocumentReference/get.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/get.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.doc().get()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if get options are not an object', function () {
       try {
         firebase.firestore().doc('bar/baz').get('foo');

--- a/packages/firestore/e2e/DocumentReference/isEqual.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/isEqual.e2e.js
@@ -63,9 +63,9 @@ describe('firestore.doc().isEqual()', function () {
 
   describe('modular', function () {
     it('throws if other is not a DocumentReference', function () {
-      const { getFirestore, doc } = firestoreModular;
+      const { getFirestore, doc, refEqual } = firestoreModular;
       try {
-        doc(getFirestore(), 'bar/baz').isEqual(123);
+        refEqual(doc(getFirestore(), 'bar/baz'), 123);
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql("'other' expected a DocumentReference instance");
@@ -74,14 +74,16 @@ describe('firestore.doc().isEqual()', function () {
     });
 
     it('returns false when not equal', function () {
-      const { getFirestore, doc } = firestoreModular;
+      const { getApp } = modular;
+      const { getFirestore, doc, refEqual } = firestoreModular;
       const db = getFirestore();
 
       const docRef = doc(db, `${COLLECTION}/baz`);
 
-      const eql1 = docRef.isEqual(doc(db, `${COLLECTION}/foo`));
-      const eql2 = docRef.isEqual(
-        doc(getFirestore(firebase.app('secondaryFromNative')), `${COLLECTION}/baz`),
+      const eql1 = refEqual(docRef, doc(db, `${COLLECTION}/foo`));
+      const eql2 = refEqual(
+        docRef,
+        doc(getFirestore(getApp('secondaryFromNative')), `${COLLECTION}/baz`),
       );
 
       eql1.should.be.False();
@@ -89,12 +91,12 @@ describe('firestore.doc().isEqual()', function () {
     });
 
     it('returns true when equal', function () {
-      const { getFirestore, doc } = firestoreModular;
+      const { getFirestore, doc, refEqual } = firestoreModular;
       const db = getFirestore();
       const docRef = doc(db, `${COLLECTION}/baz`);
 
-      const eql1 = docRef.isEqual(docRef);
-      const eql2 = docRef.isEqual(doc(db, `${COLLECTION}/baz`));
+      const eql1 = refEqual(docRef, docRef);
+      const eql2 = refEqual(docRef, doc(db, `${COLLECTION}/baz`));
 
       eql1.should.be.True();
       eql2.should.be.True();

--- a/packages/firestore/e2e/DocumentReference/isEqual.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/isEqual.e2e.js
@@ -18,6 +18,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.doc().isEqual()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if other is not a DocumentReference', function () {
       try {
         firebase.firestore().doc('bar/baz').isEqual(123);

--- a/packages/firestore/e2e/DocumentReference/onSnapshot.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/onSnapshot.e2e.js
@@ -24,6 +24,16 @@ describe('firestore().doc().onSnapshot()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no arguments are provided', function () {
       try {
         firebase.firestore().doc(`${COLLECTION}/foo`).onSnapshot();

--- a/packages/firestore/e2e/DocumentReference/properties.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/properties.e2e.js
@@ -19,6 +19,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.doc()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns a Firestore instance', function () {
       const instance = firebase.firestore().doc(`${COLLECTION}/bar`);
       should.equal(instance.firestore.constructor.name, 'FirebaseFirestoreModule');

--- a/packages/firestore/e2e/DocumentReference/set.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/set.e2e.js
@@ -353,18 +353,13 @@ describe('firestore.doc().set()', function () {
     });
 
     it('throws if mergeFields contains invalid data', function () {
-      const { getFirestore, doc, setDoc } = firestoreModular;
+      const { getFirestore, doc, setDoc, FieldPath } = firestoreModular;
       try {
         setDoc(
           doc(getFirestore(), `${COLLECTION}/baz`),
           {},
           {
-            mergeFields: [
-              'foo',
-              'foo.bar',
-              new firebase.firestore.FieldPath(COLLECTION, 'baz'),
-              123,
-            ],
+            mergeFields: ['foo', 'foo.bar', new FieldPath(COLLECTION, 'baz'), 123],
           },
         );
         return Promise.reject(new Error('Did not throw an Error.'));
@@ -408,7 +403,7 @@ describe('firestore.doc().set()', function () {
     });
 
     it('merges specific fields', async function () {
-      const { getFirestore, doc, setDoc, getDoc, deleteDoc } = firestoreModular;
+      const { getFirestore, doc, setDoc, getDoc, deleteDoc, FieldPath } = firestoreModular;
       const ref = doc(getFirestore(), `${COLLECTION}/merge`);
       const data1 = { foo: '123', bar: 123, baz: '456' };
       const data2 = { foo: '234', bar: 234, baz: '678' };
@@ -417,7 +412,7 @@ describe('firestore.doc().set()', function () {
       const snapshot1 = await getDoc(ref);
       snapshot1.data().should.eql(jet.contextify(data1));
       await setDoc(ref, data2, {
-        mergeFields: ['bar', new firebase.firestore.FieldPath('baz')],
+        mergeFields: ['bar', new FieldPath('baz')],
       });
       const snapshot2 = await getDoc(ref);
       snapshot2.data().should.eql(jet.contextify(merged));

--- a/packages/firestore/e2e/DocumentReference/set.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/set.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.doc().set()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if data is not an object', function () {
       try {
         firebase.firestore().doc(`${COLLECTION}/baz`).set('foo');

--- a/packages/firestore/e2e/DocumentReference/update.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/update.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.doc().update()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no arguments are provided', function () {
       try {
         firebase.firestore().doc(`${COLLECTION}/baz`).update();

--- a/packages/firestore/e2e/DocumentSnapshot/data.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/data.e2e.js
@@ -26,6 +26,16 @@ describe('firestore().doc() -> snapshot.data()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns undefined if document does not exist', async function () {
       const ref = firebase.firestore().doc(`${COLLECTION}/idonotexist`);
       const snapshot = await ref.get();

--- a/packages/firestore/e2e/DocumentSnapshot/get.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/get.e2e.js
@@ -23,6 +23,16 @@ describe('firestore().doc() -> snapshot.get()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if invalid fieldPath argument', async function () {
       const ref = firebase.firestore().doc(`${COLLECTION}/foo`);
       const snapshot = await ref.get();

--- a/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
@@ -91,7 +91,7 @@ describe('firestore.doc() -> snapshot.isEqual()', function () {
       await setDoc(docRef, { foo: 'bar' });
 
       const docSnapshot1 = await getDoc(docRef);
-      const docSnapshot2 = await doc(db, `${COLLECTION}/idonotexist`).get();
+      const docSnapshot2 = await getDoc(doc(db, `${COLLECTION}/idonotexist`));
       await setDoc(docRef, { foo: 'baz' });
       const docSnapshot3 = await getDoc(docRef);
 

--- a/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
@@ -61,12 +61,12 @@ describe('firestore.doc() -> snapshot.isEqual()', function () {
 
   describe('modular', function () {
     it('throws if other is not a DocumentSnapshot', async function () {
-      const { getFirestore, doc, getDoc } = firestoreModular;
+      const { getFirestore, doc, getDoc, snapshotEqual } = firestoreModular;
       try {
         const docRef = doc(getFirestore(), `${COLLECTION}/baz`);
 
         const docSnapshot = await getDoc(docRef);
-        docSnapshot.isEqual(123);
+        snapshotEqual(docSnapshot, 123);
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql("'other' expected a DocumentSnapshot instance");
@@ -75,7 +75,7 @@ describe('firestore.doc() -> snapshot.isEqual()', function () {
     });
 
     it('returns false when not equal', async function () {
-      const { getFirestore, doc, setDoc, getDoc } = firestoreModular;
+      const { getFirestore, doc, setDoc, getDoc, snapshotEqual } = firestoreModular;
       const db = getFirestore();
       const docRef = doc(db, `${COLLECTION}/isEqual-false-exists`);
       await setDoc(docRef, { foo: 'bar' });
@@ -85,21 +85,21 @@ describe('firestore.doc() -> snapshot.isEqual()', function () {
       await setDoc(docRef, { foo: 'baz' });
       const docSnapshot3 = await getDoc(docRef);
 
-      const eql1 = docSnapshot1.isEqual(docSnapshot2);
-      const eql2 = docSnapshot1.isEqual(docSnapshot3);
+      const eql1 = snapshotEqual(docSnapshot1, docSnapshot2);
+      const eql2 = snapshotEqual(docSnapshot1, docSnapshot3);
 
       eql1.should.be.False();
       eql2.should.be.False();
     });
 
     it('returns true when equal', async function () {
-      const { getFirestore, doc, setDoc, getDoc } = firestoreModular;
+      const { getFirestore, doc, setDoc, getDoc, snapshotEqual } = firestoreModular;
       const docRef = doc(getFirestore(), `${COLLECTION}/isEqual-true-exists`);
       await setDoc(docRef, { foo: 'bar' });
 
       const docSnapshot = await getDoc(docRef);
 
-      const eql1 = docSnapshot.isEqual(docSnapshot);
+      const eql1 = snapshotEqual(docSnapshot, docSnapshot);
 
       eql1.should.be.True();
     });

--- a/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/isEqual.e2e.js
@@ -18,6 +18,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.doc() -> snapshot.isEqual()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if other is not a DocumentSnapshot', async function () {
       try {
         const docRef = firebase.firestore().doc(`${COLLECTION}/baz`);

--- a/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
@@ -23,6 +23,16 @@ describe('firestore().doc() -> snapshot', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('.exists -> returns a boolean for exists', async function () {
       const ref1 = firebase.firestore().doc(`${COLLECTION}/exists`);
       const ref2 = firebase.firestore().doc(`${COLLECTION}/idonotexist`);

--- a/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
@@ -79,7 +79,7 @@ describe('firestore().doc() -> snapshot', function () {
   describe('modular', function () {
     it('.exists -> returns a boolean for exists', async function () {
       const { getFirestore, doc, setDoc, getDoc, deleteDoc } = firestoreModular;
-      const db = getFirestore(firebase.app());
+      const db = getFirestore();
 
       const ref1 = doc(db, `${COLLECTION}/exists`);
       const ref2 = doc(db, `${COLLECTION}/idonotexist`);
@@ -94,7 +94,7 @@ describe('firestore().doc() -> snapshot', function () {
 
     it('.id -> returns the correct id', async function () {
       const { getFirestore, doc, setDoc, getDoc, deleteDoc } = firestoreModular;
-      const db = getFirestore(firebase.app());
+      const db = getFirestore();
 
       const ref1 = doc(db, `${COLLECTION}/exists`);
       const ref2 = doc(db, `${COLLECTION}/idonotexist`);
@@ -116,7 +116,7 @@ describe('firestore().doc() -> snapshot', function () {
 
     it('.ref -> returns the correct document ref', async function () {
       const { getFirestore, doc, setDoc, getDoc, deleteDoc } = firestoreModular;
-      const db = getFirestore(firebase.app());
+      const db = getFirestore();
       const ref1 = doc(db, `${COLLECTION}/exists`);
       const ref2 = doc(db, `${COLLECTION}/idonotexist`);
       await setDoc(ref1, { foo: ' bar' });

--- a/packages/firestore/e2e/FieldPath.e2e.js
+++ b/packages/firestore/e2e/FieldPath.e2e.js
@@ -19,6 +19,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.FieldPath', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('should throw if no segments', function () {
       try {
         new firebase.firestore.FieldPath();

--- a/packages/firestore/e2e/FieldValue.e2e.js
+++ b/packages/firestore/e2e/FieldValue.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.FieldValue', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('should throw if constructed manually', function () {
       try {
         new firebase.firestore.FieldValue();

--- a/packages/firestore/e2e/FieldValue.e2e.js
+++ b/packages/firestore/e2e/FieldValue.e2e.js
@@ -392,8 +392,8 @@ describe('firestore.FieldValue', function () {
         snapshot1.data().foo.nanoseconds.should.be.a.Number();
         const current = snapshot1.data().foo.nanoseconds;
         await Utils.sleep(100);
-        await updateDoc(ref, { foo: firebase.firestore.FieldValue.serverTimestamp() });
-        const snapshot2 = await ref.get();
+        await updateDoc(ref, { foo: serverTimestamp() });
+        const snapshot2 = await getDoc(ref);
         snapshot2.data().foo.nanoseconds.should.be.a.Number();
         should.equal(current === snapshot2.data().foo.nanoseconds, false);
         await deleteDoc(ref);

--- a/packages/firestore/e2e/FirestoreStatics.e2e.js
+++ b/packages/firestore/e2e/FirestoreStatics.e2e.js
@@ -17,6 +17,16 @@
 
 describe('firestore.X', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('setLogLevel', function () {
       it('throws if invalid level', function () {
         try {

--- a/packages/firestore/e2e/GeoPoint.e2e.js
+++ b/packages/firestore/e2e/GeoPoint.e2e.js
@@ -22,6 +22,16 @@ describe('firestore.GeoPoint', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if invalid number of arguments', function () {
       try {
         new firebase.firestore.GeoPoint(123);

--- a/packages/firestore/e2e/Query/endAt.e2e.js
+++ b/packages/firestore/e2e/Query/endAt.e2e.js
@@ -23,6 +23,16 @@ describe('firestore().collection().endAt()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no argument provided', function () {
       try {
         firebase.firestore().collection(COLLECTION).endAt();

--- a/packages/firestore/e2e/Query/endBefore.e2e.js
+++ b/packages/firestore/e2e/Query/endBefore.e2e.js
@@ -23,6 +23,16 @@ describe('firestore().collection().endBefore()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no argument provided', function () {
       try {
         firebase.firestore().collection(COLLECTION).endBefore();

--- a/packages/firestore/e2e/Query/get.e2e.js
+++ b/packages/firestore/e2e/Query/get.e2e.js
@@ -23,6 +23,16 @@ describe('firestore().collection().get()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if get options is not an object', function () {
       try {
         firebase.firestore().collection(COLLECTION).get(123);

--- a/packages/firestore/e2e/Query/isEqual.e2e.js
+++ b/packages/firestore/e2e/Query/isEqual.e2e.js
@@ -152,7 +152,8 @@ describe('firestore().collection().isEqual()', function () {
 
     it('returns false when not equal (simple checks)', function () {
       const { getApp } = modular;
-      const { getFirestore, collection, query, where, orderBy, limit } = firestoreModular;
+      const { getFirestore, collection, query, where, orderBy, limit, queryEqual } =
+        firestoreModular;
       const db = getFirestore();
       const secondaryDb = getFirestore(getApp('secondaryFromNative'));
 
@@ -167,11 +168,11 @@ describe('firestore().collection().isEqual()', function () {
       const ref1 = query(collection(db, subCol), where('bar', '==', true));
       const ref2 = query(collection(db, subCol), where('bar', '==', true));
 
-      const eql1 = queryRef.isEqual(q1);
-      const eql2 = queryRef.isEqual(q2);
-      const eql3 = queryRef.isEqual(q3);
-      const eql4 = queryRef.isEqual(q4);
-      const eql5 = ref1.isEqual(ref2);
+      const eql1 = queryEqual(queryRef, q1);
+      const eql2 = queryEqual(queryRef, q2);
+      const eql3 = queryEqual(queryRef, q3);
+      const eql4 = queryEqual(queryRef, q4);
+      const eql5 = queryEqual(ref1, ref2);
 
       eql1.should.be.False();
       eql2.should.be.False();

--- a/packages/firestore/e2e/Query/isEqual.e2e.js
+++ b/packages/firestore/e2e/Query/isEqual.e2e.js
@@ -140,9 +140,9 @@ describe('firestore().collection().isEqual()', function () {
 
   describe('modular', function () {
     it('throws if other is not a Query', function () {
-      const { getFirestore, collection } = firestoreModular;
+      const { getFirestore, collection, refEqual } = firestoreModular;
       try {
-        collection(getFirestore(), COLLECTION).isEqual(123);
+        refEqual(collection(getFirestore(), COLLECTION), 123);
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql("'other' expected a Query instance");

--- a/packages/firestore/e2e/Query/isEqual.e2e.js
+++ b/packages/firestore/e2e/Query/isEqual.e2e.js
@@ -18,6 +18,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore().collection().isEqual()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if other is not a Query', function () {
       try {
         firebase.firestore().collection(COLLECTION).isEqual(123);

--- a/packages/firestore/e2e/Query/isEqual.e2e.js
+++ b/packages/firestore/e2e/Query/isEqual.e2e.js
@@ -151,9 +151,10 @@ describe('firestore().collection().isEqual()', function () {
     });
 
     it('returns false when not equal (simple checks)', function () {
+      const { getApp } = modular;
       const { getFirestore, collection, query, where, orderBy, limit } = firestoreModular;
       const db = getFirestore();
-      const secondaryDb = getFirestore(firebase.app('secondaryFromNative'));
+      const secondaryDb = getFirestore(getApp('secondaryFromNative'));
 
       const subCol = `${COLLECTION}/isequal/simplechecks`;
       const queryRef = collection(db, subCol);

--- a/packages/firestore/e2e/Query/limit.e2e.js
+++ b/packages/firestore/e2e/Query/limit.e2e.js
@@ -23,6 +23,16 @@ describe('firestore().collection().limit()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if limit is invalid', function () {
       try {
         firebase.firestore().collection(COLLECTION).limit(-1);

--- a/packages/firestore/e2e/Query/limitToLast.e2e.js
+++ b/packages/firestore/e2e/Query/limitToLast.e2e.js
@@ -23,6 +23,16 @@ describe('firestore().collection().limitToLast()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if limitToLast is invalid', function () {
       try {
         firebase.firestore().collection(COLLECTION).limitToLast(-1);

--- a/packages/firestore/e2e/Query/onSnapshot.e2e.js
+++ b/packages/firestore/e2e/Query/onSnapshot.e2e.js
@@ -24,6 +24,16 @@ describe('firestore().collection().onSnapshot()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no arguments are provided', function () {
       try {
         firebase.firestore().collection(COLLECTION).onSnapshot();

--- a/packages/firestore/e2e/Query/orderBy.e2e.js
+++ b/packages/firestore/e2e/Query/orderBy.e2e.js
@@ -22,6 +22,16 @@ describe('firestore().collection().orderBy()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if fieldPath is not valid', function () {
       try {
         firebase.firestore().collection(COLLECTION).orderBy(123);

--- a/packages/firestore/e2e/Query/query.e2e.js
+++ b/packages/firestore/e2e/Query/query.e2e.js
@@ -113,12 +113,12 @@ describe('FirestoreQuery/FirestoreQueryModifiers', function () {
 
       try {
         query(
-          collection(db, COLLECTION)
-            .where('foo', '==', 'bar')
-            .orderBy('bar')
-            .orderBy('foo')
-            .limit(1)
-            .endAt(2),
+          collection(db, COLLECTION),
+          where('foo', '==', 'bar'),
+          orderBy('bar'),
+          orderBy('foo'),
+          limit(1),
+          endAt(2),
         );
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {

--- a/packages/firestore/e2e/Query/query.e2e.js
+++ b/packages/firestore/e2e/Query/query.e2e.js
@@ -17,6 +17,16 @@ const COLLECTION = 'firestore';
 
 describe('FirestoreQuery/FirestoreQueryModifiers', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('should not mutate previous queries (#2691)', async function () {
       const queryBefore = firebase.firestore().collection(COLLECTION).where('age', '>', 30);
       const queryAfter = queryBefore.orderBy('age');

--- a/packages/firestore/e2e/Query/startAfter.e2e.js
+++ b/packages/firestore/e2e/Query/startAfter.e2e.js
@@ -22,6 +22,16 @@ describe('firestore().collection().startAfter()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no argument provided', function () {
       try {
         firebase.firestore().collection(COLLECTION).startAfter();

--- a/packages/firestore/e2e/Query/startAfter.e2e.js
+++ b/packages/firestore/e2e/Query/startAfter.e2e.js
@@ -256,7 +256,7 @@ describe('firestore().collection().startAfter()', function () {
     });
 
     it('starts after snapshot field values', async function () {
-      const { getFirestore, collection, doc, setDoc, query, startAfter, getDocs, getDoc } =
+      const { getFirestore, collection, doc, setDoc, query, startAfter, getDocs, getDoc, orderBy } =
         firestoreModular;
       const colRef = collection(getFirestore(), `${COLLECTION}/startAfter/snapshotFields`);
       const doc1 = doc(colRef, 'doc1');
@@ -271,7 +271,7 @@ describe('firestore().collection().startAfter()', function () {
 
       const startAfterSnapshot = await getDoc(doc2);
 
-      const qs = await getDocs(query(colRef.orderBy('bar.value'), startAfter(startAfterSnapshot)));
+      const qs = await getDocs(query(colRef, orderBy('bar.value'), startAfter(startAfterSnapshot)));
 
       qs.docs.length.should.eql(1);
       qs.docs[0].id.should.eql('doc3');

--- a/packages/firestore/e2e/Query/startAt.e2e.js
+++ b/packages/firestore/e2e/Query/startAt.e2e.js
@@ -22,6 +22,16 @@ describe('firestore().collection().startAt()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no argument provided', function () {
       try {
         firebase.firestore().collection(COLLECTION).startAt();

--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -16,11 +16,10 @@
  */
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
-let Filter;
+const { Filter } = firestoreModular;
 
 describe(' firestore().collection().where(AND Filters)', function () {
   beforeEach(async function () {
-    Filter = firebase.firestore.Filter;
     return await wipe();
   });
 
@@ -778,14 +777,14 @@ describe(' firestore().collection().where(AND Filters)', function () {
     });
 
     it('allows multiple inequalities (excluding `!=`) on different paths provided', async function () {
-      const { getFirestore, collection, query, and, where } = firestoreModular;
+      const { getFirestore, addDoc, collection, query, and, where } = firestoreModular;
       const colRef = collection(getFirestore(), `${COLLECTION}/filter/different-path-inequality`);
 
       const expected = { foo: { bar: 300 }, bar: 200 };
       await Promise.all([
-        colRef.add({ foo: { bar: 1 }, bar: 1 }),
-        colRef.add(expected),
-        colRef.add(expected),
+        addDoc(colRef, { foo: { bar: 1 }, bar: 1 }),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
       ]);
 
       const snapshot = await query(
@@ -990,15 +989,16 @@ describe(' firestore().collection().where(AND Filters)', function () {
     });
 
     it("should allow query when combining '!=' operator with any other inequality operator on a different field", async function () {
-      const { query, where, and } = firestoreModular;
-      const colRef = firebase
-        .firestore()
-        .collection(`${COLLECTION}/filter/inequality-combine-not-equal`);
+      const { getFirestore, addDoc, collection, query, where, and } = firestoreModular;
+      const colRef = collection(
+        getFirestore(),
+        `${COLLECTION}/filter/inequality-combine-not-equal`,
+      );
       const expected = { foo: { bar: 300 }, bar: 200 };
       await Promise.all([
-        colRef.add({ foo: { bar: 1 }, bar: 1 }),
-        colRef.add(expected),
-        colRef.add(expected),
+        addDoc(colRef, { foo: { bar: 1 }, bar: 1 }),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
       ]);
 
       const snapshot = await query(
@@ -1368,8 +1368,8 @@ describe(' firestore().collection().where(AND Filters)', function () {
         query(
           colRef,
           and(
-            where(new firebase.firestore.FieldPath('foo', 'bar'), '>', 1),
-            where(new firebase.firestore.FieldPath('foo', 'bar'), '<', 3),
+            where(new FieldPath('foo', 'bar'), '>', 1),
+            where(new FieldPath('foo', 'bar'), '<', 3),
           ),
           orderBy(new FieldPath('foo', 'bar')),
         ),

--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -25,6 +25,16 @@ describe(' firestore().collection().where(AND Filters)', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if fieldPath string is invalid', function () {
       try {
         firebase

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -22,6 +22,16 @@ describe('firestore().collection().where()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if fieldPath is invalid', function () {
       try {
         firebase.firestore().collection(COLLECTION).where(123);

--- a/packages/firestore/e2e/Query/where.e2e.js
+++ b/packages/firestore/e2e/Query/where.e2e.js
@@ -659,16 +659,14 @@ describe('firestore().collection().where()', function () {
     });
 
     it('allows multiple inequalities (excluding `!=`) on different paths provided', async function () {
-      const { query, where } = firestoreModular;
+      const { getFirestore, addDoc, collection, query, where } = firestoreModular;
 
-      const colRef = firebase
-        .firestore()
-        .collection(`${COLLECTION}/filter/different-path-inequality`);
+      const colRef = collection(getFirestore(), `${COLLECTION}/filter/different-path-inequality`);
       const expected = { foo: { bar: 300 }, bar: 200 };
       await Promise.all([
-        colRef.add({ foo: { bar: 1 }, bar: 1 }),
-        colRef.add(expected),
-        colRef.add(expected),
+        addDoc(colRef, { foo: { bar: 1 }, bar: 1 }),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
       ]);
 
       const snapshot = await query(
@@ -1132,16 +1130,16 @@ describe('firestore().collection().where()', function () {
     });
 
     it("should allow query when combining '!=' operator with any other inequality operator on a different field", async function () {
-      const { getFirestore, collection, query, where } = firestoreModular;
+      const { getFirestore, addDoc, collection, query, where } = firestoreModular;
       const colRef = collection(
         getFirestore(),
         `${COLLECTION}/filter/inequality-combine-not-equal`,
       );
       const expected = { foo: { bar: 300 }, bar: 200 };
       await Promise.all([
-        colRef.add({ foo: { bar: 1 }, bar: 1 }),
-        colRef.add(expected),
-        colRef.add(expected),
+        addDoc(colRef, { foo: { bar: 1 }, bar: 1 }),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
       ]);
 
       const snapshot = await query(colRef, where('foo.bar', '>', 123), where('bar', '!=', 1)).get();

--- a/packages/firestore/e2e/Query/where.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.filter.e2e.js
@@ -20,8 +20,15 @@ let Filter;
 
 describe('firestore().collection().where(Filters)', function () {
   beforeEach(async function () {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
     Filter = firebase.firestore.Filter;
     return await wipe();
+  });
+
+  afterEach(async function afterEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
   });
 
   it('throws if fieldPath string is invalid', function () {

--- a/packages/firestore/e2e/Query/where.or.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.or.filter.e2e.js
@@ -16,11 +16,10 @@
  */
 const COLLECTION = 'firestore';
 const { wipe } = require('../helpers');
-let Filter;
+const { Filter } = firestoreModular;
 
 describe('firestore().collection().where(OR Filters)', function () {
   beforeEach(async function () {
-    Filter = firebase.firestore.Filter;
     return await wipe();
   });
 
@@ -1238,16 +1237,14 @@ describe('firestore().collection().where(OR Filters)', function () {
     });
 
     it('allows multiple inequalities (excluding `!=`) on different paths provided', async function () {
-      const { where, or, and, query } = firestoreModular;
+      const { getFirestore, addDoc, collection, where, or, and, query } = firestoreModular;
 
-      const colRef = firebase
-        .firestore()
-        .collection(`${COLLECTION}/filter/different-path-inequality`);
+      const colRef = collection(getFirestore(), `${COLLECTION}/filter/different-path-inequality`);
       const expected = { foo: { bar: 300 }, bar: 200 };
       await Promise.all([
-        colRef.add({ foo: { bar: 1 }, bar: 1 }),
-        colRef.add(expected),
-        colRef.add(expected),
+        addDoc(colRef, { foo: { bar: 1 }, bar: 1 }),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
       ]);
 
       const snapshot = await query(
@@ -1519,16 +1516,16 @@ describe('firestore().collection().where(OR Filters)', function () {
     });
 
     it("should allow query when combining '!=' operator with any other inequality operator on a different field", async function () {
-      const { getFirestore, collection, where, or, and, query } = firestoreModular;
+      const { getFirestore, addDoc, collection, where, or, and, query } = firestoreModular;
       const colRef = collection(
         getFirestore(),
         `${COLLECTION}/filter/inequality-combine-not-equal`,
       );
       const expected = { foo: { bar: 300 }, bar: 200 };
       await Promise.all([
-        colRef.add({ foo: { bar: 1 }, bar: 1 }),
-        colRef.add(expected),
-        colRef.add(expected),
+        addDoc(colRef, { foo: { bar: 1 }, bar: 1 }),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
       ]);
 
       const snapshot = await query(
@@ -1851,12 +1848,16 @@ describe('firestore().collection().where(OR Filters)', function () {
     });
 
     it('returns with where "==" & "<" filter', async function () {
-      const { getFirestore, collection, where, or, and, query, getDocs } = firestoreModular;
+      const { getFirestore, addDoc, collection, where, or, and, query, getDocs } = firestoreModular;
       const colRef = collection(getFirestore(), `${COLLECTION}/filter/equals-modular`);
 
       const expected = { foo: 'bar', population: 200 };
       const notExpected = { foo: 'bar', population: 1000 };
-      await Promise.all([colRef.add(notExpected), colRef.add(expected), colRef.add(expected)]);
+      await Promise.all([
+        addDoc(colRef, notExpected),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
+      ]);
 
       const snapshot = await getDocs(
         query(

--- a/packages/firestore/e2e/Query/where.or.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.or.filter.e2e.js
@@ -25,6 +25,16 @@ describe('firestore().collection().where(OR Filters)', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if using nested Filter.or() queries', async function () {
       try {
         firebase

--- a/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
@@ -699,7 +699,7 @@ describe('Second Database', function () {
         });
 
         it('should set data with merge fields', async function () {
-          const { runTransaction, doc, getDoc, setDoc } = firestoreModular;
+          const { runTransaction, doc, getDoc, setDoc, FieldPath } = firestoreModular;
           const db = firestore;
 
           const docRef = doc(db, `${COLLECTION}/transactions/transaction/set-mergefields`);
@@ -722,7 +722,7 @@ describe('Second Database', function () {
                 baz: 'foo',
               },
               {
-                mergeFields: ['bar', new firebase.firestore.FieldPath('baz')],
+                mergeFields: ['bar', new FieldPath('baz')],
               },
             );
           });

--- a/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
@@ -26,8 +26,15 @@ describe('Second Database', function () {
     describe('v8 compatibility', function () {
       let firestore;
 
-      before(function () {
+      beforeEach(async function beforeEachTest() {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
         firestore = firebase.app().firestore(SECOND_DATABASE_ID);
+      });
+
+      afterEach(async function afterEachTest() {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
       });
 
       it('should throw if updateFunction is not a Promise', async function () {

--- a/packages/firestore/e2e/SecondDatabase/second.onSnapshot.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.onSnapshot.e2e.js
@@ -27,12 +27,16 @@ describe('Second Database', function () {
     describe('v8 compatibility', function () {
       let firestore;
 
-      before(function () {
+      beforeEach(async function () {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
         firestore = firebase.app().firestore(SECOND_DATABASE_ID);
+        return await wipe(false, SECOND_DATABASE_ID);
       });
 
-      beforeEach(async function () {
-        return await wipe(false, SECOND_DATABASE_ID);
+      afterEach(async function afterEachTest() {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
       });
 
       it('throws if no arguments are provided', function () {

--- a/packages/firestore/e2e/SecondDatabase/second.where.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.where.e2e.js
@@ -25,12 +25,16 @@ describe('Second Database', function () {
     describe('v8 compatibility', function () {
       let firestore;
 
-      before(function () {
+      beforeEach(async function () {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
         firestore = firebase.app().firestore(SECOND_DATABASE_ID);
+        return await wipe(false, SECOND_DATABASE_ID);
       });
 
-      beforeEach(async function () {
-        return await wipe(false, SECOND_DATABASE_ID);
+      afterEach(async function afterEachTest() {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
       });
 
       it('throws if fieldPath is invalid', function () {

--- a/packages/firestore/e2e/SnapshotMetadata.e2e.js
+++ b/packages/firestore/e2e/SnapshotMetadata.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.SnapshotMetadata', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('.fromCache -> returns a boolean', async function () {
       const ref1 = firebase.firestore().collection(COLLECTION);
       const ref2 = firebase.firestore().doc(`${COLLECTION}/idonotexist`);

--- a/packages/firestore/e2e/Timestamp.e2e.js
+++ b/packages/firestore/e2e/Timestamp.e2e.js
@@ -17,6 +17,16 @@
 
 describe('firestore.Timestamp', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if seconds is not a number', function () {
       try {
         new firebase.firestore.Timestamp('1234');

--- a/packages/firestore/e2e/Transaction.e2e.js
+++ b/packages/firestore/e2e/Transaction.e2e.js
@@ -701,7 +701,7 @@ describe('firestore.Transaction', function () {
       });
 
       it('should set data with merge fields', async function () {
-        const { getFirestore, runTransaction, doc, getDoc, setDoc } = firestoreModular;
+        const { getFirestore, runTransaction, doc, getDoc, setDoc, FieldPath } = firestoreModular;
         const db = getFirestore();
 
         const docRef = doc(db, `${COLLECTION}/transactions/transaction/set-mergefields`);
@@ -724,7 +724,7 @@ describe('firestore.Transaction', function () {
               baz: 'foo',
             },
             {
-              mergeFields: ['bar', new firebase.firestore.FieldPath('baz')],
+              mergeFields: ['bar', new FieldPath('baz')],
             },
           );
         });

--- a/packages/firestore/e2e/Transaction.e2e.js
+++ b/packages/firestore/e2e/Transaction.e2e.js
@@ -19,6 +19,16 @@ const NO_RULE_COLLECTION = 'no_rules';
 
 describe('firestore.Transaction', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('should throw if updateFunction is not a Promise', async function () {
       try {
         await firebase.firestore().runTransaction(() => 123);

--- a/packages/firestore/e2e/WriteBatch/commit.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/commit.e2e.js
@@ -23,6 +23,16 @@ describe('firestore.WriteBatch.commit()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns a Promise', function () {
       const commit = firebase.firestore().batch().commit();
       commit.should.be.a.Promise();

--- a/packages/firestore/e2e/WriteBatch/delete.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/delete.e2e.js
@@ -18,6 +18,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.WriteBatch.delete()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if a DocumentReference instance is not provided', function () {
       try {
         firebase.firestore().batch().delete(123);

--- a/packages/firestore/e2e/WriteBatch/delete.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/delete.e2e.js
@@ -78,12 +78,13 @@ describe('firestore.WriteBatch.delete()', function () {
     });
 
     it('throws if a DocumentReference firestore instance is different', function () {
+      const { getApp } = modular;
       const { getFirestore, doc, writeBatch } = firestoreModular;
       try {
-        const app2 = firebase.app('secondaryFromNative');
+        const app2 = getApp('secondaryFromNative');
         const docRef = doc(getFirestore(app2), `${COLLECTION}/foo`);
 
-        writeBatch(getFirestore()).delete(docRef);
+        writeBatch(getFirestore()).delete(docRef).commit();
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql(

--- a/packages/firestore/e2e/WriteBatch/set.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/set.e2e.js
@@ -227,12 +227,13 @@ describe('firestore.WriteBatch.set()', function () {
     });
 
     it('throws if a DocumentReference firestore instance is different', function () {
+      const { getApp } = modular;
       const { getFirestore, doc, writeBatch } = firestoreModular;
       try {
-        const app2 = firebase.app('secondaryFromNative');
+        const app2 = getApp('secondaryFromNative');
         const docRef = doc(getFirestore(app2), `${COLLECTION}/foo`);
 
-        writeBatch(getFirestore()).set(docRef);
+        writeBatch(getFirestore()).set(docRef, {}).commit();
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql(
@@ -385,14 +386,14 @@ describe('firestore.WriteBatch.set()', function () {
     });
 
     it('adds the DocumentReference to the internal writes', function () {
-      const { getFirestore, doc, writeBatch } = firestoreModular;
+      const { getFirestore, doc, writeBatch, FieldPath } = firestoreModular;
       const db = getFirestore();
       const docRef = doc(db, `${COLLECTION}/foo`);
 
       const wb = writeBatch(db).set(
         docRef,
         { foo: 'bar' },
-        { mergeFields: [new firebase.firestore.FieldPath('foo', 'bar')] },
+        { mergeFields: [new FieldPath('foo', 'bar')] },
       );
       wb._writes.length.should.eql(1);
       const expected = {

--- a/packages/firestore/e2e/WriteBatch/set.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/set.e2e.js
@@ -18,6 +18,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.WriteBatch.set()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if a DocumentReference instance is not provided', function () {
       try {
         firebase.firestore().batch().set(123);

--- a/packages/firestore/e2e/WriteBatch/update.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/update.e2e.js
@@ -19,6 +19,16 @@ const COLLECTION = 'firestore';
 
 describe('firestore.WriteBatch.update()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if a DocumentReference instance is not provided', function () {
       try {
         firebase.firestore().batch().update(123);

--- a/packages/firestore/e2e/WriteBatch/update.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/update.e2e.js
@@ -123,12 +123,13 @@ describe('firestore.WriteBatch.update()', function () {
     });
 
     it('throws if a DocumentReference firestore instance is different', function () {
+      const { getApp } = modular;
       const { getFirestore, doc, writeBatch } = firestoreModular;
       try {
-        const app2 = firebase.app('secondaryFromNative');
+        const app2 = getApp('secondaryFromNative');
         const docRef = doc(getFirestore(app2), `${COLLECTION}/foo`);
 
-        writeBatch(getFirestore()).update(docRef);
+        writeBatch(getFirestore()).update(docRef, {}).commit();
         return Promise.reject(new Error('Did not throw an Error.'));
       } catch (error) {
         error.message.should.containEql(

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -653,9 +653,18 @@ describe('firestore()', function () {
             // Not supported on web lite sdk
             return;
           }
-          const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc } = firestoreModular;
+          const { getApp } = modular;
+          const {
+            initializeFirestore,
+            doc,
+            onSnapshot,
+            setDoc,
+            deleteDoc,
+            serverTimestamp,
+            Timestamp,
+          } = firestoreModular;
 
-          const db = await initializeFirestore(firebase.app(), {
+          const db = await initializeFirestore(getApp(), {
             serverTimestampBehavior: 'estimate',
           });
           const ref = doc(db, `${COLLECTION}/serverTimestampEstimate`);
@@ -665,7 +674,7 @@ describe('firestore()', function () {
               ref,
               snapshot => {
                 try {
-                  should(snapshot.get('timestamp')).be.an.instanceOf(firebase.firestore.Timestamp);
+                  should(snapshot.get('timestamp')).be.an.instanceOf(Timestamp);
                   subscription();
                   resolve();
                 } catch (e) {
@@ -676,7 +685,7 @@ describe('firestore()', function () {
             );
           });
 
-          await setDoc(ref, { timestamp: firebase.firestore.FieldValue.serverTimestamp() });
+          await setDoc(ref, { timestamp: serverTimestamp() });
           await promise;
           await deleteDoc(ref);
         });
@@ -687,10 +696,19 @@ describe('firestore()', function () {
             // Not supported on web lite sdk
             return;
           }
-          const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc, snapshotEqual } =
-            firestoreModular;
+          const { getApp } = modular;
+          const {
+            initializeFirestore,
+            doc,
+            onSnapshot,
+            setDoc,
+            deleteDoc,
+            snapshotEqual,
+            serverTimestamp,
+            Timestamp,
+          } = firestoreModular;
 
-          const db = await initializeFirestore(firebase.app(), {
+          const db = await initializeFirestore(getApp(), {
             serverTimestampBehavior: 'previous',
           });
           const ref = doc(db, `${COLLECTION}/serverTimestampPrevious`);
@@ -707,22 +725,16 @@ describe('firestore()', function () {
                       should(snapshot.get('timestamp')).equal(null);
                       break;
                     case 1:
-                      should(snapshot.get('timestamp')).be.an.instanceOf(
-                        firebase.firestore.Timestamp,
-                      );
+                      should(snapshot.get('timestamp')).be.an.instanceOf(Timestamp);
                       break;
                     case 2:
-                      should(snapshot.get('timestamp')).be.an.instanceOf(
-                        firebase.firestore.Timestamp,
-                      );
+                      should(snapshot.get('timestamp')).be.an.instanceOf(Timestamp);
                       should(
                         snapshotEqual(snapshot.get('timestamp'), previous.get('timestamp')),
                       ).equal(true);
                       break;
                     case 3:
-                      should(snapshot.get('timestamp')).be.an.instanceOf(
-                        firebase.firestore.Timestamp,
-                      );
+                      should(snapshot.get('timestamp')).be.an.instanceOf(Timestamp);
                       should(
                         snapshotEqual(snapshot.get('timestamp'), previous.get('timestamp')),
                       ).equal(false);
@@ -739,9 +751,9 @@ describe('firestore()', function () {
             );
           });
 
-          await setDoc(ref, { timestamp: firebase.firestore.FieldValue.serverTimestamp() });
+          await setDoc(ref, { timestamp: serverTimestamp() });
           await new Promise(resolve => setTimeout(resolve, 100));
-          await setDoc(ref, { timestamp: firebase.firestore.FieldValue.serverTimestamp() });
+          await setDoc(ref, { timestamp: serverTimestamp() });
           await promise;
           await deleteDoc(ref);
         });
@@ -752,9 +764,18 @@ describe('firestore()', function () {
             // Not supported on web lite sdk
             return;
           }
-          const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc } = firestoreModular;
+          const { getApp } = modular;
+          const {
+            initializeFirestore,
+            doc,
+            onSnapshot,
+            setDoc,
+            deleteDoc,
+            serverTimestamp,
+            Timestamp,
+          } = firestoreModular;
 
-          const db = await initializeFirestore(firebase.app(), {
+          const db = await initializeFirestore(getApp(), {
             serverTimestampBehavior: 'none',
           });
           const ref = doc(db, `${COLLECTION}/serverTimestampNone`);
@@ -771,9 +792,7 @@ describe('firestore()', function () {
                       should(snapshot.get('timestamp')).equal(null);
                       break;
                     case 1:
-                      should(snapshot.get('timestamp')).be.an.instanceOf(
-                        firebase.firestore.Timestamp,
-                      );
+                      should(snapshot.get('timestamp')).be.an.instanceOf(Timestamp);
                       subscription();
                       resolve();
                       break;
@@ -789,7 +808,7 @@ describe('firestore()', function () {
             );
           });
 
-          await setDoc(ref, { timestamp: firebase.firestore.FieldValue.serverTimestamp() });
+          await setDoc(ref, { timestamp: serverTimestamp() });
           await promise;
           await deleteDoc(ref);
         });

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -19,6 +19,16 @@ const COLLECTION_GROUP = 'collectionGroup';
 
 describe('firestore()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('namespace', function () {
       // removing as pending if module.options.hasMultiAppSupport = true
       it('supports multiple apps', async function () {
@@ -422,9 +432,10 @@ describe('firestore()', function () {
     describe('getFirestore', function () {
       // removing as pending if module.options.hasMultiAppSupport = true
       it('supports multiple apps', async function () {
+        const { getApp } = modular;
         const { getFirestore } = firestoreModular;
         const db1 = await getFirestore();
-        const db2 = await getFirestore(firebase.app('secondaryFromNative'));
+        const db2 = await getFirestore(getApp('secondaryFromNative'));
 
         db1.app.name.should.equal('[DEFAULT]');
         db2.app.name.should.equal('secondaryFromNative');
@@ -663,9 +674,9 @@ describe('firestore()', function () {
           await deleteDoc(ref);
         });
 
-        // FIXME: works in isolation but not in suite
-        xit("handles 'previous'", async function () {
-          const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc } = firestoreModular;
+        it("handles 'previous'", async function () {
+          const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc, snapshotEqual } =
+            firestoreModular;
 
           const db = await initializeFirestore(firebase.app(), {
             serverTimestampBehavior: 'previous',
@@ -692,17 +703,17 @@ describe('firestore()', function () {
                       should(snapshot.get('timestamp')).be.an.instanceOf(
                         firebase.firestore.Timestamp,
                       );
-                      should(snapshot.get('timestamp').isEqual(previous.get('timestamp'))).equal(
-                        true,
-                      );
+                      should(
+                        snapshotEqual(snapshot.get('timestamp'), previous.get('timestamp')),
+                      ).equal(true);
                       break;
                     case 3:
                       should(snapshot.get('timestamp')).be.an.instanceOf(
                         firebase.firestore.Timestamp,
                       );
-                      should(snapshot.get('timestamp').isEqual(previous.get('timestamp'))).equal(
-                        false,
-                      );
+                      should(
+                        snapshotEqual(snapshot.get('timestamp'), previous.get('timestamp')),
+                      ).equal(false);
                       subscription();
                       resolve();
                       break;

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -219,7 +219,8 @@ describe('firestore()', function () {
 
     describe('settings', function () {
       describe('serverTimestampBehavior', function () {
-        it("handles 'estimate'", async function () {
+        // TODO flakey in new Jet setup since it conflicts with the modular tests
+        xit("handles 'estimate'", async function () {
           // TODO(ehesp): Figure out how to call settings on other.
           if (Platform.other) {
             // Not supported on web lite sdk
@@ -246,7 +247,8 @@ describe('firestore()', function () {
           await ref.delete();
         });
 
-        it("handles 'previous'", async function () {
+        // TODO flakey in new Jet setup since it conflicts with the modular tests
+        xit("handles 'previous'", async function () {
           // TODO(ehesp): Figure out how to call settings on other.
           if (Platform.other) {
             // Not supported on web lite sdk
@@ -303,7 +305,8 @@ describe('firestore()', function () {
           await ref.delete();
         });
 
-        it("handles 'none'", async function () {
+        // works in isolation but not in suite
+        xit("handles 'none'", async function () {
           // TODO(ehesp): Figure out how to call settings on other.
           if (Platform.other) {
             return;
@@ -644,8 +647,12 @@ describe('firestore()', function () {
 
     describe('settings', function () {
       describe('serverTimestampBehavior', function () {
-        // TODO flakey in new Jet setup since it conflicts with the v8 tests
-        xit("handles 'estimate'", async function () {
+        it("handles 'estimate'", async function () {
+          // TODO(ehesp): Figure out how to call settings on other.
+          if (Platform.other) {
+            // Not supported on web lite sdk
+            return;
+          }
           const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc } = firestoreModular;
 
           const db = await initializeFirestore(firebase.app(), {
@@ -675,6 +682,11 @@ describe('firestore()', function () {
         });
 
         it("handles 'previous'", async function () {
+          // TODO(ehesp): Figure out how to call settings on other.
+          if (Platform.other) {
+            // Not supported on web lite sdk
+            return;
+          }
           const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc, snapshotEqual } =
             firestoreModular;
 
@@ -734,8 +746,12 @@ describe('firestore()', function () {
           await deleteDoc(ref);
         });
 
-        // FIXME: works in isolation but not in suite
-        xit("handles 'none'", async function () {
+        it("handles 'none'", async function () {
+          // TODO(ehesp): Figure out how to call settings on other.
+          if (Platform.other) {
+            // Not supported on web lite sdk
+            return;
+          }
           const { initializeFirestore, doc, onSnapshot, setDoc, deleteDoc } = firestoreModular;
 
           const db = await initializeFirestore(firebase.app(), {

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -39,12 +39,12 @@ const testNumbers = {
 
 describe('firestore()', function () {
   describe('v8 compatibility', function () {
-    beforeEach(async function beforeEachTest() {
+    before(async function beforeEachTest() {
       // @ts-ignore
       globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
     });
 
-    afterEach(async function afterEachTest() {
+    after(async function afterEachTest() {
       // @ts-ignore
       globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -39,6 +39,16 @@ const testNumbers = {
 
 describe('firestore()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('issues', function () {
       before(async function () {
         await Promise.all([

--- a/packages/firestore/lib/FirestoreQuerySnapshot.js
+++ b/packages/firestore/lib/FirestoreQuerySnapshot.js
@@ -112,7 +112,8 @@ export default class FirestoreQuerySnapshot {
     }
   }
 
-  isEqual(other) {
+  // send '...args' through as it may contain our namespace deprecation marker
+  isEqual(other, ...args) {
     if (!(other instanceof FirestoreQuerySnapshot)) {
       throw new Error(
         "firebase.firestore() QuerySnapshot.isEqual(*) 'other' expected a QuerySnapshot instance.",
@@ -134,7 +135,8 @@ export default class FirestoreQuerySnapshot {
       const thisDoc = this.docs[i];
       const otherDoc = other.docs[i];
 
-      if (!thisDoc.isEqual(otherDoc)) {
+      // send '...args' through as it may contain our namespace deprecation marker
+      if (!thisDoc.isEqual(otherDoc, ...args)) {
         return false;
       }
     }

--- a/packages/firestore/lib/modular/index.d.ts
+++ b/packages/firestore/lib/modular/index.d.ts
@@ -276,6 +276,22 @@ export function collection(
 ): CollectionReference<DocumentData>;
 
 /**
+ *Returns true if the provided references are equal.
+ *
+ * @param left	DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>	A reference to compare.
+ * @param right	DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>	A reference to compare.
+ * @return boolean true if the references point to the same location in the same Firestore database.
+ */
+export declare function refEqual<AppModelType, DbModelType extends DocumentData>(
+  left:
+    | DocumentReference<AppModelType, DbModelType>
+    | CollectionReference<AppModelType, DbModelType>,
+  right:
+    | DocumentReference<AppModelType, DbModelType>
+    | CollectionReference<AppModelType, DbModelType>,
+): boolean;
+
+/**
  * Creates and returns a new `Query` instance that includes all documents in the
  * database that are contained in a collection or subcollection with the
  * given `collectionId`.

--- a/packages/firestore/lib/modular/index.js
+++ b/packages/firestore/lib/modular/index.js
@@ -72,6 +72,15 @@ export function collection(parent, path, ...pathSegments) {
 }
 
 /**
+ * @param {DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>} left
+ * @param {DocumentReference<AppModelType, DbModelType> | CollectionReference<AppModelType, DbModelType>} right
+ * @return boolean true if the two references are equal
+ */
+export function refEqual(left, right) {
+  return left.isEqual.call(left, right, MODULAR_DEPRECATION_ARG);
+}
+
+/**
  * @param {Firestore} firestore
  * @param {string} collectionId
  * @returns {Query<DocumentData>}

--- a/packages/firestore/lib/modular/query.js
+++ b/packages/firestore/lib/modular/query.js
@@ -224,3 +224,12 @@ export function getDocsFromServer(query) {
 export function deleteDoc(reference) {
   return reference.delete.call(reference, MODULAR_DEPRECATION_ARG);
 }
+
+/**
+ * @param {Query} left
+ * @param {Query} right
+ * @returns boolean true if left equals right
+ */
+export function queryEqual(left, right) {
+  return left.isEqual.call(left, right, MODULAR_DEPRECATION_ARG);
+}

--- a/packages/firestore/lib/modular/query.js
+++ b/packages/firestore/lib/modular/query.js
@@ -28,7 +28,7 @@ class QueryConstraint {
   }
 
   _apply(query) {
-    return query[this.type].apply(query, this._args, MODULAR_DEPRECATION_ARG);
+    return query[this.type].call(query, ...this._args, MODULAR_DEPRECATION_ARG);
   }
 }
 

--- a/packages/firestore/lib/modular/snapshot.d.ts
+++ b/packages/firestore/lib/modular/snapshot.d.ts
@@ -214,3 +214,16 @@ export function snapshotEqual<AppModelType, DbModelType extends DocumentData>(
   left: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>,
   right: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>,
 ): boolean;
+
+/**
+ * Returns true if the provided queries point to the same collection and apply the same constraints.
+ *
+ * @param left	Query<AppModelType, DbModelType> A Query to compare.
+ * @param right	Query<AppModelType, DbModelType> A Query to compare.
+ *
+ * @return boolean true if the references point to the same location in the same Firestore database.
+ */
+export declare function queryEqual<AppModelType, DbModelType extends DocumentData>(
+  left: Query<AppModelType, DbModelType>,
+  right: Query<AppModelType, DbModelType>,
+): boolean;

--- a/packages/firestore/lib/modular/snapshot.d.ts
+++ b/packages/firestore/lib/modular/snapshot.d.ts
@@ -201,3 +201,16 @@ export function onSnapshot<T>(
   onError?: (error: FirestoreError) => void,
   onCompletion?: () => void,
 ): Unsubscribe;
+
+/**
+ * Returns true if the provided snapshots are equal.
+ *
+ * @param left	DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>	A snapshot to compare.
+ * @param right	DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>	A snapshot to compare.
+ *
+ * @returns boolean true if the snapshots are equal.
+ */
+export function snapshotEqual<AppModelType, DbModelType extends DocumentData>(
+  left: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>,
+  right: DocumentSnapshot<AppModelType, DbModelType> | QuerySnapshot<AppModelType, DbModelType>,
+): boolean;

--- a/packages/firestore/lib/modular/snapshot.js
+++ b/packages/firestore/lib/modular/snapshot.js
@@ -14,3 +14,7 @@ import { MODULAR_DEPRECATION_ARG } from '../../../app/lib/common';
 export function onSnapshot(reference, ...args) {
   return reference.onSnapshot.call(reference, ...args, MODULAR_DEPRECATION_ARG);
 }
+
+export function snapshotEqual(left, right) {
+  return left.isEqual.call(left, right, MODULAR_DEPRECATION_ARG);
+}

--- a/tests/app.js
+++ b/tests/app.js
@@ -72,8 +72,8 @@ ErrorUtils.setGlobalHandler((err, isFatal) => {
 
 function loadTests(_) {
   describe('React Native Firebase', function () {
-    if (!globalThis.RNFBDebug) {
-      // Only retry tests if not debugging locally,
+    if (!globalThis.RNFBDebug && !globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE) {
+      // Only retry tests if not debugging or hunting deprecated API usage locally,
       // otherwise it gets annoying to debug.
       this.retries(4);
     }

--- a/tests/app.js
+++ b/tests/app.js
@@ -22,6 +22,7 @@ import { StyleSheet, View, StatusBar, AppRegistry, LogBox } from 'react-native';
 import { JetProvider, ConnectionText, StatusEmoji, StatusText } from 'jet';
 
 // react-native-macos 0.77.0 - pops an empty, non-dismissable logbox
+// logged as https://github.com/microsoft/react-native-macos/issues/2376
 if (Platform.other) {
   // ...unless you ignore all logs in logbox
   LogBox.ignoreAllLogs();
@@ -78,25 +79,40 @@ function loadTests(_) {
     }
 
     before(async function () {
-      if (platformSupportedModules.includes('functions'))
-        firebase.functions().useEmulator('localhost', 5001);
-      if (platformSupportedModules.includes('database'))
-        firebase.database().useEmulator('localhost', 9000);
-      if (platformSupportedModules.includes('auth'))
-        firebase.auth().useEmulator('http://localhost:9099');
+      if (platformSupportedModules.includes('functions')) {
+        const { connectFunctionsEmulator, getFunctions } = functionsModular;
+        connectFunctionsEmulator(getFunctions(), 'localhost', 5001);
+      }
+      if (platformSupportedModules.includes('database')) {
+        const { connectDatabaseEmulator, getDatabase } = databaseModular;
+        connectDatabaseEmulator(getDatabase(), 'localhost', 9000);
+      }
+      if (platformSupportedModules.includes('auth')) {
+        const { connectAuthEmulator, getAuth } = authModular;
+        connectAuthEmulator(getAuth(), 'http://localhost:9099');
+      }
       if (platformSupportedModules.includes('firestore')) {
-        firebase.firestore().useEmulator('localhost', 8080);
-        firebase.app().firestore('second-rnfb').useEmulator('localhost', 8080);
+        const { getApp } = modular;
+        const { connectFirestoreEmulator, clearIndexedDbPersistence, getFirestore } =
+          firestoreModular;
+        connectFirestoreEmulator(getFirestore(), 'localhost', 8080);
+        connectFirestoreEmulator(getFirestore(getApp(), 'second-rnfb'), 'localhost', 8080);
         // Firestore caches documents locally (a great feature!) and that confounds tests
         // as data from previous runs pollutes following runs until re-install the app. Clear it.
         if (!Platform.other) {
-          firebase.firestore().clearPersistence();
+          clearIndexedDbPersistence(getFirestore());
         }
       }
       if (platformSupportedModules.includes('storage')) {
-        firebase.storage().useEmulator('localhost', 9199);
-        firebase.app('secondaryFromNative').storage().useEmulator('localhost', 9199);
-        firebase.app().storage('gs://react-native-firebase-testing').useEmulator('localhost', 9199);
+        const { getApp } = modular;
+        const { getStorage, connectStorageEmulator } = storageModular;
+        connectStorageEmulator(getStorage(), 'localhost', 9199);
+        connectStorageEmulator(getStorage(getApp('secondaryFromNative')), 'localhost', 9199);
+        connectStorageEmulator(
+          getStorage(getApp(), 'gs://react-native-firebase-testing'),
+          'localhost',
+          9199,
+        );
       }
     });
 

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /*
  * Copyright (c) 2016-present Invertase Limited & Contributors
  *
@@ -462,7 +461,7 @@ global.jet = {
   },
 };
 
-// TODO toggle this correct in CI only.
-global.isCI = true;
+// some tests flake in CI but we still run them locally
+global.isCI = process.env.CI === true;
 // Used to tell our internals that we are running tests.
 globalThis.RNFBTest = true;

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -48,6 +48,9 @@ import shouldMatchers from 'should';
 //            [TEST->Finish][✅] uploads a base64url string
 globalThis.RNFBDebug = false;
 
+// this may be used to locate modular API errors quickly
+globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE = false;
+
 // RNFB packages.
 import '@react-native-firebase/analytics';
 import '@react-native-firebase/app-check';

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -354,8 +354,9 @@ Object.defineProperty(global, 'modular', {
 });
 
 if (global.Platform.other) {
-  firebase.initializeApp(global.FirebaseHelpers.app.config());
-  firebase.initializeApp(global.FirebaseHelpers.app.config(), 'secondaryFromNative');
+  const { initializeApp } = modular;
+  initializeApp(global.FirebaseHelpers.app.config());
+  initializeApp(global.FirebaseHelpers.app.config(), 'secondaryFromNative');
 }
 
 Object.defineProperty(global, 'functionsModular', {


### PR DESCRIPTION
### Description

This series of commits has one global aim: improve the modular namespace implementation

On the way there:

- I implemented a new "strict" mode for deprecation which will crash any time the deprecation message is triggered, and I limit retries in that case, for better focus
- I ported the global area of the e2e app to use the modular namespace, so the only errors are in modules' e2e areas
- I quieted the namespace e2e tests in crashlytics and firestore e2e areas
- I fixed up crashlytics e2e modular tests to not touch deprecated methods
- I implemented `isEquals` modular API for firestore snapshots
- I fixed query arguments so they don't trigger the deprecation warning

### Related issues

There are quite a few sprinkled around, I'll cross-reference them and notify the users before this goes in


### Release Summary

This should trigger a patch release, it's all conventional commits, a couple marked `fix` but most are perf or test or chore

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Nothing but test runs over and over and over, it's all done using the e2e directly as support

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
