### PR TITLE
fix(auth, expo): lowercase `String?` in swift using `.lowercased()`

### DIFF
--- a/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
+++ b/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
@@ -355,7 +355,7 @@ public class AppDelegate: ExpoAppDelegate {
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
 // @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY)
-    if url.host.toLowerCase() == "firebaseauth" {
+    if url.host?.lowercased() == "firebaseauth" {
       // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
       return false
     }

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -155,7 +155,7 @@ export function modifyObjcAppDelegate(contents: string): string | null {
 // NOTE: `mergeContents()` doesn't support newlines for the `anchor` regex, so we have to replace it manually
 const skipOpenUrlForFirebaseAuthBlockSwift: string = `\
 // @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY)
-    if url.host.toLowerCase() == "firebaseauth" {
+    if url.host?.lowercased() == "firebaseauth" {
       // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
       return false
     }


### PR DESCRIPTION
### Description

We currently have some javascript code being added via the new `swift`-based plugin. This simply fixes the `swift` code.

```
❌  (ios/Gizmo/AppDelegate.swift:46:17)

  44 |   ) -> Bool {
  45 | // @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY)
> 46 |     if url.host.toLowerCase() == "firebaseauth" {
     |                 ^ value of type 'String?' has no member 'toLowerCase'
  47 |       // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
  48 |       return false
  49 |     }
  ```

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I have yet to run the tests locally, is there an easy way to just run the auth package plugin's tests?

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
