### PR TITLE
fix(app, sdks): firebase-ios-sdk 11.9.0 / firebase-android-sdk 33.10.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -318,7 +318,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "33.9.0"
+        bom           : "33.10.0"
       ],
     ],
   ])
@@ -333,7 +333,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '11.8.0'
+$FirebaseSDKVersion = '11.9.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "11.8.0",
+      "firebase": "11.9.0",
       "iosTarget": "13.0",
       "macosTarget": "10.15",
       "tvosTarget": "13.0"
@@ -82,7 +82,7 @@
       "minSdk": 21,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "33.9.0",
+      "firebase": "33.10.0",
       "firebaseCrashlyticsGradle": "3.0.3",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.2",

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -36,8 +36,8 @@ buildscript {
     classpath("com.facebook.react:react-native-gradle-plugin")
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     classpath 'com.google.firebase:perf-plugin:1.4.2'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.2'
-    classpath 'com.google.firebase:firebase-appdistribution-gradle:5.0.0'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.3'
+    classpath 'com.google.firebase:firebase-appdistribution-gradle:5.1.1'
   }
 }
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -7,107 +7,107 @@ PODS:
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
   - FBLazyVector (0.77.1)
-  - Firebase/Analytics (11.8.0):
+  - Firebase/Analytics (11.9.0):
     - Firebase/Core
