### PR TITLE
docs: warning about expo-dev-client preventing native crash reporting to Firebase

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ Integration with Expo is possible when using a [development build](https://docs.
 
 _NOTE:_ React Native Firebase cannot be used in the pre-compiled [Expo Go app](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because React Native Firebase uses native code that is not compiled into Expo Go.
 
+> **Warning:** If you are using `expo-dev-client`, native crashes (such as those triggered by `crashlytics().crash()`) will **not** be reported to Firebase Crashlytics during development. This is because `expo-dev-client` provides a custom error overlay that catches and displays errors before they are sent to Firebase. To test native crash reporting, you must remove `expo-dev-client` and run your app in a standard release or debug build without the custom error overlay.
+
 To create a new Expo project, see the [Get started](https://docs.expo.dev/get-started/create-a-project/) guide in Expo documentation.
 
 ### Install React Native Firebase modules
@@ -270,10 +272,10 @@ However, you only want to do this for the web platform. For non-web / native app
 At some point during your application's bootstrap processes, initialize firebase like this:
 
 ```javascript
-import { getApp, initializeApp } from '@react-native-firebase/app';
+import { getApp, initializeApp } from "@react-native-firebase/app";
 
 // web requires dynamic initialization on web prior to using firebase
-if (Platform.OS === 'web') {
+if (Platform.OS === "web") {
   const firebaseConfig = {
     // ... config items pasted from firebase console for your web app here
   };


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This pull request updates the documentation to add a warning in the Expo installation section, clarifying that when `expo-dev-client` is installed, native crashes (such as those triggered by `crashlytics().crash()`) will **not** be reported to Firebase Crashlytics during development. This is because `expo-dev-client` provides a custom error overlay that catches and displays errors before they are sent to Firebase. The warning helps developers avoid confusion when testing crash reporting in development builds.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

Fixes #8561 

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

Added a documentation warning about the interaction between `expo-dev-client` and Firebase Crashlytics, to clarify that native crash reporting is suppressed in development builds using the custom error overlay.

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

This change is documentation-only. To verify, review the updated Expo installation section in the documentation and confirm the warning about `expo-dev-client` and native crash reporting is present and clear.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
