### PR TITLE
feat(app, sdks)!: firebase-ios-sdk 11.12.0 / firebase-android-sdk 33.13.0

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -318,7 +318,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "33.12.0"
+        bom           : "33.13.0"
       ],
     ],
   ])
@@ -333,12 +333,12 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '11.11.0'
+$FirebaseSDKVersion = '11.12.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.
 
-Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=11.11.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=11.11.0 yarn expo prebuild --clean`
+Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=11.12.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=11.12.0 yarn expo prebuild --clean`
 
 ### Android Performance
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -74,7 +74,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "11.11.0",
+      "firebase": "11.12.0",
       "iosTarget": "13.0",
       "macosTarget": "10.15",
       "tvosTarget": "13.0"
@@ -83,7 +83,7 @@
       "minSdk": 21,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "33.12.0",
+      "firebase": "33.13.0",
       "firebaseCrashlyticsGradle": "3.0.3",
       "firebasePerfGradle": "1.4.2",
       "gmsGoogleServicesGradle": "4.4.2",


### PR DESCRIPTION

### Description

Standard native SDK updates, but this one is slightly special because of this:

BREAKING CHANGE: firebase-ios-sdk 11.12.0 requires Xcode 16.2+

### Related issues

No related issues

### Release Summary

one conventional commit including the `BREAKING CHANGE` notice required for semantic-release automation, ready for a rebase merge

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Test Plan

My build demonstrator is already updated and appears to work, CI will sort the rest

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
