### PR TITLE
fix(app): firebase-ios-sdk 11.11.0 / firebase-android-sdk 33.12.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -318,7 +318,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "33.11.0"
+        bom           : "33.12.0"
       ],
     ],
   ])
@@ -333,12 +333,12 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '11.10.0'
+$FirebaseSDKVersion = '11.11.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.
 
-Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=11.10.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=11.10.0 yarn expo prebuild --clean`
+Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=11.11.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=11.11.0 yarn expo prebuild --clean`
 
 ### Android Performance
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -73,7 +73,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "11.10.0",
+      "firebase": "11.11.0",
       "iosTarget": "13.0",
       "macosTarget": "10.15",
       "tvosTarget": "13.0"
@@ -82,7 +82,7 @@
       "minSdk": 21,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "33.11.0",
+      "firebase": "33.12.0",
       "firebaseCrashlyticsGradle": "3.0.3",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.2",

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -7,107 +7,107 @@ PODS:
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
   - FBLazyVector (0.77.1)
-  - Firebase/Analytics (11.10.0):
+  - Firebase/Analytics (11.11.0):
     - Firebase/Core
-  - Firebase/AppCheck (11.10.0):
+  - Firebase/AppCheck (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 11.10.0)
-  - Firebase/AppDistribution (11.10.0):
+    - FirebaseAppCheck (~> 11.11.0)
+  - Firebase/AppDistribution (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 11.10.0-beta)
-  - Firebase/Auth (11.10.0):
+    - FirebaseAppDistribution (~> 11.11.0-beta)
+  - Firebase/Auth (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 11.10.0)
-  - Firebase/Core (11.10.0):
+    - FirebaseAuth (~> 11.11.0)
+  - Firebase/Core (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (~> 11.10.0)
-  - Firebase/CoreOnly (11.10.0):
-    - FirebaseCore (~> 11.10.0)
-  - Firebase/Crashlytics (11.10.0):
+    - FirebaseAnalytics (~> 11.11.0)
+  - Firebase/CoreOnly (11.11.0):
+    - FirebaseCore (~> 11.11.0)
+  - Firebase/Crashlytics (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 11.10.0)
-  - Firebase/Database (11.10.0):
+    - FirebaseCrashlytics (~> 11.11.0)
+  - Firebase/Database (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 11.10.0)
-  - Firebase/DynamicLinks (11.10.0):
+    - FirebaseDatabase (~> 11.11.0)
+  - Firebase/DynamicLinks (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 11.10.0)
-  - Firebase/Firestore (11.10.0):
+    - FirebaseDynamicLinks (~> 11.11.0)
+  - Firebase/Firestore (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 11.10.0)
-  - Firebase/Functions (11.10.0):
+    - FirebaseFirestore (~> 11.11.0)
+  - Firebase/Functions (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 11.10.0)
-  - Firebase/InAppMessaging (11.10.0):
+    - FirebaseFunctions (~> 11.11.0)
+  - Firebase/InAppMessaging (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 11.10.0-beta)
-  - Firebase/Installations (11.10.0):
+    - FirebaseInAppMessaging (~> 11.11.0-beta)
+  - Firebase/Installations (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 11.10.0)
-  - Firebase/Messaging (11.10.0):
+    - FirebaseInstallations (~> 11.11.0)
+  - Firebase/Messaging (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 11.10.0)
-  - Firebase/Performance (11.10.0):
+    - FirebaseMessaging (~> 11.11.0)
+  - Firebase/Performance (11.11.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 11.10.0)
-  - Firebase/RemoteConfig (11.10.0):
+    - FirebasePerformance (~> 11.11.0)
+  - Firebase/RemoteConfig (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 11.10.0)
-  - Firebase/Storage (11.10.0):
+    - FirebaseRemoteConfig (~> 11.11.0)
+  - Firebase/Storage (11.11.0):
     - Firebase/CoreOnly
-    - FirebaseStorage (~> 11.10.0)
-  - FirebaseABTesting (11.10.0):
-    - FirebaseCore (~> 11.10.0)
-  - FirebaseAnalytics (11.10.0):
-    - FirebaseAnalytics/AdIdSupport (= 11.10.0)
-    - FirebaseCore (~> 11.10.0)
+    - FirebaseStorage (~> 11.11.0)
+  - FirebaseABTesting (11.11.0):
+    - FirebaseCore (~> 11.11.0)
+  - FirebaseAnalytics (11.11.0):
+    - FirebaseAnalytics/AdIdSupport (= 11.11.0)
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/AdIdSupport (11.10.0):
-    - FirebaseCore (~> 11.10.0)
+  - FirebaseAnalytics/AdIdSupport (11.11.0):
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement (= 11.10.0)
+    - GoogleAppMeasurement (= 11.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAppCheck (11.10.0):
+  - FirebaseAppCheck (11.11.0):
     - AppCheckCore (~> 11.0)
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
+    - FirebaseCore (~> 11.11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAppCheckInterop (11.10.0)
-  - FirebaseAppDistribution (11.10.0-beta):
-    - FirebaseCore (~> 11.10.0)
+  - FirebaseAppCheckInterop (11.11.0)
+  - FirebaseAppDistribution (11.11.0-beta):
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
-  - FirebaseAuth (11.10.0):
+  - FirebaseAuth (11.11.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
-    - FirebaseCoreExtension (~> 11.10.0)
+    - FirebaseCore (~> 11.11.0)
+    - FirebaseCoreExtension (~> 11.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
-  - FirebaseAuthInterop (11.10.0)
-  - FirebaseCore (11.10.0):
-    - FirebaseCoreInternal (~> 11.10.0)
+  - FirebaseAuthInterop (11.11.0)
+  - FirebaseCore (11.11.0):
+    - FirebaseCoreInternal (~> 11.11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/Logger (~> 8.0)
-  - FirebaseCoreExtension (11.10.0):
-    - FirebaseCore (~> 11.10.0)
-  - FirebaseCoreInternal (11.10.0):
+  - FirebaseCoreExtension (11.11.0):
+    - FirebaseCore (~> 11.11.0)
+  - FirebaseCoreInternal (11.11.0):
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseCrashlytics (11.10.0):
-    - FirebaseCore (~> 11.10.0)
+  - FirebaseCrashlytics (11.11.0):
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -115,22 +115,22 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseDatabase (11.10.0):
+  - FirebaseDatabase (11.11.0):
     - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
+    - FirebaseCore (~> 11.11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (11.10.0):
-    - FirebaseCore (~> 11.10.0)
-  - FirebaseFirestore (11.10.0):
-    - FirebaseFirestoreBinary (= 11.10.0)
+  - FirebaseDynamicLinks (11.11.0):
+    - FirebaseCore (~> 11.11.0)
+  - FirebaseFirestore (11.11.0):
+    - FirebaseFirestoreBinary (= 11.11.0)
   - FirebaseFirestoreAbseilBinary (1.2024072200.0)
-  - FirebaseFirestoreBinary (11.10.0):
-    - FirebaseCore (= 11.10.0)
-    - FirebaseCoreExtension (= 11.10.0)
-    - FirebaseFirestoreInternalBinary (= 11.10.0)
-    - FirebaseSharedSwift (= 11.10.0)
+  - FirebaseFirestoreBinary (11.11.0):
+    - FirebaseCore (= 11.11.0)
+    - FirebaseCoreExtension (= 11.11.0)
+    - FirebaseFirestoreInternalBinary (= 11.11.0)
+    - FirebaseSharedSwift (= 11.11.0)
   - FirebaseFirestoreGRPCBoringSSLBinary (1.69.0)
   - FirebaseFirestoreGRPCCoreBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
@@ -138,34 +138,34 @@ PODS:
   - FirebaseFirestoreGRPCCPPBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCoreBinary (= 1.69.0)
-  - FirebaseFirestoreInternalBinary (11.10.0):
-    - FirebaseCore (= 11.10.0)
+  - FirebaseFirestoreInternalBinary (11.11.0):
+    - FirebaseCore (= 11.11.0)
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCPPBinary (= 1.69.0)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseFunctions (11.10.0):
+  - FirebaseFunctions (11.11.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
-    - FirebaseCoreExtension (~> 11.10.0)
+    - FirebaseCore (~> 11.11.0)
+    - FirebaseCoreExtension (~> 11.11.0)
     - FirebaseMessagingInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
-  - FirebaseInAppMessaging (11.10.0-beta):
+  - FirebaseInAppMessaging (11.11.0-beta):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseInstallations (11.10.0):
-    - FirebaseCore (~> 11.10.0)
+  - FirebaseInstallations (11.11.0):
+    - FirebaseCore (~> 11.11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.10.0):
-    - FirebaseCore (~> 11.10.0)
+  - FirebaseMessaging (11.11.0):
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
@@ -173,9 +173,9 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseMessagingInterop (11.10.0)
-  - FirebasePerformance (11.10.0):
-    - FirebaseCore (~> 11.10.0)
+  - FirebaseMessagingInterop (11.11.0)
+  - FirebasePerformance (11.11.0):
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfig (~> 11.0)
     - FirebaseSessions (~> 11.0)
@@ -184,55 +184,55 @@ PODS:
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
-  - FirebaseRemoteConfig (11.10.0):
+  - FirebaseRemoteConfig (11.11.0):
     - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
+    - FirebaseCore (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - FirebaseRemoteConfigInterop (~> 11.0)
     - FirebaseSharedSwift (~> 11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
-  - FirebaseRemoteConfigInterop (11.10.0)
-  - FirebaseSessions (11.10.0):
-    - FirebaseCore (~> 11.10.0)
-    - FirebaseCoreExtension (~> 11.10.0)
+  - FirebaseRemoteConfigInterop (11.11.0)
+  - FirebaseSessions (11.11.0):
+    - FirebaseCore (~> 11.11.0)
+    - FirebaseCoreExtension (~> 11.11.0)
     - FirebaseInstallations (~> 11.0)
     - GoogleDataTransport (~> 10.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GoogleUtilities/UserDefaults (~> 8.0)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.10.0)
-  - FirebaseStorage (11.10.0):
+  - FirebaseSharedSwift (11.11.0)
+  - FirebaseStorage (11.11.0):
     - FirebaseAppCheckInterop (~> 11.0)
     - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.10.0)
-    - FirebaseCoreExtension (~> 11.10.0)
+    - FirebaseCore (~> 11.11.0)
+    - FirebaseCoreExtension (~> 11.11.0)
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - GoogleAppMeasurement (11.10.0):
-    - GoogleAppMeasurement/AdIdSupport (= 11.10.0)
+  - GoogleAppMeasurement (11.11.0):
+    - GoogleAppMeasurement/AdIdSupport (= 11.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/AdIdSupport (11.10.0):
-    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.10.0)
+  - GoogleAppMeasurement/AdIdSupport (11.11.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 11.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/WithoutAdIdSupport (11.10.0):
+  - GoogleAppMeasurement/WithoutAdIdSupport (11.11.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
     - GoogleUtilities/MethodSwizzler (~> 8.0)
     - GoogleUtilities/Network (~> 8.0)
     - "GoogleUtilities/NSData+zlib (~> 8.0)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurementOnDeviceConversion (11.10.0)
+  - GoogleAppMeasurementOnDeviceConversion (11.11.0)
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
@@ -1791,74 +1791,74 @@ PODS:
     - Yoga
   - RNDeviceInfo (14.0.4):
     - React-Core
-  - RNFBAnalytics (21.12.2):
-    - Firebase/Analytics (= 11.10.0)
-    - GoogleAppMeasurementOnDeviceConversion (= 11.10.0)
+  - RNFBAnalytics (21.13.0):
+    - Firebase/Analytics (= 11.11.0)
+    - GoogleAppMeasurementOnDeviceConversion (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBApp (21.12.2):
-    - Firebase/CoreOnly (= 11.10.0)
+  - RNFBApp (21.13.0):
+    - Firebase/CoreOnly (= 11.11.0)
     - React-Core
-  - RNFBAppCheck (21.12.2):
-    - Firebase/AppCheck (= 11.10.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (21.12.2):
-    - Firebase/AppDistribution (= 11.10.0)
+  - RNFBAppCheck (21.13.0):
+    - Firebase/AppCheck (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (21.12.2):
-    - Firebase/Auth (= 11.10.0)
+  - RNFBAppDistribution (21.13.0):
+    - Firebase/AppDistribution (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (21.12.2):
-    - Firebase/Crashlytics (= 11.10.0)
+  - RNFBAuth (21.13.0):
+    - Firebase/Auth (= 11.11.0)
+    - React-Core
+    - RNFBApp
+  - RNFBCrashlytics (21.13.0):
+    - Firebase/Crashlytics (= 11.11.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (21.12.2):
-    - Firebase/Database (= 11.10.0)
+  - RNFBDatabase (21.13.0):
+    - Firebase/Database (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (21.12.2):
-    - Firebase/DynamicLinks (= 11.10.0)
+  - RNFBDynamicLinks (21.13.0):
+    - Firebase/DynamicLinks (= 11.11.0)
     - GoogleUtilities/AppDelegateSwizzler
     - React-Core
     - RNFBApp
-  - RNFBFirestore (21.12.2):
-    - Firebase/Firestore (= 11.10.0)
+  - RNFBFirestore (21.13.0):
+    - Firebase/Firestore (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (21.12.2):
-    - Firebase/Functions (= 11.10.0)
+  - RNFBFunctions (21.13.0):
+    - Firebase/Functions (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (21.12.2):
-    - Firebase/InAppMessaging (= 11.10.0)
+  - RNFBInAppMessaging (21.13.0):
+    - Firebase/InAppMessaging (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (21.12.2):
-    - Firebase/Installations (= 11.10.0)
+  - RNFBInstallations (21.13.0):
+    - Firebase/Installations (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (21.12.2):
-    - Firebase/Messaging (= 11.10.0)
+  - RNFBMessaging (21.13.0):
+    - Firebase/Messaging (= 11.11.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (21.12.2):
+  - RNFBML (21.13.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (21.12.2):
-    - Firebase/Performance (= 11.10.0)
+  - RNFBPerf (21.13.0):
+    - Firebase/Performance (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (21.12.2):
-    - Firebase/RemoteConfig (= 11.10.0)
+  - RNFBRemoteConfig (21.13.0):
+    - Firebase/RemoteConfig (= 11.11.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (21.12.2):
-    - Firebase/Storage (= 11.10.0)
+  - RNFBStorage (21.13.0):
+    - Firebase/Storage (= 11.11.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.7.1)
@@ -1869,7 +1869,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.10.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.11.0`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -2011,7 +2011,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.10.0
+    :tag: 11.11.0
   fmt:
     :podspec: "../node_modules/react-native/third-party-podspecs/fmt.podspec"
   glog:
@@ -2179,7 +2179,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.10.0
+    :tag: 11.11.0
 
 SPEC CHECKSUMS:
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
@@ -2187,42 +2187,42 @@ SPEC CHECKSUMS:
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 79c4b7ec726447eec5f8593379466bd9fde1aa14
-  Firebase: 1fe1c0a7d9aaea32efe01fbea5f0ebd8d70e53a2
-  FirebaseABTesting: dfc10eb6cc08fe3b391ac9e5aa40396d43ea6675
-  FirebaseAnalytics: 4e42333f02cf78ed93703a5c36f36dd518aebdef
-  FirebaseAppCheck: 9687ebd909702469bc09d2d58008697b83f4ac27
-  FirebaseAppCheckInterop: 9664c858489710f682766ef54e2b6741d3b62070
-  FirebaseAppDistribution: 9b63632c01190132cbffe2b41397fdedb2a52816
-  FirebaseAuth: c4146bdfdc87329f9962babd24dae89373f49a32
-  FirebaseAuthInterop: 01a804fb074424fd58b92dd50dd0272277199356
-  FirebaseCore: 8344daef5e2661eb004b177488d6f9f0f24251b7
-  FirebaseCoreExtension: 6f357679327f3614e995dc7cf3f2d600bdc774ac
-  FirebaseCoreInternal: ef4505d2afb1d0ebbc33162cb3795382904b5679
-  FirebaseCrashlytics: 84b073c997235740e6a951b7ee49608932877e5c
-  FirebaseDatabase: 229b4959145d197dab99ab9d7033b6d4fab897a1
-  FirebaseDynamicLinks: a76f75ddb0612301c34b3f598100449b41bc2669
-  FirebaseFirestore: e5c3d65fef6c6e07c47af2130aaadfb89dd07ea7
+  Firebase: 6a8f201c61eda24e98f1ce2b44b1b9c2caf525cc
+  FirebaseABTesting: 8551c24eb28e300ce697f8eb72c1a519bb96eb40
+  FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
+  FirebaseAppCheck: cd8a337021ec2779e6b73eed8d8ba8247be6082c
+  FirebaseAppCheckInterop: f23709c9ce92d810aa53ff4ce12ad3e666a3c7be
+  FirebaseAppDistribution: 4a4211611c6b2612f171114e0b979e4557165b2f
+  FirebaseAuth: 783fa4cc0420b0f6eed580721b12d4f0a5306746
+  FirebaseAuthInterop: ac22ed402c2f4e3a8c63ebd3278af9a06073c1be
+  FirebaseCore: 2321536f9c423b1f857e047a82b8a42abc6d9e2c
+  FirebaseCoreExtension: 3a64994969dd05f4bcb7e6896c654eded238e75b
+  FirebaseCoreInternal: 31ee350d87b30a9349e907f84bf49ef8e6791e5a
+  FirebaseCrashlytics: 5058c465e10782f54337b394c37254e0595174e9
+  FirebaseDatabase: d91ea8ab77099cb8dbac6eb0d569ff0d525c4506
+  FirebaseDynamicLinks: 583591e36d7659ba1cd4c1ac6ea0825faf45f161
+  FirebaseFirestore: 04537d6080b4706645d90070961ac0969870e0fa
   FirebaseFirestoreAbseilBinary: 4cfa8823cedc1b774843e04fe578ad279b387f97
-  FirebaseFirestoreBinary: 6cf15472267bbb89ce9ac5e645eb0abae29208ce
+  FirebaseFirestoreBinary: 9f92d1c97b1670c2f69895ce2f37cfc31802b2c9
   FirebaseFirestoreGRPCBoringSSLBinary: c3dfef3ff448ae2c1c85f9baf9fac5afc4db99fa
   FirebaseFirestoreGRPCCoreBinary: 565534e160a0415d12185f7f171c52a567382fbd
   FirebaseFirestoreGRPCCPPBinary: 6c0134e8d230ee58b9d51dec2a30a48efd6d5dc7
-  FirebaseFirestoreInternalBinary: 96b309279c4efdf00b83ab80e8af4d0a73d30258
-  FirebaseFunctions: e89e0cf2091c9fb19aa58df270317c0a91963f4f
-  FirebaseInAppMessaging: 3f96b5715f1e2dffdb4189300f8054b2d7059a5e
-  FirebaseInstallations: 9980995bdd06ec8081dfb6ab364162bdd64245c3
-  FirebaseMessaging: 2b9f56aa4ed286e1f0ce2ee1d413aabb8f9f5cb9
-  FirebaseMessagingInterop: 2fb9a3ca813c3b7b495232f1fbedd365eb60da45
-  FirebasePerformance: f0bd14be05aaa1136cbb1c9aaaf87d213d0e6fbf
-  FirebaseRemoteConfig: 10695bc0ce3b103e3706a5578c43f2a9f69d5aaa
-  FirebaseRemoteConfigInterop: 7c9a9c65eff32cbb0f7bf8d18140612ad57dfcc6
-  FirebaseSessions: 9b3b30947b97a15370e0902ee7a90f50ef60ead6
-  FirebaseSharedSwift: 1baacae75939499b5def867cbe34129464536a38
-  FirebaseStorage: e83d1b9c8a5318d46ccfb2955f0d98095e0bf598
+  FirebaseFirestoreInternalBinary: cef73ef0a15c869cf55ceccf1bb0095a04b82fa2
+  FirebaseFunctions: 5a3e5aabdb843d25328de248f8fcec14bf86b964
+  FirebaseInAppMessaging: 6a9f84fcec3f465d8c42a93f4d4d0073ae615953
+  FirebaseInstallations: 781e0e37aa0e1c92b44d00e739aba79ad31b2dba
+  FirebaseMessaging: c7be9357fd8ba33bc45b9a6c3cdff0b466e1e2a4
+  FirebaseMessagingInterop: 87d4a0a3a78644576c681974ce895599f9a867c9
+  FirebasePerformance: 788093952ee3df4774c8317f3670b4afecf796ee
+  FirebaseRemoteConfig: ca2e03fdd86e31d79ded53e24fa4ac719494dc35
+  FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
+  FirebaseSessions: f5c6bfeb66a7202deaf33352017bb6365e395820
+  FirebaseSharedSwift: b1d32c3b29a911dc174bcf363f2f70bda9509d2f
+  FirebaseStorage: 1c04b0ac8126b6fada8c9a09458f59c31868f2df
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  GoogleAppMeasurement: 36684bfb3ee034e2b42b4321eb19da3a1b81e65d
-  GoogleAppMeasurementOnDeviceConversion: f312bf446027ca1a72f44c348bd9bc130e1f0af0
+  GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
+  GoogleAppMeasurementOnDeviceConversion: 693f1ebd5562675d39c630ca4e41df1c228c65c5
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMSessionFetcher: 75b671f9e551e4c49153d4c4f8659ef4f559b970
@@ -2292,23 +2292,23 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 849b77e6ab3eb838361a902b492993056924faab
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNFBAnalytics: 33fd0fae8f501cc106511493b2328be6779f66fd
-  RNFBApp: fed929c76589400be1cb89ff3a457b3cef876907
-  RNFBAppCheck: db03e185469ae9a4edc2b20dd88fd419a9367c85
-  RNFBAppDistribution: 03dc37ec4b59b0377e6faf92b82fc4b299978533
-  RNFBAuth: 68cfc1eeb8e2e668b3c4bac8ecea25f40c7ca4d5
-  RNFBCrashlytics: 4dcf8df32c86a6933cba0ba86a7236593eb0e8cc
-  RNFBDatabase: adddfb0375fd5bf5a85a46360d9b63041b4999a7
-  RNFBDynamicLinks: 3750b52d20f3d249251576c67da87fa51b98459a
-  RNFBFirestore: 4e6cbd256ef02ea5a6089b1bbfdeb91668175ace
-  RNFBFunctions: 3bf3d1206423108810ceb978726927602d8b4697
-  RNFBInAppMessaging: d4a6b52ab2efc8e3c7741e1f204ff30866240d67
-  RNFBInstallations: 20f02076fc4cc1d200e8218894bda0b4ed9d5174
-  RNFBMessaging: e4172056d9ae9231d6859080185851b734ca8755
-  RNFBML: fbed28d0ceb592d109d13077bee5e52eda4f4fcb
-  RNFBPerf: 5770aa9f177e40e221196ef48066fbeeda2e7adb
-  RNFBRemoteConfig: 9b7b9276edf8dcfa23195fc469585e2e799a1746
-  RNFBStorage: 258c888f33589a5228359cd6e9652453a6975e5e
+  RNFBAnalytics: c717e2ff66b0f55ecf6942a9cfa6d80a3e158a2c
+  RNFBApp: 1993c73b660bdba34ef7056f3df94ed6654e0b79
+  RNFBAppCheck: cd14fc4491b793cd00f23259ca55efacca0a18ad
+  RNFBAppDistribution: 02aca1afd6654d0a5e507508efc987fe123318b0
+  RNFBAuth: 07509849e8687a13e9076ed08a2173efee6da472
+  RNFBCrashlytics: 7f157d0c3344631956187828d0b90c147179728a
+  RNFBDatabase: 0983c2417d3f0417e6211e324c0ebe0c3b9f1d1c
+  RNFBDynamicLinks: 0e11b81eef9c96f0e3d2f1e0a66bc84b57eaf8be
+  RNFBFirestore: 43a2620e0b666b8a55f85f2e41e24f5fe4dcd9da
+  RNFBFunctions: 1c83f7a927813eb878d31c53320ea513ade64dbd
+  RNFBInAppMessaging: ff47df86b2ed1a1fcc5a655998dc43c196bc7fe8
+  RNFBInstallations: c931248313e9c1ec5c4872e30810c42bf5ca63c9
+  RNFBMessaging: bca6e94dbca818260d771b2cd51ff2f5f93dc600
+  RNFBML: 9d27a2adb598f13b393d583d68e3d656f7e9674e
+  RNFBPerf: d653292619859a13f828efc835f6488f078c8046
+  RNFBRemoteConfig: 8b712f84dd543a1429e53d1dda22b6c6b77bdcbe
+  RNFBStorage: dd180ccda4dc44b31e40040025f0ed08f111ddb0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 28b8cda182ee3092ff80203da66dcb3ffc8cf401
 


### PR DESCRIPTION
### Description

Simple SDK update of underlying native SDKs

### Related Issues

No related issues, however I also ran a publish on firestore-ios-sdk-frameworks so that this would work (since our e2e tests depend on the pre-compiled version)

### Release Summary

Single conventional commit that would trigger a patch release by itself

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Checked the e2e tests locally with this, they seem to work

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
