### PR TITLE
fix(auth): fix faulty AuthListenerCallback import

### DIFF
--- a/packages/auth/lib/modular/index.d.ts
+++ b/packages/auth/lib/modular/index.d.ts
@@ -16,7 +16,7 @@
  */
 
 import { ReactNativeFirebase } from '@react-native-firebase/app';
-import { FirebaseAuthTypes, CallbackOrObserver, AuthListenerCallback } from '../index';
+import { FirebaseAuthTypes, CallbackOrObserver } from '../index';
 import { firebase } from '..';
 
 import Auth = FirebaseAuthTypes.Module;
@@ -182,7 +182,7 @@ export function isSignInWithEmailLink(auth: Auth, emailLink: string): boolean;
  */
 export function onAuthStateChanged(
   auth: Auth,
-  nextOrObserver: CallbackOrObserver<AuthListenerCallback>,
+  nextOrObserver: CallbackOrObserver<FirebaseAuthTypes.AuthListenerCallback>,
 ): () => void;
 
 /**
@@ -194,7 +194,7 @@ export function onAuthStateChanged(
  */
 export function onIdTokenChanged(
   auth: Auth,
-  nextOrObserver: CallbackOrObserver<AuthListenerCallback>,
+  nextOrObserver: CallbackOrObserver<FirebaseAuthTypes.AuthListenerCallback>,
 ): () => void;
 
 /**

--- a/packages/auth/type-test.ts
+++ b/packages/auth/type-test.ts
@@ -1,5 +1,5 @@
 // import firebase from '@react-native-firebase/app';
-import firebase, { FirebaseAuthTypes, signInWithPhoneNumber } from '.';
+import firebase, { FirebaseAuthTypes, onAuthStateChanged, signInWithPhoneNumber} from '.';
 
 console.log(firebase.default().currentUser);
 
@@ -55,4 +55,5 @@ firebase.auth().signInAnonymously().then();
 firebase.auth().signInWithEmailAndPassword('', '').then();
 
 // Verify Modular API
+onAuthStateChanged(firebase.auth(), user => console.log(user));
 signInWithPhoneNumber(firebase.auth(), '+1234567890');


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This PR fixes that the `user` argument of the `onAuthStateChanged` method's callback was `any` in the modular API. The reason for that was that `AuthListenerCallback` was not correctly imported from the `FirebaseAuthTypes` namespace.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

I updated the `type-test.ts` file of the `auth` package and verified, that the test fails without this PR and passes with this PR.

:fire: 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
