### PR TITLE
fix(firestore)!: Make DocumentSnapshot.exists() a method rather than a property (BREAKING CHANGE)

### DIFF
--- a/packages/firestore/e2e/CollectionReference/add.e2e.js
+++ b/packages/firestore/e2e/CollectionReference/add.e2e.js
@@ -49,7 +49,7 @@ describe('firestore.collection().add()', function () {
       should.equal(docRef.constructor.name, 'FirestoreDocumentReference');
       const docSnap = await docRef.get();
       docSnap.data().should.eql(jet.contextify(data));
-      docSnap.exists.should.eql(true);
+      docSnap.exists().should.eql(true);
       await docRef.delete();
     });
   });
@@ -75,7 +75,7 @@ describe('firestore.collection().add()', function () {
       should.equal(docRef.constructor.name, 'FirestoreDocumentReference');
       const docSnap = await getDoc(docRef);
       docSnap.data().should.eql(jet.contextify(data));
-      docSnap.exists.should.eql(true);
+      docSnap.exists().should.eql(true);
       await deleteDoc(docRef);
     });
   });

--- a/packages/firestore/e2e/DocumentReference/delete.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/delete.e2e.js
@@ -38,11 +38,11 @@ describe('firestore.doc().delete()', function () {
       await ref.set({ foo: 'bar' });
       const snapshot1 = await ref.get();
       snapshot1.id.should.equal('deleteme');
-      snapshot1.exists.should.equal(true);
+      snapshot1.exists().should.equal(true);
       await ref.delete();
       const snapshot2 = await ref.get();
       snapshot2.id.should.equal('deleteme');
-      snapshot2.exists.should.equal(false);
+      snapshot2.exists().should.equal(false);
     });
   });
 
@@ -54,11 +54,11 @@ describe('firestore.doc().delete()', function () {
       await setDoc(ref, { foo: 'bar' });
       const snapshot1 = await getDoc(ref);
       snapshot1.id.should.equal('deleteme');
-      snapshot1.exists.should.equal(true);
+      snapshot1.exists().should.equal(true);
       await deleteDoc(ref);
       const snapshot2 = await getDoc(ref);
       snapshot2.id.should.equal('deleteme');
-      snapshot2.exists.should.equal(false);
+      snapshot2.exists().should.equal(false);
     });
   });
 });

--- a/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
+++ b/packages/firestore/e2e/DocumentSnapshot/properties.e2e.js
@@ -40,8 +40,8 @@ describe('firestore().doc() -> snapshot', function () {
       const snapshot1 = await ref1.get();
       const snapshot2 = await ref2.get();
 
-      snapshot1.exists.should.equal(true);
-      snapshot2.exists.should.equal(false);
+      snapshot1.exists().should.equal(true);
+      snapshot2.exists().should.equal(false);
       await ref1.delete();
     });
 
@@ -87,8 +87,8 @@ describe('firestore().doc() -> snapshot', function () {
       const snapshot1 = await getDoc(ref1);
       const snapshot2 = await getDoc(ref2);
 
-      snapshot1.exists.should.equal(true);
-      snapshot2.exists.should.equal(false);
+      snapshot1.exists().should.equal(true);
+      snapshot2.exists().should.equal(false);
       await deleteDoc(ref1);
     });
 

--- a/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
+++ b/packages/firestore/e2e/SecondDatabase/second.Transation.e2e.js
@@ -114,7 +114,7 @@ describe('Second Database', function () {
           await firestore.runTransaction(async t => {
             const docSnapshot = await t.get(docRef);
             docSnapshot.constructor.name.should.eql('FirestoreDocumentSnapshot');
-            docSnapshot.exists.should.eql(true);
+            docSnapshot.exists().should.eql(true);
             docSnapshot.id.should.eql('get-delete');
 
             t.delete(docRef);
@@ -148,10 +148,10 @@ describe('Second Database', function () {
           });
 
           const snapshot1 = await docRef1.get();
-          snapshot1.exists.should.eql(false);
+          snapshot1.exists().should.eql(false);
 
           const snapshot2 = await docRef2.get();
-          snapshot2.exists.should.eql(false);
+          snapshot2.exists().should.eql(false);
         });
       });
 
