### PR TITLE
fix: e2e modular deprecation fixes + auth MFA modular fixes

### DIFF
--- a/packages/app-distribution/e2e/app-distribution.e2e.js
+++ b/packages/app-distribution/e2e/app-distribution.e2e.js
@@ -17,6 +17,16 @@
 
 describe('appDistribution()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('native module is loaded', function () {
       it('checks native module load status', function () {
         firebase.appDistribution().native;

--- a/packages/app/e2e/app.e2e.js
+++ b/packages/app/e2e/app.e2e.js
@@ -17,6 +17,16 @@
 
 describe('modular', function () {
   describe('firebase v8 compat', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('it should allow read the default app from native', function () {
       if (Platform.other) return; // Not supported on non-native platforms.
       // app is created in tests app before all hook
@@ -201,21 +211,20 @@ describe('modular', function () {
     });
 
     it('it should initialize dynamic apps', async function () {
-      const { initializeApp, getApps, getApp } = modular;
+      const { initializeApp, getApps, getApp, deleteApp } = modular;
 
-      const appCount = firebase.apps.length;
+      const appCount = getApps().length;
       const name = `testscoreapp${FirebaseHelpers.id}`;
       const platformAppConfig = FirebaseHelpers.app.config();
       const newApp = await initializeApp(platformAppConfig, name);
       newApp.name.should.equal(name);
-      newApp.toString().should.equal(name);
       newApp.options.apiKey.should.equal(platformAppConfig.apiKey);
 
       const apps = getApps();
 
       should.equal(apps.includes(getApp(name)), true);
       should.equal(apps.length, appCount + 1);
-      return newApp.delete();
+      return deleteApp(newApp);
     });
 
     it('should error if dynamic app initialization values are incorrect', async function () {
@@ -257,8 +266,8 @@ describe('modular', function () {
       } catch (e) {
         e.code.should.containEql('app/unknown');
         e.message.should.containEql('Configuration fails');
-        should.equal(firebase.apps.length, appCount);
-        should.equal(firebase.apps.includes('myname'), false);
+        should.equal(getApps().length, appCount);
+        should.equal(getApps().includes('myname'), false);
       }
     });
 
@@ -270,7 +279,6 @@ describe('modular', function () {
       const newApp = await initializeApp(platformAppConfig, name);
 
       newApp.name.should.equal(name);
-      newApp.toString().should.equal(name);
       newApp.options.apiKey.should.equal(platformAppConfig.apiKey);
 
       await deleteApp(newApp);

--- a/packages/app/e2e/asyncStorage.e2e.js
+++ b/packages/app/e2e/asyncStorage.e2e.js
@@ -16,8 +16,9 @@ describe('firebase.setReactNativeAsyncStorage()', function () {
   });
 
   it('throws if asyncStorage is not an object', function () {
+    const { setReactNativeAsyncStorage } = modular;
     try {
-      firebase.setReactNativeAsyncStorage(123);
+      setReactNativeAsyncStorage(123);
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {
       error.message.should.containEql("'asyncStorage' must be an object");
@@ -26,8 +27,9 @@ describe('firebase.setReactNativeAsyncStorage()', function () {
   });
 
   it('throws if asyncStorage.setItem is not a function', function () {
+    const { setReactNativeAsyncStorage } = modular;
     try {
-      firebase.setReactNativeAsyncStorage({ setItem: 123 });
+      setReactNativeAsyncStorage({ setItem: 123 });
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {
       error.message.should.containEql("'asyncStorage.setItem' must be a function");
@@ -36,8 +38,9 @@ describe('firebase.setReactNativeAsyncStorage()', function () {
   });
 
   it('throws if asyncStorage.getItem is not a function', function () {
+    const { setReactNativeAsyncStorage } = modular;
     try {
-      firebase.setReactNativeAsyncStorage({ setItem: sinon.spy(), getItem: 123 });
+      setReactNativeAsyncStorage({ setItem: sinon.spy(), getItem: 123 });
       return Promise.reject(new Error('Did not throw an Error.'));
     } catch (error) {
       error.message.should.containEql("'asyncStorage.getItem' must be a function");
@@ -46,8 +49,9 @@ describe('firebase.setReactNativeAsyncStorage()', function () {
   });
 
   it('throws if asyncStorage.removeItem is not a function', function () {
+    const { setReactNativeAsyncStorage } = modular;
     try {
-      firebase.setReactNativeAsyncStorage({
+      setReactNativeAsyncStorage({
         setItem: sinon.spy(),
         getItem: sinon.spy(),
         removeItem: 123,
@@ -60,13 +64,14 @@ describe('firebase.setReactNativeAsyncStorage()', function () {
   });
 
   it('sets the async storage instance', async function () {
+    const { setReactNativeAsyncStorage } = modular;
     isMemoryStorage().should.equal(true);
 
     const setItemSpy = sinon.spy();
     const getItemSpy = sinon.spy();
     const removeItemSpy = sinon.spy();
 
-    firebase.setReactNativeAsyncStorage({
+    setReactNativeAsyncStorage({
       setItem: setItemSpy,
       getItem: getItemSpy,
       removeItem: removeItemSpy,
@@ -84,10 +89,11 @@ describe('firebase.setReactNativeAsyncStorage()', function () {
   });
 
   it('works with @react-native-async-storage/async-storage', async function () {
+    const { setReactNativeAsyncStorage } = modular;
     isMemoryStorage().should.equal(true);
     const key = Date.now().toString();
     const value = 'bar';
-    firebase.setReactNativeAsyncStorage(asyncStorage);
+    setReactNativeAsyncStorage(asyncStorage);
     isMemoryStorage().should.equal(false);
 
     // Through our internals,

--- a/packages/app/e2e/config.e2e.js
+++ b/packages/app/e2e/config.e2e.js
@@ -18,7 +18,8 @@
 describe('config', function () {
   describe('meta', function () {
     it('should read Info.plist/AndroidManifest.xml meta data', async function () {
-      const metaData = await NativeModules.RNFBAppModule.metaGetAll();
+      const { metaGetAll } = modular;
+      const metaData = await metaGetAll();
       if (Platform.other) return;
       metaData.rnfirebase_meta_testing_string.should.equal('abc');
       metaData.rnfirebase_meta_testing_boolean_false.should.equal(false);
@@ -28,7 +29,8 @@ describe('config', function () {
 
   describe('json', function () {
     it('should read firebase.json data', async function () {
-      const jsonData = await NativeModules.RNFBAppModule.jsonGetAll();
+      const { jsonGetAll } = modular;
+      const jsonData = await jsonGetAll();
       if (Platform.other) return;
       jsonData.rnfirebase_json_testing_string.should.equal('abc');
       jsonData.rnfirebase_json_testing_boolean_false.should.equal(false);
@@ -38,40 +40,43 @@ describe('config', function () {
 
   describe('prefs', function () {
     beforeEach(async function () {
-      await NativeModules.RNFBAppModule.preferencesClearAll();
+      const { preferencesClearAll } = modular;
+      await preferencesClearAll();
     });
 
     // NOTE: "preferencesClearAll" clears Firestore settings. Set DB as emulator again.
     after(async function () {
+      const { connectFirestoreEmulator, getFirestore } = firestoreModular;
       if (Platform.other) return;
-      await firebase
-        .firestore()
-        .settings({ host: 'localhost:8080', ssl: false, persistence: true });
+      connectFirestoreEmulator(getFirestore(), 'localhost', 8080);
     });
 
     it('should set bool values', async function () {
-      const prefsBefore = await NativeModules.RNFBAppModule.preferencesGetAll();
+      const { preferencesGetAll, preferencesSetBool } = modular;
+      const prefsBefore = await preferencesGetAll();
       should.equal(prefsBefore.invertase_oss, undefined);
-      await NativeModules.RNFBAppModule.preferencesSetBool('invertase_oss', true);
-      const prefsAfter = await NativeModules.RNFBAppModule.preferencesGetAll();
+      await preferencesSetBool('invertase_oss', true);
+      const prefsAfter = await preferencesGetAll();
       prefsAfter.invertase_oss.should.equal(true);
     });
 
     it('should set string values', async function () {
-      const prefsBefore = await NativeModules.RNFBAppModule.preferencesGetAll();
+      const { preferencesGetAll, preferencesSetString } = modular;
+      const prefsBefore = await preferencesGetAll();
       should.equal(prefsBefore.invertase_oss, undefined);
-      await NativeModules.RNFBAppModule.preferencesSetString('invertase_oss', 'invertase.io');
-      const prefsAfter = await NativeModules.RNFBAppModule.preferencesGetAll();
+      await preferencesSetString('invertase_oss', 'invertase.io');
+      const prefsAfter = await preferencesGetAll();
       prefsAfter.invertase_oss.should.equal('invertase.io');
     });
 
     it('should clear all values', async function () {
-      await NativeModules.RNFBAppModule.preferencesSetString('invertase_oss', 'invertase.io');
-      const prefsBefore = await NativeModules.RNFBAppModule.preferencesGetAll();
+      const { preferencesClearAll, preferencesGetAll, preferencesSetString } = modular;
+      await preferencesSetString('invertase_oss', 'invertase.io');
+      const prefsBefore = await preferencesGetAll();
       prefsBefore.invertase_oss.should.equal('invertase.io');
 
-      await NativeModules.RNFBAppModule.preferencesClearAll();
-      const prefsAfter = await NativeModules.RNFBAppModule.preferencesGetAll();
+      await preferencesClearAll();
+      const prefsAfter = await preferencesGetAll();
       should.equal(prefsAfter.invertase_oss, undefined);
     });
   });

--- a/packages/app/e2e/utils.e2e.js
+++ b/packages/app/e2e/utils.e2e.js
@@ -19,34 +19,44 @@ describe('utils()', function () {
   if (Platform.other) return; // Not supported on non-native platforms.
 
   describe('namespace', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('accessible from firebase.app()', function () {
       const app = firebase.app();
       should.exist(app.utils);
       app.utils().app.should.equal(app);
     });
-  });
 
-  describe('isRunningInTestLab', function () {
-    it('returns true or false', function () {
-      should.equal(firebase.utils().isRunningInTestLab, false);
+    describe('isRunningInTestLab', function () {
+      it('returns true or false', function () {
+        should.equal(firebase.utils().isRunningInTestLab, false);
+      });
     });
-  });
 
-  describe('playServicesAvailability', function () {
-    it('returns isAvailable and Play Service status', async function () {
-      const playService = await firebase.utils().playServicesAvailability;
-      //iOS always returns { isAvailable: true, status: 0}
-      should(playService.isAvailable).equal(true);
-      should(playService.status).equal(0);
+    describe('playServicesAvailability', function () {
+      it('returns isAvailable and Play Service status', async function () {
+        const playService = await firebase.utils().playServicesAvailability;
+        //iOS always returns { isAvailable: true, status: 0}
+        should(playService.isAvailable).equal(true);
+        should(playService.status).equal(0);
+      });
     });
-  });
 
-  describe('getPlayServicesStatus', function () {
-    it('returns isAvailable and Play Service status', async function () {
-      const status = await firebase.utils().getPlayServicesStatus();
-      //iOS always returns { isAvailable: true, status: 0}
-      should(status.isAvailable).equal(true);
-      should(status.status).equal(0);
+    describe('getPlayServicesStatus', function () {
+      it('returns isAvailable and Play Service status', async function () {
+        const status = await firebase.utils().getPlayServicesStatus();
+        //iOS always returns { isAvailable: true, status: 0}
+        should(status.isAvailable).equal(true);
+        should(status.status).equal(0);
+      });
     });
   });
 });

--- a/packages/app/lib/FirebaseApp.js
+++ b/packages/app/lib/FirebaseApp.js
@@ -73,7 +73,7 @@ export default class FirebaseApp {
   }
 
   toString() {
-    warnIfNotModularCall(arguments);
+    warnIfNotModularCall(arguments, '.name property');
     return this.name;
   }
 }

--- a/packages/app/lib/modular/index.d.ts
+++ b/packages/app/lib/modular/index.d.ts
@@ -72,6 +72,46 @@ export function getApp(name?: string): FirebaseApp;
 export function setLogLevel(logLevel: LogLevelString): void;
 
 /**
+ * Gets react-native-firebase specific "meta" data from native Info.plist / AndroidManifest.xml
+ * @returns map of key / value pairs containing native meta data
+ */
+export function metaGetAll(): Promise<{ [keyof: string]: string | boolean }>;
+
+/**
+ * Gets react-native-firebase specific "firebase.json" data
+ * @returns map of key / value pairs containing native firebase.json constants
+ */
+export function jsonGetAll(): Promise<{ [keyof: string]: string | boolean }>;
+
+/**
+ * Clears react-native-firebase specific native preferences
+ * @returns Promise<void>
+ */
+export function preferencesClearAll(): Promise<void>;
+
+/**
+ * Gets react-native-firebase specific native preferences
+ * @returns map of key / value pairs containing native preferences data
+ */
+export function preferencesGetAll(): Promise<{ [keyof: string]: string | boolean }>;
+
+/**
+ * Sets react-native-firebase specific native boolean preference
+ * @param key the name of the native preference to set
+ * @param value the value of the native preference to set
+ * @returns Promise<void>
+ */
+export function preferencesSetBool(key: string, value: boolean): Promise<void>;
+
+/**
+ * Sets react-native-firebase specific native string preference
+ * @param key the name of the native preference to set
+ * @param value the value of the native preference to set
+ * @returns Promise<void>
+ */
+export function preferencesSetString(key: string, value: string): Promise<void>;
+
+/**
  * The `AsyncStorage` implementation to use for persisting data on 'Other' platforms.
  * If not specified, in memory persistence is used.
  *

--- a/packages/app/lib/modular/index.js
+++ b/packages/app/lib/modular/index.js
@@ -95,4 +95,56 @@ export function setReactNativeAsyncStorage(asyncStorage) {
   return setReactNativeAsyncStorageCompat.call(null, asyncStorage, MODULAR_DEPRECATION_ARG);
 }
 
+/**
+ * Gets react-native-firebase specific "meta" data from native Info.plist / AndroidManifest.xml
+ * @returns map of key / value pairs containing native meta data
+ */
+export function metaGetAll() {
+  return NativeModules.RNFBAppModule.metaGetAll();
+}
+
+/**
+ * Gets react-native-firebase specific "firebase.json" data
+ * @returns map of key / value pairs containing native firebase.json constants
+ */
+export function jsonGetAll() {
+  return NativeModules.RNFBAppModule.jsonGetAll();
+}
+
+/**
+ * Clears react-native-firebase specific native preferences
+ * @returns Promise<void>
+ */
+export function preferencesClearAll() {
+  return NativeModules.RNFBAppModule.preferencesClearAll();
+}
+
+/**
+ * Gets react-native-firebase specific native preferences
+ * @returns map of key / value pairs containing native preferences data
+ */
+export function preferencesGetAll() {
+  return NativeModules.RNFBAppModule.preferencesGetAll();
+}
+
+/**
+ * Sets react-native-firebase specific native boolean preference
+ * @param key the name of the native preference to set
+ * @param value the value of the native preference to set
+ * @returns Promise<void>
+ */
+export function preferencesSetBool(key, value) {
+  return NativeModules.RNFBAppModule.preferencesSetBool(key, value);
+}
+
+/**
+ * Sets react-native-firebase specific native string preference
+ * @param key the name of the native preference to set
+ * @param value the value of the native preference to set
+ * @returns Promise<void>
+ */
+export function preferencesSetString(key, value) {
+  return NativeModules.RNFBAppModule.preferencesSetString(key, value);
+}
+
 export const SDK_VERSION = sdkVersion;

--- a/packages/auth/e2e/phone.e2e.js
+++ b/packages/auth/e2e/phone.e2e.js
@@ -11,20 +11,30 @@ describe('auth() => Phone', function () {
 
   describe('firebase v8 compatibility', function () {
     before(async function () {
+      const { getApp } = modular;
+      const { getAuth } = authModular;
       try {
         await clearAllUsers();
       } catch (e) {
         throw e;
       }
-      firebase.auth().settings.appVerificationDisabledForTesting = true;
+      getAuth(getApp()).settings.appVerificationDisabledForTesting = true;
       await Utils.sleep(50);
     });
 
-    beforeEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+
       if (firebase.auth().currentUser) {
         await firebase.auth().signOut();
         await Utils.sleep(50);
       }
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     describe('signInWithPhoneNumber', function () {
@@ -189,10 +199,9 @@ describe('auth() => Phone', function () {
 
   describe('modular', function () {
     before(async function () {
+      const { getApp } = modular;
       const { getAuth } = authModular;
-
-      const defaultApp = firebase.app();
-      const defaultAuth = getAuth(defaultApp);
+      const defaultAuth = getAuth(getApp());
 
       try {
         await clearAllUsers();
@@ -204,10 +213,9 @@ describe('auth() => Phone', function () {
     });
 
     beforeEach(async function () {
+      const { getApp } = modular;
       const { getAuth, signOut } = authModular;
-
-      const defaultApp = firebase.app();
-      const defaultAuth = getAuth(defaultApp);
+      const defaultAuth = getAuth(getApp());
 
       if (defaultAuth.currentUser) {
         await signOut(defaultAuth);
@@ -217,10 +225,10 @@ describe('auth() => Phone', function () {
 
     describe('signInWithPhoneNumber', function () {
       it('signs in with a valid code', async function () {
+        const { getApp } = modular;
         const { getAuth, signInWithPhoneNumber } = authModular;
 
-        const defaultApp = firebase.app();
-        const defaultAuth = getAuth(defaultApp);
+        const defaultAuth = getAuth(getApp());
 
         const testPhone = getRandomPhoneNumber();
         const confirmResult = await signInWithPhoneNumber(defaultAuth, testPhone);
@@ -238,10 +246,10 @@ describe('auth() => Phone', function () {
       });
 
       it('errors on invalid code', async function () {
+        const { getApp } = modular;
         const { getAuth, signInWithPhoneNumber } = authModular;
 
-        const defaultApp = firebase.app();
-        const defaultAuth = getAuth(defaultApp);
+        const defaultAuth = getAuth(getApp());
 
         const testPhone = getRandomPhoneNumber();
         const confirmResult = await signInWithPhoneNumber(defaultAuth, testPhone);

--- a/packages/auth/e2e/provider.e2e.js
+++ b/packages/auth/e2e/provider.e2e.js
@@ -1,10 +1,18 @@
 describe('auth() -> Providers', function () {
   describe('firebase v8 compatibility', function () {
-    beforeEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+
       if (firebase.auth().currentUser) {
         await firebase.auth().signOut();
         await Utils.sleep(50);
       }
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     describe('EmailAuthProvider', function () {
@@ -263,9 +271,10 @@ describe('auth() -> Providers', function () {
 
   describe('modular', function () {
     beforeEach(async function () {
+      const { getApp } = modular;
       const { signOut, getAuth } = authModular;
 
-      const defaultApp = firebase.app();
+      const defaultApp = getApp();
       const defaultAuth = getAuth(defaultApp);
 
       if (defaultAuth.currentUser) {

--- a/packages/auth/e2e/user.e2e.js
+++ b/packages/auth/e2e/user.e2e.js
@@ -12,24 +12,25 @@ const {
 describe('auth().currentUser', function () {
   describe('firebase v8 compatibility', function () {
     before(async function () {
-      try {
-        await clearAllUsers();
-      } catch (e) {
-        throw e;
-      }
-      firebase.auth().settings.appVerificationDisabledForTesting = true;
-      try {
-        await firebase.auth().createUserWithEmailAndPassword(TEST_EMAIL, TEST_PASS);
-      } catch (_) {
-        // they may already exist, that's fine
-      }
+      const { getAuth, createUserWithEmailAndPassword } = authModular;
+      await clearAllUsers();
+      getAuth().settings.appVerificationDisabledForTesting = true;
+      await createUserWithEmailAndPassword(getAuth(), TEST_EMAIL, TEST_PASS);
     });
 
-    beforeEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+
       if (firebase.auth().currentUser) {
         await firebase.auth().signOut();
         await Utils.sleep(50);
       }
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     describe('getIdToken()', function () {

--- a/packages/auth/lib/modular/index.js
+++ b/packages/auth/lib/modular/index.js
@@ -19,6 +19,7 @@ import { getApp } from '@react-native-firebase/app';
 import { fetchPasswordPolicy } from '../password-policy/passwordPolicyApi';
 import { PasswordPolicyImpl } from '../password-policy/PasswordPolicyImpl';
 import FacebookAuthProvider from '../providers/FacebookAuthProvider';
+import { MultiFactorUser } from '../multiFactor';
 export { FacebookAuthProvider };
 
 /**
@@ -462,7 +463,7 @@ export async function linkWithRedirect(user, provider, resolver) {
  * @returns {MultiFactorUser}
  */
 export function multiFactor(user) {
-  return user._auth.multiFactor(user);
+  return new MultiFactorUser(getAuth(), user);
 }
 
 /**

--- a/packages/database/e2e/DatabaseStatics.e2e.js
+++ b/packages/database/e2e/DatabaseStatics.e2e.js
@@ -21,6 +21,16 @@ const TEST_PATH = `${PATH}/statics`;
 
 describe('database.X', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     after(function () {
       return wipe(TEST_PATH);
     });

--- a/packages/database/e2e/database.e2e.js
+++ b/packages/database/e2e/database.e2e.js
@@ -17,6 +17,16 @@
 
 describe('database()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('namespace', function () {
       it('accessible from firebase.app()', function () {
         const app = firebase.app();
@@ -204,24 +214,22 @@ describe('database()', function () {
   describe('modular', function () {
     describe('namespace', function () {
       it('accessible from getDatabase', function () {
+        const { getApp } = modular;
         const { getDatabase } = databaseModular;
 
-        const app = firebase.app();
-        const database = getDatabase(app);
-        should.exist(app.database);
-        database.app.should.eql(app);
+        const database = getDatabase(getApp());
+        database.app.should.eql(getApp());
       });
 
       it('supports multiple apps', async function () {
+        const { getApp } = modular;
         const { getDatabase } = databaseModular;
         const database = getDatabase();
-        const secondaryDatabase = getDatabase(firebase.app('secondaryFromNative'));
+        const secondaryDatabase = getDatabase(getApp('secondaryFromNative'));
 
         database.app.name.should.eql('[DEFAULT]');
 
         secondaryDatabase.app.name.should.eql('secondaryFromNative');
-
-        firebase.app('secondaryFromNative').database().app.name.should.eql('secondaryFromNative');
       });
     });
 

--- a/packages/database/e2e/helpers.js
+++ b/packages/database/e2e/helpers.js
@@ -52,9 +52,10 @@ const CONTENT = {
 };
 
 exports.seed = function seed(path) {
+  const { getDatabase, ref } = databaseModular;
   return Promise.all([
-    firebase.database().ref(`${path}/types`).set(CONTENT.TYPES),
-    firebase.database().ref(`${path}/query`).set(CONTENT.QUERY),
+    ref(getDatabase(), `${path}/types`).set(CONTENT.TYPES),
+    ref(getDatabase(), `${path}/query`).set(CONTENT.QUERY),
     // The database emulator does not load rules correctly. We force them pre-test.
     // TODO(ehesp): This is current erroring - however without it, we can't test rules.
     testingUtils.initializeTestEnvironment({
@@ -70,7 +71,8 @@ exports.seed = function seed(path) {
 };
 
 exports.wipe = function wipe(path) {
-  return firebase.database().ref(path).remove();
+  const { getDatabase, ref } = databaseModular;
+  return ref(getDatabase(), path).remove();
 };
 
 exports.PATH = PATH;

--- a/packages/database/e2e/internal/connected.e2e.js
+++ b/packages/database/e2e/internal/connected.e2e.js
@@ -19,13 +19,19 @@ const { PATH } = require('../helpers');
 const TEST_PATH = `${PATH}/connected`;
 
 describe("database().ref('.info/connected')", function () {
-  before(async function () {
-    await firebase.database().goOnline();
-  });
-
   describe('v8 compatibility', function () {
-    after(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
       await firebase.database().goOnline();
+    });
+
+    afterEach(async function afterEachTest() {
+      // Ensures the db is online before running each test
+      await firebase.database().goOnline();
+
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     xit('returns true when used with once', async function () {
@@ -61,6 +67,12 @@ describe("database().ref('.info/connected')", function () {
   });
 
   describe('modular', function () {
+    before(async function () {
+      const { getDatabase, goOnline } = databaseModular;
+
+      await goOnline(getDatabase());
+    });
+
     after(async function () {
       const { getDatabase, goOnline } = databaseModular;
 

--- a/packages/database/e2e/internal/serverTimeOffset.e2e.js
+++ b/packages/database/e2e/internal/serverTimeOffset.e2e.js
@@ -17,6 +17,16 @@
 
 describe("database().ref('.info/serverTimeOffset')", function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns a valid number value', async function () {
       const snapshot = await firebase.database().ref('.info/serverTimeOffset').once('value');
 

--- a/packages/database/e2e/issues.e2e.js
+++ b/packages/database/e2e/issues.e2e.js
@@ -29,6 +29,16 @@ describe('database issues', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     // FIXME requires a second database set up locally, full app initialization etc
     xit('#2813 should return a null snapshot key if path is root', async function () {
       firebase.database('https://react-native-firebase-testing-db2.firebaseio.com');

--- a/packages/database/e2e/onDisconnect/cancel.e2e.js
+++ b/packages/database/e2e/onDisconnect/cancel.e2e.js
@@ -25,9 +25,17 @@ describe('database().ref().onDisconnect().cancel()', function () {
   });
 
   describe('v8 compatibility', function () {
-    afterEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
       // Ensures the db is online before running each test
       await firebase.database().goOnline();
+
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     it('throws if onComplete is not a function', function () {

--- a/packages/database/e2e/onDisconnect/remove.e2e.js
+++ b/packages/database/e2e/onDisconnect/remove.e2e.js
@@ -25,9 +25,17 @@ describe('database().ref().onDisconnect().remove()', function () {
   });
 
   describe('v8 compatibility', function () {
-    afterEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
       // Ensures the db is online before running each test
       await firebase.database().goOnline();
+
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     it('throws if onComplete is not a function', function () {

--- a/packages/database/e2e/onDisconnect/set.e2e.js
+++ b/packages/database/e2e/onDisconnect/set.e2e.js
@@ -25,9 +25,17 @@ describe('database().ref().onDisconnect().set()', function () {
   });
 
   describe('v8 compatibility', function () {
-    afterEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
       // Ensures the db is online before running each test
       await firebase.database().goOnline();
+
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     it('throws if value is not a defined', function () {

--- a/packages/database/e2e/onDisconnect/setWithPriority.e2e.js
+++ b/packages/database/e2e/onDisconnect/setWithPriority.e2e.js
@@ -25,9 +25,17 @@ describe('database().ref().onDisconnect().setWithPriority()', function () {
   });
 
   describe('v8 compatibility', function () {
-    afterEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
       // Ensures the db is online before running each test
       await firebase.database().goOnline();
+
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     it('throws if value is not a defined', function () {

--- a/packages/database/e2e/onDisconnect/update.e2e.js
+++ b/packages/database/e2e/onDisconnect/update.e2e.js
@@ -25,9 +25,17 @@ describe('database().ref().onDisconnect().update()', function () {
   });
 
   describe('v8 compatibility', function () {
-    afterEach(async function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
       // Ensures the db is online before running each test
       await firebase.database().goOnline();
+
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
     });
 
     it('throws if values is not an object', async function () {

--- a/packages/database/e2e/query/endAt.e2e.js
+++ b/packages/database/e2e/query/endAt.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().endAt()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if an value is undefined', async function () {
       try {
         await firebase.database().ref().endAt();

--- a/packages/database/e2e/query/equalTo.e2e.js
+++ b/packages/database/e2e/query/equalTo.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().equalTo()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if value is not a valid type', async function () {
       try {
         await firebase.database().ref().equalTo({ foo: 'bar' });

--- a/packages/database/e2e/query/isEqual.e2e.js
+++ b/packages/database/e2e/query/isEqual.e2e.js
@@ -16,6 +16,16 @@
  */
 
 describe('database().ref().isEqual()', function () {
+  beforeEach(async function beforeEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+  });
+
+  afterEach(async function afterEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+  });
+
   it('throws if limit other param is not a query instance', async function () {
     try {
       await firebase.database().ref().isEqual('foo');

--- a/packages/database/e2e/query/keepSynced.e2e.js
+++ b/packages/database/e2e/query/keepSynced.e2e.js
@@ -17,6 +17,16 @@
 
 describe('database().ref().keepSynced()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if bool is not a valid type', async function () {
       try {
         await firebase.database().ref().keepSynced('foo');

--- a/packages/database/e2e/query/limitToFirst.e2e.js
+++ b/packages/database/e2e/query/limitToFirst.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().limitToFirst()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if limit is invalid', async function () {
       try {
         await firebase.database().ref().limitToFirst('foo');

--- a/packages/database/e2e/query/limitToLast.e2e.js
+++ b/packages/database/e2e/query/limitToLast.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().limitToLast()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if limit is invalid', async function () {
       try {
         await firebase.database().ref().limitToLast('foo');

--- a/packages/database/e2e/query/on.e2e.js
+++ b/packages/database/e2e/query/on.e2e.js
@@ -28,6 +28,16 @@ describe('database().ref().on()', function () {
     await wipe(TEST_PATH);
   });
 
+  beforeEach(async function beforeEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+  });
+
+  afterEach(async function afterEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+  });
+
   it('throws if event type is invalid', async function () {
     try {
       await firebase.database().ref().on('foo');

--- a/packages/database/e2e/query/once.e2e.js
+++ b/packages/database/e2e/query/once.e2e.js
@@ -28,6 +28,16 @@ describe('database().ref().once()', function () {
     return wipe(TEST_PATH);
   });
 
+  beforeEach(async function beforeEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+  });
+
+  afterEach(async function afterEachTest() {
+    // @ts-ignore
+    globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+  });
+
   it('throws if event type is invalid', async function () {
     try {
       await firebase.database().ref().once('foo');

--- a/packages/database/e2e/query/orderByChild.e2e.js
+++ b/packages/database/e2e/query/orderByChild.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().orderByChild()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if path is not a string value', async function () {
       try {
         await firebase.database().ref().orderByChild({ foo: 'bar' });

--- a/packages/database/e2e/query/orderByKey.e2e.js
+++ b/packages/database/e2e/query/orderByKey.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().orderByKey()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if an orderBy call has already been set', async function () {
       try {
         await firebase.database().ref().orderByChild('foo').orderByKey();

--- a/packages/database/e2e/query/orderByPriority.e2e.js
+++ b/packages/database/e2e/query/orderByPriority.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().orderByPriority()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if an orderBy call has already been set', async function () {
       try {
         await firebase.database().ref().orderByChild('foo').orderByPriority();

--- a/packages/database/e2e/query/orderByValue.e2e.js
+++ b/packages/database/e2e/query/orderByValue.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().orderByValue()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if an orderBy call has already been set', async function () {
       try {
         await firebase.database().ref().orderByChild('foo').orderByValue();

--- a/packages/database/e2e/query/query.e2e.js
+++ b/packages/database/e2e/query/query.e2e.js
@@ -16,6 +16,16 @@
 
 describe('DatabaseQuery/DatabaseQueryModifiers', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('should not mutate previous queries (#2691)', async function () {
       const queryBefore = firebase.database().ref();
       queryBefore._modifiers._modifiers.length.should.equal(0);

--- a/packages/database/e2e/query/startAt.e2e.js
+++ b/packages/database/e2e/query/startAt.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().startAt()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if an value is undefined', async function () {
       try {
         await firebase.database().ref().startAt();

--- a/packages/database/e2e/query/toJSON.e2e.js
+++ b/packages/database/e2e/query/toJSON.e2e.js
@@ -17,6 +17,16 @@
 
 describe('database().ref().toJSON()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns a string version of the current query path', async function () {
       const res = firebase.database().ref('foo/bar/baz').toJSON();
       const expected = `${firebase.database()._customUrlOrRegion}/foo/bar/baz`;

--- a/packages/database/e2e/reference/child.e2e.js
+++ b/packages/database/e2e/reference/child.e2e.js
@@ -17,6 +17,16 @@
 
 describe('database().ref().child()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if path is not a string', async function () {
       try {
         firebase.database().ref().child({ foo: 'bar' });

--- a/packages/database/e2e/reference/key.e2e.js
+++ b/packages/database/e2e/reference/key.e2e.js
@@ -17,6 +17,16 @@
 
 describe('database().ref().key', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns null when no reference path is provides', function () {
       const ref = firebase.database().ref();
       should.equal(ref.key, null);

--- a/packages/database/e2e/reference/onDisconnect.e2e.js
+++ b/packages/database/e2e/reference/onDisconnect.e2e.js
@@ -19,6 +19,16 @@
 
 describe('database().ref().onDisconnect()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns a new DatabaseOnDisconnect instance', function () {
       const instance = firebase.database().ref().onDisconnect();
       instance.constructor.name.should.eql('DatabaseOnDisconnect');

--- a/packages/database/e2e/reference/parent.e2e.js
+++ b/packages/database/e2e/reference/parent.e2e.js
@@ -17,6 +17,16 @@
 
 describe('database().ref().parent', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns null when no reference path is provides', function () {
       const ref = firebase.database().ref();
       should.equal(ref.parent, null);

--- a/packages/database/e2e/reference/push.e2e.js
+++ b/packages/database/e2e/reference/push.e2e.js
@@ -21,6 +21,16 @@ const TEST_PATH = `${PATH}/push`;
 
 describe('database().ref().push()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if on complete callback is not a function', function () {
       try {
         firebase.database().ref(TEST_PATH).push('foo', 'bar');

--- a/packages/database/e2e/reference/remove.e2e.js
+++ b/packages/database/e2e/reference/remove.e2e.js
@@ -21,6 +21,16 @@ const TEST_PATH = `${PATH}/remove`;
 
 describe('database().ref().remove()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if onComplete is not a function', async function () {
       try {
         await firebase.database().ref(TEST_PATH).remove('foo');

--- a/packages/database/e2e/reference/root.e2e.js
+++ b/packages/database/e2e/reference/root.e2e.js
@@ -17,6 +17,16 @@
 
 describe('database().ref().root', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns a root reference', function () {
       const ref = firebase.database().ref('foo/bar/baz');
       should.equal(ref.root.key, null);

--- a/packages/database/e2e/reference/set.e2e.js
+++ b/packages/database/e2e/reference/set.e2e.js
@@ -29,6 +29,16 @@ describe('set', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no value is provided', async function () {
       try {
         await firebase.database().ref(TEST_PATH).set();

--- a/packages/database/e2e/reference/setPriority.e2e.js
+++ b/packages/database/e2e/reference/setPriority.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().setPriority()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if priority is not a valid type', async function () {
       try {
         await firebase.database().ref().setPriority({});

--- a/packages/database/e2e/reference/setWithPriority.e2e.js
+++ b/packages/database/e2e/reference/setWithPriority.e2e.js
@@ -29,6 +29,16 @@ describe('database().ref().setWithPriority()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if newVal is not defined', async function () {
       try {
         await firebase.database().ref().setWithPriority();

--- a/packages/database/e2e/reference/transaction.e2e.js
+++ b/packages/database/e2e/reference/transaction.e2e.js
@@ -30,6 +30,16 @@ describe('database().ref().transaction()', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if no transactionUpdate is provided', async function () {
       try {
         await firebase.database().ref(TEST_PATH).transaction();

--- a/packages/database/e2e/reference/update.e2e.js
+++ b/packages/database/e2e/reference/update.e2e.js
@@ -21,10 +21,21 @@ const TEST_PATH = `${PATH}/update`;
 
 describe('database().ref().update()', function () {
   after(async function () {
-    await firebase.database().ref(TEST_PATH).remove();
+    const { getDatabase, ref } = databaseModular;
+    await ref(getDatabase(), TEST_PATH).remove();
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if values is not an object', async function () {
       try {
         await firebase.database().ref(TEST_PATH).update('foo');

--- a/packages/database/e2e/snapshot/snapshot.e2e.js
+++ b/packages/database/e2e/snapshot/snapshot.e2e.js
@@ -29,6 +29,16 @@ describe('database()...snapshot', function () {
   });
 
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('returns the snapshot key', async function () {
       const snapshot = await firebase
         .database()

--- a/packages/dynamic-links/e2e/builder.analytics.e2e.js
+++ b/packages/dynamic-links/e2e/builder.analytics.e2e.js
@@ -19,6 +19,16 @@ const { baseParams } = require('./dynamicLinks.e2e');
 
 describe('dynamicLinks() dynamicLinkParams.analytics', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if analytics is not an object', function () {
       try {
         firebase.dynamicLinks().buildLink({

--- a/packages/dynamic-links/e2e/builder.android.e2e.js
+++ b/packages/dynamic-links/e2e/builder.android.e2e.js
@@ -19,6 +19,16 @@ const { baseParams } = require('./dynamicLinks.e2e');
 
 describe('dynamicLinks() dynamicLinkParams.android', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if android is not an object', function () {
       try {
         firebase.dynamicLinks().buildLink({

--- a/packages/dynamic-links/e2e/builder.e2e.js
+++ b/packages/dynamic-links/e2e/builder.e2e.js
@@ -17,6 +17,16 @@
 
 describe('dynamicLinks() dynamicLinkParams', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if params are not an object', function () {
       try {
         firebase.dynamicLinks().buildLink(123);

--- a/packages/dynamic-links/e2e/builder.ios.e2e.js
+++ b/packages/dynamic-links/e2e/builder.ios.e2e.js
@@ -19,6 +19,16 @@ const { baseParams } = require('./dynamicLinks.e2e');
 
 describe('dynamicLinks() dynamicLinkParams.ios', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if ios is not an object', function () {
       try {
         firebase.dynamicLinks().buildLink({

--- a/packages/dynamic-links/e2e/builder.itunes.e2e.js
+++ b/packages/dynamic-links/e2e/builder.itunes.e2e.js
@@ -19,6 +19,16 @@ const { baseParams } = require('./dynamicLinks.e2e');
 
 describe('dynamicLinks() dynamicLinkParams.itunes', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if itunes is not an object', function () {
       try {
         firebase.dynamicLinks().buildLink({

--- a/packages/dynamic-links/e2e/builder.navigation.e2e.js
+++ b/packages/dynamic-links/e2e/builder.navigation.e2e.js
@@ -19,6 +19,16 @@ const { baseParams } = require('./dynamicLinks.e2e');
 
 describe('dynamicLinks() dynamicLinkParams.navigation', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if navigation is not an object', function () {
       try {
         firebase.dynamicLinks().buildLink({

--- a/packages/dynamic-links/e2e/builder.otherplatform.e2e.js
+++ b/packages/dynamic-links/e2e/builder.otherplatform.e2e.js
@@ -2,6 +2,16 @@ const { baseParams } = require('./dynamicLinks.e2e');
 
 describe('dynamicLinks() dynamicLinkParams.otherPlatform', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if otherPlatform is not an object', function () {
       try {
         firebase.dynamicLinks().buildLink({

--- a/packages/dynamic-links/e2e/builder.social.e2e.js
+++ b/packages/dynamic-links/e2e/builder.social.e2e.js
@@ -19,6 +19,16 @@ const { baseParams } = require('./dynamicLinks.e2e');
 
 describe('dynamicLinks() dynamicLinkParams.social', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     it('throws if social is not an object', function () {
       try {
         firebase.dynamicLinks().buildLink({

--- a/packages/dynamic-links/e2e/dynamicLinks.e2e.js
+++ b/packages/dynamic-links/e2e/dynamicLinks.e2e.js
@@ -61,6 +61,16 @@ module.exports.baseParams = baseParams;
 
 describe('dynamicLinks()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('namespace', function () {
       it('accessible from firebase.app()', function () {
         const app = firebase.app();

--- a/packages/functions/e2e/functions.e2e.js
+++ b/packages/functions/e2e/functions.e2e.js
@@ -90,6 +90,16 @@ const SAMPLE_DATA = {
 
 describe('functions() modular', function () {
   describe('firebase v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('namespace', function () {
       it('accepts passing in an FirebaseApp instance as first arg', async function () {
         const appName = `functionsApp${FirebaseHelpers.id}2`;
@@ -407,27 +417,25 @@ describe('functions() modular', function () {
   describe('modular', function () {
     describe('getFunctions', function () {
       it('pass app as argument', function () {
+        const { getApp } = modular;
         const { getFunctions } = functionsModular;
-
-        const functions = getFunctions(firebase.app());
-
+        const functions = getFunctions(getApp());
         functions.constructor.name.should.be.equal('FirebaseFunctionsModule');
       });
 
       it('no app as argument', function () {
         const { getFunctions } = functionsModular;
-
         const functions = getFunctions();
-
         functions.constructor.name.should.be.equal('FirebaseFunctionsModule');
       });
     });
 
     it('accepts passing in an FirebaseApp instance as first arg', async function () {
+      const { initializeApp } = modular;
       const { getFunctions } = functionsModular;
       const appName = `functionsApp${FirebaseHelpers.id}3`;
       const platformAppConfig = FirebaseHelpers.app.config();
-      const app = await firebase.initializeApp(platformAppConfig, appName);
+      const app = await initializeApp(platformAppConfig, appName);
       const functions = getFunctions(app);
 
       functions.app.should.equal(app);
@@ -439,18 +447,19 @@ describe('functions() modular', function () {
     });
 
     it('accepts passing in a region string as first arg to an app', async function () {
+      const { getApp } = modular;
       const { getFunctions } = functionsModular;
       const region = 'europe-west1';
 
-      const functionsForRegion = getFunctions(firebase.app(), region);
+      const functionsForRegion = getFunctions(getApp(), region);
 
       functionsForRegion._customUrlOrRegion.should.equal(region);
-      functionsForRegion.app.should.equal(firebase.app());
-      functionsForRegion.app.name.should.equal(firebase.app().name);
+      functionsForRegion.app.should.equal(getApp());
+      functionsForRegion.app.name.should.equal(getApp().name);
 
-      firebase.app().functions(region).app.should.equal(firebase.app());
+      getApp().functions(region).app.should.equal(getApp());
 
-      firebase.app().functions(region)._customUrlOrRegion.should.equal(region);
+      getApp().functions(region)._customUrlOrRegion.should.equal(region);
 
       const functionRunner = functionsForRegion.httpsCallable('testFunctionCustomRegion');
 
@@ -459,16 +468,17 @@ describe('functions() modular', function () {
     });
 
     it('accepts passing in a custom url string as first arg to an app', async function () {
+      const { getApp } = modular;
       const { getFunctions } = functionsModular;
       const customUrl = 'https://us-central1-react-native-firebase-testing.cloudfunctions.net';
 
-      const functionsForCustomUrl = getFunctions(firebase.app(), customUrl);
+      const functionsForCustomUrl = getFunctions(getApp(), customUrl);
 
       functionsForCustomUrl._customUrlOrRegion.should.equal(customUrl);
-      functionsForCustomUrl.app.should.equal(firebase.app());
-      functionsForCustomUrl.app.name.should.equal(firebase.app().name);
+      functionsForCustomUrl.app.should.equal(getApp());
+      functionsForCustomUrl.app.name.should.equal(getApp().name);
 
-      functionsForCustomUrl.app.should.equal(firebase.app());
+      functionsForCustomUrl.app.should.equal(getApp());
 
       functionsForCustomUrl._customUrlOrRegion.should.equal(customUrl);
 
@@ -480,21 +490,23 @@ describe('functions() modular', function () {
 
     describe('emulator', function () {
       it('configures functions emulator via deprecated method with no port', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable, connectFunctionsEmulator } = functionsModular;
         const region = 'us-central1';
         const fnName = 'helloWorldV2';
         // const functions = firebase.app().functions(region);
-        const functions = getFunctions(firebase.app(), region);
+        const functions = getFunctions(getApp(), region);
         connectFunctionsEmulator(functions, 'localhost', 5001);
         const response = await httpsCallable(functions, fnName)();
         response.data.should.equal('Hello from Firebase!');
       });
 
       it('configures functions emulator via deprecated method with port', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable, connectFunctionsEmulator } = functionsModular;
         const region = 'us-central1';
         const fnName = 'helloWorldV2';
-        const functions = getFunctions(firebase.app(), region);
+        const functions = getFunctions(getApp(), region);
         connectFunctionsEmulator(functions, 'localhost', 5001);
         const response = await httpsCallable(functions, fnName)();
         response.data.should.equal('Hello from Firebase!');
@@ -503,13 +515,14 @@ describe('functions() modular', function () {
 
     describe('httpsCallableFromUrl()', function () {
       it('Calls a function by URL', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallableFromUrl } = functionsModular;
 
         let hostname = 'localhost';
         if (Platform.android) {
           hostname = '10.0.2.2';
         }
-        const functions = getFunctions(firebase.app());
+        const functions = getFunctions(getApp());
         const functionRunner = httpsCallableFromUrl(
           functions,
           `http://${hostname}:5001/react-native-firebase-testing/us-central1/helloWorldV2`,
@@ -521,73 +534,59 @@ describe('functions() modular', function () {
 
     describe('httpsCallable(fnName)(args)', function () {
       it('accepts primitive args: undefined', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const response = await functionRunner();
         response.data.should.equal('null');
       });
 
       it('accepts primitive args: string', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const response = await functionRunner('hello');
         response.data.should.equal('string');
       });
 
       it('accepts primitive args: number', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const response = await functionRunner(123);
         response.data.should.equal('number');
       });
 
       it('accepts primitive args: boolean', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const response = await functionRunner(true);
         response.data.should.equal('boolean');
       });
 
       it('accepts primitive args: null', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const response = await functionRunner(null);
         response.data.should.equal('null');
       });
 
       it('accepts array args', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const response = await functionRunner([1, 2, 3, 4]);
         response.data.should.equal('array');
       });
 
       it('accepts object args', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
         const type = 'object';
         const inputData = SAMPLE_DATA[type];
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const { data: outputData } = await functionRunner({
           type,
           inputData,
@@ -596,13 +595,11 @@ describe('functions() modular', function () {
       });
 
       it('accepts complex nested objects', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
         const type = 'deepObject';
         const inputData = SAMPLE_DATA[type];
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const { data: outputData } = await functionRunner({
           type,
           inputData,
@@ -611,13 +608,11 @@ describe('functions() modular', function () {
       });
 
       it('accepts complex nested arrays', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
         const type = 'deepArray';
         const inputData = SAMPLE_DATA[type];
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         const { data: outputData } = await functionRunner({
           type,
           inputData,
@@ -628,11 +623,9 @@ describe('functions() modular', function () {
 
     describe('HttpsError', function () {
       it('errors return instance of HttpsError', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
 
         try {
           await functionRunner({});
@@ -649,11 +642,9 @@ describe('functions() modular', function () {
       it('HttpsError.details -> allows returning complex data', async function () {
         let type = 'deepObject';
         let inputData = SAMPLE_DATA[type];
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         try {
           await functionRunner({
             type,
@@ -690,13 +681,11 @@ describe('functions() modular', function () {
       });
 
       it('HttpsError.details -> allows returning primitives', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
         let type = 'number';
         let inputData = SAMPLE_DATA[type];
-        const functionRunner = httpsCallable(
-          getFunctions(firebase.app()),
-          'testFunctionDefaultRegionV2',
-        );
+        const functionRunner = httpsCallable(getFunctions(getApp()), 'testFunctionDefaultRegionV2');
         try {
           await functionRunner({
             type,
@@ -767,8 +756,9 @@ describe('functions() modular', function () {
       });
 
       it('HttpsCallableOptions.timeout will error when timeout is exceeded', async function () {
+        const { getApp } = modular;
         const { getFunctions, httpsCallable } = functionsModular;
-        const functions = getFunctions(firebase.app());
+        const functions = getFunctions(getApp());
         const functionRunner = httpsCallable(functions, 'sleeperV2', { timeout: 1000 });
 
         try {

--- a/packages/installations/e2e/installations.e2e.js
+++ b/packages/installations/e2e/installations.e2e.js
@@ -62,6 +62,16 @@ const PROJECT_ID = 448618578101; // this is "magic", it's the react-native-fireb
 
 describe('installations() modular', function () {
   describe('firebase v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('getId()', function () {
       it('returns a valid installation id', async function () {
         const id = await firebase.installations().getId();

--- a/packages/ml/e2e/ml.e2e.js
+++ b/packages/ml/e2e/ml.e2e.js
@@ -17,6 +17,16 @@
 
 describe('ml()', function () {
   describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('namespace', function () {
       it('accessible from firebase.app()', function () {
         const app = firebase.app();
@@ -38,9 +48,10 @@ describe('ml()', function () {
 
   describe('modular', function () {
     it('supports multiple apps', function () {
+      const { getApp } = modular;
       const { getML } = mlModular;
       const ml = getML();
-      const secondaryML = getML(firebase.app('secondaryFromNative'));
+      const secondaryML = getML(getApp('secondaryFromNative'));
 
       ml.app.name.should.equal('[DEFAULT]');
 

--- a/packages/ml/lib/modular/index.js
+++ b/packages/ml/lib/modular/index.js
@@ -11,7 +11,7 @@ import { getApp } from '@react-native-firebase/app';
  */
 export function getML(app) {
   if (app) {
-    return getApp(app).ml();
+    return getApp(app.name).ml();
   }
   return getApp().ml();
 }

--- a/packages/perf/e2e/HttpMetric.e2e.js
+++ b/packages/perf/e2e/HttpMetric.e2e.js
@@ -19,6 +19,16 @@ const aCoolUrl = 'https://invertase.io';
 
 describe('HttpMetric modular', function () {
   describe('firebase v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('start()', function () {
       it('correctly starts with internal flag ', async function () {
         const httpMetric = firebase.perf().newHttpMetric(aCoolUrl, 'GET');

--- a/packages/perf/e2e/Trace.e2e.js
+++ b/packages/perf/e2e/Trace.e2e.js
@@ -17,6 +17,16 @@
 
 describe('Trace modular', function () {
   describe('firebase v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('start()', function () {
       it('correctly starts with internal flag ', async function () {
         const trace = firebase.perf().newTrace('invertase');
@@ -416,36 +426,31 @@ describe('Trace modular', function () {
       });
 
       it('should return an attribute string value', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putAttribute('inver', 'tase');
-        const value = trace.getAttribute('inver');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putAttribute('inver', 'tase');
+        const value = traceInvertase.getAttribute('inver');
         should.equal(value, 'tase');
-      });
-
-      it('errors if attribute name is not a string', async function () {
-        try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.getAttribute(1337);
-          return Promise.reject(new Error('Did not throw'));
-        } catch (e) {
-          e.message.should.containEql('must be a string');
-          return Promise.resolve();
-        }
       });
     });
 
     describe('putAttribute()', function () {
       it('sets an attribute string value', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putAttribute('inver', 'tase');
-        const value = trace.getAttribute('inver');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putAttribute('inver', 'tase');
+        const value = traceInvertase.getAttribute('inver');
         value.should.equal('tase');
       });
 
       it('errors if attribute name is not a string', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.putAttribute(1337, 'invertase');
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.putAttribute(1337, 'invertase');
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a string');
@@ -455,8 +460,10 @@ describe('Trace modular', function () {
 
       it('errors if attribute value is not a string', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.putAttribute('invertase', 1337);
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.putAttribute('invertase', 1337);
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a string');
@@ -466,8 +473,10 @@ describe('Trace modular', function () {
 
       it('errors if attribute name is greater than 40 characters', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.putAttribute(new Array(41).fill('1').join(''), 1337);
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.putAttribute(new Array(41).fill('1').join(''), 1337);
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('a maximum length of 40 characters');
@@ -477,8 +486,10 @@ describe('Trace modular', function () {
 
       it('errors if attribute value is greater than 100 characters', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.putAttribute('invertase', new Array(101).fill('1').join(''));
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.putAttribute('invertase', new Array(101).fill('1').join(''));
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('a maximum length of 100 characters');
@@ -487,14 +498,16 @@ describe('Trace modular', function () {
       });
 
       it('errors if more than 5 attributes are put', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putAttribute('invertase1', '1337');
-        trace.putAttribute('invertase2', '1337');
-        trace.putAttribute('invertase3', '1337');
-        trace.putAttribute('invertase4', '1337');
-        trace.putAttribute('invertase5', '1337');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putAttribute('invertase1', '1337');
+        traceInvertase.putAttribute('invertase2', '1337');
+        traceInvertase.putAttribute('invertase3', '1337');
+        traceInvertase.putAttribute('invertase4', '1337');
+        traceInvertase.putAttribute('invertase5', '1337');
         try {
-          trace.putAttribute('invertase6', '1337');
+          traceInvertase.putAttribute('invertase6', '1337');
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('maximum number of attributes');
@@ -515,10 +528,12 @@ describe('Trace modular', function () {
 
     describe('removeMetric()', function () {
       it('errors if name not a string', async function () {
-        const trace = firebase.perf().newTrace('invertase');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
         try {
-          trace.putMetric('likes', 1337);
-          trace.removeMetric(13377331);
+          traceInvertase.putMetric('likes', 1337);
+          traceInvertase.removeMetric(13377331);
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a string');
@@ -527,34 +542,42 @@ describe('Trace modular', function () {
       });
 
       it('removes a metric', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putMetric('likes', 1337);
-        const value = trace.getMetric('likes');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putMetric('likes', 1337);
+        const value = traceInvertase.getMetric('likes');
         should.equal(value, 1337);
-        trace.removeMetric('likes');
-        const value2 = trace.getMetric('likes');
+        traceInvertase.removeMetric('likes');
+        const value2 = traceInvertase.getMetric('likes');
         should.equal(value2, 0);
       });
     });
 
     describe('getMetric()', function () {
       it('should return 0 if metric does not exist', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        const value = trace.getMetric('likes');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        const value = traceInvertase.getMetric('likes');
         should.equal(value, 0);
       });
 
       it('should return an metric number value', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putMetric('likes', 7331);
-        const value = trace.getMetric('likes');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putMetric('likes', 7331);
+        const value = traceInvertase.getMetric('likes');
         should.equal(value, 7331);
       });
 
       it('errors if metric name is not a string', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.getMetric(1337);
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.getMetric(1337);
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a string');
@@ -565,27 +588,33 @@ describe('Trace modular', function () {
 
     describe('putMetric()', function () {
       it('sets a metric number value', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putMetric('likes', 9001);
-        const value = trace.getMetric('likes');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putMetric('likes', 9001);
+        const value = traceInvertase.getMetric('likes');
         value.should.equal(9001);
       });
 
       it('overwrites existing metric if it exists', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putMetric('likes', 1);
-        trace.incrementMetric('likes', 9000);
-        const value = trace.getMetric('likes');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putMetric('likes', 1);
+        traceInvertase.incrementMetric('likes', 9000);
+        const value = traceInvertase.getMetric('likes');
         value.should.equal(9001);
-        trace.putMetric('likes', 1);
-        const value2 = trace.getMetric('likes');
+        traceInvertase.putMetric('likes', 1);
+        const value2 = traceInvertase.getMetric('likes');
         value2.should.equal(1);
       });
 
       it('errors if metric name is not a string', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.putMetric(1337, 7331);
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.putMetric(1337, 7331);
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a string');
@@ -595,8 +624,10 @@ describe('Trace modular', function () {
 
       it('errors if metric value is not a number', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.putMetric('likes', '1337');
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.putMetric('likes', '1337');
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a number');
@@ -607,24 +638,30 @@ describe('Trace modular', function () {
 
     describe('incrementMetric()', function () {
       it('increments a metric number value', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.putMetric('likes', 9000);
-        trace.incrementMetric('likes', 1);
-        const value = trace.getMetric('likes');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.putMetric('likes', 9000);
+        traceInvertase.incrementMetric('likes', 1);
+        const value = traceInvertase.getMetric('likes');
         value.should.equal(9001);
       });
 
       it('increments a metric even if it does not already exist', async function () {
-        const trace = firebase.perf().newTrace('invertase');
-        trace.incrementMetric('likes', 9001);
-        const value = trace.getMetric('likes');
+        const { getPerformance, trace } = perfModular;
+        const perf = getPerformance();
+        const traceInvertase = trace(perf, 'invertase');
+        traceInvertase.incrementMetric('likes', 9001);
+        const value = traceInvertase.getMetric('likes');
         value.should.equal(9001);
       });
 
       it('errors if metric name is not a string', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.incrementMetric(1337, 1);
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.incrementMetric(1337, 1);
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a string');
@@ -634,8 +671,10 @@ describe('Trace modular', function () {
 
       it('errors if incrementBy value is not a number', async function () {
         try {
-          const trace = firebase.perf().newTrace('invertase');
-          trace.incrementMetric('likes', '1');
+          const { getPerformance, trace } = perfModular;
+          const perf = getPerformance();
+          const traceInvertase = trace(perf, 'invertase');
+          traceInvertase.incrementMetric('likes', '1');
           return Promise.reject(new Error('Did not throw'));
         } catch (e) {
           e.message.should.containEql('must be a number');
@@ -645,10 +684,12 @@ describe('Trace modular', function () {
     });
 
     it('getMetrics()', async function () {
-      const trace = firebase.perf().newTrace('invertase');
-      trace.putMetric('likes', 1337);
-      trace.putMetric('stars', 6832);
-      const value = trace.getMetrics();
+      const { getPerformance, trace } = perfModular;
+      const perf = getPerformance();
+      const traceInvertase = trace(perf, 'invertase');
+      traceInvertase.putMetric('likes', 1337);
+      traceInvertase.putMetric('stars', 6832);
+      const value = traceInvertase.getMetrics();
       JSON.parse(JSON.stringify(value)).should.deepEqual({
         likes: 1337,
         stars: 6832,

--- a/packages/perf/e2e/perf.e2e.js
+++ b/packages/perf/e2e/perf.e2e.js
@@ -17,6 +17,16 @@
 
 describe('perf() modular', function () {
   describe('firebase v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('setPerformanceCollectionEnabled()', function () {
       // These depend on `tests/firebase.json` having `perf_auto_collection_enabled` set to false the first time
       // The setting is persisted across restarts, reset to false after for local runs where prefs are sticky
@@ -119,9 +129,10 @@ describe('perf() modular', function () {
   describe('modular', function () {
     describe('getPerformance', function () {
       it('pass app as argument', function () {
+        const { getApp } = modular;
         const { getPerformance } = perfModular;
 
-        const perf = getPerformance(firebase.app());
+        const perf = getPerformance(getApp());
 
         perf.constructor.name.should.be.equal('FirebasePerfModule');
       });
@@ -137,9 +148,10 @@ describe('perf() modular', function () {
 
     describe('initializePerformance()', function () {
       it('call and set "dataCollectionEnabled" to `false`', async function () {
+        const { getApp } = modular;
         const { initializePerformance } = perfModular;
 
-        const perf = await initializePerformance(firebase.app(), { dataCollectionEnabled: false });
+        const perf = await initializePerformance(getApp(), { dataCollectionEnabled: false });
 
         const enabled = perf.dataCollectionEnabled;
 
@@ -147,9 +159,10 @@ describe('perf() modular', function () {
       });
 
       it('call and set "dataCollectionEnabled" to `true`', async function () {
+        const { getApp } = modular;
         const { initializePerformance } = perfModular;
 
-        const perf = await initializePerformance(firebase.app(), { dataCollectionEnabled: true });
+        const perf = await initializePerformance(getApp(), { dataCollectionEnabled: true });
 
         const enabled = perf.dataCollectionEnabled;
 

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -19,6 +19,16 @@ const { updateTemplate } = require('./helpers');
 
 describe('remoteConfig()', function () {
   describe('firebase v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('fetch()', function () {
       it('with expiration provided', async function () {
         const date = Date.now() - 30000;
@@ -349,17 +359,19 @@ describe('remoteConfig()', function () {
   describe('modular', function () {
     describe('getRemoteConfig', function () {
       it('pass app as argument', function () {
+        const { getApp } = modular;
         const { getRemoteConfig } = remoteConfigModular;
 
-        const remoteConfig = getRemoteConfig(firebase.app());
+        const remoteConfig = getRemoteConfig(getApp());
 
         remoteConfig.constructor.name.should.be.equal('FirebaseConfigModule');
       });
 
       it('no app as argument', function () {
+        const { getApp } = modular;
         const { getRemoteConfig } = remoteConfigModular;
 
-        const remoteConfig = getRemoteConfig(firebase.app());
+        const remoteConfig = getRemoteConfig(getApp());
 
         remoteConfig.constructor.name.should.be.equal('FirebaseConfigModule');
       });
@@ -379,7 +391,7 @@ describe('remoteConfig()', function () {
 
         await fetch(remoteConfig, 0);
         remoteConfig.lastFetchStatus.should.equal(firebase.remoteConfig.LastFetchStatus.SUCCESS);
-        should.equal(firebase.remoteConfig().fetchTimeMillis >= date, true);
+        should.equal(getRemoteConfig().fetchTimeMillis >= date, true);
       });
 
       it('without expiration provided', function () {
@@ -957,8 +969,9 @@ describe('remoteConfig()', function () {
 
     describe('setCustomSignals()', function () {
       it('should resolve with valid signal value; `string`, `number` or `null`', async function () {
+        const { getApp } = modular;
         const { setCustomSignals, getRemoteConfig } = remoteConfigModular;
-        const remoteConfig = getRemoteConfig(firebase.app());
+        const remoteConfig = getRemoteConfig(getApp());
         // native SDKs just ignore invalid key/values (e.g. too long) and just log warning
         const signals = {
           string: 'string',
@@ -972,8 +985,9 @@ describe('remoteConfig()', function () {
       });
 
       it('should reject with invalid signal value', async function () {
+        const { getApp } = modular;
         const { setCustomSignals, getRemoteConfig } = remoteConfigModular;
-        const remoteConfig = getRemoteConfig(firebase.app());
+        const remoteConfig = getRemoteConfig(getApp());
 
         const invalidSignals = [
           { signal1: true },

--- a/packages/storage/e2e/StorageTask.e2e.js
+++ b/packages/storage/e2e/StorageTask.e2e.js
@@ -31,6 +31,14 @@ describe('storage() -> StorageTask', function () {
     describe('firebase v8 compatibility', function () {
       before(async function () {
         await seed(PATH);
+
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+      });
+
+      after(async function afterEachTest() {
+        // @ts-ignore
+        globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
       });
 
       describe('writeToFile()', function () {

--- a/packages/storage/e2e/helpers.js
+++ b/packages/storage/e2e/helpers.js
@@ -8,20 +8,20 @@ const WRITE_ONLY_NAME = 'writeOnly.jpeg';
 exports.seed = async function seed(path) {
   let leakDetectCurrent = globalThis.RNFBDebugInTestLeakDetection;
   globalThis.RNFBDebugInTestLeakDetection = false;
+  const { getStorage, ref } = storageModular;
 
   try {
     // Add a write only file
-    await firebase.storage().ref(WRITE_ONLY_NAME).putString('Write Only');
+    await ref(getStorage(), WRITE_ONLY_NAME).putString('Write Only');
 
     // Setup list items - Future.wait not working...
-    await firebase
-      .storage()
-      .ref(`${path}/list/file1.txt`)
-      .putString('File 1', 'raw', { contentType: 'text/plain' });
-    await firebase.storage().ref(`${path}/list/file2.txt`).putString('File 2');
-    await firebase.storage().ref(`${path}/list/file3.txt`).putString('File 3');
-    await firebase.storage().ref(`${path}/list/file4.txt`).putString('File 4');
-    await firebase.storage().ref(`${path}/list/nested/file5.txt`).putString('File 5');
+    await ref(getStorage(), `${path}/list/file1.txt`).putString('File 1', 'raw', {
+      contentType: 'text/plain',
+    });
+    await ref(getStorage(), `${path}/list/file2.txt`).putString('File 2');
+    await ref(getStorage(), `${path}/list/file3.txt`).putString('File 3');
+    await ref(getStorage(), `${path}/list/file4.txt`).putString('File 4');
+    await ref(getStorage(), `${path}/list/nested/file5.txt`).putString('File 5');
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error('unable to seed storage service with test fixtures');
@@ -32,7 +32,8 @@ exports.seed = async function seed(path) {
 };
 
 exports.wipe = function wipe(path) {
-  return firebase.storage().ref(path).remove();
+  const { getStorage, ref } = storageModular;
+  return ref(getStorage(), path).remove();
 };
 
 exports.PATH = PATH;

--- a/packages/storage/e2e/storage.e2e.js
+++ b/packages/storage/e2e/storage.e2e.js
@@ -18,6 +18,16 @@ const { PATH } = require('./helpers');
 
 describe('storage() modular', function () {
   describe('firebase v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
     describe('storage()', function () {
       describe('namespace', function () {
         it('accessible from firebase.app()', function () {
@@ -241,9 +251,10 @@ describe('storage() modular', function () {
   describe('modular', function () {
     describe('getStorage', function () {
       it('pass app as argument', function () {
+        const { getApp } = modular;
         const { getStorage } = storageModular;
 
-        const storage = getStorage(firebase.app());
+        const storage = getStorage(getApp());
 
         storage.constructor.name.should.be.equal('FirebaseStorageModule');
       });

--- a/tests/app.js
+++ b/tests/app.js
@@ -69,7 +69,7 @@ ErrorUtils.setGlobalHandler((err, isFatal) => {
 
 function loadTests(_) {
   describe('React Native Firebase', function () {
-    if (!globalThis.RNFBDebug && !globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE) {
+    if (!globalThis.RNFBDebug) {
       // Only retry tests if not debugging or hunting deprecated API usage locally,
       // otherwise it gets annoying to debug.
       this.retries(4);

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -49,7 +49,7 @@ import shouldMatchers from 'should';
 globalThis.RNFBDebug = false;
 
 // this may be used to locate modular API errors quickly
-globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE = false;
+globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE = true;
 
 // Needed for Platform.Other session storage
 import AsyncStorage from '@react-native-async-storage/async-storage';


### PR DESCRIPTION
### Description

This is a huge package of commits aimed at cleaning up the entire e2e suite so there are no more deprecation warnings and it passes the suite in deprecation strict mode

With this and #8498 merged, the e2e suite looks modular-clean for the non-v8/namespaced tests

### Related issues

This PR is also needed to get rid of messaging deprecations:
- #8498

This docs PR prompted me to do this, since the auth API surface area had a gap for modular (`multiFactor`) and I wanted to verify my direction to @DoctorJohn that the direct imports I was prescribing actually existed:
- #8327 

### Release Summary

All commits are conventional and ready for semantic release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

The whole thing is prompted by testing and backed by testing - including all of the functionality changes

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
