### PR TITLE
fix(app-check, expo): init app-check shared instance before firebase in plugin

### DIFF
--- a/packages/app-check/plugin/src/ios/appDelegate.ts
+++ b/packages/app-check/plugin/src/ios/appDelegate.ts
@@ -101,16 +101,16 @@ import RNFBAppCheck`,
     return contents.replace(
       firebaseLine,
       `${firebaseLine}
-        FirebaseApp.configure()
         RNFBAppCheckModule.sharedInstance()
+        FirebaseApp.configure()
       `,
     );
   }
 
   // If Firebase initialization block not found, add both Firebase and App Check initialization
   // This is to make sure Firebase is initialized before App Check
-  const methodInvocationBlock = `FirebaseApp.configure()
-    RNFBAppCheckModule.sharedInstance()`;
+  const methodInvocationBlock = `RNFBAppCheckModule.sharedInstance()
+    FirebaseApp.configure()`;
 
   const methodInvocationLineMatcher = /(?:factory\.startReactNative\()/;
 


### PR DESCRIPTION
### Description

This resolves an issue where AppCheck does not work in iOS simulators even when following the documentation around `ReactNativeFirebaseAppCheckProvider`

### Related issues

#6934
#6184

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
