### PR TITLE
fix(app-check): correct modular API usage, rn77 docs

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -74,6 +74,7 @@ firebase-admin
 firebase-ios-sdk
 firebase-js-sdk
 FirebaseApp
+FirebaseCore
 firestore
 Firestore
 GDPR

--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -89,6 +89,30 @@ For instructions on how to generate required keys and register an app for the de
 
 You must call initialize the AppCheck module prior to calling any firebase back-end services for App Check to function.
 
+#### Configure AppCheck with iOS credentials (react-native 0.77+)
+
+To do that, edit your `ios/ProjectName/AppDelegate.swift` and add the following two lines:
+
+At the top of the file, import the FirebaseCore SDK right after `import UIKit`:
+And within your existing `didFinishLaunchingWithOptions` method, add the following to the top of the method:
+
+```diff
+import UIKit
++ import RNFBAppCheck  // <-- This is the import for AppCheck to work
++ import FirebaseCore  // <-- From App/Core integration, no other Firebase items needed
+import React
+import React_RCTAppDelegate
+import ReactAppDependencyProvider
+
+@main
+class AppDelegate: RCTAppDelegate {
+  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
++   RNFBAppCheckModule.sharedInstance()  // <-- new for AppCheck to work
++   FirebaseApp.configure()              // <-- From App/Core integration
+```
+
+#### Configure Firebase with iOS credentials (react-native < 0.77)
+
 To do that, edit your `ios/ProjectName/AppDelegate.mm` and add the following two lines:
 
 ```objectivec

--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -149,7 +149,9 @@ So AppCheck module initialization is done in two steps in react-native-firebase 
 To configure the react-native-firebase custom provider, first obtain one, then configure it according to the providers you want to use on each platform.
 
 ```javascript
