### PR TITLE
docs(remote-config, ios): remove android-only marker on setConfigSettings

### DIFF
--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -195,7 +195,6 @@ export function reset(remoteConfig) {
 /**
  * Set the Remote RemoteConfig settings, currently able to set
  * `fetchTimeMillis` & `minimumFetchIntervalMillis`
- * Android only. iOS does not reset anything.
  * @param {RemoteConfig} remoteConfig - RemoteConfig instance
  * @param {ConfigSettings} settings - ConfigSettings instance
  * @returns {Promise<void>}


### PR DESCRIPTION


### Description

fixes copy-paste docs text error from the `reset` method which *is* android-only

### Related issues

- Fixes #8380 

### Release Summary

docs only update, no release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

CI will check grammar and such, not a functional change

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
