### PR TITLE
docs(app, expo): Google sign in and Expo doc correction

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -215,7 +215,6 @@ Ensure the "Google" sign-in provider is enabled on the [Firebase Console](https:
 
 For Expo projects, follow [the setup instructions for Expo](https://react-native-google-signin.github.io/docs/category/setting-up) from `react-native-google-signin`.
 
-
 Before triggering a sign-in request, you must initialize the Google SDK.
 
 ```js

--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -215,6 +215,15 @@ Ensure the "Google" sign-in provider is enabled on the [Firebase Console](https:
 
 For Expo projects, follow [the setup instructions for Expo](https://react-native-google-signin.github.io/docs/category/setting-up) from `react-native-google-signin`.
 
+
+Before triggering a sign-in request, you must initialize the Google SDK.
+
+```js
+import { GoogleSignin } from '@react-native-google-signin/google-signin';
+
+GoogleSignin.configure();
+```
+
 ### Configure a React-Native (non-Expo) project
 
 For bare React-Native projects, most configuration is already setup when using Google Sign-In with React-Native-Firebase's configuration, however you need to ensure your machines SHA1 key has been configured for use with Android. You can see how to generate the key on the [Getting Started](/) documentation.


### PR DESCRIPTION


### Description

Correcting confusing documentation regarding Google sign in and Expo. See https://github.com/react-native-google-signin/google-signin/issues/1364#issuecomment-2692864846

The docs currently indicate the `GoogleSignin.configure` is not required with Expo, however it is.

### Related issues

https://github.com/react-native-google-signin/google-signin/issues/1364


### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [X] `iOS`
  - [ ] `Other` (macOS, web)
- This is a breaking change;
  - [ ] Yes
  - [X] No