-rnfbProvider = firebase.appCheck().newReactNativeFirebaseAppCheckProvider();
+import { ReactNativeFirebaseAppCheckProvider } from `@react-native-firebase/app-check`;
+
+rnfbProvider = new ReactNativeFirebaseAppCheckProvider();
 rnfbProvider.configure({
   android: {
     provider: __DEV__ ? 'debug' : 'playIntegrity',
@@ -168,10 +170,12 @@ rnfbProvider.configure({
 
 ### Install the Custom Provider
 
-Once you have the custom provider configured, install it in app-check using the firebase-js-sdk compatible API:
+Once you have the custom provider configured, install it in app-check using the firebase-js-sdk compatible API, while saving the returned instance for usage:
 
 ```javascript
-firebase.appCheck().initializeAppCheck({ provider: rnfbProvider, isTokenAutoRefreshEnabled: true });
+import { initializeAppCheck  } from `@react-native-firebase/app-check`;
+
+const appCheck = initializeAppCheck({ provider: rnfbProvider, isTokenAutoRefreshEnabled: true });
 ```
 
 ### Verify AppCheck was initialized correctly
@@ -179,8 +183,11 @@ firebase.appCheck().initializeAppCheck({ provider: rnfbProvider, isTokenAutoRefr
 After initializing the custom provider, you can verify AppCheck is working by logging a response from the token server:
 
 ```javascript
+import { getToken  } from `@react-native-firebase/app-check`;
+
 try {
-  const { token } = await firebase.appCheck().getToken(true);
+  // `appCheckInstance` is the saved return value from initializeAppCheck
+  const { token } = await appCheckInstance.getToken( true);
 
   if (token.length > 0) {
     console.log('AppCheck verification passed');

--- a/packages/app-check/e2e/appcheck.e2e.js
+++ b/packages/app-check/e2e/appcheck.e2e.js
@@ -58,287 +58,309 @@ function decodeJWT(token) {
 }
 
 describe('appCheck()', function () {
-  describe('CustomProvider', function () {
-    if (!Platform.other) {
-      return;
-    }
-
-    it('should throw an error if no provider options are defined', function () {
-      try {
-        new firebase.appCheck.CustomProvider();
-        return Promise.reject(new Error('Did not throw an error.'));
-      } catch (e) {
-        e.message.should.containEql('no provider options defined');
-        return Promise.resolve();
-      }
-    });
-
-    it('should throw an error if no getToken function is defined', function () {
-      try {
-        new firebase.appCheck.CustomProvider({});
-        return Promise.reject(new Error('Did not throw an error.'));
-      } catch (e) {
-        e.message.should.containEql('no getToken function defined');
-        return Promise.resolve();
-      }
-    });
-
-    it('should return a token from a custom provider', async function () {
-      const spy = sinon.spy();
-      const provider = new firebase.appCheck.CustomProvider({
-        getToken() {
-          spy();
-          return FirebaseHelpers.fetchAppCheckToken();
-        },
-      });
-
-      // Call from the provider directly.
-      const { token, expireTimeMillis } = await provider.getToken();
-      spy.should.be.calledOnce();
-      token.should.be.a.String();
-      expireTimeMillis.should.be.a.Number();
-
-      // Call from the app check instance.
-      await firebase.appCheck().initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
-      const { token: tokenFromAppCheck } = await firebase.appCheck().getToken(true);
-      tokenFromAppCheck.should.be.a.String();
-
-      // Confirm that app check used the custom provider getToken function.
-      spy.should.be.calledTwice();
-    });
-
-    it('should return a limited use token from a custom provider', async function () {
-      const provider = new firebase.appCheck.CustomProvider({
-        getToken() {
-          return FirebaseHelpers.fetchAppCheckToken();
-        },
-      });
-
-      await firebase.appCheck().initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
-      const { token: tokenFromAppCheck } = await firebase.appCheck().getLimitedUseToken();
-      tokenFromAppCheck.should.be.a.String();
-    });
-
-    it('should listen for token changes', async function () {
-      const provider = new firebase.appCheck.CustomProvider({
-        getToken() {
-          return FirebaseHelpers.fetchAppCheckToken();
-        },
-      });
-
-      await firebase.appCheck().initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
-      const unsubscribe = firebase.appCheck().onTokenChanged(_ => {
-        // TODO - improve testing cloud function to allow us to return tokens with low expiry
-      });
-
-      // TODO - improve testing cloud function to allow us to return tokens with low expiry
-      // result.should.be.an.Object();
-      // const { token, expireTimeMillis } = result;
-      // token.should.be.a.String();
-      // expireTimeMillis.should.be.a.Number();
-      unsubscribe();
-    });
-  });
-
   describe('firebase v8 compatibility', function () {
-    before(function () {
-      let provider;
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
 
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
+    describe('CustomProvider', function () {
       if (!Platform.other) {
-        provider = firebase.appCheck().newReactNativeFirebaseAppCheckProvider();
-        provider.configure({
-          android: {
-            provider: 'debug',
-            debugToken: '698956B2-187B-49C6-9E25-C3F3530EEBAF',
-          },
-          apple: {
-            provider: 'debug',
-            debugToken: '698956B2-187B-49C6-9E25-C3F3530EEBAF',
-          },
-          web: {
-            provider: 'debug',
-            siteKey: 'none',
+        return;
+      }
+
+      it('should throw an error if no provider options are defined', function () {
+        try {
+          new firebase.appCheck.CustomProvider();
+          return Promise.reject(new Error('Did not throw an error.'));
+        } catch (e) {
+          e.message.should.containEql('no provider options defined');
+          return Promise.resolve();
+        }
+      });
+
+      it('should throw an error if no getToken function is defined', function () {
+        try {
+          new firebase.appCheck.CustomProvider({});
+          return Promise.reject(new Error('Did not throw an error.'));
+        } catch (e) {
+          e.message.should.containEql('no getToken function defined');
+          return Promise.resolve();
+        }
+      });
+
+      it('should return a token from a custom provider', async function () {
+        const spy = sinon.spy();
+        const provider = new firebase.appCheck.CustomProvider({
+          getToken() {
+            spy();
+            return FirebaseHelpers.fetchAppCheckToken();
           },
         });
-      } else {
-        provider = new firebase.appCheck.CustomProvider({
+
+        // Call from the provider directly.
+        const { token, expireTimeMillis } = await provider.getToken();
+        spy.should.be.calledOnce();
+        token.should.be.a.String();
+        expireTimeMillis.should.be.a.Number();
+
+        // Call from the app check instance.
+        await firebase
+          .appCheck()
+          .initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
+        const { token: tokenFromAppCheck } = await firebase.appCheck().getToken(true);
+        tokenFromAppCheck.should.be.a.String();
+
+        // Confirm that app check used the custom provider getToken function.
+        spy.should.be.calledTwice();
+      });
+
+      // TODO flakey after many runs, sometimes fails on android & ios,
+      // possibly a rate limiting issue on the server side
+      xit('should return a limited use token from a custom provider', async function () {
+        const provider = new firebase.appCheck.CustomProvider({
           getToken() {
             return FirebaseHelpers.fetchAppCheckToken();
           },
         });
-      }
 
-      // Our tests configure a debug provider with shared secret so we should get a valid token
-      firebase.appCheck().initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
-    });
-
-    describe('config', function () {
-      // This depends on firebase.json containing a false value for token auto refresh, we
-      // verify here that it was carried in to the Info.plist correctly
-      // it relies on token auto refresh being left false for local tests where the app is reused, since it is persistent
-      // but in CI it's fresh every time and would be true if not overridden in Info.plist
-      it('should configure token auto refresh in Info.plist on ios', async function () {
-        if (Platform.ios) {
-          const tokenRefresh =
-            await NativeModules.RNFBAppCheckModule.isTokenAutoRefreshEnabled('[DEFAULT]');
-          tokenRefresh.should.equal(false);
-        } else {
-          this.skip();
-        }
-      });
-    });
-
-    describe('setTokenAutoRefresh())', function () {
-      it('should set token refresh', async function () {
-        firebase.appCheck().setTokenAutoRefreshEnabled(false);
-
-        // Only iOS lets us assert on this unfortunately, other platforms have no accessor
-        if (Platform.ios) {
-          let tokenRefresh =
-            await NativeModules.RNFBAppCheckModule.isTokenAutoRefreshEnabled('[DEFAULT]');
-          tokenRefresh.should.equal(false);
-        }
-        firebase.appCheck().setTokenAutoRefreshEnabled(true);
-        // Only iOS lets us assert on this unfortunately, other platforms have no accessor
-        if (Platform.ios) {
-          tokenRefresh =
-            await NativeModules.RNFBAppCheckModule.isTokenAutoRefreshEnabled('[DEFAULT]');
-          tokenRefresh.should.equal(true);
-        }
-      });
-    });
-
-    // TODO flakey after many runs, sometimes fails on android & ios,
-    // possibly a rate limiting issue on the server side
-    xdescribe('getToken()', function () {
-      it('token fetch attempt with configured debug token should work', async function () {
-        const { token } = await firebase.appCheck().getToken(true);
-        token.should.not.equal('');
-        const decodedToken = decodeJWT(token);
-        decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
-        if (decodedToken.exp * 1000 < Date.now()) {
-          return Promise.reject(
-            `Token expired? now ${Date.now()} token exp: ${decodedToken.exp * 1000}`,
-          );
-        }
-
-        // on android if you move too fast, you may not get a fresh token
-        await Utils.sleep(2000);
-
-        // Force refresh should get a different token?
-        // TODO sometimes fails on android https://github.com/firebase/firebase-android-sdk/issues/2954
-        const { token: token2 } = await firebase.appCheck().getToken(true);
-        token2.should.not.equal('');
-        const decodedToken2 = decodeJWT(token2);
-        decodedToken2.aud[1].should.equal('projects/react-native-firebase-testing');
-        if (decodedToken2.exp * 1000 < Date.now()) {
-          return Promise.reject(
-            `Token expired? now ${Date.now()} token exp: ${decodedToken2.exp * 1000}`,
-          );
-        }
-        (token === token2).should.be.false();
+        await firebase
+          .appCheck()
+          .initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
+        const { token: tokenFromAppCheck } = await firebase.appCheck().getLimitedUseToken();
+        tokenFromAppCheck.should.be.a.String();
       });
 
-      it('token fetch with config switch to invalid then valid should fail then work', async function () {
-        rnfbProvider = firebase.appCheck().newReactNativeFirebaseAppCheckProvider();
-        rnfbProvider.configure({
-          android: {
-            provider: 'playIntegrity',
-          },
-          apple: {
-            provider: 'appAttest',
-          },
-          web: {
-            provider: 'debug',
-            siteKey: 'none',
+      it('should listen for token changes', async function () {
+        const provider = new firebase.appCheck.CustomProvider({
+          getToken() {
+            return FirebaseHelpers.fetchAppCheckToken();
           },
         });
+
+        await firebase
+          .appCheck()
+          .initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
+        const unsubscribe = firebase.appCheck().onTokenChanged(_ => {
+          // TODO - improve testing cloud function to allow us to return tokens with low expiry
+        });
+
+        // TODO - improve testing cloud function to allow us to return tokens with low expiry
+        // result.should.be.an.Object();
+        // const { token, expireTimeMillis } = result;
+        // token.should.be.a.String();
+        // expireTimeMillis.should.be.a.Number();
+        unsubscribe();
+      });
+    });
+
+    describe('AppCheck API methods', function () {
+      before(function () {
+        const { initializeAppCheck, ReactNativeFirebaseAppCheckProvider } = appCheckModular;
+
+        let provider;
+
+        if (!Platform.other) {
+          provider = new ReactNativeFirebaseAppCheckProvider();
+          provider.configure({
+            android: {
+              provider: 'debug',
+              debugToken: '698956B2-187B-49C6-9E25-C3F3530EEBAF',
+            },
+            apple: {
+              provider: 'debug',
+              debugToken: '698956B2-187B-49C6-9E25-C3F3530EEBAF',
+            },
+            web: {
+              provider: 'debug',
+              siteKey: 'none',
+            },
+          });
+        } else {
+          provider = new ReactNativeFirebaseAppCheckProvider({
+            getToken() {
+              return FirebaseHelpers.fetchAppCheckToken();
+            },
+          });
+        }
 
         // Our tests configure a debug provider with shared secret so we should get a valid token
-        firebase
-          .appCheck()
-          .initializeAppCheck({ provider: rnfbProvider, isTokenAutoRefreshEnabled: false });
-        try {
-          await firebase.appCheck().getToken(true);
-          return Promise.reject(new Error('should have thrown an error'));
-        } catch (e) {
-          e.message.should.containEql('appCheck/token-error');
-        }
+        initializeAppCheck({ provider, isTokenAutoRefreshEnabled: false });
+      });
 
-        rnfbProvider.configure({
-          android: {
-            provider: 'debug',
-            debugToken: '698956B2-187B-49C6-9E25-C3F3530EEBAF',
-          },
-          apple: {
-            provider: 'debug',
-          },
-          web: {
-            provider: 'debug',
-            siteKey: 'none',
-          },
+      describe('config', function () {
+        // This depends on firebase.json containing a false value for token auto refresh, we
+        // verify here that it was carried in to the Info.plist correctly
+        // it relies on token auto refresh being left false for local tests where the app is reused, since it is persistent
+        // but in CI it's fresh every time and would be true if not overridden in Info.plist
+        it('should configure token auto refresh in Info.plist on ios', async function () {
+          if (Platform.ios) {
+            const tokenRefresh =
+              await NativeModules.RNFBAppCheckModule.isTokenAutoRefreshEnabled('[DEFAULT]');
+            tokenRefresh.should.equal(false);
+          } else {
+            this.skip();
+          }
         });
-        firebase
-          .appCheck()
-          .initializeAppCheck({ provider: rnfbProvider, isTokenAutoRefreshEnabled: false });
-
-        const { token } = await firebase.appCheck().getToken(true);
-        token.should.not.equal('');
-        const decodedToken = decodeJWT(token);
-        decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
-        if (decodedToken.exp * 1000 < Date.now()) {
-          return Promise.reject(
-            `Token expired? now ${Date.now()} token exp: ${decodedToken.exp * 1000}`,
-          );
-        }
-      });
-    });
-
-    // TODO flakey after many runs, sometimes fails on android & ios,
-    // possibly a rate limiting issue on the server side
-    xdescribe('getLimitedUseToken()', function () {
-      it('limited use token fetch attempt with configured debug token should work', async function () {
-        const { token } = await firebase.appCheck().getLimitedUseToken();
-        token.should.not.equal('');
-        const decodedToken = decodeJWT(token);
-        decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
-        if (decodedToken.exp * 1000 < Date.now()) {
-          return Promise.reject(
-            `Token expired? now ${Date.now()} token exp: ${decodedToken.exp * 1000}`,
-          );
-        }
-      });
-    });
-
-    describe('activate())', function () {
-      if (Platform.other) {
-        return;
-      }
-
-      it('should activate with default provider and defined token refresh', function () {
-        firebase
-          .appCheck()
-          .activate('ignored', false)
-          .then(value => expect(value).toBe(undefined))
-          .catch(e => new Error('app-check activate failed? ' + e));
       });
 
-      it('should error if activate gets no parameters', async function () {
-        try {
-          firebase.appCheck().activate();
-          return Promise.reject(new Error('should have thrown an error'));
-        } catch (e) {
-          e.message.should.containEql('siteKeyOrProvider must be a string value');
-        }
+      describe('setTokenAutoRefresh())', function () {
+        it('should set token refresh', async function () {
+          firebase.appCheck().setTokenAutoRefreshEnabled(false);
+
+          // Only iOS lets us assert on this unfortunately, other platforms have no accessor
+          if (Platform.ios) {
+            let tokenRefresh =
+              await NativeModules.RNFBAppCheckModule.isTokenAutoRefreshEnabled('[DEFAULT]');
+            tokenRefresh.should.equal(false);
+          }
+          firebase.appCheck().setTokenAutoRefreshEnabled(true);
+          // Only iOS lets us assert on this unfortunately, other platforms have no accessor
+          if (Platform.ios) {
+            tokenRefresh =
+              await NativeModules.RNFBAppCheckModule.isTokenAutoRefreshEnabled('[DEFAULT]');
+            tokenRefresh.should.equal(true);
+          }
+        });
       });
 
-      it('should not error if activate called with no token refresh value', async function () {
-        try {
-          firebase.appCheck().activate('ignored');
-          return Promise.resolve(true);
-        } catch (e) {
-          return Promise.reject(new Error('should not have thrown an error - ' + e));
+      // TODO flakey after many runs, sometimes fails on android & ios,
+      // possibly a rate limiting issue on the server side
+      xdescribe('getToken()', function () {
+        it('token fetch attempt with configured debug token should work', async function () {
+          const { token } = await firebase.appCheck().getToken(true);
+          token.should.not.equal('');
+          const decodedToken = decodeJWT(token);
+          decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
+          if (decodedToken.exp * 1000 < Date.now()) {
+            return Promise.reject(
+              `Token expired? now ${Date.now()} token exp: ${decodedToken.exp * 1000}`,
+            );
+          }
+
+          // on android if you move too fast, you may not get a fresh token
+          await Utils.sleep(2000);
+
+          // Force refresh should get a different token?
+          // TODO sometimes fails on android https://github.com/firebase/firebase-android-sdk/issues/2954
+          const { token: token2 } = await firebase.appCheck().getToken(true);
+          token2.should.not.equal('');
+          const decodedToken2 = decodeJWT(token2);
+          decodedToken2.aud[1].should.equal('projects/react-native-firebase-testing');
+          if (decodedToken2.exp * 1000 < Date.now()) {
+            return Promise.reject(
+              `Token expired? now ${Date.now()} token exp: ${decodedToken2.exp * 1000}`,
+            );
+          }
+          (token === token2).should.be.false();
+        });
+
+        it('token fetch with config switch to invalid then valid should fail then work', async function () {
+          rnfbProvider = firebase.appCheck().newReactNativeFirebaseAppCheckProvider();
+          rnfbProvider.configure({
+            android: {
+              provider: 'playIntegrity',
+            },
+            apple: {
+              provider: 'appAttest',
+            },
+            web: {
+              provider: 'debug',
+              siteKey: 'none',
+            },
+          });
+
+          // Our tests configure a debug provider with shared secret so we should get a valid token
+          firebase
+            .appCheck()
+            .initializeAppCheck({ provider: rnfbProvider, isTokenAutoRefreshEnabled: false });
+          try {
+            await firebase.appCheck().getToken(true);
+            return Promise.reject(new Error('should have thrown an error'));
+          } catch (e) {
+            e.message.should.containEql('appCheck/token-error');
+          }
+
+          rnfbProvider.configure({
+            android: {
+              provider: 'debug',
+              debugToken: '698956B2-187B-49C6-9E25-C3F3530EEBAF',
+            },
+            apple: {
+              provider: 'debug',
+            },
+            web: {
+              provider: 'debug',
+              siteKey: 'none',
+            },
+          });
+          firebase
+            .appCheck()
+            .initializeAppCheck({ provider: rnfbProvider, isTokenAutoRefreshEnabled: false });
+
+          const { token } = await firebase.appCheck().getToken(true);
+          token.should.not.equal('');
+          const decodedToken = decodeJWT(token);
+          decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
+          if (decodedToken.exp * 1000 < Date.now()) {
+            return Promise.reject(
+              `Token expired? now ${Date.now()} token exp: ${decodedToken.exp * 1000}`,
+            );
+          }
+        });
+      });
+
+      // TODO flakey after many runs, sometimes fails on android & ios,
+      // possibly a rate limiting issue on the server side
+      xdescribe('getLimitedUseToken()', function () {
+        it('limited use token fetch attempt with configured debug token should work', async function () {
+          const { token } = await firebase.appCheck().getLimitedUseToken();
+          token.should.not.equal('');
+          const decodedToken = decodeJWT(token);
+          decodedToken.aud[1].should.equal('projects/react-native-firebase-testing');
+          if (decodedToken.exp * 1000 < Date.now()) {
+            return Promise.reject(
+              `Token expired? now ${Date.now()} token exp: ${decodedToken.exp * 1000}`,
+            );
+          }
+        });
+      });
+
+      describe('activate())', function () {
+        if (Platform.other) {
+          return;
         }
+
+        it('should activate with default provider and defined token refresh', function () {
+          firebase
+            .appCheck()
+            .activate('ignored', false)
+            .then(value => expect(value).toBe(undefined))
+            .catch(e => new Error('app-check activate failed? ' + e));
+        });
+
+        it('should error if activate gets no parameters', async function () {
+          try {
+            firebase.appCheck().activate();
+            return Promise.reject(new Error('should have thrown an error'));
+          } catch (e) {
+            e.message.should.containEql('siteKeyOrProvider must be a string value');
+          }
+        });
+
+        it('should not error if activate called with no token refresh value', async function () {
+          try {
+            firebase.appCheck().activate('ignored');
+            return Promise.resolve(true);
+          } catch (e) {
+            return Promise.reject(new Error('should not have thrown an error - ' + e));
+          }
+        });
       });
     });
   });
@@ -347,12 +369,12 @@ describe('appCheck()', function () {
     let appCheckInstance;
 
     before(async function () {
-      const { initializeAppCheck } = appCheckModular;
+      const { initializeAppCheck, ReactNativeFirebaseAppCheckProvider } = appCheckModular;
 
       let provider;
 
       if (!Platform.other) {
-        provider = firebase.appCheck().newReactNativeFirebaseAppCheckProvider();
+        provider = new ReactNativeFirebaseAppCheckProvider();
         provider.configure({
           android: {
             provider: 'debug',
@@ -368,7 +390,7 @@ describe('appCheck()', function () {
           },
         });
       } else {
-        provider = new firebase.appCheck.CustomProvider({
+        provider = new ReactNativeFirebaseAppCheckProvider({
           getToken() {
             return FirebaseHelpers.fetchAppCheckToken();
           },
@@ -437,9 +459,10 @@ describe('appCheck()', function () {
       });
 
       it('token fetch with config switch to invalid then valid should fail then work', async function () {
-        const { initializeAppCheck, getToken } = appCheckModular;
+        const { initializeAppCheck, getToken, ReactNativeFirebaseAppCheckProvider } =
+          appCheckModular;
 
-        rnfbProvider = firebase.appCheck().newReactNativeFirebaseAppCheckProvider();
+        rnfbProvider = new ReactNativeFirebaseAppCheckProvider();
         rnfbProvider.configure({
           android: {
             provider: 'playIntegrity',
@@ -495,13 +518,12 @@ describe('appCheck()', function () {
       });
     });
 
-    // TODO flakey after many runs, sometimes fails on android & ios,
-    // possibly a rate limiting issue on the server side
-    xdescribe('getLimitedUseToken()', function () {
+    describe('getLimitedUseToken()', function () {
       it('limited use token fetch attempt with configured debug token should work', async function () {
-        const { initializeAppCheck, getLimitedUseToken } = appCheckModular;
+        const { initializeAppCheck, getLimitedUseToken, ReactNativeFirebaseAppCheckProvider } =
+          appCheckModular;
 
-        rnfbProvider = firebase.appCheck().newReactNativeFirebaseAppCheckProvider();
+        const rnfbProvider = new ReactNativeFirebaseAppCheckProvider();
         rnfbProvider.configure({
           android: {
             provider: 'debug',

--- a/packages/app-check/lib/modular/index.js
+++ b/packages/app-check/lib/modular/index.js
@@ -17,7 +17,7 @@
 
 import { getApp } from '@react-native-firebase/app';
 import { MODULAR_DEPRECATION_ARG } from '../../../app/lib/common';
-import CustomProvider from '../ReactNativeFirebaseAppCheckProvider';
+import ReactNativeFirebaseAppCheckProvider from '../ReactNativeFirebaseAppCheckProvider';
 
 /**
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
@@ -103,4 +103,4 @@ export function onTokenChanged(appCheckInstance, onNextOrObserver, onError, onCo
   );
 }
 
-export { CustomProvider };
+export { ReactNativeFirebaseAppCheckProvider };


### PR DESCRIPTION
### Description

Made an unfortunate push to repo on @wneel's clone and accidentally closed #8351

This is the stream of commits we were collaborating on there to get app-check set up for react-native 0.77 and also to fix it up for modular API usage

### Related issues

- Fixes #8333

### Release Summary

conventional commits ready for rebase merge

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

almost nothing but tests - e2e suite working fine now

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
