### PR TITLE
fix(auth, android): handle native exception in signInWithEmailLink

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -459,18 +459,23 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
     FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
 
-    firebaseAuth
-        .signInWithEmailLink(email, emailLink)
-        .addOnSuccessListener(
-            authResult -> {
-              Log.d(TAG, "signInWithEmailLink:onComplete:success");
-              promiseWithAuthResult(authResult, promise);
-            })
-        .addOnFailureListener(
-            exception -> {
-              Log.e(TAG, "signInWithEmailLink:onComplete:failure", exception);
-              promiseRejectAuthException(promise, exception);
-            });
+    try {
+      firebaseAuth
+          .signInWithEmailLink(email, emailLink)
+          .addOnSuccessListener(
+              authResult -> {
+                Log.d(TAG, "signInWithEmailLink:onComplete:success");
+                promiseWithAuthResult(authResult, promise);
+              })
+          .addOnFailureListener(
+              exception -> {
+                Log.e(TAG, "signInWithEmailLink:onComplete:failure", exception);
+                promiseRejectAuthException(promise, exception);
+              });
+    } catch (Exception exception) {
+      Log.e(TAG, "signInWithEmailLink:onComplete:totalfailure", exception);
+      promiseRejectAuthException(promise, exception);
+    }
   }
 
   @ReactMethod

--- a/packages/auth/e2e/emailLink.e2e.js
+++ b/packages/auth/e2e/emailLink.e2e.js
@@ -96,9 +96,55 @@ describe('auth() -> emailLink Provider', function () {
     });
   });
 
-  // FOR MANUAL TESTING ONLY
-  xdescribe('signInWithEmailLink', function () {
-    it('should signIn', async function () {
+  describe('signInWithEmailLink', function () {
+    it('sign in via email does not crash with missing apiKey', async function () {
+      const { getAuth, sendSignInLinkToEmail, signInWithEmailLink } = authModular;
+
+      const auth = getAuth();
+      const random = Utils.randString(12, '#aa');
+      const email = `${random}@${random}.com`;
+      const continueUrl = `http://${Platform.android ? '10.0.2.2' : '127.0.0.1'}:8081/authLinkFoo?bar=${random}`;
+      const actionCodeSettings = {
+        url: continueUrl,
+        handleCodeInApp: true,
+        iOS: {
+          bundleId: 'com.testing',
+        },
+        android: {
+          packageName: 'com.testing',
+          installApp: true,
+          minimumVersion: '12',
+        },
+      };
+      await sendSignInLinkToEmail(auth, email, actionCodeSettings);
+      const oobInfo = await getLastOob(email);
+      oobInfo.oobLink.should.containEql(encodeURIComponent(continueUrl));
+
+      // Specifically remove the apiKey param. Android requires it and needs
+      // specific error handling or it crashes, See #8360
+      let linkNoApiKey = oobInfo.oobLink.replace('&apiKey=fake-api-key', '');
+      try {
+        const signInResponse = await signInWithEmailLink(auth, email, linkNoApiKey);
+        if (Platform.OS !== 'ios') {
+          throw new Error('Should have rejected on Android and Other');
+        } else {
+          signInResponse.user.email.should.equal(email);
+          auth.currentUser.email.should.equal(email);
+        }
+      } catch (e) {
+        if (Platform.OS === 'android') {
+          e.message.should.containEql('Given link is not a valid email link');
+        } else if (Platform.OS === 'macos') {
+          e.message.should.containEql('auth/argument-error');
+        } else {
+          // ios should have been fine without apiKey
+          throw e;
+        }
+      }
+    });
+
+    // FOR MANUAL TESTING ONLY
+    xit('should signIn', async function () {
       const auth = getAuth();
       const email = 'MANUAL TEST EMAIL HERE';
       const emailLink = 'MANUAL TEST CODE HERE';

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -2008,15 +2008,16 @@ export namespace FirebaseAuthTypes {
     sendSignInLinkToEmail(email: string, actionCodeSettings?: ActionCodeSettings): Promise<void>;
 
     /**
-     * Returns whether the user signed in with a given email link.
+     * Checks if an incoming link is a sign-in with email link suitable for signInWithEmailLink.
+     * Note that android and other platforms require `apiKey` link parameter for signInWithEmailLink
      *
      * #### Example
      *
      * ```js
-     * const signedInWithLink = await firebase.auth().isSignInWithEmailLink(link);
+     * const valid = await firebase.auth().isSignInWithEmailLink(link);
      * ```
      *
-     * @param emailLink The email link to check whether the user signed in with it.
+     * @param emailLink The email link to verify prior to using signInWithEmailLink
      */
     isSignInWithEmailLink(emailLink: string): Promise<boolean>;
 

--- a/packages/auth/lib/modular/index.d.ts
+++ b/packages/auth/lib/modular/index.d.ts
@@ -165,7 +165,8 @@ export interface PopupRedirectResolver {}
 export function initializeRecaptchaConfig(auth: Auth): Promise<void>;
 
 /**
- * Checks if an incoming link is a sign-in with email link suitable for signInWithEmailLink().
+ * Checks if an incoming link is a sign-in with email link suitable for signInWithEmailLink.
+ * Note that android and other platforms require `apiKey` link parameter for signInWithEmailLink
  *
  * @param auth - The Auth instance.
  * @param emailLink - The email link to check.


### PR DESCRIPTION
### Description

@Willham12 pointed out multiple problems with our sign in link handling, and even submitted a PR that handled part of the problem already - this PR handles the remaining two aspects of the problem - a docs update and a native error handling fix

Specifically, the native android signInWithEmailLink method throws an error outside it's Task continuation failure handling, which was unexpected and unhandled in our code. This PR handles that correctly now

### Related issues

- Fixes #8360

### Release Summary

two conventional commits ready for a rebase and a semantic release

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Subtle to fix, but correctness was enforced because I started it by adding an e2e test and then made our code meet the test expectations

One very subtle thing (for me) is that the new react-native new architecture error handling for bridgeless compatibility mode code is to helpfully package up even unhandled native code exceptions. This changed since the error was logged so I was seeing different behavior in the unhandled exception case - not IllegalArgumentException + crash like expected, but a 'HostError' javascript error object that wasn't from us but was from react-native

Anyway, all handled now

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