@@ -210,11 +210,11 @@ describe('Second Database', function () {
           };
 
           const snapshot1 = await docRef1.get();
-          snapshot1.exists.should.eql(true);
+          snapshot1.exists().should.eql(true);
           snapshot1.data().should.eql(jet.contextify(expected));
 
           const snapshot2 = await docRef2.get();
-          snapshot2.exists.should.eql(true);
+          snapshot2.exists().should.eql(true);
           snapshot2.data().should.eql(jet.contextify(expected));
         });
       });
@@ -487,7 +487,7 @@ describe('Second Database', function () {
           await runTransaction(db, async t => {
             const docSnapshot = await t.get(docRef);
             docSnapshot.constructor.name.should.eql('FirestoreDocumentSnapshot');
-            docSnapshot.exists.should.eql(true);
+            docSnapshot.exists().should.eql(true);
             docSnapshot.id.should.eql('get-delete');
 
             t.delete(docRef);
@@ -524,10 +524,10 @@ describe('Second Database', function () {
           });
 
           const snapshot1 = await getDoc(docRef1);
-          snapshot1.exists.should.eql(false);
+          snapshot1.exists().should.eql(false);
 
           const snapshot2 = await getDoc(docRef2);
-          snapshot2.exists.should.eql(false);
+          snapshot2.exists().should.eql(false);
         });
       });
 
@@ -591,11 +591,11 @@ describe('Second Database', function () {
           };
 
           const snapshot1 = await getDoc(docRef1);
-          snapshot1.exists.should.eql(true);
+          snapshot1.exists().should.eql(true);
           snapshot1.data().should.eql(jet.contextify(expected));
 
           const snapshot2 = await getDoc(docRef2);
-          snapshot2.exists.should.eql(true);
+          snapshot2.exists().should.eql(true);
           snapshot2.data().should.eql(jet.contextify(expected));
         });
       });

--- a/packages/firestore/e2e/Transaction.e2e.js
+++ b/packages/firestore/e2e/Transaction.e2e.js
@@ -108,7 +108,7 @@ describe('firestore.Transaction', function () {
         await firebase.firestore().runTransaction(async t => {
           const docSnapshot = await t.get(docRef);
           docSnapshot.constructor.name.should.eql('FirestoreDocumentSnapshot');
-          docSnapshot.exists.should.eql(true);
+          docSnapshot.exists().should.eql(true);
           docSnapshot.id.should.eql('get-delete');
 
           t.delete(docRef);

--- a/packages/firestore/e2e/Transaction.e2e.js
+++ b/packages/firestore/e2e/Transaction.e2e.js
@@ -146,10 +146,10 @@ describe('firestore.Transaction', function () {
         });
 
         const snapshot1 = await docRef1.get();
-        snapshot1.exists.should.eql(false);
+        snapshot1.exists().should.eql(false);
 
         const snapshot2 = await docRef2.get();
-        snapshot2.exists.should.eql(false);
+        snapshot2.exists().should.eql(false);
       });
     });
 
@@ -212,11 +212,11 @@ describe('firestore.Transaction', function () {
         };
 
         const snapshot1 = await docRef1.get();
-        snapshot1.exists.should.eql(true);
+        snapshot1.exists().should.eql(true);
         snapshot1.data().should.eql(jet.contextify(expected));
 
         const snapshot2 = await docRef2.get();
-        snapshot2.exists.should.eql(true);
+        snapshot2.exists().should.eql(true);
         snapshot2.data().should.eql(jet.contextify(expected));
       });
     });
@@ -484,7 +484,7 @@ describe('firestore.Transaction', function () {
         await runTransaction(db, async t => {
           const docSnapshot = await t.get(docRef);
           docSnapshot.constructor.name.should.eql('FirestoreDocumentSnapshot');
-          docSnapshot.exists.should.eql(true);
+          docSnapshot.exists().should.eql(true);
           docSnapshot.id.should.eql('get-delete');
 
           t.delete(docRef);
@@ -521,10 +521,10 @@ describe('firestore.Transaction', function () {
         });
 
         const snapshot1 = await getDoc(docRef1);
-        snapshot1.exists.should.eql(false);
+        snapshot1.exists().should.eql(false);
 
         const snapshot2 = await getDoc(docRef2);
-        snapshot2.exists.should.eql(false);
+        snapshot2.exists().should.eql(false);
       });
     });
 
