### PR TITLE
fix(firestore): use correct key to cache instance

### DIFF
--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.m
@@ -47,7 +47,7 @@ NSMutableDictionary *instanceCache;
                      appName:[RNFBSharedUtils getAppJavaScriptName:app.name]
                   databaseId:databaseId];
 
-  instanceCache[[app name]] = instance;
+  instanceCache[firestoreKey] = instance;
 
   return instance;
 }


### PR DESCRIPTION
### Description
We were seeing new firestores instances being constantly generated instead of being cached.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
- Tested that instances are cached and accessed correctly

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
