### PR TITLE
test(macos): upstream has a fix for the logbox now

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,7 @@
 - My change supports the following platforms;
   - [ ] `Android`
   - [ ] `iOS`
+  - [ ] `Other` (macOS, web)
 - My change includes tests;
   - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
   - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`

--- a/tests/app.js
+++ b/tests/app.js
@@ -21,13 +21,6 @@ import { StyleSheet, View, StatusBar, AppRegistry, LogBox } from 'react-native';
 
 import { JetProvider, ConnectionText, StatusEmoji, StatusText } from 'jet';
 
-// react-native-macos 0.77.0 - pops an empty, non-dismissable logbox
-// logged as https://github.com/microsoft/react-native-macos/issues/2376
-if (Platform.other) {
-  // ...unless you ignore all logs in logbox
-  LogBox.ignoreAllLogs();
-}
-
 const platformSupportedModules = [];
 
 if (Platform.other) {

--- a/tests/patches/react-native-macos+0.77.0.patch
+++ b/tests/patches/react-native-macos+0.77.0.patch
@@ -26,3 +26,16 @@ index f4c5ed3..7628f81 100644
        }
        if (part instanceof Blob) {
          return {
+diff --git a/node_modules/react-native-macos/Libraries/Utilities/Platform.macos.js b/node_modules/react-native-macos/Libraries/Utilities/Platform.macos.js
+index 3b1e7cd..e5a1274 100644
+--- a/node_modules/react-native-macos/Libraries/Utilities/Platform.macos.js
++++ b/node_modules/react-native-macos/Libraries/Utilities/Platform.macos.js
+@@ -84,7 +84,7 @@ const Platform: PlatformType = {
+   },
+   select: <T>(spec: PlatformSelectSpec<T>): T =>
+     // $FlowFixMe[incompatible-return]
+-    'ios' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
++    'macos' in spec ? spec.macos : 'native' in spec ? spec.native : spec.default,
+ };
+ 
+ module.exports = Platform;


### PR DESCRIPTION
### Description

- integrating upstream fix via patch-package
- can drop that patch hunk likely with react-native-macos 0.77.1

### Related issues

- Upstream Issue https://github.com/microsoft/react-native-macos/issues/2376
- Upstream PR https://github.com/microsoft/react-native-macos/pull/2375

### Release Summary

test only, no release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Re-ran `yarn test:macos:test-cover` after integrating the patch and disabling the workaround, it worked

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
