### PR TITLE
test(ci): updated lint:android package script w/better messaging, better status reporting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -50,7 +50,7 @@ jobs:
           timeout_minutes: 3
           retry_wait_seconds: 10
           max_attempts: 3
-          command: yarn lint && git diff --exit-code
+          command: yarn lint
       - uses: actions/cache/save@v4
         name: Yarn Cache Save
         if: "${{ github.ref == 'refs/heads/main' }}"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "firebase": "^11.3.1",
     "firebase-tools": "^13.31.1",
     "genversion": "^3.2.0",
-    "google-java-format": "^1.4.0",
+    "google-java-format": "^2.0.0",
     "jest": "^29.7.0",
     "lerna": "^8.1.9",
     "patch-package": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:all:build": "lerna run build",
     "lint": "yarn lint:js && yarn lint:android && yarn lint:ios:check",
     "lint:js": "eslint packages/* --max-warnings=0",
-    "lint:android": "google-java-format --set-exit-if-changed --replace --glob=\"packages/*/android/src/**/*.java\"",
+    "lint:android": "(google-java-format --set-exit-if-changed --replace --glob=\"packages/*/android/src/**/*.java\" || (echo \"\n\nandroid formatting error - please re-run\n\n\" && exit 1)) && (git diff --exit-code packages/*/android/src || (echo \"\n\nandroid files changed from linting, please examine and commit result\n\n\" && exit 1))",
     "lint:ios:check": "clang-format --glob=\"packages/*/ios/**/*.{h,cpp,m,mm}\" --style=Google -n -Werror",
     "lint:ios:fix": "clang-format -i --glob=\"packages/*/ios/**/*.{h,cpp,m,mm}\" --style=Google",
     "lint:markdown": "prettier --check \"docs/**/*.md\"",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6735,6 +6735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^3.2.6":
+  version: 3.2.6
+  resolution: "async@npm:3.2.6"
+  checksum: 10/cb6e0561a3c01c4b56a799cc8bab6ea5fef45f069ab32500b6e19508db270ef2dffa55e5aed5865c5526e9907b1f8be61b27530823b411ffafb5e1538c86c368
+  languageName: node
+  linkType: hard
+
 "asynckit@npm:^0.4.0":
   version: 0.4.0
   resolution: "asynckit@npm:0.4.0"
@@ -11581,16 +11588,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"google-java-format@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "google-java-format@npm:1.4.0"
+"google-java-format@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "google-java-format@npm:2.0.0"
   dependencies:
-    async: "npm:^3.2.4"
+    async: "npm:^3.2.6"
     glob: "npm:^8.1.0"
-    resolve: "npm:^1.22.8"
+    resolve: "npm:^1.22.10"
   bin:
     google-java-format: index.js
-  checksum: 10/87c64e45981583d0e27a0cc07db9d6ff16fc7b44937e921261f2fb2e0ebc6691b50fd1cb4139d7a79f53d3cbed7ecf3f45af33368e848fbc0ab5d1e8c1c228c0
+  checksum: 10/8bb3d67a96a3cbcfdd2c47ee554d86e9e6dbb5740c995f7e06c181a732624749104bd02fbb844e126b9d6a9eb390eab8de01f5fc87b03ab162d4107f34100e49
   languageName: node
   linkType: hard
 
@@ -12482,6 +12489,15 @@ __metadata:
   dependencies:
     hasown: "npm:^2.0.0"
   checksum: 10/d53bd0cc24b0a0351fb4b206ee3908f71b9bbf1c47e9c9e14e5f06d292af1663704d2abd7e67700d6487b2b7864e0d0f6f10a1edf1892864bdffcb197d1845a2
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.16.0":
+  version: 2.16.1
+  resolution: "is-core-module@npm:2.16.1"
+  dependencies:
+    hasown: "npm:^2.0.2"
+  checksum: 10/452b2c2fb7f889cbbf7e54609ef92cf6c24637c568acc7e63d166812a0fb365ae8a504c333a29add8bdb1686704068caa7f4e4b639b650dde4f00a038b8941fb
   languageName: node
   linkType: hard
 
@@ -18392,7 +18408,7 @@ __metadata:
     firebase: "npm:^11.3.1"
     firebase-tools: "npm:^13.31.1"
     genversion: "npm:^3.2.0"
-    google-java-format: "npm:^1.4.0"
+    google-java-format: "npm:^2.0.0"
     jest: "npm:^29.7.0"
     lerna: "npm:^8.1.9"
     patch-package: "npm:^8.0.0"
@@ -19129,7 +19145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.2, resolve@npm:^1.22.8":
+"resolve@npm:^1.1.6, resolve@npm:^1.10.0, resolve@npm:^1.14.2, resolve@npm:^1.20.0, resolve@npm:^1.22.2":
   version: 1.22.8
   resolution: "resolve@npm:1.22.8"
   dependencies:
@@ -19139,6 +19155,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10/c473506ee01eb45cbcfefb68652ae5759e092e6b0fb64547feadf9736a6394f258fbc6f88e00c5ca36d5477fbb65388b272432a3600fa223062e54333c156753
+  languageName: node
+  linkType: hard
+
+"resolve@npm:^1.22.10":
+  version: 1.22.10
+  resolution: "resolve@npm:1.22.10"
+  dependencies:
+    is-core-module: "npm:^2.16.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/0a398b44da5c05e6e421d70108822c327675febb880eebe905587628de401854c61d5df02866ff34fc4cb1173a51c9f0e84a94702738df3611a62e2acdc68181
   languageName: node
   linkType: hard
 
@@ -19164,7 +19193,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.6#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.10.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.14.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>":
   version: 1.22.8
   resolution: "resolve@patch:resolve@npm%3A1.22.8#optional!builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
@@ -19174,6 +19203,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10/f345cd37f56a2c0275e3fe062517c650bb673815d885e7507566df589375d165bbbf4bdb6aa95600a9bc55f4744b81f452b5a63f95b9f10a72787dba3c90890a
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@npm%3A^1.22.10#optional!builtin<compat/resolve>":
+  version: 1.22.10
+  resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
+  dependencies:
+    is-core-module: "npm:^2.16.0"
+    path-parse: "npm:^1.0.7"
+    supports-preserve-symlinks-flag: "npm:^1.0.0"
+  bin:
+    resolve: bin/resolve
+  checksum: 10/d4d878bfe3702d215ea23e75e0e9caf99468e3db76f5ca100d27ebdc527366fee3877e54bce7d47cc72ca8952fc2782a070d238bfa79a550eeb0082384c3b81a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Russell mentioned that the lint:android run script had poor reporting leading to confusion over whether it was working or not

This combined with poor exit status handling resulted in poor overall experience

I cleaned all that up

### Related issues


None logged

### Release Summary

One non-release-generating semantic commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

yarn lint and yarn lint:android a few times locally, both with and without improperly formatted files
CI will check the change there as well

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
