### PR TITLE
chore: Allow type-safety for subcollections

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -253,7 +253,10 @@ export namespace FirebaseFirestoreTypes {
    * to the location. The document at the referenced location may or may not exist. A `DocumentReference` can also be used
    * to create a `CollectionReference` to a subcollection.
    */
-  export interface DocumentReference<T extends DocumentData = DocumentData> {
+  export interface DocumentReference<
+    T extends DocumentData = DocumentData,
+    C extends DocumentData = DocumentData,
+  > {
     /**
      * The Firestore instance the document is in. This is useful for performing transactions, for example.
      */
@@ -285,7 +288,7 @@ export namespace FirebaseFirestoreTypes {
      *
      * @param collectionPath A slash-separated path to a collection.
      */
-    collection(collectionPath: string): CollectionReference;
+    collection(collectionPath: string): CollectionReference<C>;
 
     /**
      * Deletes the document referred to by this DocumentReference.


### PR DESCRIPTION
### Description
Root collections currently allow strong typing:
```typescript
const allYourBase = firestore()
  .collection<SetUsUp>("are-belong")
  .get();
```
But subcollections cannot be typed:
```typescript
const allYourBase = firestore()
  .collection<SetUsUp>("are-belong")
  .doc("8675309")
  .collection<TheBomb>("to-us")  // This is not accepted by index.d.ts
  .get();
```

This PR attempts to make that possible.

### Release Summary

Support strong typing for subcollections

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
  - [X] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No

### Test Plan

Installed local version in my project, and verified that Typescript accepts a subcollection type.