### PR TITLE
fix(auth): missing PhoneMultiFactorGenerator export

### DIFF
--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -70,6 +70,7 @@ import auth, {
   OAuthProvider,
   OIDCAuthProvider,
   PhoneAuthProvider,
+  PhoneMultiFactorGenerator,
   TwitterAuthProvider,
 } from '../lib';
 
@@ -535,6 +536,10 @@ describe('Auth', function () {
 
     it('`PhoneAuthProvider` class is properly exposed to end user', function () {
       expect(PhoneAuthProvider).toBeDefined();
+    });
+
+    it('`PhoneMultiFactorGenerator` class is properly exposed to end user', function () {
+      expect(PhoneMultiFactorGenerator).toBeDefined();
     });
 
     it('`TwitterAuthProvider` class is properly exposed to end user', function () {

--- a/packages/auth/lib/modular/index.d.ts
+++ b/packages/auth/lib/modular/index.d.ts
@@ -779,5 +779,6 @@ export {
   OAuthProvider,
   OIDCAuthProvider,
   PhoneAuthProvider,
+  PhoneMultiFactorGenerator,
   TwitterAuthProvider,
 } from '../index';


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This PR fixes that the `PhoneMultiFactorGenerator` class was not properly exported via the modular API.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

- follows what has been done in #8323 for other types
- I noticed the missing export while working on #8327

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

I updated the auth package's jest tests and verified they pass/fail with/without the relevant code changes.

:fire: 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
