### PR TITLE
fix(firestore): a single or/and filter is allowed, 2+ not required

### DIFF
--- a/packages/firestore/e2e/Query/where.and.filter.e2e.js
+++ b/packages/firestore/e2e/Query/where.and.filter.e2e.js
@@ -1056,6 +1056,46 @@ describe(' firestore().collection().where(AND Filters)', function () {
       });
     });
 
+    it('returns with single where "==" in or filter', async function () {
+      const { getFirestore, collection, addDoc, getDocs, query, where, and } = firestoreModular;
+      const colRef = collection(getFirestore(), `${COLLECTION}/filter/single-or`);
+
+      const expected = { foo: 'bar', baz: 'baz' };
+      const notExpected = { foo: 'bar', baz: 'something' };
+      await Promise.all([
+        addDoc(colRef, notExpected),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
+      ]);
+
+      const snapshot = await getDocs(query(colRef, and(where('baz', '==', 'baz'))));
+
+      snapshot.size.should.eql(2);
+      snapshot.forEach(s => {
+        s.data().should.eql(jet.contextify(expected));
+      });
+    });
+
+    it('returns with single where "==" in and filter', async function () {
+      const { getFirestore, collection, addDoc, getDocs, query, where, or } = firestoreModular;
+      const colRef = collection(getFirestore(), `${COLLECTION}/filter/single-and`);
+
+      const expected = { foo: 'bar', baz: 'baz' };
+      const notExpected = { foo: 'bar', baz: 'something' };
+      await Promise.all([
+        addDoc(colRef, notExpected),
+        addDoc(colRef, expected),
+        addDoc(colRef, expected),
+      ]);
+
+      const snapshot = await getDocs(query(colRef, or(where('baz', '==', 'baz'))));
+
+      snapshot.size.should.eql(2);
+      snapshot.forEach(s => {
+        s.data().should.eql(jet.contextify(expected));
+      });
+    });
+
     it('returns with where "==" & ">" filter', async function () {
       const { getFirestore, collection, addDoc, getDocs, query, where, and } = firestoreModular;
       const colRef = collection(getFirestore(), `${COLLECTION}/filter/equals`);

--- a/packages/firestore/lib/FirestoreFilter.js
+++ b/packages/firestore/lib/FirestoreFilter.js
@@ -42,8 +42,8 @@ export function _Filter(fieldPath, operator, value, filterOperator, queries) {
 }
 
 Filter.and = function and(...queries) {
-  if (queries.length > 10 || queries.length < 2) {
-    throw new Error(`Expected 2-10 instances of Filter, but got ${queries.length} Filters`);
+  if (queries.length > 10 || queries.length < 1) {
+    throw new Error(`Expected 1-10 instances of Filter, but got ${queries.length} Filters`);
   }
 
   const validateFilters = queries.every(filter => filter instanceof _Filter);
@@ -60,8 +60,8 @@ function hasOrOperator(obj) {
 }
 
 Filter.or = function or(...queries) {
-  if (queries.length > 10 || queries.length < 2) {
-    throw new Error(`Expected 2-10 instances of Filter, but got ${queries.length} Filters`);
+  if (queries.length > 10 || queries.length < 1) {
+    throw new Error(`Expected 1-10 instances of Filter, but got ${queries.length} Filters`);
   }
 
   const validateFilters = queries.every(filter => filter instanceof _Filter);


### PR DESCRIPTION

### Description

You can have a single or or and in a where, this is allowed in firebase-js-sdk

We were constraining to 2+ queries so loosened that to 1, and added a test to verify

Thanks to user @ycmjason for reporting and doing diligence to verify firebase-js-sdk works

### Related issues

- Fixes #8418

### Release Summary

Single conventional commit

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Added new e2e test, it works, also this was verified against firebase-js-sdk in related issue

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
