### PR TITLE
fix(app, expo): SDK 53 config plugin

### DIFF
--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -71,7 +71,7 @@ export function modifyObjcAppDelegate(contents: string): string {
 export function modifySwiftAppDelegate(contents: string): string {
   const methodInvocationBlock = `FirebaseApp.configure()`;
   const methodInvocationLineMatcher =
-    /(?:self\.moduleName\s*=\s*"([^"]*)")|(?:reactNativeFactory\?\.\s*startReactNative)/;
+    /(?:self\.moduleName\s*=\s*"([^"]*)")|(?:factory\.startReactNative\()/;
 
   // Add import
   if (!contents.includes('import FirebaseCore')) {


### PR DESCRIPTION
### Description

Hey @mikehardy, we just talked about it in https://github.com/invertase/react-native-firebase/pull/8495 and it happened. The template change got merged. 

Expo SDK 53.0.1 is already out and I think there is no need to keep the change we merged a couple of hours ago.
I updated the mod. In the future, we could think about using [AppDelegate subscriber](https://docs.expo.dev/modules/appdelegate-subscribers/) instead. These dangerous mod are annoying :D


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
<img width="1102" alt="Screenshot 2025-04-29 at 04 43 03" src="https://github.com/user-attachments/assets/31901be4-6c14-4cc5-8c72-15eedc0a2ce4" />

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
