### PR TITLE
fix(app): annotate initializeApp return as a promise

### DIFF
--- a/packages/app/lib/modular/index.d.ts
+++ b/packages/app/lib/modular/index.d.ts
@@ -43,9 +43,9 @@ export function getApps(): FirebaseApp[];
  * Initializes a Firebase app with the provided options and name.
  * @param options - Options to configure the services used in the app.
  * @param name - The optional name of the app to initialize ('[DEFAULT]' if omitted).
- * @returns FirebaseApp - The initialized Firebase app.
+ * @returns Promise<FirebaseApp> - The initialized Firebase app.
  */
-export function initializeApp(options: FirebaseAppOptions, name?: string): FirebaseApp;
+export function initializeApp(options: FirebaseAppOptions, name?: string): Promise<FirebaseApp>;
 
 /**
  * Retrieves an instance of a Firebase app.


### PR DESCRIPTION
### Description
`initializeApp` in the modular API is annotated is returning the app directly, but like in the namespaced API it actually returns a promise
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests; N/A
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
N/A