### PR TITLE
fix(messaging, ios): serialize access to background handler state

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -163,14 +163,16 @@
       // If app is in background state, register background task to guarantee async queues aren't
       // frozen.
       sharedInstance.backgroundTaskId = [application beginBackgroundTaskWithExpirationHandler:^{
-        if (sharedInstance.backgroundTaskId != UIBackgroundTaskInvalid) {
-          [application endBackgroundTask:sharedInstance.backgroundTaskId];
-          sharedInstance.backgroundTaskId = UIBackgroundTaskInvalid;
-        }
+        dispatch_get_main_queue(), ^{
+          if (sharedInstance.backgroundTaskId != UIBackgroundTaskInvalid) {
+            [application endBackgroundTask:sharedInstance.backgroundTaskId];
+            sharedInstance.backgroundTaskId = UIBackgroundTaskInvalid;
+          }
+        };
       }];
 
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(25 * NSEC_PER_SEC)),
-                     dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+                     dispatch_get_main_queue(), ^{
                        if (sharedInstance.completionHandler) {
                          sharedInstance.completionHandler(UIBackgroundFetchResultNewData);
                          sharedInstance.completionHandler = nil;

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -220,7 +220,7 @@ RCT_EXPORT_METHOD(getIsHeadless : (RCTPromiseResolveBlock)resolve : (RCTPromiseR
 }
 
 RCT_EXPORT_METHOD(completeNotificationProcessing) {
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+  dispatch_get_main_queue(), ^{
     RNFBMessagingAppDelegate *appDelegate = [RNFBMessagingAppDelegate sharedInstance];
     if (appDelegate.completionHandler) {
       appDelegate.completionHandler(UIBackgroundFetchResultNewData);
@@ -230,7 +230,7 @@ RCT_EXPORT_METHOD(completeNotificationProcessing) {
       [[UIApplication sharedApplication] endBackgroundTask:appDelegate.backgroundTaskId];
       appDelegate.backgroundTaskId = UIBackgroundTaskInvalid;
     }
-  });
+  };
 }
 
 RCT_EXPORT_METHOD(requestPermission


### PR DESCRIPTION
### Description

switched from dispatch_async + global queues to dispatch_get_main_queue -  should make race conditions impossible, in case that was the cause for a recent crash

https://github.com/invertase/react-native-firebase/pull/8349/files?diff=unified&w=1

note that the 25 second timeout block did *not* execute in testing if the completion handler was called - the app went back to sleep immediately, so no create_dispatch_block / dispatch_block_cancel was needed

### Related issues

- Fixes #8347 

### Release Summary

single conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I used my rnfbdemo app with "send silent notification" buttons in combination with the SendFCM method in react-native-firebase-testing Firebase project to probe the code around background handling with handlers using `setTimeout` to sleep various amounts of time

I wasn't able to trigger the crash reported by the user but I no longer can imagine any case there would be unbalanced queue activity. Why?

- it was observed that the app immediately backgrounded again after the notification completion handler was called - that is *no* timeout code block execution happened after 25 seconds
- so if all the blocks are serialized with the change to use main queue dispatch, then the completion handler will be called by one of them while others queue without entering their blocks, and the app should terminate again without any further block execution

That's the theory anyway - sometimes my imagination is missing cases that are discovered later

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
