### PR TITLE
docs(auth, google): move topic headings for clarity

### DIFF
--- a/docs/auth/social-auth.md
+++ b/docs/auth/social-auth.md
@@ -219,7 +219,9 @@ For Expo projects, follow [the setup instructions for Expo](https://react-native
 
 For bare React-Native projects, most configuration is already setup when using Google Sign-In with React-Native-Firebase's configuration, however you need to ensure your machines SHA1 key has been configured for use with Android. You can see how to generate the key on the [Getting Started](/) documentation.
 
-Before triggering a sign-in request, you must initialize the Google SDK using your any required scopes and the
+### Using Google Sign-In
+
+Before triggering a sign-in request, you must initialize the Google SDK with any required scopes and the
 `webClientId`, which can be found in the `android/app/google-services.json` file as the `client/oauth_client/client_id` property (the id ends with `.apps.googleusercontent.com`). Make sure to pick the `client_id` with `client_type: 3`
 
 ```js
@@ -229,8 +231,6 @@ GoogleSignin.configure({
   webClientId: '',
 });
 ```
-
-### Using Google Sign-In
 
 Once initialized, setup your application to trigger a sign-in request with Google using the `signIn` method.
 


### PR DESCRIPTION
### Description

The google sign-in docs were not wrong, exactly, but the way the headings were aligned it was possible to interpret some non-optional things as optional. Definitely not intended, resulted in lost developer time

### Related issues

Previous PR - not exactly on target, but discussion inspired this:

- #8389

### Release Summary

Just a docs commit, docs site will auto-build off it once commited

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Will canvas conversation participants for review, merge when there is consensus

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
