### PR TITLE
feat(messaging, android): implement notification delegation APIs, disable by default

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -215,6 +215,7 @@ uri-scheme
 userData
 utils
 Utils
+v1
 v15
 v5
 v6

--- a/docs/messaging/usage/index.md
+++ b/docs/messaging/usage/index.md
@@ -64,6 +64,16 @@ If you require `remote notification` on Expo, you can also add this to your Expo
 }
 ```
 
+## Android - Google Play Notification Delegation
+
+If you use the REST v1 APIs (used by the Firebase admin SDKs) and your app is running on Android Q+ with current Google Play services, Google implemented "Notification Delegation" for messages. Notification delegation is not currently compatible with react-native-firebase. Specifically, if your notifications are delegated via proxy to Play Services, then your messaging listeners will not be called.
+
+To work around this incompatibility, react-native-firebase disables notification delegation by default currently, using the `AndroidManifest.xml` method listed as one of the options described here: <https://firebase.google.com/docs/cloud-messaging/android/message-priority#proxy>.
+
+You may re-enable notification delegation if your use case requires it and you can accept the messaging listener methods not executing for delegated messages by altering the firebase.json setting `messaging_android_notification_delegation_enabled` to `true`.
+
+You may also use the new messaging APIs to get and set the notification delegation state for the app, as desired.
+
 # What does it do
 
 React Native Firebase provides native integration of Firebase Cloud Messaging (FCM) for both Android & iOS. FCM is a cost

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -56,12 +56,7 @@
         "app_log_level": {
           "description": "Set the log level across all modules. Only applies to iOS currently. Can be 'error', 'warn', 'info', 'debug'.\n Logs messages at the configured level or lower.\n Note that if an app is running from AppStore, it will never log above info even if level is set to a higher (more verbose) setting",
           "type": "string",
-          "enum": [
-            "error",
-            "warn",
-            "info",
-            "debug"
-          ]
+          "enum": ["error", "warn", "info", "debug"]
         },
         "app_check_token_auto_refresh": {
           "description": "If this flag is disabled then Firebase App Check will not periodically auto-refresh the app check token.\n This is useful for opt-in-first data flows, for example when dealing with GDPR compliance. \nIf unset it will default to the SDK-wide data collection default enabled setting. This may be overridden dynamically in Javascript.",
@@ -99,6 +94,10 @@
           "description": "On Android, a background event sent to setBackgroundMessageHandler has 60 seconds to resolve before it is automatically canceled to free up device resources. If you wish to override this value, set the number of milliseconds in your config.",
           "type": "number",
           "minimum": 0
+        },
+        "messaging_android_notification_delegation_enabled": {
+          "description": "On Android Q+ and current Play Services, your FCM may be delegated which disables firebase message listeners. Disabled by default. You may re-enable if necessary",
+          "type": "boolean"
         },
         "messaging_android_notification_channel_id": {
           "description": "On Android, any message which displays a Notification use a default Notification Channel (created by FCM called `Miscellaneous`). This channel contains basic notification settings which may not be appropriate for your application. You can change what Channel is used by updating the `messaging_android_notification_channel_id` property.",

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -104,6 +104,10 @@
           "description": "On Android, any message which displays a Notification use a default Notification Channel (created by FCM called `Miscellaneous`). This channel contains basic notification settings which may not be appropriate for your application. You can change what Channel is used by updating the `messaging_android_notification_channel_id` property.",
           "type": "string"
         },
+        "messaging_android_notification_delivery_metrics_export_enabled": {
+          "description": "Determines whether Firebase Cloud Messaging exports message delivery metrics to BigQuery. Defaults to disabled.",
+          "type": "boolean"
+        },
         "messaging_android_notification_color": {
           "description": "On Android, any messages which display a Notification do not use a color to tint the content (such as the small icon, title etc). To provide a custom tint color, update the messaging_android_notification_color property with a Android color resource name. \n The library provides a set of predefined colors corresponding to the HTML colors for convenience",
           "type": "string"

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -71,6 +71,8 @@ String deliveryMetricsExportEnabled = 'false'
 // If nothing is defined, data collection defaults to true
 String dataCollectionEnabled = 'true'
 
+String notificationDelegationEnabled = 'false'
+
 if (rootProject.ext && rootProject.ext.firebaseJson) {
   /* groovylint-disable-next-line NoDef, VariableTypeRequired */
   def rnfbConfig = rootProject.ext.firebaseJson
@@ -92,6 +94,10 @@ if (rootProject.ext && rootProject.ext.firebaseJson) {
   }
   notificationChannelId = rnfbConfig.getStringValue('messaging_android_notification_channel_id', defaultNotificationChannelId)
   notificationColor = rnfbConfig.getStringValue('messaging_android_notification_color', defaultNotificationColor)
+
+  if (rnfbConfig.isFlagEnabled('messaging_android_notification_delegation_enabled', false)) {
+    notificationDelegationEnabled = 'true'
+  }
 }
 
 android {
@@ -106,7 +112,8 @@ android {
       firebaseJsonDeliveryMetricsExportEnabled: deliveryMetricsExportEnabled,
       firebaseJsonAutoInitEnabled: dataCollectionEnabled,
       firebaseJsonNotificationChannelId: notificationChannelId,
-      firebaseJsonNotificationColor: notificationColor
+      firebaseJsonNotificationColor: notificationColor,
+      firebaseJsonNotificationDelegationEnabled: notificationDelegationEnabled
     ]
   }
 

--- a/packages/messaging/android/build.gradle
+++ b/packages/messaging/android/build.gradle
@@ -61,9 +61,12 @@ project.ext {
 
 apply from: file('./../../app/android/firebase-json.gradle')
 
-String notificationChannelId = ''
+String defaultNotificationChannelId = ''
+String notificationChannelId = defaultNotificationChannelId
 String defaultNotificationColor = '@color/white'
 String notificationColor = defaultNotificationColor
+
+String deliveryMetricsExportEnabled = 'false'
 
 // If nothing is defined, data collection defaults to true
 String dataCollectionEnabled = 'true'
@@ -84,7 +87,10 @@ if (rootProject.ext && rootProject.ext.firebaseJson) {
     }
   }
 
-  notificationChannelId = rnfbConfig.getStringValue('messaging_android_notification_channel_id', '')
+  if (rnfbConfig.isFlagEnabled('messaging_android_notification_delivery_metrics_export_enabled', false)) {
+    deliveryMetricsExportEnabled = 'true'
+  }
+  notificationChannelId = rnfbConfig.getStringValue('messaging_android_notification_channel_id', defaultNotificationChannelId)
   notificationColor = rnfbConfig.getStringValue('messaging_android_notification_color', defaultNotificationColor)
 }
 
@@ -97,6 +103,7 @@ android {
   defaultConfig {
     multiDexEnabled true
     manifestPlaceholders = [
+      firebaseJsonDeliveryMetricsExportEnabled: deliveryMetricsExportEnabled,
       firebaseJsonAutoInitEnabled: dataCollectionEnabled,
       firebaseJsonNotificationChannelId: notificationChannelId,
       firebaseJsonNotificationColor: notificationColor

--- a/packages/messaging/android/src/main/AndroidManifest.xml
+++ b/packages/messaging/android/src/main/AndroidManifest.xml
@@ -25,6 +25,9 @@
     </receiver>
 
     <meta-data
+      android:name= "delivery_metrics_exported_to_big_query_enabled"
+      android:value="${firebaseJsonDeliveryMetricsExportEnabled}"/>
+    <meta-data
       android:name="firebase_messaging_auto_init_enabled"
       android:value="${firebaseJsonAutoInitEnabled}"/>
     <meta-data

--- a/packages/messaging/android/src/main/AndroidManifest.xml
+++ b/packages/messaging/android/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@
       android:name="firebase_messaging_auto_init_enabled"
       android:value="${firebaseJsonAutoInitEnabled}"/>
     <meta-data
+      android:name="firebase_messaging_notification_delegation_enabled"
+      android:value="${firebaseJsonNotificationDelegationEnabled}"/>
+    <meta-data
       android:name="com.google.firebase.messaging.default_notification_channel_id"
       android:value="${firebaseJsonNotificationChannelId}" />
     <meta-data

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingModule.java
@@ -121,6 +121,42 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
   }
 
   @ReactMethod
+  public void isNotificationDelegationEnabled(Promise promise) {
+    Tasks.call(
+            getExecutor(),
+            () -> {
+              FirebaseMessaging.getInstance().isNotificationDelegationEnabled();
+              return null;
+            })
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                promise.resolve(task.getResult());
+              } else {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+              }
+            });
+  }
+
+  @ReactMethod
+  public void setNotificationDelegationEnabled(Boolean enabled, Promise promise) {
+    Tasks.call(
+            getExecutor(),
+            () -> {
+              FirebaseMessaging.getInstance().setNotificationDelegationEnabled(enabled);
+              return null;
+            })
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                promise.resolve(FirebaseMessaging.getInstance().isNotificationDelegationEnabled());
+              } else {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+              }
+            });
+  }
+
+  @ReactMethod
   public void getToken(String appName, String senderId, Promise promise) {
     FirebaseMessaging messagingInstance =
         FirebaseApp.getInstance(appName).get(FirebaseMessaging.class);
@@ -247,6 +283,9 @@ public class ReactNativeFirebaseMessagingModule extends ReactNativeFirebaseModul
     constants.put(
         "isDeliveryMetricsExportToBigQueryEnabled",
         FirebaseMessaging.getInstance().deliveryMetricsExportToBigQueryEnabled());
+    constants.put(
+        "isNotificationDelegationEnabled",
+        FirebaseMessaging.getInstance().isNotificationDelegationEnabled());
     return constants;
   }
 

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -445,6 +445,28 @@ describe('messaging()', function () {
       });
     });
 
+    describe('setNotificationDelegationEnabled()', function () {
+      afterEach(async function () {
+        await firebase.messaging().setNotificationDelegationEnabled(false);
+      });
+
+      it('throws if enabled is not a boolean', function () {
+        try {
+          firebase.messaging().setNotificationDelegationEnabled(123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'enabled' expected a boolean value");
+          return Promise.resolve();
+        }
+      });
+
+      it('sets the value', async function () {
+        should.equal(firebase.messaging().isNotificationDelegationEnabled, false);
+        await firebase.messaging().setNotificationDelegationEnabled(true);
+        should.equal(firebase.messaging().isNotificationDelegationEnabled, true);
+      });
+    });
+
     describe('isSupported()', function () {
       it('should return "true" if the device or browser supports Firebase Messaging', async function () {
         // For android, when the play services are available, it will return "true"
@@ -894,6 +916,33 @@ describe('messaging()', function () {
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
         await experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), true);
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), true);
+      });
+    });
+
+    describe('setNotificationDelegationEnabled()', function () {
+      afterEach(async function () {
+        const { getMessaging, setNotificationDelegationEnabled } = messagingModular;
+        await setNotificationDelegationEnabled(getMessaging(), false);
+      });
+
+      it('throws if enabled is not a boolean', function () {
+        const { getMessaging, setNotificationDelegationEnabled } = messagingModular;
+        try {
+          setNotificationDelegationEnabled(getMessaging(), 123);
+          return Promise.reject(new Error('Did not throw Error.'));
+        } catch (e) {
+          e.message.should.containEql("'enabled' expected a boolean value");
+          return Promise.resolve();
+        }
+      });
+
+      it('sets the value', async function () {
+        const { getMessaging, setNotificationDelegationEnabled, isNotificationDelegationEnabled } =
+          messagingModular;
+
+        should.equal(isNotificationDelegationEnabled(getMessaging()), false);
+        await setNotificationDelegationEnabled(getMessaging(), true);
+        should.equal(isNotificationDelegationEnabled(getMessaging()), true);
       });
     });
 

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -895,14 +895,14 @@ describe('messaging()', function () {
         await experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), true);
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), true);
       });
+    });
 
-      describe('isSupported()', function () {
-        it('should return "true" if the device or browser supports Firebase Messaging', async function () {
-          const { isSupported, getMessaging } = messagingModular;
-          // For android, when the play services are available, it will return "true"
-          // iOS & web always return "true". Web can be fully implemented when the platform is supported
-          should.equal(await isSupported(getMessaging()), true);
-        });
+    describe('isSupported()', function () {
+      it('should return "true" if the device or browser supports Firebase Messaging', async function () {
+        const { isSupported, getMessaging } = messagingModular;
+        // For android, when the play services are available, it will return "true"
+        // iOS & web always return "true". Web can be fully implemented when the platform is supported
+        should.equal(await isSupported(getMessaging()), true);
       });
     });
   });

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -442,10 +442,6 @@ describe('messaging()', function () {
         should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
         await firebase.messaging().setDeliveryMetricsExportToBigQuery(true);
         should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, true);
-
-        // Set it back to the default value for future runs in re-use mode
-        await firebase.messaging().setDeliveryMetricsExportToBigQuery(false);
-        should.equal(firebase.messaging().isDeliveryMetricsExportToBigQueryEnabled, false);
       });
     });
 
@@ -898,10 +894,6 @@ describe('messaging()', function () {
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
         await experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), true);
         should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), true);
-
-        // Set it back to the default value for future runs in re-use mode
-        await experimentalSetDeliveryMetricsExportedToBigQueryEnabled(getMessaging(), false);
-        should.equal(isDeliveryMetricsExportToBigQueryEnabled(getMessaging()), false);
       });
 
       describe('isSupported()', function () {

--- a/packages/messaging/lib/index.d.ts
+++ b/packages/messaging/lib/index.d.ts
@@ -1145,6 +1145,40 @@ export namespace FirebaseMessagingTypes {
      * @param enabled A boolean value to enable or disable exporting of message delivery metrics to BigQuery.
      */
     setDeliveryMetricsExportToBigQuery(enabled: boolean): Promise<void>;
+
+    /**
+     * Sets whether remote notification delegation to Google Play Services is enabled or disabled.
+     *
+     * The value is false by default. Set this to true to allow remote notification delegation.
+     *
+     * Warning: this will disable notification handlers on Android, and on iOS it has no effect
+     *
+     *
+     * #### Example
+     *
+     * ```js
+     * // Enable delegation of remote notifications to Google Play Services
+     * await firebase.messaging().setNotificationDelegationEnabled(true);
+     * ```
+     *
+     * @param enabled A boolean value to enable or disable remote notification delegation to Google Play Services.
+     */
+    setNotificationDelegationEnabled(enabled: boolean): Promise<void>;
+
+    /**
+     * Gets whether remote notification delegation to Google Play Services is enabled or disabled.
+     *
+     * #### Example
+     *
+     * ```js
+     * // Determine if delegation of remote notifications to Google Play Services is enabled
+     * const delegationEnabled = await firebase.messaging().isNotificationDelegationEnabled();
+     * ```
+     *
+     * @returns enabled A boolean value indicatign if remote notification delegation to Google Play Services is enabled.
+     */
+    istNotificationDelegationEnabled(): Promise<boolean>;
+
     /**
      * Checks if all required APIs exist in the browser.
      *

--- a/packages/messaging/lib/index.js
+++ b/packages/messaging/lib/index.js
@@ -60,6 +60,10 @@ class FirebaseMessagingModule extends FirebaseModule {
       this.native.isRegisteredForRemoteNotifications != null
         ? this.native.isRegisteredForRemoteNotifications
         : true;
+    this._isNotificationDelegationEnabled =
+      this.native.isNotificationDelegationEnabled != null
+        ? this.native.isNotificationDelegationEnabled
+        : false;
 
     AppRegistry.registerHeadlessTask('ReactNativeFirebaseMessagingHeadlessTask', () => {
       if (!backgroundMessageHandler) {
@@ -119,6 +123,10 @@ class FirebaseMessagingModule extends FirebaseModule {
     }
 
     return this._isRegisteredForRemoteNotifications;
+  }
+
+  get isNotificationDelegationEnabled() {
+    return this._isNotificationDelegationEnabled;
   }
 
   get isDeliveryMetricsExportToBigQueryEnabled() {
@@ -458,6 +466,21 @@ class FirebaseMessagingModule extends FirebaseModule {
 
     this._isDeliveryMetricsExportToBigQueryEnabled = enabled;
     return this.native.setDeliveryMetricsExportToBigQuery(enabled);
+  }
+
+  setNotificationDelegationEnabled(enabled) {
+    if (!isBoolean(enabled)) {
+      throw new Error(
+        "firebase.messaging().setNotificationDelegationEnabled(*) 'enabled' expected a boolean value.",
+      );
+    }
+
+    this._isNotificationDelegationEnabled = enabled;
+    if (isIOS) {
+      return;
+    }
+
+    return this.native.setNotificationDelegationEnabled(enabled);
   }
 
   async isSupported() {

--- a/packages/messaging/lib/modular/index.d.ts
+++ b/packages/messaging/lib/modular/index.d.ts
@@ -100,6 +100,29 @@ export function isAutoInitEnabled(messaging: Messaging): boolean;
 export function setAutoInitEnabled(messaging: Messaging, enabled: boolean): Promise<void>;
 
 /**
+ * Sets whether remote notification delegation to Google Play Services is enabled or disabled.
+ *
+ * The value is false by default. Set this to true to allow remote notification delegation.
+ *
+ * Warning: this will disable notification handlers on Android, and on iOS it has no effect
+ *
+ * @param messaging - Messaging instance.
+ * @param enabled A boolean value to enable or disable remote notification delegation to Google Play Services.
+ */
+export function setNotificationDelegationEnabled(
+  messaging: Messaging,
+  enabled: boolean,
+): Promise<void>;
+
+/**
+ * Gets whether remote notification delegation to Google Play Services is enabled or disabled.
+ *
+ * @param messaging - Messaging instance.
+ * @returns enabled A boolean value indicatign if remote notification delegation to Google Play Services is enabled.
+ */
+export function istNotificationDelegationEnabled(messaging: Messaging): Promise<boolean>;
+
+/**
  * When a notification from FCM has triggered the application to open from a quit state,
  * this method will return a `RemoteMessage` containing the notification data, or `null` if
  * the app was opened via another method.

--- a/packages/messaging/lib/modular/index.js
+++ b/packages/messaging/lib/modular/index.js
@@ -318,6 +318,28 @@ export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
 }
 
 /**
+ * Returns a boolean whether message delegation is enabled. Android only,
+ * always returns false on iOS
+ * @param {Messaging} messaging - Messaging instance.
+ * @returns {boolean}
+ */
+export function isNotificationDelegationEnabled(messaging) {
+  return messaging.isNotificationDelegationEnabled;
+}
+
+/**
+ * Sets whether message notification delegation is enabled or disabled.
+ * The value is false by default. Set this to true to allow delegation of notification to Google Play Services.
+ * Note if true message handlers will not function on Android, and it has no effect on iOS
+ * @param {Messaging} messaging - Messaging instance.
+ * @param {boolean} enabled - A boolean value to enable or disable delegation of messages to Google Play Services.
+ * @returns {Promise<void>}
+ */
+export function setNotificationDelegationEnabled(messaging, enabled) {
+  return messaging.setNotificationDelegationEnabled(enabled);
+}
+
+/**
  * Checks if all required APIs exist in the browser.
  * @param {Messaging} messaging - Messaging instance.
  * @returns {boolean}

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -16,6 +16,7 @@
 
     "messaging_auto_init_enabled": false,
     "messaging_android_headless_task_timeout": 30000,
+    "messaging_android_notification_delivery_metrics_export_enabled": true,
     "messaging_android_notification_channel_id": "",
     "messaging_android_notification_color": "@color/hotpink",
     "messaging_ios_auto_register_for_remote_messages": false,

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -20,6 +20,7 @@
     "messaging_android_notification_channel_id": "",
     "messaging_android_notification_color": "@color/hotpink",
     "messaging_ios_auto_register_for_remote_messages": false,
+    "messaging_android_notification_delegation_enabled": true,
 
     "analytics_auto_collection_enabled": true,
     "analytics_collection_deactivated": false,


### PR DESCRIPTION
### Description

In Android Q+ with current Google Play Services, play services has started installing itself as a default "notification delegation proxy" for remote notifications sent via FCM REST v1 APIs

That sounds good, except the application affect is that on Android the message handlers are no longer called when the user interacts with these delegated notifications

So there is an immediate need to disable these by default for most people, though just in case some use cases for some people require this, we also implement a firebase.json toggle and programmatic APIs to enable it in case people need it.

A future PR could or should follow after investigating *why* the message handlers are not called in response to delegated FCM, so that the root cause can be fixed

https://firebase.google.com/docs/cloud-messaging/android/message-priority#proxy

(although note that the XML attribute they specify there is incorrect in their documentation, the actual `AndroidManifest.xml` entry is "firebase_messaging_notification_delegation_enabled")

### Related issues

- Fixes #8112 
- Fixes #8392

### Release Summary

conventional commits
- note I included the feature toggle via firebase.json for BigQuery export as well, it was missing - non-breaking as it defaults to false normally and that is the default I set
- note I included two extra commits that cleans up the test prior to adding new tests for this

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I added an e2e test for the APIs implemented
It is hard to test the feature toggles as they rely on startup application state which may be altered by test state depending on which tests have run. What I did was log the startup state of each flag to verify it was correct in these states:

- nothing set in firebase.json (both feature were correctly false on startup)
- set to false in firebase.json (both feature were correctly false on startup)
- set to true in firebase.json (both feature were correctly true on startup)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
