### PR TITLE
test(vertexai): handle new vertexai mock responses version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -583,5 +583,5 @@ website/public
 *.tsbuildinfo
 
 # vertexai test data
-vertexai-sdk-test-data
+vertexai-sdk-test-data*
 mocks-lookup.ts

--- a/packages/vertexai/__tests__/test-utils/convert-mocks.ts
+++ b/packages/vertexai/__tests__/test-utils/convert-mocks.ts
@@ -36,7 +36,7 @@ function findMockResponseDir(): string {
     throw new Error('Multiple directories starting with "vertexai-sdk-test-data*" found');
   }
 
-  return join(__dirname, directories[0], 'mock-responses');
+  return join(__dirname, directories[0], 'mock-responses', 'vertexai');
 }
 
 async function main(): Promise<void> {
@@ -45,6 +45,7 @@ async function main(): Promise<void> {
   const lookup: Record<string, string> = {};
   // eslint-disable-next-line guard-for-in
   for (const fileName of list) {
+    console.log(`attempting to read ${mockResponseDir}/${fileName}`)
     const fullText = fs.readFileSync(join(mockResponseDir, fileName), 'utf-8');
     lookup[fileName] = fullText;
   }


### PR DESCRIPTION
### Description

Attempting to run e2e tests locally this morning, hit a snag with the vertexai package, it appears they have updated their test repository and we need to forward-port slightly:

- has a new v7 on the end, so update gitignore
- moved responses to subdirectory, add new subdir to dir lookup

Fixes:
- Fixes #8409 

### Release Summary

single conventional commit with test tag so will not trigger a release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The whole PR is about tests, so if the tests pass for vertexai, it works

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
