### PR TITLE
fix(ios): adopt firebase-ios-sdk 11.10.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -333,12 +333,12 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '11.9.0'
+$FirebaseSDKVersion = '11.10.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.
 
-Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=11.5.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=11.5.0 yarn expo prebuild --clean`
+Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=11.10.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=11.10.0 yarn expo prebuild --clean`
 
 ### Increasing Android build memory
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "11.9.0",
+      "firebase": "11.10.0",
       "iosTarget": "13.0",
       "macosTarget": "10.15",
       "tvosTarget": "13.0"

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -7,107 +7,107 @@ PODS:
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
   - FBLazyVector (0.77.1)
-  - Firebase/Analytics (11.9.0):
+  - Firebase/Analytics (11.10.0):
     - Firebase/Core
-  - Firebase/AppCheck (11.9.0):
+  - Firebase/AppCheck (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 11.9.0)
-  - Firebase/AppDistribution (11.9.0):
+    - FirebaseAppCheck (~> 11.10.0)
+  - Firebase/AppDistribution (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 11.9.0-beta)
-  - Firebase/Auth (11.9.0):
+    - FirebaseAppDistribution (~> 11.10.0-beta)
+  - Firebase/Auth (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 11.9.0)
-  - Firebase/Core (11.9.0):
+    - FirebaseAuth (~> 11.10.0)
+  - Firebase/Core (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 11.9.0)
-  - Firebase/CoreOnly (11.9.0):
-    - FirebaseCore (~> 11.9.0)
-  - Firebase/Crashlytics (11.9.0):
+    - FirebaseAnalytics (~> 11.10.0)
+  - Firebase/CoreOnly (11.10.0):
+    - FirebaseCore (~> 11.10.0)
+  - Firebase/Crashlytics (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 11.9.0)
-  - Firebase/Database (11.9.0):
+    - FirebaseCrashlytics (~> 11.10.0)
+  - Firebase/Database (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 11.9.0)
-  - Firebase/DynamicLinks (11.9.0):
+    - FirebaseDatabase (~> 11.10.0)
+  - Firebase/DynamicLinks (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 11.9.0)
-  - Firebase/Firestore (11.9.0):
+    - FirebaseDynamicLinks (~> 11.10.0)
+  - Firebase/Firestore (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 11.9.0)
-  - Firebase/Functions (11.9.0):
+    - FirebaseFirestore (~> 11.10.0)
+  - Firebase/Functions (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 11.9.0)
-  - Firebase/InAppMessaging (11.9.0):
+    - FirebaseFunctions (~> 11.10.0)
+  - Firebase/InAppMessaging (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 11.9.0-beta)
-  - Firebase/Installations (11.9.0):
+    - FirebaseInAppMessaging (~> 11.10.0-beta)
+  - Firebase/Installations (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 11.9.0)
-  - Firebase/Messaging (11.9.0):
+    - FirebaseInstallations (~> 11.10.0)
+  - Firebase/Messaging (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 11.9.0)
-  - Firebase/Performance (11.9.0):
+    - FirebaseMessaging (~> 11.10.0)
+  - Firebase/Performance (11.10.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 11.9.0)
-  - Firebase/RemoteConfig (11.9.0):
+    - FirebasePerformance (~> 11.10.0)
+  - Firebase/RemoteConfig (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 11.9.0)
-  - Firebase/Storage (11.9.0):
+    - FirebaseRemoteConfig (~> 11.10.0)
+  - Firebase/Storage (11.10.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 11.9.0)
-  - FirebaseABTesting (11.9.0):
-    - FirebaseCore (~> 11.9.0)
-  - FirebaseAnalytics (11.9.0):
-    - FirebaseAnalytics/AdIdSupport (= 11.9.0)
-    - FirebaseCore (~> 11.9.0)
+    - FirebaseStorage (~> 11.10.0)
+  - FirebaseABTesting (11.10.0):
+    - FirebaseCore (~> 11.10.0)
+  - FirebaseAnalytics (11.10.0):
+    - FirebaseAnalytics/AdIdSupport (= 11.10.0)
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/AdIdSupport (11.9.0):
-    - FirebaseCore (~> 11.9.0)
+  - FirebaseAnalytics/AdIdSupport (11.10.0):
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement (= 11.9.0)
+    - GoogleAppMeasurement (= 11.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAppCheck (11.9.0):
+  - FirebaseAppCheck (11.10.0):
     - AppCheckCore (~> 11.0)
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.9.0)
+    - FirebaseCore (~> 11.10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAppCheckInterop (11.9.0)
-  - FirebaseAppDistribution (11.9.0-beta):
-    - FirebaseCore (~> 11.9.0)
+  - FirebaseAppCheckInterop (11.10.0)
+  - FirebaseAppDistribution (11.10.0-beta):
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAuth (11.9.0):
+  - FirebaseAuth (11.10.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.9.0)
-    - FirebaseCoreExtension (~> 11.9.0)
+    - FirebaseCore (~> 11.10.0)
+    - FirebaseCoreExtension (~> 11.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
-  - FirebaseAuthInterop (11.9.0)
-  - FirebaseCore (11.9.0):
-    - FirebaseCoreInternal (~> 11.9.0)
+  - FirebaseAuthInterop (11.10.0)
+  - FirebaseCore (11.10.0):
+    - FirebaseCoreInternal (~> 11.10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreExtension (11.9.0):
-    - FirebaseCore (~> 11.9.0)
-  - FirebaseCoreInternal (11.9.0):
+  - FirebaseCoreExtension (11.10.0):
+    - FirebaseCore (~> 11.10.0)
+  - FirebaseCoreInternal (11.10.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseCrashlytics (11.9.0):
-    - FirebaseCore (~> 11.9.0)
+  - FirebaseCrashlytics (11.10.0):
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -115,22 +115,22 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseDatabase (11.9.0):
+  - FirebaseDatabase (11.10.0):
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.9.0)
+    - FirebaseCore (~> 11.10.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (11.9.0):
-    - FirebaseCore (~> 11.9.0)
-  - FirebaseFirestore (11.9.0):
-    - FirebaseFirestoreBinary (= 11.9.0)
+  - FirebaseDynamicLinks (11.10.0):
+    - FirebaseCore (~> 11.10.0)
+  - FirebaseFirestore (11.10.0):
+    - FirebaseFirestoreBinary (= 11.10.0)
   - FirebaseFirestoreAbseilBinary (1.2024072200.0)
-  - FirebaseFirestoreBinary (11.9.0):
-    - FirebaseCore (= 11.9.0)
-    - FirebaseCoreExtension (= 11.9.0)
-    - FirebaseFirestoreInternalBinary (= 11.9.0)
-    - FirebaseSharedSwift (= 11.9.0)
+  - FirebaseFirestoreBinary (11.10.0):
+    - FirebaseCore (= 11.10.0)
+    - FirebaseCoreExtension (= 11.10.0)
+    - FirebaseFirestoreInternalBinary (= 11.10.0)
+    - FirebaseSharedSwift (= 11.10.0)
   - FirebaseFirestoreGRPCBoringSSLBinary (1.69.0)
   - FirebaseFirestoreGRPCCoreBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
@@ -138,34 +138,34 @@ PODS:
   - FirebaseFirestoreGRPCCPPBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCoreBinary (= 1.69.0)
-  - FirebaseFirestoreInternalBinary (11.9.0):
-    - FirebaseCore (= 11.9.0)
+  - FirebaseFirestoreInternalBinary (11.10.0):
+    - FirebaseCore (= 11.10.0)
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCPPBinary (= 1.69.0)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseFunctions (11.9.0):
+  - FirebaseFunctions (11.10.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.9.0)
-    - FirebaseCoreExtension (~> 11.9.0)
+    - FirebaseCore (~> 11.10.0)
+    - FirebaseCoreExtension (~> 11.10.0)
     - FirebaseMessagingInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
-  - FirebaseInAppMessaging (11.9.0-beta):
+  - FirebaseInAppMessaging (11.10.0-beta):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.9.0)
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseInstallations (11.9.0):
-    - FirebaseCore (~> 11.9.0)
+  - FirebaseInstallations (11.10.0):
+    - FirebaseCore (~> 11.10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.9.0):
-    - FirebaseCore (~> 11.9.0)
+  - FirebaseMessaging (11.10.0):
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -173,9 +173,9 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseMessagingInterop (11.9.0)
-  - FirebasePerformance (11.9.0):
-    - FirebaseCore (~> 11.9.0)
+  - FirebaseMessagingInterop (11.10.0)
+  - FirebasePerformance (11.10.0):
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfig (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -184,55 +184,55 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseRemoteConfig (11.9.0):
+  - FirebaseRemoteConfig (11.10.0):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.9.0)
+    - FirebaseCore (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.9.0)
-  - FirebaseSessions (11.9.0):
-    - FirebaseCore (~> 11.9.0)
-    - FirebaseCoreExtension (~> 11.9.0)
+  - FirebaseRemoteConfigInterop (11.10.0)
+  - FirebaseSessions (11.10.0):
+    - FirebaseCore (~> 11.10.0)
+    - FirebaseCoreExtension (~> 11.10.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.9.0)
-  - FirebaseStorage (11.9.0):
+  - FirebaseSharedSwift (11.10.0)
+  - FirebaseStorage (11.10.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.9.0)
-    - FirebaseCoreExtension (~> 11.9.0)
+    - FirebaseCore (~> 11.10.0)
+    - FirebaseCoreExtension (~> 11.10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - GoogleAppMeasurement (11.9.0):
-    - GoogleAppMeasurement/AdIdSupport (= 11.9.0)
+  - GoogleAppMeasurement (11.10.0):
+    - GoogleAppMeasurement/AdIdSupport (= 11.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/AdIdSupport (11.9.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.9.0)
+  - GoogleAppMeasurement/AdIdSupport (11.10.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (11.9.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (11.10.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurementOnDeviceConversion (11.9.0)
+  - GoogleAppMeasurementOnDeviceConversion (11.10.0)
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
@@ -1791,74 +1791,74 @@ PODS:
     - Yoga
   - RNDeviceInfo (14.0.4):
     - React-Core
-  - RNFBAnalytics (21.11.0):
-    - Firebase/Analytics (= 11.9.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 11.9.0)
+  - RNFBAnalytics (21.12.0):
+    - Firebase/Analytics (= 11.10.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (21.11.0):
-    - Firebase/CoreOnly (= 11.9.0)
+  - RNFBApp (21.12.0):
+    - Firebase/CoreOnly (= 11.10.0)
     - React-Core
-  - RNFBAppCheck (21.11.0):
-    - Firebase/AppCheck (= 11.9.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (21.11.0):
-    - Firebase/AppDistribution (= 11.9.0)
+  - RNFBAppCheck (21.12.0):
+    - Firebase/AppCheck (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.11.0):
-    - Firebase/Auth (= 11.9.0)
+  - RNFBAppDistribution (21.12.0):
+    - Firebase/AppDistribution (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.11.0):
-    - Firebase/Crashlytics (= 11.9.0)
+  - RNFBAuth (21.12.0):
+    - Firebase/Auth (= 11.10.0)
+    - React-Core
+    - RNFBApp
+  - RNFBCrashlytics (21.12.0):
+    - Firebase/Crashlytics (= 11.10.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.11.0):
-    - Firebase/Database (= 11.9.0)
+  - RNFBDatabase (21.12.0):
+    - Firebase/Database (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.11.0):
-    - Firebase/DynamicLinks (= 11.9.0)
+  - RNFBDynamicLinks (21.12.0):
+    - Firebase/DynamicLinks (= 11.10.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.11.0):
-    - Firebase/Firestore (= 11.9.0)
+  - RNFBFirestore (21.12.0):
+    - Firebase/Firestore (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.11.0):
-    - Firebase/Functions (= 11.9.0)
+  - RNFBFunctions (21.12.0):
+    - Firebase/Functions (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.11.0):
-    - Firebase/InAppMessaging (= 11.9.0)
+  - RNFBInAppMessaging (21.12.0):
+    - Firebase/InAppMessaging (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.11.0):
-    - Firebase/Installations (= 11.9.0)
+  - RNFBInstallations (21.12.0):
+    - Firebase/Installations (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.11.0):
-    - Firebase/Messaging (= 11.9.0)
+  - RNFBMessaging (21.12.0):
+    - Firebase/Messaging (= 11.10.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (21.11.0):
+  - RNFBML (21.12.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.11.0):
-    - Firebase/Performance (= 11.9.0)
+  - RNFBPerf (21.12.0):
+    - Firebase/Performance (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.11.0):
-    - Firebase/RemoteConfig (= 11.9.0)
+  - RNFBRemoteConfig (21.12.0):
+    - Firebase/RemoteConfig (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.11.0):
-    - Firebase/Storage (= 11.9.0)
+  - RNFBStorage (21.12.0):
+    - Firebase/Storage (= 11.10.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.7.1)
@@ -1869,7 +1869,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.9.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.10.0`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -2011,7 +2011,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.9.0
+    :tag: 11.10.0
   fmt:
     :podspec: "../node_modules/react-native/third-party-podspecs/fmt.podspec"
   glog:
@@ -2179,7 +2179,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.9.0
+    :tag: 11.10.0
 
 SPEC CHECKSUMS:
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
@@ -2187,42 +2187,42 @@ SPEC CHECKSUMS:
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 79c4b7ec726447eec5f8593379466bd9fde1aa14
-  Firebase: 819b973f669bc894c85e181f814171e9d4440b29
-  FirebaseABTesting: 7edd6acbd2b75ed72bd7c4d4957ee57914eafc9b
-  FirebaseAnalytics: 68aa43d0556fb7ea3957570f65417813851fcf95
-  FirebaseAppCheck: c5484ddaa59961a76ddc59b51041124d56e8b967
-  FirebaseAppCheckInterop: 9226f7217b43e99dfa0bc9f674ad8108cef89feb
-  FirebaseAppDistribution: 7e0968542cf034f4248de4a3158b93c01ca74ed1
-  FirebaseAuth: 8eebb43f35cd2c1bb1981e3cef27c45617b85316
-  FirebaseAuthInterop: 2a26ee1bea6d47df8048683cfa071e7da657798f
-  FirebaseCore: 7cfcf7e8b33985c06478fd2b96e2f7101eb61a1c
-  FirebaseCoreExtension: b35fed507db40e6224fe36b163d34d18147da368
-  FirebaseCoreInternal: 154779013b85b4b290fdba38414df475f42e3096
-  FirebaseCrashlytics: 2eb9e0a0fc7394ae28825ca8ee18ca24452663cd
-  FirebaseDatabase: 3753a5df354b0557ba96da9cdfead7900fb65d92
-  FirebaseDynamicLinks: f4c11fcd7ee237a3cea11c629a9192e6ff9cda1f
-  FirebaseFirestore: 49a5ea68154b21ba8fe8f8d941a8881465a946f7
+  Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
+  FirebaseABTesting: dfc10eb6cc08fe3b391ac9e5aa40396d43ea6675
+  FirebaseAnalytics: 4e42333f02cf78ed93703a5c36f36dd518aebdef
+  FirebaseAppCheck: 9687ebd909702469bc09d2d58008697b83f4ac27
+  FirebaseAppCheckInterop: 9664c858489710f682766ef54e2b6741d3b62070
+  FirebaseAppDistribution: 9b63632c01190132cbffe2b41397fdedb2a52816
+  FirebaseAuth: c4146bdfdc87329f9962babd24dae89373f49a32
+  FirebaseAuthInterop: 01a804fb074424fd58b92dd50dd0272277199356
+  FirebaseCore: 8344daef5e2661eb004b177488d6f9f0f24251b7
+  FirebaseCoreExtension: 6f357679327f3614e995dc7cf3f2d600bdc774ac
+  FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
+  FirebaseCrashlytics: 84b073c997235740e6a951b7ee49608932877e5c
+  FirebaseDatabase: 229b4959145d197dab99ab9d7033b6d4fab897a1
+  FirebaseDynamicLinks: a76f75ddb0612301c34b3f598100449b41bc2669
+  FirebaseFirestore: e5c3d65fef6c6e07c47af2130aaadfb89dd07ea7
   FirebaseFirestoreAbseilBinary: 4cfa8823cedc1b774843e04fe578ad279b387f97
-  FirebaseFirestoreBinary: 7cc90a5a7e3fb10c975d1ef7f1277ffdc90e3a04
+  FirebaseFirestoreBinary: 6cf15472267bbb89ce9ac5e645eb0abae29208ce
   FirebaseFirestoreGRPCBoringSSLBinary: c3dfef3ff448ae2c1c85f9baf9fac5afc4db99fa
   FirebaseFirestoreGRPCCoreBinary: 565534e160a0415d12185f7f171c52a567382fbd
   FirebaseFirestoreGRPCCPPBinary: 6c0134e8d230ee58b9d51dec2a30a48efd6d5dc7
-  FirebaseFirestoreInternalBinary: 9aa966b7c51eb0492eb136b72bf4a220e7a49f54
-  FirebaseFunctions: f5aaaaaa167ddda9bc1e5b88ac03eb1c7eb9ed6d
-  FirebaseInAppMessaging: b465809e91b883a5de3cace3b3bd8097170b2ec9
-  FirebaseInstallations: c76d4931a485fc0cc2dc1d62d3ed0369846ea4b8
-  FirebaseMessaging: 07e196b68580e68104df5c1c1b09ac26d04b24ea
-  FirebaseMessagingInterop: ced922294784e3f7cce3b5bcbd6c55a54a94d737
-  FirebasePerformance: 954de962f256dc475a16e307276c92b849e61932
-  FirebaseRemoteConfig: 69a9fa23e134776ec99b2bef3ce7804aab7956ea
-  FirebaseRemoteConfigInterop: 710954a00e956c5fe5144a8e46164f0361389203
-  FirebaseSessions: 0a5e23cc8cfb84a4f6b7914b08aaaaac31ae5e58
-  FirebaseSharedSwift: 574e6a5602afe4397a55c8d4f767382d620285de
-  FirebaseStorage: ef4654f6c54b702deb4d74650dde22c7b8ff0d60
+  FirebaseFirestoreInternalBinary: 96b309279c4efdf00b83ab80e8af4d0a73d30258
+  FirebaseFunctions: e89e0cf2091c9fb19aa58df270317c0a91963f4f
+  FirebaseInAppMessaging: 3f96b5715f1e2dffdb4189300f8054b2d7059a5e
+  FirebaseInstallations: 9980995bdd06ec8081dfb6ab364162bdd64245c3
+  FirebaseMessaging: 2b9f56aa4ed286e1f0ce2ee1d413aabb8f9f5cb9
+  FirebaseMessagingInterop: 2fb9a3ca813c3b7b495232f1fbedd365eb60da45
+  FirebasePerformance: f0bd14be05aaa1136cbb1c9aaaf87d213d0e6fbf
+  FirebaseRemoteConfig: 10695bc0ce3b103e3706a5578c43f2a9f69d5aaa
+  FirebaseRemoteConfigInterop: 7c9a9c65eff32cbb0f7bf8d18140612ad57dfcc6
+  FirebaseSessions: 9b3b30947b97a15370e0902ee7a90f50ef60ead6
+  FirebaseSharedSwift: 1baacae75939499b5def867cbe34129464536a38
+  FirebaseStorage: e83d1b9c8a5318d46ccfb2955f0d98095e0bf598
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  GoogleAppMeasurement: 7225e5d0cdd2687b5cefaa0d1a052fe51c448903
-  GoogleAppMeasurementOnDeviceConversion: 3b1fd17f8e4d7e251063cfb32e71997a73e6d082
+  GoogleAppMeasurement: 36684bfb3ee034e2b42b4321eb19da3a1b81e65d
+  GoogleAppMeasurementOnDeviceConversion: f312bf446027ca1a72f44c348bd9bc130e1f0af0
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMSessionFetcher: 75b671f9e551e4c49153d4c4f8659ef4f559b970
@@ -2292,23 +2292,23 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 849b77e6ab3eb838361a902b492993056924faab
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNFBAnalytics: 6ceca390c59fc65550a6c5c3cd13c986274c64ae
-  RNFBApp: 0bddcc5bbb6b25ce72727fea01ad5bf68eb69e9b
-  RNFBAppCheck: f15c2288ef5664a5510d4eb5ee429673f84ac7eb
-  RNFBAppDistribution: 93ef16c883f7bc59e3d51928d870547650d7b587
-  RNFBAuth: dee7d8f9d9103fa424cd1251defdaffd7de3ab66
-  RNFBCrashlytics: 73ab7a9391937aee8210bace7cad07b26237d4f8
-  RNFBDatabase: fd755e7880a87911a25e1dbaf57000cc9ec3faf1
-  RNFBDynamicLinks: b8b1ae91aa28bc73a3c0031273aa5ff573628920
-  RNFBFirestore: 98d8bfa14388025c26d27db41263170c7077a6fe
-  RNFBFunctions: 3ca174f351b9982660039e7a8a531e52bad3b065
-  RNFBInAppMessaging: 0b30eb2b9cdad9b64f58a631d10bad0ae2f493ac
-  RNFBInstallations: edca6b44d2d442ca7f01bf0b996b33af34d95787
-  RNFBMessaging: e1c523bf6600209f7209040947aa1bc6283e09ca
-  RNFBML: 208649b6bd1f6bcfbde9a8b008fd088385991698
-  RNFBPerf: afc3de55ff735b46688ec7619c22b82e60e916f9
-  RNFBRemoteConfig: 905959b9d4833ab9811902ef680afa44fbad19b5
-  RNFBStorage: 88444f0553432ec07698fc9344be845c0042c279
+  RNFBAnalytics: 16174be0106d1bc3356ab5bbc6dc5cfc079e2534
+  RNFBApp: 35f4ce8ca75b23ab7bf8a30f8a951196c143291d
+  RNFBAppCheck: 59b8083d9f2ecb9f4ed57705318b7f618cc5a6f7
+  RNFBAppDistribution: b04ef8d462bfab9da761c36967137f73b89fa870
+  RNFBAuth: 0acbe87b295c7d5551d1a013f22ef1404bea1dd7
+  RNFBCrashlytics: e997e0b4652036853c17b269dd773fdb2e6e6868
+  RNFBDatabase: 011f62bd40c63535f3af5a5d48db5a3fa2fdd047
+  RNFBDynamicLinks: 2b2ce6b512a0f50b794826e2edfd93c482ff756d
+  RNFBFirestore: 17c13b4c34db6f0617a68334dd0239a784d4af4c
+  RNFBFunctions: 04e8b2b516c8b8d3f4b21663ba4cee290889abda
+  RNFBInAppMessaging: 6522c86b5e740a0e6390c54c4ca430b605a0fc84
+  RNFBInstallations: 7aa2972fe49c5e4de60b9ac8add2322199e4522c
+  RNFBMessaging: ac9009a487aed6e9549789696b864d14edad6ec9
+  RNFBML: 0bc8bbd9e4d00764ba0bb8d71faf9296bba8e89b
+  RNFBPerf: d88d0e3598761753e726222db24cf7114c43facf
+  RNFBRemoteConfig: 24ce9c6772473e6d047fe0a3d8e2aaecd151cc12
+  RNFBStorage: 929c8635f00facf7b4d8ba9d64db5d294fd78b90
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 28b8cda182ee3092ff80203da66dcb3ffc8cf401
 


### PR DESCRIPTION
### Description

Simple adoption of updated firebase-ios-sdk

### Related issues

Note that there were/are publishing problems for the firestore-ios-sdk-frameworks artifacts, however, despite the build over there not completing successfully, the artifacts it created appear to have been published enough to function:

- Related https://github.com/invertase/firestore-ios-sdk-frameworks/issues/121

### Release Summary

Single conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

This appears to work in my local testing, if it passes CI it should be good to go

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
