### PR TITLE
test: tighten rules-unit-testing patch, matches upstream PR attempt

### DIFF
--- a/tests/patches/@firebase+rules-unit-testing+4.0.1.patch
+++ b/tests/patches/@firebase+rules-unit-testing+4.0.1.patch
@@ -1,14 +1,15 @@
 diff --git a/node_modules/@firebase/rules-unit-testing/dist/index.cjs.js b/node_modules/@firebase/rules-unit-testing/dist/index.cjs.js
-index dd6426f..15b64b9 100644
+index dd6426f..d053c39 100644
 --- a/node_modules/@firebase/rules-unit-testing/dist/index.cjs.js
 +++ b/node_modules/@firebase/rules-unit-testing/dist/index.cjs.js
-@@ -60,8 +60,7 @@ function makeUrl(hostAndPort, path) {
+@@ -60,9 +60,7 @@ function makeUrl(hostAndPort, path) {
              hostAndPort = `${host}:${port}`;
          }
      }
 -    const url = new URL(`http://${hostAndPort}/`);
 -    url.pathname = path;
-+    const url = new URL(`http://${hostAndPort}/${path}`);
-     return url;
+-    return url;
++    return new URL(`http://${hostAndPort}/${path}`);
  }
  
+ /**


### PR DESCRIPTION
### Description

Doing some dependency upgrades and I always look to trim the count of patches we carry, attempting to upstream this one now and the PR I proposed (after testing it...) is more minimal than our current in-tree patch, synching it here

works in testing, is minimal compared to previous

### Related issues

See:
- https://github.com/firebase/firebase-js-sdk/pull/8861


### Release Summary

Test-only code, no release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Most of the database e2e tests uses the `database/e2e/helpers.js::seed` function, which uses this rules-unit-testing feature requiring the patch, if database e2e passes this works - and it passes for me locally


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
