### PR TITLE
fix(app-check, types): modular exports of ReactNativeFirebaseAppCheckProvider types

### DIFF
--- a/packages/app-check/__tests__/appcheck.test.ts
+++ b/packages/app-check/__tests__/appcheck.test.ts
@@ -20,6 +20,11 @@ import {
   setTokenAutoRefreshEnabled,
   onTokenChanged,
   CustomProvider,
+  ReactNativeFirebaseAppCheckProviderOptions,
+  ReactNativeFirebaseAppCheckProviderAndroidOptions,
+  ReactNativeFirebaseAppCheckProviderAppleOptions,
+  ReactNativeFirebaseAppCheckProviderWebOptions,
+  ReactNativeFirebaseAppCheckProvider,
 } from '../lib';
 
 describe('appCheck()', function () {
@@ -76,6 +81,28 @@ describe('appCheck()', function () {
 
     it('`CustomProvider` function is properly exposed to end user', function () {
       expect(CustomProvider).toBeDefined();
+    });
+
+    it('`ReactNativeAppCheckProvider objects are properly exposed to end user', function () {
+      expect(ReactNativeFirebaseAppCheckProvider).toBeDefined();
+      const provider = new ReactNativeFirebaseAppCheckProvider();
+      expect(provider.configure).toBeDefined();
+      const options = { debugToken: 'foo' } as ReactNativeFirebaseAppCheckProviderOptions;
+      const appleOptions = {
+        provider: 'debug',
+        ...options,
+      } as ReactNativeFirebaseAppCheckProviderAppleOptions;
+      expect(appleOptions).toBeDefined();
+      const androidOptions = {
+        provider: 'debug',
+        ...options,
+      } as ReactNativeFirebaseAppCheckProviderAndroidOptions;
+      expect(androidOptions).toBeDefined();
+      const webOptions = {
+        provider: 'debug',
+        ...options,
+      } as ReactNativeFirebaseAppCheckProviderWebOptions;
+      expect(webOptions).toBeDefined();
     });
   });
 

--- a/packages/app-check/lib/modular/index.d.ts
+++ b/packages/app-check/lib/modular/index.d.ts
@@ -92,3 +92,61 @@ export function setTokenAutoRefreshEnabled(
 export class CustomProvider implements AppCheckProvider {
   constructor(customProviderOptions: CustomProviderOptions);
 }
+
+/**
+ * React-Native-Firebase AppCheckProvider that allows hot-swapping native AppCheck implementations
+ */
+export interface ReactNativeFirebaseAppCheckProviderOptions {
+  /**
+   * debug token to use, if any. Defaults to undefined, pre-configure tokens in firebase web console if needed
+   */
+  debugToken?: string;
+}
+
+export interface ReactNativeFirebaseAppCheckProviderWebOptions
+  extends ReactNativeFirebaseAppCheckProviderOptions {
+  /**
+   * The web provider to use, either `reCaptchaV3` or `reCaptchaEnterprise`, defaults to `reCaptchaV3`
+   */
+  provider?: 'debug' | 'reCaptchaV3' | 'reCaptchaEnterprise';
+
+  /**
+   * siteKey for use in web queries, defaults to `none`
+   */
+  siteKey?: string;
+}
+
+export interface ReactNativeFirebaseAppCheckProviderAppleOptions
+  extends ReactNativeFirebaseAppCheckProviderOptions {
+  /**
+   * The apple provider to use, either `deviceCheck` or `appAttest`, or `appAttestWithDeviceCheckFallback`,
+   * defaults to `DeviceCheck`. `appAttest` requires iOS 14+ or will fail, `appAttestWithDeviceCheckFallback`
+   * will use `appAttest` for iOS14+ and fallback to `deviceCheck` on devices with ios13 and lower
+   */
+  provider?: 'debug' | 'deviceCheck' | 'appAttest' | 'appAttestWithDeviceCheckFallback';
+}
+
+export interface ReactNativeFirebaseAppCheckProviderAndroidOptions
+  extends ReactNativeFirebaseAppCheckProviderOptions {
+  /**
+   * The android provider to use, either `debug` or `playIntegrity`. default is `playIntegrity`.
+   */
+  provider?: 'debug' | 'playIntegrity';
+}
+
+export class ReactNativeFirebaseAppCheckProvider extends AppCheckProvider {
+  /**
+   * Specify how the app check provider should be configured. The new configuration is
+   * in effect when this call returns. You must call `getToken()`
+   * after this call to get a token using the new configuration.
+   * This custom provider allows for delayed configuration and re-configuration on all platforms
+   * so AppCheck has the same experience across all platforms, with the only difference being the native
+   * providers you choose to use on each platform.
+   */
+  configure(options: {
+    web?: ReactNativeFirebaseAppCheckProviderWebOptions;
+    android?: ReactNativeFirebaseAppCheckProviderAndroidOptions;
+    apple?: ReactNativeFirebaseAppCheckProviderAppleOptions;
+    isTokenAutoRefreshEnabled?: boolean;
+  }): void;
+}


### PR DESCRIPTION

These types were missed before - they *worked* in practice, at the javascript layer, but typescript didn't have them as exports in modular usage

- Fixes #8512