### PR TITLE
docs(auth): clarify signInWithEmailAndPassword error behavior under email enumeration protection

### DIFF
--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -1806,17 +1806,27 @@ export namespace FirebaseAuthTypes {
     /**
      * Signs a user in with an email and password.
      *
+     * ⚠️ Note:
+     * If "Email Enumeration Protection" is enabled in your Firebase Authentication settings (enabled by default),
+     * Firebase may return a generic `auth/invalid-login-credentials` error instead of more specific ones like
+     * `auth/user-not-found` or `auth/wrong-password`. This behavior is intended to prevent leaking information
+     * about whether an account with the given email exists.
+     *
+     * To receive detailed error codes, you must disable "Email Enumeration Protection", which may increase
+     * security risks if not properly handled on the frontend.
+     *
      * #### Example
      *
      * ```js
      * const userCredential = await firebase.auth().signInWithEmailAndPassword('joe.bloggs@example.com', '123456');
-     * ````
+     * ```
+     *
      * @error auth/invalid-email Thrown if the email address is not valid.
      * @error auth/user-disabled Thrown if the user corresponding to the given email has been disabled.
-     * @error auth/user-not-found Thrown if there is no user corresponding to the given email.
-     * @error auth/wrong-password Thrown if the password is invalid for the given email, or the account corresponding to the email does not have a password set.
-     * @param email The users email address.
-     * @param password The users password.
+     * @error auth/user-not-found Thrown if there is no user corresponding to the given email. (May be suppressed if email enumeration protection is enabled.)
+     * @error auth/wrong-password Thrown if the password is invalid or missing. (May be suppressed if email enumeration protection is enabled.)
+     * @param email The user's email address.
+     * @param password The user's password.
      */
     signInWithEmailAndPassword(email: string, password: string): Promise<UserCredential>;
 


### PR DESCRIPTION
## docs(auth): clarify signInWithEmailAndPassword error behavior under email enumeration protection

### Description

This PR improves the JSDoc comment for `signInWithEmailAndPassword` by adding a note about how **Email Enumeration Protection** (enabled by default in Firebase) affects the returned error codes.

Specifically:
- When enabled, Firebase returns a **generic** `auth/invalid-login-credentials` error for login failures, instead of revealing whether the user does not exist (`auth/user-not-found`) or the password is incorrect (`auth/wrong-password`).
- The update warns developers that if they want to rely on detailed error codes, they need to explicitly disable this protection — and that doing so introduces potential security risks (enumeration).

This helps developers understand why error behavior might differ and promotes secure usage patterns.

### Related issues

_No open issue directly related, but improves consistency with Firebase backend behavior._

### Release Summary

Documented the impact of Email Enumeration Protection on the behavior of `signInWithEmailAndPassword`.

### Checklist

- [x] I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] My change supports the following platforms:
  - [x] Android
  - [x] iOS
- [x] My change includes tests:
  - [ ] e2e tests added or updated in `packages/**/e2e`
  - [ ] jest tests added or updated in `packages/**/__tests__`
  - [x] Not applicable (documentation only)
- [x] I have updated TypeScript types that are affected by my change (only JSDoc).
- [x] This is **not** a breaking change.

### Test Plan

No runtime code changes — documentation only.

---

Think `react-native-firebase` is helpful? Consider supporting:

- ⭐ Star the repo on GitHub  
- 🐦 Follow [React Native Firebase](https://twitter.com/rnfirebase) and [Invertase](https://twitter.com/invertaseio) on Twitter
