### PR TITLE
fix(firestore, types): exist -> exists() change reflected in types

### DIFF
--- a/packages/firestore/lib/index.d.ts
+++ b/packages/firestore/lib/index.d.ts
@@ -523,13 +523,13 @@ export namespace FirebaseFirestoreTypes {
    * .`data()` or `.get(:field)` to get a specific field.
    *
    * For a DocumentSnapshot that points to a non-existing document, any data access will return 'undefined'.
-   * You can use the `exists` property to explicitly verify a document's existence.
+   * You can use the `exists()` method to explicitly verify a document's existence.
    */
   export interface DocumentSnapshot<T extends DocumentData = DocumentData> {
     /**
-     * Property of the `DocumentSnapshot` that signals whether or not the data exists. True if the document exists.
+     * Method of the `DocumentSnapshot` that signals whether or not the data exists. True if the document exists.
      */
-    exists: boolean;
+    exists(): boolean;
 
     /**
      * Property of the `DocumentSnapshot` that provides the document's ID.
@@ -597,14 +597,14 @@ export namespace FirebaseFirestoreTypes {
    * The document is guaranteed to exist and its data can be extracted with .data() or .get(:field) to get a specific field.
    *
    * A QueryDocumentSnapshot offers the same API surface as a DocumentSnapshot.
-   * Since query results contain only existing documents, the exists property will always be true and data() will never return 'undefined'.
+   * Since query results contain only existing documents, the exists() method will always be true and data() will never return 'undefined'.
    */
   export interface QueryDocumentSnapshot<T extends DocumentData = DocumentData>
     extends DocumentSnapshot<T> {
     /**
      * A QueryDocumentSnapshot is always guaranteed to exist.
      */
-    exists: true;
+    exists(): true;
 
     /**
      * Retrieves all fields in the document as an Object.


### PR DESCRIPTION
### Description

@MorganTrudeau noticed in https://github.com/invertase/react-native-firebase/pull/8483#issuecomment-2832514693 that the firestore types were not updated with the recent change of `exists` from a property to a method in #8483

This PR updates the types documentation to reflect the current implementation reality

### Related issues

- https://github.com/invertase/react-native-firebase/pull/8483#issuecomment-2832514693

### Release Summary

single semantic-release compliant conventional commit ready for a rebase merge + release cycle

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

CI should sort it out - passed all lint checks locally

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
