### PR TITLE
feat(analytics): allow undefined fields in item type

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -328,6 +328,12 @@ describe('Analytics', function () {
           firebase.analytics().logAddToWishlist({ items: [{ foo: 'bar' }] }),
         ).not.toThrow();
       });
+
+      it('items accept arbitrary custom event parameters that can be undefined', function () {
+        expect(() =>
+          firebase.analytics().logAddToWishlist({ items: [{ foo: undefined }] }),
+        ).not.toThrow();
+      });
     });
 
     describe('logBeginCheckout()', function () {

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -145,7 +145,7 @@ export namespace FirebaseAnalyticsTypes {
      * Custom event parameters. The parameter names can be up to 40 characters long and must start with an alphabetic character and contain only alphanumeric characters and underscores. String parameter values can be up to 100 characters long.
      * The "firebase_", "google_" and "ga_" prefixes are reserved and should not be used for parameter names.
      */
-    [key: string]: string | number;
+    [key: string]: string | number | undefined;
   }
 
   export interface AddPaymentInfoEventParameters {

--- a/packages/analytics/lib/index.d.ts
+++ b/packages/analytics/lib/index.d.ts
@@ -145,7 +145,7 @@ export namespace FirebaseAnalyticsTypes {
      * Custom event parameters. The parameter names can be up to 40 characters long and must start with an alphabetic character and contain only alphanumeric characters and underscores. String parameter values can be up to 100 characters long.
      * The "firebase_", "google_" and "ga_" prefixes are reserved and should not be used for parameter names.
      */
-    [key: string]: string | number | undefined;
+    [key: string]: any;
   }
 
   export interface AddPaymentInfoEventParameters {


### PR DESCRIPTION
### Description

Closes https://github.com/invertase/react-native-firebase/issues/8370
Allow undefined fields apart from just string and number in Item objects.
https://github.com/firebase/firebase-js-sdk/blob/main/packages/analytics-types/index.d.ts
https://firebase.google.com/docs/reference/js/v8/firebase.analytics.CustomParams (Modular API docs do not say anything more)


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
