### PR TITLE
fix(crashlytics): convert internal API usage to modular

### DIFF
--- a/packages/crashlytics/lib/handlers.js
+++ b/packages/crashlytics/lib/handlers.js
@@ -15,8 +15,8 @@
  *
  */
 
-import { firebase } from '@react-native-firebase/app';
 import { isError, once } from '@react-native-firebase/app/lib/common';
+import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
 import tracking from 'promise/setimmediate/rejection-tracking';
 import StackTrace from 'stacktrace-js';
 
@@ -96,7 +96,8 @@ export const setGlobalErrorHandler = once(nativeModule => {
 
         // Notify analytics, if it exists - throws error if not
         try {
-          await firebase.app().analytics().logEvent(
+          await logEvent(
+            getAnalytics(),
             'app_exception', // 'app_exception' is reserved but we make an exception for JS->fatal transforms
             {
               fatal: 1, // as in firebase-android-sdk


### PR DESCRIPTION
### Description

previously the handler accessed analytics using the namespaced API

The e2e suite for crsahlytics is now "modular-clean" so I'm unaware of any other crashlytics issues besides this one

### Related issues

- Fixes: #8326

### Release Summary


single conventional commit, rebase merge

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Discovered from user - can only be seen during crash when you have crashlytics and analytics both installed

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
