### PR TITLE
fix(auth, ios): fixes inappropriate linking when host is nil

### DIFF
--- a/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
+++ b/packages/auth/plugin/__tests__/__snapshots__/iosPlugin_openUrlFix.test.ts.snap
@@ -76,8 +76,8 @@ static void InitializeFlipper(UIApplication *application) {
 
 // Linking API
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-11c57ab508c3e776ab45ad4f3c3cb28310f617ea
+  if (url.host && [url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
     // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
     return NO;
   }
@@ -165,8 +165,8 @@ static void InitializeFlipper(UIApplication *application) {
 
 // Linking API
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-11c57ab508c3e776ab45ad4f3c3cb28310f617ea
+  if (url.host && [url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
     // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
     return NO;
   }
@@ -266,8 +266,8 @@ exports[`Config Plugin iOS Tests - openUrlFix munges AppDelegate correctly - App
 
 // Linking API
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-11c57ab508c3e776ab45ad4f3c3cb28310f617ea
+  if (url.host && [url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
     // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
     return NO;
   }
@@ -378,8 +378,8 @@ public class AppDelegate: ExpoAppDelegate {
 
 exports[`Config Plugin iOS Tests - openUrlFix must match positiveTemplateCases[0] 1`] = `
 "- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
-// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-11c57ab508c3e776ab45ad4f3c3cb28310f617ea
+  if (url.host && [url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
     // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
     return NO;
   }
@@ -392,8 +392,8 @@ exports[`Config Plugin iOS Tests - openUrlFix must match positiveTemplateCases[3
 
 {
 
-// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-5e029a87ac71df3ca5665387eb712d1b32274c6a
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY) sync-11c57ab508c3e776ab45ad4f3c3cb28310f617ea
+  if (url.host && [url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
     // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
     return NO;
   }

--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -101,7 +101,7 @@ export function modifyAppDelegate(contents: string, language: string): string | 
 }
 
 const skipOpenUrlForFirebaseAuthBlock: string = `\
-  if ([url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
+  if (url.host && [url.host caseInsensitiveCompare:@"firebaseauth"] == NSOrderedSame) {
     // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
     return NO;
   }\


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

I have a universal link that has nothing to do with firebase. but when i link into the url, the link has nil url host and falls into the generated expo prebuild linking code and returns NO. which is inappropriate and needed that url to pass to the very bottom of the linking delegate code.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

you can test with url with nullable(nil) url host. in my case, i tested with a custom universal link that has nothing to do with firebase app

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
