### PR TITLE
fix(crashlytics): crashlytics should not have hard dep on analytics

### DIFF
--- a/packages/crashlytics/lib/handlers.js
+++ b/packages/crashlytics/lib/handlers.js
@@ -94,8 +94,19 @@ export const setGlobalErrorHandler = once(nativeModule => {
         // Flag the Crashlytics backend that we have a fatal error, they will transform it
         await nativeModule.setAttribute(FATAL_FLAG, fatalTime);
 
+        // remember our current deprecation warning state in case users
+        // have set it to non-default
+        const currentDeprecationWarningToggle =
+          globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS;
+
         // Notify analytics, if it exists - throws error if not
         try {
+          // FIXME - disable warnings and use the old namespaced style,
+          // See https://github.com/invertase/react-native-firebase/issues/8381
+          // Unfortunately, this fails completely when using modular!
+          // Did not matter if I did named imports above or dynamic require here.
+          // So temporarily reverting and silencing warnings instead
+          globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
           await firebase.app().analytics().logEvent(
             'app_exception', // 'app_exception' is reserved but we make an exception for JS->fatal transforms
             {
@@ -106,6 +117,8 @@ export const setGlobalErrorHandler = once(nativeModule => {
         } catch (_) {
           // This just means analytics was not present, so we could not log the analytics event
           // console.log('error logging analytics app_exception: ' + e);
+        } finally {
+          globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = currentDeprecationWarningToggle;
         }
 
         // If we are chaining to other handlers, just record the error, otherwise we need to crash with it

--- a/packages/crashlytics/lib/handlers.js
+++ b/packages/crashlytics/lib/handlers.js
@@ -15,8 +15,8 @@
  *
  */
 
+import { firebase } from '@react-native-firebase/app';
 import { isError, once } from '@react-native-firebase/app/lib/common';
-import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
 import tracking from 'promise/setimmediate/rejection-tracking';
 import StackTrace from 'stacktrace-js';
 
@@ -96,8 +96,7 @@ export const setGlobalErrorHandler = once(nativeModule => {
 
         // Notify analytics, if it exists - throws error if not
         try {
-          await logEvent(
-            getAnalytics(),
+          await firebase.app().analytics().logEvent(
             'app_exception', // 'app_exception' is reserved but we make an exception for JS->fatal transforms
             {
               fatal: 1, // as in firebase-android-sdk

--- a/tests/app.js
+++ b/tests/app.js
@@ -17,7 +17,7 @@
  */
 
 import React from 'react';
-import { StyleSheet, View, StatusBar, AppRegistry, LogBox } from 'react-native';
+import { StyleSheet, View, StatusBar, AppRegistry } from 'react-native';
 
 import { JetProvider, ConnectionText, StatusEmoji, StatusText } from 'jet';
 
@@ -263,16 +263,18 @@ function loadTests(_) {
 
 function App() {
   return (
-    <JetProvider tests={loadTests}>
+    <>
       <StatusBar hidden />
       <View style={styles.container}>
-        <ConnectionText style={styles.connectionText} />
-        <View style={styles.statusContainer}>
-          <StatusEmoji style={styles.statusEmoji} />
-          <StatusText style={styles.statusText} />
-        </View>
+        <JetProvider tests={loadTests}>
+          <ConnectionText style={styles.connectionText} />
+          <View style={styles.statusContainer}>
+            <StatusEmoji style={styles.statusEmoji} />
+            <StatusText style={styles.statusText} />
+          </View>
+        </JetProvider>
       </View>
-    </JetProvider>
+    </>
   );
 }
 
@@ -280,6 +282,11 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#fff',
+    // instead of depending on react-native-safe-area-context to avoid
+    // colliding with system UI we are just going to pad things out for simplicity
+    marginTop: 60,
+    paddingHorizontal: '5%',
+    paddingBottom: '5%',
   },
   statusContainer: {
     flex: 1,

--- a/tests/app.js
+++ b/tests/app.js
@@ -17,9 +17,11 @@
  */
 
 import React from 'react';
-import { StyleSheet, View, StatusBar, AppRegistry } from 'react-native';
+import { StyleSheet, View, StatusBar, AppRegistry, Text } from 'react-native';
 
 import { JetProvider, ConnectionText, StatusEmoji, StatusText } from 'jet';
+
+import { LocalTests } from './local-test-component';
 
 const platformSupportedModules = [];
 
@@ -266,6 +268,11 @@ function App() {
     <>
       <StatusBar hidden />
       <View style={styles.container}>
+        <View style={styles.hardRule} />
+        <Text>Local Manual Tests:</Text>
+        <LocalTests />
+        <View style={styles.hardRule} />
+        <Text>Automated Tests:</Text>
         <JetProvider tests={loadTests}>
           <ConnectionText style={styles.connectionText} />
           <View style={styles.statusContainer}>
@@ -307,6 +314,11 @@ const styles = StyleSheet.create({
   connectionText: {
     textAlign: 'center',
     color: 'black',
+  },
+  hardRule: {
+    height: 1,
+    backgroundColor: 'black',
+    width: '100%',
   },
 });
 

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1791,73 +1791,73 @@ PODS:
     - Yoga
   - RNDeviceInfo (14.0.4):
     - React-Core
-  - RNFBAnalytics (21.12.0):
+  - RNFBAnalytics (21.12.2):
     - Firebase/Analytics (= 11.10.0)
     - GoogleAppMeasurementOnDeviceConversion (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (21.12.0):
+  - RNFBApp (21.12.2):
     - Firebase/CoreOnly (= 11.10.0)
     - React-Core
-  - RNFBAppCheck (21.12.0):
+  - RNFBAppCheck (21.12.2):
     - Firebase/AppCheck (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (21.12.0):
+  - RNFBAppDistribution (21.12.2):
     - Firebase/AppDistribution (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.12.0):
+  - RNFBAuth (21.12.2):
     - Firebase/Auth (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.12.0):
+  - RNFBCrashlytics (21.12.2):
     - Firebase/Crashlytics (= 11.10.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.12.0):
+  - RNFBDatabase (21.12.2):
     - Firebase/Database (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.12.0):
+  - RNFBDynamicLinks (21.12.2):
     - Firebase/DynamicLinks (= 11.10.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.12.0):
+  - RNFBFirestore (21.12.2):
     - Firebase/Firestore (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.12.0):
+  - RNFBFunctions (21.12.2):
     - Firebase/Functions (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.12.0):
+  - RNFBInAppMessaging (21.12.2):
     - Firebase/InAppMessaging (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.12.0):
+  - RNFBInstallations (21.12.2):
     - Firebase/Installations (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.12.0):
+  - RNFBMessaging (21.12.2):
     - Firebase/Messaging (= 11.10.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (21.12.0):
+  - RNFBML (21.12.2):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.12.0):
+  - RNFBPerf (21.12.2):
     - Firebase/Performance (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.12.0):
+  - RNFBRemoteConfig (21.12.2):
     - Firebase/RemoteConfig (= 11.10.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.12.0):
+  - RNFBStorage (21.12.2):
     - Firebase/Storage (= 11.10.0)
     - React-Core
     - RNFBApp
@@ -2292,23 +2292,23 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 849b77e6ab3eb838361a902b492993056924faab
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNFBAnalytics: 16174be0106d1bc3356ab5bbc6dc5cfc079e2534
-  RNFBApp: 35f4ce8ca75b23ab7bf8a30f8a951196c143291d
-  RNFBAppCheck: 59b8083d9f2ecb9f4ed57705318b7f618cc5a6f7
-  RNFBAppDistribution: b04ef8d462bfab9da761c36967137f73b89fa870
-  RNFBAuth: 0acbe87b295c7d5551d1a013f22ef1404bea1dd7
-  RNFBCrashlytics: e997e0b4652036853c17b269dd773fdb2e6e6868
-  RNFBDatabase: 011f62bd40c63535f3af5a5d48db5a3fa2fdd047
-  RNFBDynamicLinks: 2b2ce6b512a0f50b794826e2edfd93c482ff756d
-  RNFBFirestore: 17c13b4c34db6f0617a68334dd0239a784d4af4c
-  RNFBFunctions: 04e8b2b516c8b8d3f4b21663ba4cee290889abda
-  RNFBInAppMessaging: 6522c86b5e740a0e6390c54c4ca430b605a0fc84
-  RNFBInstallations: 7aa2972fe49c5e4de60b9ac8add2322199e4522c
-  RNFBMessaging: ac9009a487aed6e9549789696b864d14edad6ec9
-  RNFBML: 0bc8bbd9e4d00764ba0bb8d71faf9296bba8e89b
-  RNFBPerf: d88d0e3598761753e726222db24cf7114c43facf
-  RNFBRemoteConfig: 24ce9c6772473e6d047fe0a3d8e2aaecd151cc12
-  RNFBStorage: 929c8635f00facf7b4d8ba9d64db5d294fd78b90
+  RNFBAnalytics: 33fd0fae8f501cc106511493b2328be6779f66fd
+  RNFBApp: fed929c76589400be1cb89ff3a457b3cef876907
+  RNFBAppCheck: db03e185469ae9a4edc2b20dd88fd419a9367c85
+  RNFBAppDistribution: 03dc37ec4b59b0377e6faf92b82fc4b299978533
+  RNFBAuth: 68cfc1eeb8e2e668b3c4bac8ecea25f40c7ca4d5
+  RNFBCrashlytics: 4dcf8df32c86a6933cba0ba86a7236593eb0e8cc
+  RNFBDatabase: adddfb0375fd5bf5a85a46360d9b63041b4999a7
+  RNFBDynamicLinks: 3750b52d20f3d249251576c67da87fa51b98459a
+  RNFBFirestore: 4e6cbd256ef02ea5a6089b1bbfdeb91668175ace
+  RNFBFunctions: 3bf3d1206423108810ceb978726927602d8b4697
+  RNFBInAppMessaging: d4a6b52ab2efc8e3c7741e1f204ff30866240d67
+  RNFBInstallations: 20f02076fc4cc1d200e8218894bda0b4ed9d5174
+  RNFBMessaging: e4172056d9ae9231d6859080185851b734ca8755
+  RNFBML: fbed28d0ceb592d109d13077bee5e52eda4f4fcb
+  RNFBPerf: 5770aa9f177e40e221196ef48066fbeeda2e7adb
+  RNFBRemoteConfig: 9b7b9276edf8dcfa23195fc469585e2e799a1746
+  RNFBStorage: 258c888f33589a5228359cd6e9652453a6975e5e
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 28b8cda182ee3092ff80203da66dcb3ffc8cf401
 

--- a/tests/local-test-component.jsx
+++ b/tests/local-test-component.jsx
@@ -1,0 +1,24 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+// Add new components in `local-tests` sub-directory,
+// with a corresponding import/export in the `local-tests/index.js` file
+//
+// that file itself is copied during `yarn lerna:prepare` from
+// `local-tests/index.example.js` if it does not exist, then
+// you are free to modify it
+//
+// Why do we maintain a list and copy a template?
+//
+// 1) react-native has no way to do dynamic requires or imports, they require
+// constant strings, so we can't just read directory contents and dynamically
+// iterate on them unfortunately. So we have to maintain a list of local-only things.
+//
+// 2) But if you maintain a local-only change, you risk of accidentally committing
+// the local-only changes. To keep local changes without commit risk we have to
+// do a template copy from an example.
+
+import { TestComponents } from './local-tests';
+
+export function LocalTests() {
+  return <TestComponents />;
+}

--- a/tests/local-tests/.gitignore
+++ b/tests/local-tests/.gitignore
@@ -1,0 +1,9 @@
+# To start with, we want nothing in this directory in general
+*
+
+# ... except our template index file (copied during prepare)
+!index.example.js
+# ... our example component
+!crash-test.jsx
+# ... and this gitignore file
+!.gitignore

--- a/tests/local-tests/crash-test.jsx
+++ b/tests/local-tests/crash-test.jsx
@@ -1,0 +1,31 @@
+/* eslint-disable react/react-in-jsx-scope */
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { crash, getCrashlytics } from '@react-native-firebase/crashlytics';
+
+export function CrashTestComponent() {
+  return (
+    <View style={styles.horizontalCentered}>
+      <Text>Crashlytics:</Text>
+      <Button
+        style={{ color: 'blue', flex: 1 }}
+        title="JS Crash"
+        onPress={() => nonExistentObject.nonExistentFunction()}
+      />
+      <Button
+        style={{ color: 'blue', flex: 1 }}
+        title="Native Crash"
+        onPress={() => crash(getCrashlytics())}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  horizontalCentered: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    alignContent: 'center',
+    paddingHorizontal: 10,
+  },
+});

--- a/tests/local-tests/index.example.js
+++ b/tests/local-tests/index.example.js
@@ -1,0 +1,18 @@
+/* eslint-disable react/react-in-jsx-scope */
+import { View } from 'react-native';
+
+import { CrashTestComponent } from './crash-test.jsx';
+
+// import your components from your local-tests jsx file here...
+
+const testComponents = [
+  CrashTestComponent,
+
+  // List your imported components here...
+];
+
+export function TestComponents() {
+  return testComponents.map((component, index) => {
+    return <View key={index}>{component.call()}</View>;
+  });
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build:clean": "rimraf dist && rimraf android/build && rimraf android/app/build && rimraf android/.gradle && rimraf ios/build && rimraf macos/build",
     "build:macos": "xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace macos/io.invertase.testing.xcworkspace -scheme io.invertase.testing-macOS -configuration Debug -derivedDataPath macos/build | xcbeautify",
-    "prepare": "patch-package"
+    "prepare": "patch-package && cd local-tests && (yarn cpy --no-overwrite index.example.js ./ --rename=index.js || echo 'Looks like the local test file is already there. Previous copy error may be ignored.')"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.1.1",
@@ -43,6 +43,7 @@
     "@react-native/metro-config": "^0.77.1",
     "assert": "^2.1.0",
     "axios": "^1.7.9",
+    "cpy-cli": "^5.0.0",
     "detox": "20.34.0",
     "firebase": "^11.3.1",
     "firebase-tools": "^13.31.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6307,6 +6307,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aggregate-error@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "aggregate-error@npm:4.0.1"
+  dependencies:
+    clean-stack: "npm:^4.0.0"
+    indent-string: "npm:^5.0.0"
+  checksum: 10/bb3ffdfd13447800fff237c2cba752c59868ee669104bb995dfbbe0b8320e967d679e683dabb640feb32e4882d60258165cde0baafc4cd467cc7d275a13ad6b5
+  languageName: node
+  linkType: hard
+
 "ajv-formats@npm:3.0.1":
   version: 3.0.1
   resolution: "ajv-formats@npm:3.0.1"
@@ -6737,6 +6747,13 @@ __metadata:
   version: 2.0.1
   resolution: "arrify@npm:2.0.1"
   checksum: 10/067c4c1afd182806a82e4c1cb8acee16ab8b5284fbca1ce29408e6e91281c36bb5b612f6ddfbd40a0f7a7e0c75bf2696eb94c027f6e328d6e9c52465c98e4209
+  languageName: node
+  linkType: hard
+
+"arrify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "arrify@npm:3.0.0"
+  checksum: 10/d6c6f3dad9571234f320e130d57fddb2cc283c87f2ac7df6c7005dffc5161b7bb9376f4be655ed257050330336e84afc4f3020d77696ad231ff580a94ae5aba6
   languageName: node
   linkType: hard
 
@@ -7882,6 +7899,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"clean-stack@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "clean-stack@npm:4.2.0"
+  dependencies:
+    escape-string-regexp: "npm:5.0.0"
+  checksum: 10/373f656a31face5c615c0839213b9b542a0a48057abfb1df66900eab4dc2a5c6097628e4a0b5aa559cdfc4e66f8a14ea47be9681773165a44470ef5fb8ccc172
+  languageName: node
+  linkType: hard
+
 "cli-boxes@npm:^2.2.1":
   version: 2.2.1
   resolution: "cli-boxes@npm:2.2.1"
@@ -8701,6 +8727,45 @@ __metadata:
     js-yaml: "npm:^3.13.1"
     parse-json: "npm:^4.0.0"
   checksum: 10/1d617668e1367b8d66617fb8a1bd8c13e9598534959ac0cc86195b1b0cbe7afbba2b9faa300c60b9d9d35409cf4f064b0f6e377f4ea036434e5250c69c76932f
+  languageName: node
+  linkType: hard
+
+"cp-file@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "cp-file@npm:10.0.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.10"
+    nested-error-stacks: "npm:^2.1.1"
+    p-event: "npm:^5.0.1"
+  checksum: 10/9b2432e35f4200ae55b5d120755998a49548813380ea34431c6a1ca148a1df4416fb3a80af14baa926cf4bf021173bce49d5ab7dd51fca4a31c402de39a3fc92
+  languageName: node
+  linkType: hard
+
+"cpy-cli@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "cpy-cli@npm:5.0.0"
+  dependencies:
+    cpy: "npm:^10.1.0"
+    meow: "npm:^12.0.1"
+  bin:
+    cpy: cli.js
+  checksum: 10/f575e8e80262320c1b7c8ff57546a7dff69dcef892ac9dd381b9ec2418c5ecd5bdda5f6c6a900566af087c2167db57ae25521b66efe34dd59d8a41b16c4e5f96
+  languageName: node
+  linkType: hard
+
+"cpy@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "cpy@npm:10.1.0"
+  dependencies:
+    arrify: "npm:^3.0.0"
+    cp-file: "npm:^10.0.0"
+    globby: "npm:^13.1.4"
+    junk: "npm:^4.0.1"
+    micromatch: "npm:^4.0.5"
+    nested-error-stacks: "npm:^2.1.1"
+    p-filter: "npm:^3.0.0"
+    p-map: "npm:^6.0.0"
+  checksum: 10/39da11b58b3a6fb7a849a59108fc42113cb8f8f64899d9e44719686b37b720050218b66f04b9be5d12d152c7b4d19314dbed187dfe63bb7a79e0da6f9e322b74
   languageName: node
   linkType: hard
 
@@ -9823,6 +9888,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 10/20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^1.0.5":
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
@@ -10507,6 +10579,19 @@ __metadata:
     merge2: "npm:^1.3.0"
     micromatch: "npm:^4.0.4"
   checksum: 10/222512e9315a0efca1276af9adb2127f02105d7288fa746145bf45e2716383fb79eb983c89601a72a399a56b7c18d38ce70457c5466218c5f13fad957cee16df
+  languageName: node
+  linkType: hard
+
+"fast-glob@npm:^3.3.0":
+  version: 3.3.3
+  resolution: "fast-glob@npm:3.3.3"
+  dependencies:
+    "@nodelib/fs.stat": "npm:^2.0.2"
+    "@nodelib/fs.walk": "npm:^1.2.3"
+    glob-parent: "npm:^5.1.2"
+    merge2: "npm:^1.3.0"
+    micromatch: "npm:^4.0.8"
+  checksum: 10/dcc6432b269762dd47381d8b8358bf964d8f4f60286ac6aa41c01ade70bda459ff2001b516690b96d5365f68a49242966112b5d5cc9cd82395fa8f9d017c90ad
   languageName: node
   linkType: hard
 
@@ -11726,6 +11811,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globby@npm:^13.1.4":
+  version: 13.2.2
+  resolution: "globby@npm:13.2.2"
+  dependencies:
+    dir-glob: "npm:^3.0.1"
+    fast-glob: "npm:^3.3.0"
+    ignore: "npm:^5.2.4"
+    merge2: "npm:^1.4.1"
+    slash: "npm:^4.0.0"
+  checksum: 10/4494a9d2162a7e4d327988b26be66d8eab87d7f59a83219e74b065e2c3ced23698f68fb10482bf9337133819281803fb886d6ae06afbb2affa743623eb0b1949
+  languageName: node
+  linkType: hard
+
 "google-auth-library@npm:^9.11.0, google-auth-library@npm:^9.2.0, google-auth-library@npm:^9.3.0, google-auth-library@npm:^9.7.0":
   version: 9.14.1
   resolution: "google-auth-library@npm:9.14.1"
@@ -11801,7 +11899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:4.2.11, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.3, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.10, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -12321,6 +12419,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^5.2.4":
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2"
+  checksum: 10/cceb6a457000f8f6a50e1196429750d782afce5680dd878aa4221bd79972d68b3a55b4b1458fc682be978f4d3c6a249046aa0880637367216444ab7b014cfc98
+  languageName: node
+  linkType: hard
+
 "image-size@npm:^1.0.2":
   version: 1.1.1
   resolution: "image-size@npm:1.1.1"
@@ -12382,6 +12487,13 @@ __metadata:
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
   checksum: 10/cd3f5cbc9ca2d624c6a1f53f12e6b341659aba0e2d3254ae2b4464aaea8b4294cdb09616abbc59458f980531f2429784ed6a420d48d245bcad0811980c9efae9
+  languageName: node
+  linkType: hard
+
+"indent-string@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "indent-string@npm:5.0.0"
+  checksum: 10/e466c27b6373440e6d84fbc19e750219ce25865cb82d578e41a6053d727e5520dc5725217d6eb1cc76005a1bb1696a0f106d84ce7ebda3033b963a38583fb3b3
   languageName: node
   linkType: hard
 
@@ -14257,6 +14369,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"junk@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "junk@npm:4.0.1"
+  checksum: 10/4f0c94c0b2e46172284d9eaeb57bf1b784d86d218dbc673a1c8e08ef3443d03164238eb067591d0ad9f2c76a6ad012aeb618bb8135a2f0f26a6da931058e131b
+  languageName: node
+  linkType: hard
+
 "just-diff-apply@npm:^5.2.0":
   version: 5.5.0
   resolution: "just-diff-apply@npm:5.5.0"
@@ -16084,7 +16203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.7, micromatch@npm:^4.0.8":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.7, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -16618,6 +16737,13 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10/1a7948fea86f2b33ec766bc899c88796a51ba76a4afc9026764aedc6e7cde692a09067031e4a1bf6db4f978ccd99e7f5b6c03fe47ad9865c3d4f99050d67e002
+  languageName: node
+  linkType: hard
+
+"nested-error-stacks@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "nested-error-stacks@npm:2.1.1"
+  checksum: 10/5f452fad75db8480b4db584e1602894ff5977f8bf3d2822f7ba5cb7be80e89adf1fffa34dada3347ef313a4288850b4486eb0635b315c32bdfb505577e8880e3
   languageName: node
   linkType: hard
 
@@ -17462,6 +17588,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-event@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "p-event@npm:5.0.1"
+  dependencies:
+    p-timeout: "npm:^5.0.2"
+  checksum: 10/755a737e3d4fe912772daaa7262f7f3a4b45e3dbcfb0212a3a913c2db47b0981ddc2e9b1c5ec5fbbfb0cb622ce5b67bc04751ec8ced7e340398107e536d5aab2
+  languageName: node
+  linkType: hard
+
+"p-filter@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-filter@npm:3.0.0"
+  dependencies:
+    p-map: "npm:^5.1.0"
+  checksum: 10/aacc36820f0531c01963334edc6debf5038b47c83a1c2255b7c14f6964a9a5fc1887ce0b93e72d137727403253bcc9bb26eed9bb79896ece1fa9f52d979bb97b
+  languageName: node
+  linkType: hard
+
 "p-finally@npm:^1.0.0":
   version: 1.0.0
   resolution: "p-finally@npm:1.0.0"
@@ -17575,6 +17719,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-map@npm:^5.1.0":
+  version: 5.5.0
+  resolution: "p-map@npm:5.5.0"
+  dependencies:
+    aggregate-error: "npm:^4.0.0"
+  checksum: 10/089a709d2525208a965b7907cc8e58af950542629b538198fc142c40e7f36b3b492dd6a46a1279515ccab58bb6f047e04593c0ab5ef4539d312adf7f761edf55
+  languageName: node
+  linkType: hard
+
+"p-map@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "p-map@npm:6.0.0"
+  checksum: 10/1fd59257b3828a4c4def676ef64acb0edb7809b161ada25efd9a0c8db312ad81c66bcaa9e5d8fd982fd20d412609aabcb8da9b090e81f6c449bc1203752ba0eb
+  languageName: node
+  linkType: hard
+
 "p-pipe@npm:3.1.0":
   version: 3.1.0
   resolution: "p-pipe@npm:3.1.0"
@@ -17612,6 +17772,13 @@ __metadata:
   dependencies:
     p-finally: "npm:^1.0.0"
   checksum: 10/3dd0eaa048780a6f23e5855df3dd45c7beacff1f820476c1d0d1bcd6648e3298752ba2c877aa1c92f6453c7dd23faaf13d9f5149fc14c0598a142e2c5e8d649c
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^5.0.2":
+  version: 5.1.0
+  resolution: "p-timeout@npm:5.1.0"
+  checksum: 10/f5cd4e17301ff1ff1d8dbf2817df0ad88c6bba99349fc24d8d181827176ad4f8aca649190b8a5b1a428dfd6ddc091af4606835d3e0cb0656e04045da5c9e270c
   languageName: node
   linkType: hard
 
@@ -18880,6 +19047,7 @@ __metadata:
     "@react-native/metro-config": "npm:^0.77.1"
     assert: "npm:^2.1.0"
     axios: "npm:^1.7.9"
+    cpy-cli: "npm:^5.0.0"
     detox: "npm:20.34.0"
     firebase: "npm:^11.3.1"
     firebase-tools: "npm:^13.31.1"
@@ -20644,6 +20812,13 @@ __metadata:
   version: 2.0.0
   resolution: "slash@npm:2.0.0"
   checksum: 10/512d4350735375bd11647233cb0e2f93beca6f53441015eea241fe784d8068281c3987fbaa93e7ef1c38df68d9c60013045c92837423c69115297d6169aa85e6
+  languageName: node
+  linkType: hard
+
+"slash@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "slash@npm:4.0.0"
+  checksum: 10/da8e4af73712253acd21b7853b7e0dbba776b786e82b010a5bfc8b5051a1db38ed8aba8e1e8f400dd2c9f373be91eb1c42b66e91abb407ff42b10feece5e1d2d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR reverts a commit that moved the analytics usage in crashlytics to modular API but inadvertently created a hard dependency on analytics from crashlytics vs a dynamic one where it was okay if analytics wasn't installed

In addition I enhanced our test app to make it easy to add little local manual tests, I needed that to turn our e2e app into a crash-testing dummy as you can only do that with a manual button.

### Related issues

- Fixes #8381

### Release Summary

2 of the commits are `fix` and should trigger a release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Unbelievable amount of build/test runs, with surprising results, until I finally just had to revert and suppress warnings then document findings.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
