### PR TITLE
feat(auth, expo): add support for AppDelegate.swift

### DIFF
--- a/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
+++ b/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
@@ -324,6 +324,58 @@ exports[`Config Plugin iOS Tests - openUrlFix munges AppDelegate correctly - App
 "
 `;
 
+exports[`Config Plugin iOS Tests - openUrlFix munges AppDelegate correctly - AppDelegate_sdk53.swift 1`] = `
+"import React
+import Expo
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    self.moduleName = "HelloWorld"
+    self.initialProps = [:]
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  public override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+
+  // Linking API
+  public override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY)
+    if url.host.toLowerCase() == "firebaseauth" {
+      // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
+      return false
+    }
+// @generated end @react-native-firebase/auth-openURL
+    return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
+  }
+
+  // Universal Links
+  public override func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }
+}
+"
+`;
+
 exports[`Config Plugin iOS Tests - openUrlFix must match positiveTemplateCases[0] 1`] = `
 "- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
 // @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a

--- a/packages/auth/plugin/__tests__/fixtures/AppDelegate_noOpenURL_sdk53.swift
+++ b/packages/auth/plugin/__tests__/fixtures/AppDelegate_noOpenURL_sdk53.swift
@@ -1,0 +1,33 @@
+import React
+import Expo
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    self.moduleName = "HelloWorld"
+    self.initialProps = [:]
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  public override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+
+  // Universal Links
+  public override func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }
+}

--- a/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk53.swift
+++ b/packages/auth/plugin/__tests__/fixtures/AppDelegate_sdk53.swift
@@ -1,0 +1,42 @@
+import React
+import Expo
+
+@UIApplicationMain
+public class AppDelegate: ExpoAppDelegate {
+  public override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    self.moduleName = "HelloWorld"
+    self.initialProps = [:]
+
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  public override func bundleURL() -> URL? {
+#if DEBUG
+    return RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: ".expo/.virtual-metro-entry")
+#else
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle")
+#endif
+  }
+
+  // Linking API
+  public override func application(
+    _ app: UIApplication,
+    open url: URL,
+    options: [UIApplication.OpenURLOptionsKey: Any] = [:]
+  ) -> Bool {
+    return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
+  }
+
+  // Universal Links
+  public override func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    let result = RCTLinkingManager.application(application, continue: userActivity, restorationHandler: restorationHandler)
+    return super.application(application, continue: userActivity, restorationHandler: restorationHandler) || result
+  }
+}

--- a/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
+++ b/packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts
@@ -10,6 +10,7 @@ import {
   ensureFirebaseSwizzlingIsEnabled,
   appDelegateOpenUrlInsertionPointAfter,
   multiline_appDelegateOpenUrlInsertionPointAfter,
+  modifyAppDelegate,
 } from '../src/ios/openUrlFix';
 import type { ExpoConfigPluginEntry } from '../src/ios/openUrlFix';
 
@@ -188,15 +189,16 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
   });
 
   const appDelegateFixturesPatch = [
-    'AppDelegate_bare_sdk43.m',
-    'AppDelegate_sdk44.m',
-    'AppDelegate_sdk45.mm',
+    { fixtureName: 'AppDelegate_bare_sdk43.m', language: 'objc' },
+    { fixtureName: 'AppDelegate_sdk44.m', language: 'objc' },
+    { fixtureName: 'AppDelegate_sdk45.mm', language: 'objcpp' },
+    { fixtureName: 'AppDelegate_sdk53.swift', language: 'swift' },
   ];
-  appDelegateFixturesPatch.forEach(fixtureName => {
+  appDelegateFixturesPatch.forEach(({ fixtureName, language }) => {
     it(`munges AppDelegate correctly - ${fixtureName}`, async () => {
       const fixturePath = path.join(__dirname, 'fixtures', fixtureName);
       const appDelegate = await fs.readFile(fixturePath, { encoding: 'utf-8' });
-      const result = modifyObjcAppDelegate(appDelegate);
+      const result = modifyAppDelegate(appDelegate, language);
       expect(result).toMatchSnapshot();
     });
 
@@ -209,7 +211,7 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
         modRequest: { projectRoot: path.join(__dirname, 'fixtures') } as any,
         modResults: {
           path: fixturePath,
-          language: 'objc',
+          language: language,
           contents: appDelegate,
         } as AppDelegateProjectFile,
         modRawConfig: { name: 'TestName', slug: 'TestSlug' },
@@ -226,8 +228,12 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
     });
   });
 
-  const appDelegateFixturesNoop = ['AppDelegate_sdk42.m', 'AppDelegate_fallback.m'];
-  appDelegateFixturesNoop.forEach(fixtureName => {
+  const appDelegateFixturesNoop = [
+    { fixtureName: 'AppDelegate_sdk42.m', language: 'objc' },
+    { fixtureName: 'AppDelegate_fallback.m', language: 'objc' },
+    { fixtureName: 'AppDelegate_noOpenURL_sdk53.swift', language: 'swift' },
+  ];
+  appDelegateFixturesNoop.forEach(({ fixtureName, language }) => {
     it(`skips AppDelegate without openURL - ${fixtureName}`, async () => {
       const fixturePath = path.join(__dirname, 'fixtures', fixtureName);
       const appDelegate = await fs.readFile(fixturePath, { encoding: 'utf-8' });
@@ -238,7 +244,7 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
         modRequest: { projectRoot: path.join(__dirname, 'fixtures') } as any,
         modResults: {
           path: fixturePath,
-          language: 'objc',
+          language: language,
           contents: appDelegate,
         } as AppDelegateProjectFile,
         modRawConfig: { name: 'TestName', slug: 'TestSlug' },
@@ -264,7 +270,7 @@ describe('Config Plugin iOS Tests - openUrlFix', () => {
         modRequest: { projectRoot: path.join(__dirname, 'fixtures') } as any,
         modResults: {
           path: fixturePath,
-          language: 'objc',
+          language: language,
           contents: appDelegate,
         } as AppDelegateProjectFile,
         modRawConfig: { name: 'TestName', slug: 'TestSlug' },


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

With Expo SDK 53 forthcoming, they have moved to an AppDelegate.swift file. The auth Expo config plugin currently only supports an objective-c AppDelegate file. This PR adds support for the swift AppDelegate file.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
Fixes #8487 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan 🔥

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

<details><summary>Test results:</summary>

```sh
 PASS  packages/database/__tests__/database.test.ts
 PASS  packages/crashlytics/__tests__/crashlytics.test.ts
 PASS  packages/app-check/__tests__/appcheck.test.ts
 PASS  packages/vertexai/__tests__/stream-reader.test.ts
 PASS  packages/vertexai/__tests__/schema-builder.test.ts
 PASS  packages/remote-config/__tests__/remote-config.test.ts
 PASS  packages/vertexai/__tests__/count-tokens.test.ts
 PASS  packages/vertexai/__tests__/request.test.ts
 PASS  packages/vertexai/__tests__/chat-session.test.ts
 PASS  packages/vertexai/__tests__/generate-content.test.ts
 PASS  packages/perf/__tests__/perf.test.ts
 PASS  packages/vertexai/__tests__/generative-model.test.ts
 PASS  packages/app-check/plugin/__tests__/iosPlugin.test.ts
 PASS  packages/dynamic-links/plugin/__tests__/iosPlugin.test.ts
 PASS  packages/dynamic-links/__tests__/dynamic-links.test.ts
 PASS  packages/auth/plugin/__tests__/iosPlugin_urlTypes.test.ts
 PASS  packages/vertexai/__tests__/service.test.ts
 PASS  packages/analytics/__tests__/analytics.test.ts
 PASS  packages/ml/__tests__/ml.test.ts
 PASS  packages/app-distribution/__tests__/app-distribution.test.ts
 PASS  packages/firestore/__tests__/firestore.test.ts
 PASS  packages/storage/__tests__/storage.test.ts
 PASS  packages/messaging/plugin/__tests__/androidPlugin.test.ts
 PASS  packages/app/__tests__/app.test.ts
 PASS  packages/auth/__tests__/auth.test.ts
 PASS  packages/app-distribution/plugin/__tests__/androidPlugin.test.ts
 PASS  packages/crashlytics/plugin/__tests__/androidPlugin.test.ts
 PASS  packages/perf/plugin/__tests__/androidPlugin.test.ts
 PASS  packages/installations/__tests__/installations.test.ts
 PASS  packages/vertexai/__tests__/request-helpers.test.ts
 PASS  packages/app/plugin/__tests__/androidPlugin.test.ts
 PASS  packages/app/plugin/__tests__/iosPlugin.test.ts
 PASS  packages/in-app-messaging/__tests__/inappmessaging.test.ts
 PASS  packages/messaging/__tests__/messaging.test.ts
 PASS  packages/functions/__tests__/functions.test.ts
 PASS  packages/vertexai/__tests__/response-helpers.test.ts
 PASS  packages/vertexai/__tests__/chat-session-helpers.test.ts
 PASS  packages/vertexai/__tests__/api.test.ts
 PASS  packages/auth/plugin/__tests__/iosPlugin_openUrlFix.test.ts

Test Suites: 39 passed, 39 total
Tests:       1 skipped, 787 passed, 788 total
Snapshots:   31 passed, 31 total
Time:        4.291 s
Ran all test suites.
```
</details>

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