@@ -588,11 +588,11 @@ describe('firestore.Transaction', function () {
         };
 
         const snapshot1 = await getDoc(docRef1);
-        snapshot1.exists.should.eql(true);
+        snapshot1.exists().should.eql(true);
         snapshot1.data().should.eql(jet.contextify(expected));
 
         const snapshot2 = await getDoc(docRef2);
-        snapshot2.exists.should.eql(true);
+        snapshot2.exists().should.eql(true);
         snapshot2.data().should.eql(jet.contextify(expected));
       });
     });

--- a/packages/firestore/e2e/WriteBatch/commit.e2e.js
+++ b/packages/firestore/e2e/WriteBatch/commit.e2e.js
@@ -181,9 +181,9 @@ describe('firestore.WriteBatch.commit()', function () {
 
       const [lDoc, nycDoc, sDoc] = await Promise.all([lRef.get(), nycRef.get(), sfRef.get()]);
 
-      lDoc.exists.should.be.False();
-      nycDoc.exists.should.be.False();
-      sDoc.exists.should.be.False();
+      lDoc.exists().should.be.False();
+      nycDoc.exists().should.be.False();
+      sDoc.exists().should.be.False();
     });
 
     it('should update & commit', async function () {
@@ -376,9 +376,9 @@ describe('firestore.WriteBatch.commit()', function () {
 
       const [lDoc, nycDoc, sDoc] = await Promise.all([getDoc(lRef), getDoc(nycRef), getDoc(sfRef)]);
 
-      lDoc.exists.should.be.False();
-      nycDoc.exists.should.be.False();
-      sDoc.exists.should.be.False();
+      lDoc.exists().should.be.False();
+      nycDoc.exists().should.be.False();
+      sDoc.exists().should.be.False();
     });
 
     it('should update & commit', async function () {

--- a/packages/firestore/lib/FirestoreDocumentSnapshot.js
+++ b/packages/firestore/lib/FirestoreDocumentSnapshot.js
@@ -33,10 +33,6 @@ export default class FirestoreDocumentSnapshot {
     this._exists = nativeData.exists;
   }
 
-  get exists() {
-    return this._exists;
-  }
-
   get id() {
     return this._ref.id;
   }
@@ -47,6 +43,10 @@ export default class FirestoreDocumentSnapshot {
 
   get ref() {
     return this._ref;
+  }
+
+  exists() {
+    return this._data !== null && this._data !== undefined;
   }
 
   data() {

--- a/packages/firestore/lib/FirestoreDocumentSnapshot.js
+++ b/packages/firestore/lib/FirestoreDocumentSnapshot.js
@@ -46,7 +46,7 @@ export default class FirestoreDocumentSnapshot {
   }
 
   exists() {
-    return this._data !== null && this._data !== undefined;
+    return this._exists;
   }
 
   data() {

--- a/packages/firestore/lib/FirestoreDocumentSnapshot.js
+++ b/packages/firestore/lib/FirestoreDocumentSnapshot.js
@@ -114,7 +114,7 @@ export default class FirestoreDocumentSnapshot {
     }
 
     if (
-      this.exists !== other.exists ||
+      this.exists() !== other.exists() ||
       !this.metadata.isEqual(other.metadata) ||
       !this.ref.isEqual(other.ref)
     ) {

--- a/packages/firestore/lib/FirestoreQuery.js
+++ b/packages/firestore/lib/FirestoreQuery.js
@@ -65,7 +65,7 @@ export default class FirestoreQuery {
 
       const documentSnapshot = docOrField;
 
-      if (!documentSnapshot.exists) {
+      if (!documentSnapshot.exists()) {
         throw new Error(
           `firebase.firestore().collection().${cursor}(*) Can't use a DocumentSnapshot that doesn't exist.`,
         );


### PR DESCRIPTION
### Description

closes https://github.com/invertase/react-native-firebase/issues/8460

Just as @mikehardy says, JS documentation states exists() is a method returning true or false.
https://firebase.google.com/docs/reference/js/database.datasnapshot.md#datasnapshotexists
Very small breaking change, users just need to change snapshot.exists to snapshot.exists().

To be shipped with other breaking changes.
### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