-  - Firebase/AppCheck (11.8.0):
+  - Firebase/AppCheck (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 11.8.0)
-  - Firebase/AppDistribution (11.8.0):
+    - FirebaseAppCheck (~> 11.9.0)
+  - Firebase/AppDistribution (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 11.8.0-beta)
-  - Firebase/Auth (11.8.0):
+    - FirebaseAppDistribution (~> 11.9.0-beta)
+  - Firebase/Auth (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 11.8.0)
-  - Firebase/Core (11.8.0):
+    - FirebaseAuth (~> 11.9.0)
+  - Firebase/Core (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 11.8.0)
-  - Firebase/CoreOnly (11.8.0):
-    - FirebaseCore (~> 11.8.0)
-  - Firebase/Crashlytics (11.8.0):
+    - FirebaseAnalytics (~> 11.9.0)
+  - Firebase/CoreOnly (11.9.0):
+    - FirebaseCore (~> 11.9.0)
+  - Firebase/Crashlytics (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 11.8.0)
-  - Firebase/Database (11.8.0):
+    - FirebaseCrashlytics (~> 11.9.0)
+  - Firebase/Database (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 11.8.0)
-  - Firebase/DynamicLinks (11.8.0):
+    - FirebaseDatabase (~> 11.9.0)
+  - Firebase/DynamicLinks (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 11.8.0)
-  - Firebase/Firestore (11.8.0):
+    - FirebaseDynamicLinks (~> 11.9.0)
+  - Firebase/Firestore (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 11.8.0)
-  - Firebase/Functions (11.8.0):
+    - FirebaseFirestore (~> 11.9.0)
+  - Firebase/Functions (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 11.8.0)
-  - Firebase/InAppMessaging (11.8.0):
+    - FirebaseFunctions (~> 11.9.0)
+  - Firebase/InAppMessaging (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 11.8.0-beta)
-  - Firebase/Installations (11.8.0):
+    - FirebaseInAppMessaging (~> 11.9.0-beta)
+  - Firebase/Installations (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 11.8.0)
-  - Firebase/Messaging (11.8.0):
+    - FirebaseInstallations (~> 11.9.0)
+  - Firebase/Messaging (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 11.8.0)
-  - Firebase/Performance (11.8.0):
+    - FirebaseMessaging (~> 11.9.0)
+  - Firebase/Performance (11.9.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 11.8.0)
-  - Firebase/RemoteConfig (11.8.0):
+    - FirebasePerformance (~> 11.9.0)
+  - Firebase/RemoteConfig (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 11.8.0)
-  - Firebase/Storage (11.8.0):
+    - FirebaseRemoteConfig (~> 11.9.0)
+  - Firebase/Storage (11.9.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 11.8.0)
-  - FirebaseABTesting (11.8.0):
-    - FirebaseCore (~> 11.8.0)
-  - FirebaseAnalytics (11.8.0):
-    - FirebaseAnalytics/AdIdSupport (= 11.8.0)
-    - FirebaseCore (~> 11.8.0)
+    - FirebaseStorage (~> 11.9.0)
+  - FirebaseABTesting (11.9.0):
+    - FirebaseCore (~> 11.9.0)
+  - FirebaseAnalytics (11.9.0):
+    - FirebaseAnalytics/AdIdSupport (= 11.9.0)
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/AdIdSupport (11.8.0):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseAnalytics/AdIdSupport (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement (= 11.8.0)
+    - GoogleAppMeasurement (= 11.9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAppCheck (11.8.0):
+  - FirebaseAppCheck (11.9.0):
     - AppCheckCore (~> 11.0)
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.8.0)
+    - FirebaseCore (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAppCheckInterop (11.8.0)
-  - FirebaseAppDistribution (11.8.0-beta):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseAppCheckInterop (11.9.0)
+  - FirebaseAppDistribution (11.9.0-beta):
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAuth (11.8.1):
+  - FirebaseAuth (11.9.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.8.0)
-    - FirebaseCoreExtension (~> 11.8.0)
+    - FirebaseCore (~> 11.9.0)
+    - FirebaseCoreExtension (~> 11.9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
-    - RecaptchaInterop (~> 100.0)
-  - FirebaseAuthInterop (11.8.0)
-  - FirebaseCore (11.8.0):
-    - FirebaseCoreInternal (~> 11.8.0)
+    - RecaptchaInterop (~> 101.0)
+  - FirebaseAuthInterop (11.9.0)
+  - FirebaseCore (11.9.0):
+    - FirebaseCoreInternal (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreExtension (11.8.0):
-    - FirebaseCore (~> 11.8.0)
-  - FirebaseCoreInternal (11.8.0):
+  - FirebaseCoreExtension (11.9.0):
+    - FirebaseCore (~> 11.9.0)
+  - FirebaseCoreInternal (11.9.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseCrashlytics (11.8.0):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseCrashlytics (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -115,57 +115,57 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseDatabase (11.8.0):
+  - FirebaseDatabase (11.9.0):
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.8.0)
+    - FirebaseCore (~> 11.9.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (11.8.0):
-    - FirebaseCore (~> 11.8.0)
-  - FirebaseFirestore (11.8.0):
-    - FirebaseFirestoreBinary (= 11.8.0)
-  - FirebaseFirestoreAbseilBinary (1.2024011602.0)
-  - FirebaseFirestoreBinary (11.8.0):
-    - FirebaseCore (= 11.8.0)
-    - FirebaseCoreExtension (= 11.8.0)
-    - FirebaseFirestoreInternalBinary (= 11.8.0)
-    - FirebaseSharedSwift (= 11.8.0)
-  - FirebaseFirestoreGRPCBoringSSLBinary (1.65.1)
-  - FirebaseFirestoreGRPCCoreBinary (1.65.1):
-    - FirebaseFirestoreAbseilBinary (= 1.2024011602.0)
-    - FirebaseFirestoreGRPCBoringSSLBinary (= 1.65.1)
-  - FirebaseFirestoreGRPCCPPBinary (1.65.1):
-    - FirebaseFirestoreAbseilBinary (= 1.2024011602.0)
-    - FirebaseFirestoreGRPCCoreBinary (= 1.65.1)
-  - FirebaseFirestoreInternalBinary (11.8.0):
-    - FirebaseCore (= 11.8.0)
-    - FirebaseFirestoreAbseilBinary (= 1.2024011602.0)
-    - FirebaseFirestoreGRPCCPPBinary (= 1.65.1)
+  - FirebaseDynamicLinks (11.9.0):
+    - FirebaseCore (~> 11.9.0)
+  - FirebaseFirestore (11.9.0):
+    - FirebaseFirestoreBinary (= 11.9.0)
+  - FirebaseFirestoreAbseilBinary (1.2024072200.0)
+  - FirebaseFirestoreBinary (11.9.0):
+    - FirebaseCore (= 11.9.0)
+    - FirebaseCoreExtension (= 11.9.0)
+    - FirebaseFirestoreInternalBinary (= 11.9.0)
+    - FirebaseSharedSwift (= 11.9.0)
+  - FirebaseFirestoreGRPCBoringSSLBinary (1.69.0)
+  - FirebaseFirestoreGRPCCoreBinary (1.69.0):
+    - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
+    - FirebaseFirestoreGRPCBoringSSLBinary (= 1.69.0)
+  - FirebaseFirestoreGRPCCPPBinary (1.69.0):
+    - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
+    - FirebaseFirestoreGRPCCoreBinary (= 1.69.0)
+  - FirebaseFirestoreInternalBinary (11.9.0):
+    - FirebaseCore (= 11.9.0)
+    - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
+    - FirebaseFirestoreGRPCCPPBinary (= 1.69.0)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseFunctions (11.8.0):
+  - FirebaseFunctions (11.9.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.8.0)
-    - FirebaseCoreExtension (~> 11.8.0)
+    - FirebaseCore (~> 11.9.0)
+    - FirebaseCoreExtension (~> 11.9.0)
     - FirebaseMessagingInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
-  - FirebaseInAppMessaging (11.8.0-beta):
+  - FirebaseInAppMessaging (11.9.0-beta):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.8.0)
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseInstallations (11.8.0):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseInstallations (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.8.0):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseMessaging (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -173,9 +173,9 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseMessagingInterop (11.8.0)
-  - FirebasePerformance (11.8.0):
-    - FirebaseCore (~> 11.8.0)
+  - FirebaseMessagingInterop (11.9.0)
+  - FirebasePerformance (11.9.0):
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfig (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -184,55 +184,55 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseRemoteConfig (11.8.0):
+  - FirebaseRemoteConfig (11.9.0):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.8.0)
+    - FirebaseCore (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.8.0)
-  - FirebaseSessions (11.8.0):
-    - FirebaseCore (~> 11.8.0)
-    - FirebaseCoreExtension (~> 11.8.0)
+  - FirebaseRemoteConfigInterop (11.9.0)
+  - FirebaseSessions (11.9.0):
+    - FirebaseCore (~> 11.9.0)
+    - FirebaseCoreExtension (~> 11.9.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.8.0)
-  - FirebaseStorage (11.8.0):
+  - FirebaseSharedSwift (11.9.0)
+  - FirebaseStorage (11.9.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.8.0)
-    - FirebaseCoreExtension (~> 11.8.0)
+    - FirebaseCore (~> 11.9.0)
+    - FirebaseCoreExtension (~> 11.9.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - GoogleAppMeasurement (11.8.0):
-    - GoogleAppMeasurement/AdIdSupport (= 11.8.0)
+  - GoogleAppMeasurement (11.9.0):
+    - GoogleAppMeasurement/AdIdSupport (= 11.9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/AdIdSupport (11.8.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.8.0)
+  - GoogleAppMeasurement/AdIdSupport (11.9.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.9.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (11.8.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (11.9.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurementOnDeviceConversion (11.8.0)
+  - GoogleAppMeasurementOnDeviceConversion (11.9.0)
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
@@ -263,7 +263,7 @@ PODS:
   - GoogleUtilities/UserDefaults (8.0.2):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GTMSessionFetcher/Core (4.3.0)
+  - GTMSessionFetcher/Core (4.4.0)
   - hermes-engine (0.77.1):
     - hermes-engine/Pre-built (= 0.77.1)
   - hermes-engine/Pre-built (0.77.1)
@@ -1767,7 +1767,7 @@ PODS:
     - React-logger (= 0.77.1)
     - React-perflogger (= 0.77.1)
     - React-utils (= 0.77.1)
-  - RecaptchaInterop (100.0.0)
+  - RecaptchaInterop (101.0.0)
   - RNCAsyncStorage (2.1.1):
     - DoubleConversion
     - glog
@@ -1791,74 +1791,74 @@ PODS:
     - Yoga
   - RNDeviceInfo (14.0.4):
     - React-Core
-  - RNFBAnalytics (21.10.0):
-    - Firebase/Analytics (= 11.8.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 11.8.0)
+  - RNFBAnalytics (21.11.0):
+    - Firebase/Analytics (= 11.9.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (21.10.0):
-    - Firebase/CoreOnly (= 11.8.0)
+  - RNFBApp (21.11.0):
+    - Firebase/CoreOnly (= 11.9.0)
     - React-Core
-  - RNFBAppCheck (21.10.0):
-    - Firebase/AppCheck (= 11.8.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (21.10.0):
-    - Firebase/AppDistribution (= 11.8.0)
+  - RNFBAppCheck (21.11.0):
+    - Firebase/AppCheck (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.10.0):
-    - Firebase/Auth (= 11.8.0)
+  - RNFBAppDistribution (21.11.0):
+    - Firebase/AppDistribution (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.10.0):
-    - Firebase/Crashlytics (= 11.8.0)
+  - RNFBAuth (21.11.0):
+    - Firebase/Auth (= 11.9.0)
+    - React-Core
+    - RNFBApp
+  - RNFBCrashlytics (21.11.0):
+    - Firebase/Crashlytics (= 11.9.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.10.0):
-    - Firebase/Database (= 11.8.0)
+  - RNFBDatabase (21.11.0):
+    - Firebase/Database (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.10.0):
-    - Firebase/DynamicLinks (= 11.8.0)
+  - RNFBDynamicLinks (21.11.0):
+    - Firebase/DynamicLinks (= 11.9.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.10.0):
-    - Firebase/Firestore (= 11.8.0)
+  - RNFBFirestore (21.11.0):
+    - Firebase/Firestore (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.10.0):
-    - Firebase/Functions (= 11.8.0)
+  - RNFBFunctions (21.11.0):
+    - Firebase/Functions (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.10.0):
-    - Firebase/InAppMessaging (= 11.8.0)
+  - RNFBInAppMessaging (21.11.0):
+    - Firebase/InAppMessaging (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.10.0):
-    - Firebase/Installations (= 11.8.0)
+  - RNFBInstallations (21.11.0):
+    - Firebase/Installations (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.10.0):
-    - Firebase/Messaging (= 11.8.0)
+  - RNFBMessaging (21.11.0):
+    - Firebase/Messaging (= 11.9.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (21.10.0):
+  - RNFBML (21.11.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.10.0):
-    - Firebase/Performance (= 11.8.0)
+  - RNFBPerf (21.11.0):
+    - Firebase/Performance (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.10.0):
-    - Firebase/RemoteConfig (= 11.8.0)
+  - RNFBRemoteConfig (21.11.0):
+    - Firebase/RemoteConfig (= 11.9.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.10.0):
-    - Firebase/Storage (= 11.8.0)
+  - RNFBStorage (21.11.0):
+    - Firebase/Storage (= 11.9.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.7.1)
@@ -1869,7 +1869,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.8.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.9.0`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -2011,7 +2011,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.8.0
+    :tag: 11.9.0
   fmt:
     :podspec: "../node_modules/react-native/third-party-podspecs/fmt.podspec"
   glog:
@@ -2179,7 +2179,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.8.0
+    :tag: 11.9.0
 
 SPEC CHECKSUMS:
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
@@ -2187,45 +2187,45 @@ SPEC CHECKSUMS:
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 79c4b7ec726447eec5f8593379466bd9fde1aa14
-  Firebase: d80354ed7f6df5f9aca55e9eb47cc4b634735eaf
-  FirebaseABTesting: 7d6eee42b9137541eac2610e5fea3568d956707a
-  FirebaseAnalytics: 4fd42def128146e24e480e89f310e3d8534ea42b
-  FirebaseAppCheck: f6648d6d2b321ecf94cf72f6737fc68d4fddc010
-  FirebaseAppCheckInterop: 7bf86d55a2b7e9bd91464120eba3e52e4b63b2e2
-  FirebaseAppDistribution: 16e10663203dcca63dafcead9a3afdb01941f84b
-  FirebaseAuth: ad59a1a7b161e75f74c39f70179d2482d40e2737
-  FirebaseAuthInterop: 651756e70d9a0b9160db39ead71fd5507dbb6c84
-  FirebaseCore: 861681f012101000fba3c2a321ed00181d257591
-  FirebaseCoreExtension: 3d3f2017a00d06e09ab4ebe065391b0bb642565e
-  FirebaseCoreInternal: df24ce5af28864660ecbd13596fc8dd3a8c34629
-  FirebaseCrashlytics: a1102c035f18d5dd94a5969ee439c526d0c9e313
-  FirebaseDatabase: f86d3da3a67e41b551a84a8c5b081d0f86a5a896
-  FirebaseDynamicLinks: 629256017b6ed32a5629fd1a90bc734ab213edfb
-  FirebaseFirestore: c3c9dfb2e2ab96bd74a42804bbefb3a7edd32c88
-  FirebaseFirestoreAbseilBinary: fa2ebd2ed02cadef5382e4f7c93f1b265c812c85
-  FirebaseFirestoreBinary: 072a7121be7fbe601733a039c5ed80936ffb1e9b
-  FirebaseFirestoreGRPCBoringSSLBinary: d86ebbe2adc8d15d7ebf305fff7d6358385327f8
-  FirebaseFirestoreGRPCCoreBinary: 472bd808e1886a5efb2fd03dd09b98d34641a335
-  FirebaseFirestoreGRPCCPPBinary: db76d83d2b7517623f8426ed7f7a17bad2478084
-  FirebaseFirestoreInternalBinary: 4695c807651ee9775867026ea85712b3442995f9
-  FirebaseFunctions: 63d23f720c9a2c537369add7e54cf7e56eb3520a
-  FirebaseInAppMessaging: e332d3534d11bc5e4f800953dd4e1fff9866f53b
-  FirebaseInstallations: 6c963bd2a86aca0481eef4f48f5a4df783ae5917
-  FirebaseMessaging: 487b634ccdf6f7b7ff180fdcb2a9935490f764e8
-  FirebaseMessagingInterop: 75220a5ee806720951fd8df07c359266a54c1980
-  FirebasePerformance: 4db21c8ac5a967d38ca8625ce77f58a7abb59bc0
-  FirebaseRemoteConfig: f63724461fd97f0d62f20021314b59388f3e8ef8
-  FirebaseRemoteConfigInterop: 98897a64aa372eac3c5b3fe2816594ccfaac55ef
-  FirebaseSessions: c4d40a97f88f9eaff2834d61b4fea0a522d62123
-  FirebaseSharedSwift: 672954eac7b141d6954fab9a32d45d6b1d922df8
-  FirebaseStorage: 8eede00081a6ce904eaa8d2daa66f1e053e8e6ea
+  Firebase: 819b973f669bc894c85e181f814171e9d4440b29
+  FirebaseABTesting: 7edd6acbd2b75ed72bd7c4d4957ee57914eafc9b
+  FirebaseAnalytics: 68aa43d0556fb7ea3957570f65417813851fcf95
+  FirebaseAppCheck: c5484ddaa59961a76ddc59b51041124d56e8b967
+  FirebaseAppCheckInterop: 9226f7217b43e99dfa0bc9f674ad8108cef89feb
+  FirebaseAppDistribution: 7e0968542cf034f4248de4a3158b93c01ca74ed1
+  FirebaseAuth: 8eebb43f35cd2c1bb1981e3cef27c45617b85316
+  FirebaseAuthInterop: 2a26ee1bea6d47df8048683cfa071e7da657798f
+  FirebaseCore: 7cfcf7e8b33985c06478fd2b96e2f7101eb61a1c
+  FirebaseCoreExtension: b35fed507db40e6224fe36b163d34d18147da368
+  FirebaseCoreInternal: 154779013b85b4b290fdba38414df475f42e3096
+  FirebaseCrashlytics: 2eb9e0a0fc7394ae28825ca8ee18ca24452663cd
+  FirebaseDatabase: 3753a5df354b0557ba96da9cdfead7900fb65d92
+  FirebaseDynamicLinks: f4c11fcd7ee237a3cea11c629a9192e6ff9cda1f
+  FirebaseFirestore: 49a5ea68154b21ba8fe8f8d941a8881465a946f7
+  FirebaseFirestoreAbseilBinary: 4cfa8823cedc1b774843e04fe578ad279b387f97
+  FirebaseFirestoreBinary: 7cc90a5a7e3fb10c975d1ef7f1277ffdc90e3a04
+  FirebaseFirestoreGRPCBoringSSLBinary: c3dfef3ff448ae2c1c85f9baf9fac5afc4db99fa
+  FirebaseFirestoreGRPCCoreBinary: 565534e160a0415d12185f7f171c52a567382fbd
+  FirebaseFirestoreGRPCCPPBinary: 6c0134e8d230ee58b9d51dec2a30a48efd6d5dc7
+  FirebaseFirestoreInternalBinary: 9aa966b7c51eb0492eb136b72bf4a220e7a49f54
+  FirebaseFunctions: f5aaaaaa167ddda9bc1e5b88ac03eb1c7eb9ed6d
+  FirebaseInAppMessaging: b465809e91b883a5de3cace3b3bd8097170b2ec9
+  FirebaseInstallations: c76d4931a485fc0cc2dc1d62d3ed0369846ea4b8
+  FirebaseMessaging: 07e196b68580e68104df5c1c1b09ac26d04b24ea
+  FirebaseMessagingInterop: ced922294784e3f7cce3b5bcbd6c55a54a94d737
+  FirebasePerformance: 954de962f256dc475a16e307276c92b849e61932
+  FirebaseRemoteConfig: 69a9fa23e134776ec99b2bef3ce7804aab7956ea
+  FirebaseRemoteConfigInterop: 710954a00e956c5fe5144a8e46164f0361389203
+  FirebaseSessions: 0a5e23cc8cfb84a4f6b7914b08aaaaac31ae5e58
+  FirebaseSharedSwift: 574e6a5602afe4397a55c8d4f767382d620285de
+  FirebaseStorage: ef4654f6c54b702deb4d74650dde22c7b8ff0d60
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  GoogleAppMeasurement: fc0817122bd4d4189164f85374e06773b9561896
-  GoogleAppMeasurementOnDeviceConversion: 6231837f01cee71b064dc0113a817a345894872f
+  GoogleAppMeasurement: 7225e5d0cdd2687b5cefaa0d1a052fe51c448903
+  GoogleAppMeasurementOnDeviceConversion: 3b1fd17f8e4d7e251063cfb32e71997a73e6d082
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  GTMSessionFetcher: 257ead9ba8e15a2d389d79496e02b9cc5dd0c62c
+  GTMSessionFetcher: 75b671f9e551e4c49153d4c4f8659ef4f559b970
   hermes-engine: ccc24d29d650ea725d582a9a53d57cd417fbdb53
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
@@ -2289,26 +2289,26 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 41e9fb63606c32cce924653d2d410cb01ec81286
   ReactCodegen: 90bb8dd83136fc05f54b8aaab40345affc93aeff
   ReactCommon: 8953b677c1d2ed01905f3cd5dced07ead9ec4c8e
-  RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
+  RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 849b77e6ab3eb838361a902b492993056924faab
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNFBAnalytics: 54914faeb8fd8ca7368525f8af4dece0779b2bb8
-  RNFBApp: c0e35c80b0da1c93767dcb0060491735518dbebb
-  RNFBAppCheck: 2c1edb1e9fcbbebe3143948ac0de354c868c5b4a
-  RNFBAppDistribution: 84863562e5b450fefec6f2c44badf13ebb7ad869
-  RNFBAuth: 43c7e51ed74e7c71caae2c296819d00a4cae78eb
-  RNFBCrashlytics: b753359110799c000510e8c9137626f838c0cfad
-  RNFBDatabase: 141fffa67b2b7b7bd63ede3f3e6d37b2d49970f8
-  RNFBDynamicLinks: 9a14a2bc2a6fe02daf50d33a2f41dc64a4ede97b
-  RNFBFirestore: 5a4b835d053005914f33388bfe7a00f5a4036110
-  RNFBFunctions: 34e6186001bab6b705fa037dcafd46d06e3afd25
-  RNFBInAppMessaging: e199c47798638b233f202096602db4308b85d4ce
-  RNFBInstallations: bcb2c66748d091175a3add4d87b62dc264fb2f7c
-  RNFBMessaging: b8d712a6e70f9c4710928749950aeeb595270939
-  RNFBML: a74e2c5219bfe85e2db3c27dee7c4cbc5ce743eb
-  RNFBPerf: 5452c5cfd7bed7158e04dfa7f8d2bb786ae7bc35
-  RNFBRemoteConfig: f31f73790c0b77cc2ef041c8f3068e5578cfbe19
-  RNFBStorage: e2355c77f0335abd85ee8a0703f95ca80f846008
+  RNFBAnalytics: 6ceca390c59fc65550a6c5c3cd13c986274c64ae
+  RNFBApp: 0bddcc5bbb6b25ce72727fea01ad5bf68eb69e9b
+  RNFBAppCheck: f15c2288ef5664a5510d4eb5ee429673f84ac7eb
+  RNFBAppDistribution: 93ef16c883f7bc59e3d51928d870547650d7b587
+  RNFBAuth: dee7d8f9d9103fa424cd1251defdaffd7de3ab66
+  RNFBCrashlytics: 73ab7a9391937aee8210bace7cad07b26237d4f8
+  RNFBDatabase: fd755e7880a87911a25e1dbaf57000cc9ec3faf1
+  RNFBDynamicLinks: b8b1ae91aa28bc73a3c0031273aa5ff573628920
+  RNFBFirestore: 98d8bfa14388025c26d27db41263170c7077a6fe
+  RNFBFunctions: 3ca174f351b9982660039e7a8a531e52bad3b065
+  RNFBInAppMessaging: 0b30eb2b9cdad9b64f58a631d10bad0ae2f493ac
+  RNFBInstallations: edca6b44d2d442ca7f01bf0b996b33af34d95787
+  RNFBMessaging: e1c523bf6600209f7209040947aa1bc6283e09ca
+  RNFBML: 208649b6bd1f6bcfbde9a8b008fd088385991698
+  RNFBPerf: afc3de55ff735b46688ec7619c22b82e60e916f9
+  RNFBRemoteConfig: 905959b9d4833ab9811902ef680afa44fbad19b5
+  RNFBStorage: 88444f0553432ec07698fc9344be845c0042c279
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 28b8cda182ee3092ff80203da66dcb3ffc8cf401
 


### PR DESCRIPTION
### Description

Nothing more and nothing less than the title, SDK bumps

### Related issues

There are a few issues logged about database connections and listeners being lost on iOS, and this release should help those as it switches back to SocketRocket on iOS, which was last used in firebase-ios-sdk 10.27.0 and appears to have better reconnection behavior

### Release Summary

single conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Going to trust CI on this one

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
