### PR TITLE
fix(functions, ios): repair release mode crash in functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "tests:ios:build": "cd tests && yarn detox build --configuration ios.sim.debug",
     "tests:ios:build-release": "cd tests && yarn detox build --configuration ios.sim.release",
     "tests:ios:test": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.debug --loglevel warn",
+    "tests:ios:test-release": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.release --loglevel warn",
     "tests:ios:test:debug": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.debug --loglevel warn --inspect",
     "tests:ios:test-reuse": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.debug --reuse --loglevel warn",
     "tests:ios:test-cover": "cd tests && SIMCTL_CHILD_GULGeneratedClassDisposeDisabled=1 yarn detox test --configuration ios.sim.debug --loglevel verbose",

--- a/tests/.detoxrc.js
+++ b/tests/.detoxrc.js
@@ -2,87 +2,83 @@
 module.exports = {
   testRunner: {
     args: {
-      '$0': 'jest',
-      config: 'e2e/jest.config.js'
+      $0: 'jest',
+      config: 'e2e/jest.config.js',
     },
     jest: {
-      setupTimeout: 120000
-    }
+      setupTimeout: 120000,
+    },
   },
   apps: {
     'ios.debug': {
       type: 'ios.app',
       binaryPath: 'ios/build/Build/Products/Debug-iphonesimulator/testing.app',
-      build: 'set -o pipefail && xcodebuild VALID_ARCHS="`uname -m`"  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify'
+      build:
+        'set -o pipefail && xcodebuild VALID_ARCHS="`uname -m`"  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify',
     },
     'ios.release': {
       type: 'ios.app',
       binaryPath: 'ios/build/Build/Products/Release-iphonesimulator/testing.app',
-      build: 'export RCT_NO_LAUNCH_PACKAGER=true && set -o pipefail | xcodebuild  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify'
+      build:
+        'export RCT_NO_LAUNCH_PACKAGER=true && set -o pipefail | xcodebuild  CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace ios/testing.xcworkspace -scheme testing -configuration Release -sdk iphonesimulator -derivedDataPath ios/build | xcbeautify',
     },
     'android.debug': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
-      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest lintDebug -DtestBuildType=debug --warning-mode all && cd ..',
-      reversePorts: [
-        8080,
-        8081,
-        8090,
-        9000,
-        9099,
-        9199
-      ]
+      build:
+        'cd android && ./gradlew assembleDebug assembleAndroidTest lintDebug -DtestBuildType=debug --warning-mode all && cd ..',
+      reversePorts: [8080, 8081, 8090, 9000, 9099, 9199],
     },
     'android.release': {
       type: 'android.apk',
       binaryPath: 'android/app/build/outputs/apk/release/app-release.apk',
-      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release'
-    }
+      build: 'cd android && ./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release',
+    },
   },
   devices: {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 15'
-      }
+        type: 'iPhone 15',
+      },
     },
     attached: {
       type: 'android.attached',
       device: {
-        adbName: '.*'
-      }
+        adbName: '.*',
+      },
     },
     emulator: {
       type: 'android.emulator',
       device: {
-        avdName: 'TestingAVD'
-      }
-    }
+        avdName: 'TestingAVD',
+      },
+    },
   },
   configurations: {
     'ios.sim.debug': {
       device: 'simulator',
-      app: 'ios.debug'
+      app: 'ios.debug',
     },
     'ios.sim.release': {
       device: 'simulator',
-      app: 'ios.release'
+      app: 'ios.release',
     },
     'android.att.debug': {
       device: 'attached',
-      app: 'android.debug'
+      app: 'android.debug',
     },
     'android.att.release': {
       device: 'attached',
-      app: 'android.release'
+      app: 'android.release',
     },
     'android.emu.debug': {
       device: 'emulator',
-      app: 'android.debug'
+      app: 'android.debug',
     },
     'android.emu.release': {
       device: 'emulator',
-      app: 'android.release'
-    }
-  }
+      app: 'android.release',
+    },
+  },
 };


### PR DESCRIPTION
### Description

This should be / will be a PR to fix a functions crash that reproduces in release mode on iOS

Currently this only has the small addition to our run scripts required to build / run e2e test in release mode, which shows the crash in the functions suite. Check the Test Plan section below for reproduction steps on this branch

### Related issues

- Fixes #8369 

### Release Summary

Ideally this will have a commit in here with a `fix` semantic release tag

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

With the commit on this PR you can run these and see the crash:

```bash
yarn test:ios:build-release
yarn test:ios:test-release
```

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
