### PR TITLE
feat(firestore): added support for non-default databases

### DIFF
--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -1013,12 +1013,15 @@ describe('firestore()', function () {
     });
 
     describe('non-default db', function () {
-      it('should be able to initialize a non-default db', async function () {
-        const { initializeFirestore } = firestoreModular;
-        const { getApp } = modular;
-        const app = getApp('secondaryFromNative');
-        const db = await initializeFirestore(app, { persistence: false }, 'test2ndDb');
-        db.customUrlOrRegion.should.equal('test2ndDb');
+      it('should be able to initialize a non-default db on mobile platforms', async function () {
+        // Not allowed to initiliaze a non-default db on web lite sdk
+        if (!Platform.other) {
+          const { initializeFirestore } = firestoreModular;
+          const { getApp } = modular;
+          const app = getApp('secondaryFromNative');
+          const db = await initializeFirestore(app, { persistence: false }, 'test2ndDb');
+          db.customUrlOrRegion.should.equal('test2ndDb');
+        }
       });
     });
   });

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -1011,5 +1011,15 @@ describe('firestore()', function () {
         events.forEach(event => event.should.equal('sync'));
       });
     });
+
+    describe('non-default db', function () {
+      it('should be able to initialize a non-default db', async function () {
+        const { initializeFirestore } = firestoreModular;
+        const { getApp } = modular;
+        const app = getApp('secondaryFromNative');
+        const db = await initializeFirestore(app, { persistence: false }, 'test2ndDb');
+        db.customUrlOrRegion.should.equal('test2ndDb');
+      });
+    });
   });
 });

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -1014,7 +1014,7 @@ describe('firestore()', function () {
 
     describe('non-default db', function () {
       it('should be able to initialize a non-default db on mobile platforms', async function () {
-        // Not allowed to initiliaze a non-default db on web lite sdk
+        // Not supported on web lite sdk
         if (!Platform.other) {
           const { initializeFirestore } = firestoreModular;
           const { getApp } = modular;

--- a/packages/firestore/lib/index.js
+++ b/packages/firestore/lib/index.js
@@ -97,6 +97,11 @@ class FirebaseFirestoreModule extends FirebaseModule {
       persistence: true,
     };
   }
+
+  get customUrlOrRegion() {
+    return this._customUrlOrRegion;
+  }
+
   // We override the FirebaseModule's `eventNameForApp()` method to include the customUrlOrRegion
   eventNameForApp(...args) {
     return `${this.app.name}-${this._customUrlOrRegion}-${args.join('-')}`;

--- a/packages/firestore/lib/modular/index.js
+++ b/packages/firestore/lib/modular/index.js
@@ -210,10 +210,9 @@ export function waitForPendingWrites(firestore) {
  * @param {string?} databaseId
  * @returns {Promise<Firestore>}
  */
-export async function initializeFirestore(app, settings /* databaseId */) {
-  // TODO(exaby73): implement 2nd database once it's supported
+export async function initializeFirestore(app, settings, databaseId) {
   const firebase = getApp(app.name);
-  const firestore = firebase.firestore();
+  const firestore = firebase.firestore(databaseId);
   await firestore.settings.call(firestore, settings, MODULAR_DEPRECATION_ARG);
   return firestore;
 }


### PR DESCRIPTION
### Description

Adds support for initalizing firestore with a non-default database

### Related issues

Fixes #8456 

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


