### PR TITLE
fix(storage): add missing type for StringFormat object values

### DIFF
--- a/packages/storage/lib/modular/index.d.ts
+++ b/packages/storage/lib/modular/index.d.ts
@@ -27,12 +27,16 @@ import Task = FirebaseStorageTypes.Task;
 import ListOptions = FirebaseStorageTypes.ListOptions;
 import SettableMetadata = FirebaseStorageTypes.SettableMetadata;
 import EmulatorMockTokenOptions = FirebaseStorageTypes.EmulatorMockTokenOptions;
-import StringFormat = FirebaseStorageTypes.StringFormat;
 import FirebaseApp = ReactNativeFirebase.FirebaseApp;
 
 export const StringFormat: FirebaseStorageTypes.StringFormat;
 export const TaskEvent: FirebaseStorageTypes.TaskEvent;
 export const TaskState: FirebaseStorageTypes.TaskState;
+
+/**
+ * Union of literal string values in StringFormat "enum" object
+ */
+export type StringFormat = (typeof StringFormat)[keyof typeof StringFormat];
 
 /**
  * Returns the existing default {@link Storage} instance that is associated with the


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This is a TypeScript Type Only change. The type declarations for the storage module were missing the union type that aggregates the string literal values of the `StringFormat` "enum" object. Without this type, the `uploadString` function's 3rd parameter expects an Object (corresponding to the StringFormat interface) instead of a string that specifies the format of the uploaded data. This causes a TypeScript compile/check error, but does not otherwise affect the functionality of the function implementation.

This PR adds the appropriate type declaration to satisfy type checking as described in [Firebase docs](https://firebase.google.com/docs/reference/js/storage.md#stringformat_2)



### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
- Fixes #8524 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->
I don't believe there is a trivial way to write a Jest test for this issue as it involves a type annotation. In my personal code, a `@ts-ignore` to suppress the error, with subsequent passing of a valid string for the argument resulted in perfectly functional run-time behavior.

The changes in this PR remove the need for the error suppression comment and the dev-time string inference is performed as expected.

It may be noted that there already exists a run-time value assertion to ensure the value for the format argument is one of the expected strings.

See:
https://github.com/invertase/react-native-firebase/blob/8c631e14375f97ec6ad7f72cf359b8f7a048479a/packages/storage/lib/StorageReference.js#L273-L279


🔥 
---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
