### PR TITLE
feat(app-check): add Swift AppDelegate support for Expo SDK53+

### DIFF
--- a/packages/app-check/plugin/__tests__/fixtures/AppDelegate_sdk53.swift
+++ b/packages/app-check/plugin/__tests__/fixtures/AppDelegate_sdk53.swift
@@ -1,0 +1,12 @@
+import Expo
+import React
+
+@UIApplicationMain
+class AppDelegate: ExpoAppDelegate {
+  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+    // Initialize the factory
+    let factory = ExpoReactNativeFactory(delegate: delegate)
+    factory.startReactNative(withModuleName: "main", in: window, launchOptions: launchOptions)
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+}

--- a/packages/app-check/plugin/src/ios/appDelegate.ts
+++ b/packages/app-check/plugin/src/ios/appDelegate.ts
@@ -131,7 +131,7 @@ import RNFBAppCheck`,
       offset: 0,
       comment: '//',
     }).contents;
-  } catch (e) {
+  } catch (_e) {
     WarningAggregator.addWarningIOS(
       '@react-native-firebase/app-check',
       'Failed to insert App Check initialization code.',

--- a/packages/app-check/plugin/src/ios/appDelegate.ts
+++ b/packages/app-check/plugin/src/ios/appDelegate.ts
@@ -68,16 +68,91 @@ export function modifyObjcAppDelegate(contents: string): string {
   }
 }
 
+export function modifySwiftAppDelegate(contents: string): string {
+  // Add imports for Swift
+  if (!contents.includes('import RNFBAppCheck')) {
+    // Try to add after FirebaseCore if it exists
+    if (contents.includes('import FirebaseCore')) {
+      contents = contents.replace(
+        /import FirebaseCore/g,
+        `import FirebaseCore
+import RNFBAppCheck`,
+      );
+    } else {
+      // Otherwise add after Expo
+      contents = contents.replace(
+        /import Expo/g,
+        `import Expo
+import RNFBAppCheck`,
+      );
+    }
+  }
+
+  // Check if App Check code is already added to avoid duplication
+  if (contents.includes('RNFBAppCheckModule.sharedInstance()')) {
+    return contents;
+  }
+
+  // Find the Firebase initialization end line to insert after
+  const firebaseLine = '// @generated end @react-native-firebase/app-didFinishLaunchingWithOptions';
+
+  if (contents.includes(firebaseLine)) {
+    // Insert right after Firebase initialization
+    return contents.replace(
+      firebaseLine,
+      `${firebaseLine}
+        FirebaseApp.configure()
+        RNFBAppCheckModule.sharedInstance()
+      `,
+    );
+  }
+
+  // If Firebase initialization block not found, add both Firebase and App Check initialization
+  // This is to make sure Firebase is initialized before App Check
+  const methodInvocationBlock = `FirebaseApp.configure()
+    RNFBAppCheckModule.sharedInstance()`;
+
+  const methodInvocationLineMatcher = /(?:factory\.startReactNative\()/;
+
+  if (!methodInvocationLineMatcher.test(contents)) {
+    WarningAggregator.addWarningIOS(
+      '@react-native-firebase/app-check',
+      'Unable to determine correct insertion point in AppDelegate.swift. Skipping App Check addition.',
+    );
+    return contents;
+  }
+
+  try {
+    return mergeContents({
+      tag: '@react-native-firebase/app-check',
+      src: contents,
+      newSrc: methodInvocationBlock,
+      anchor: methodInvocationLineMatcher,
+      offset: 0,
+      comment: '//',
+    }).contents;
+  } catch (e) {
+    WarningAggregator.addWarningIOS(
+      '@react-native-firebase/app-check',
+      'Failed to insert App Check initialization code.',
+    );
+    return contents;
+  }
+}
+
 export async function modifyAppDelegateAsync(appDelegateFileInfo: AppDelegateProjectFile) {
   const { language, path, contents } = appDelegateFileInfo;
 
+  let newContents;
   if (['objc', 'objcpp'].includes(language)) {
-    const newContents = modifyObjcAppDelegate(contents);
-    await fs.promises.writeFile(path, newContents);
+    newContents = modifyObjcAppDelegate(contents);
+  } else if (language === 'swift') {
+    newContents = modifySwiftAppDelegate(contents);
   } else {
-    // TODO: Support Swift
     throw new Error(`Cannot add Firebase code to AppDelegate of language "${language}"`);
   }
+
+  await fs.promises.writeFile(path, newContents);
 }
 
 export const withFirebaseAppDelegate: ConfigPlugin = config => {


### PR DESCRIPTION
### Description

Adding  support for Swift AppDelegate for the new version of Expo SDK (53) for Firebase AppCheck.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

**Unit Tests:**
Test Suites: 39 passed, 39 total
Tests:       1 skipped, 789 passed, 790 total
Snapshots:   31 passed, 31 total
Time:        3.848 s

**E2E Tests:**
 PASS  e2e/firebase.test.js (556.894 s)
  Jet Tests
    ✓ runs all tests (527266 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        556.965 s
Ran all test suites.

---

🔥
