### PR TITLE
feat(messaging, android): Add check for expo-notifications notification icon configurations

### DIFF
--- a/packages/messaging/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/messaging/plugin/__tests__/androidPlugin.test.ts
@@ -3,7 +3,7 @@ import { setFireBaseMessagingAndroidManifest } from '../src/android/setupFirebas
 import { ExpoConfig } from '@expo/config-types';
 import {
   expoConfigExample,
-  expoConfigExampleWithExpoNotificationsPlugin,
+  expoConfigExampleWithExpoNotificationsPlugins,
 } from './fixtures/expo-config-example';
 import manifestApplicationExample from './fixtures/application-example';
 import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
@@ -73,7 +73,7 @@ describe('Config Plugin Android Tests', function () {
 
   it('applies changes to app/src/main/AndroidManifest.xml with expo-notifications plugin config when app.json notification is undefined', async function () {
     const config: ExpoConfig = JSON.parse(
-      JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin),
+      JSON.stringify(expoConfigExampleWithExpoNotificationsPlugins),
     );
     const manifestApplication: ManifestApplication = JSON.parse(
       JSON.stringify(manifestApplicationExample),
@@ -97,7 +97,7 @@ describe('Config Plugin Android Tests', function () {
 
   it('applies changes to app/src/main/AndroidManifest.xml with app.json notification config when both configs are defined', async function () {
     const config: ExpoConfig = JSON.parse(
-      JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin),
+      JSON.stringify(expoConfigExampleWithExpoNotificationsPlugins),
     );
     const manifestApplication: ManifestApplication = JSON.parse(
       JSON.stringify(manifestApplicationExample),

--- a/packages/messaging/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/messaging/plugin/__tests__/androidPlugin.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { setFireBaseMessagingAndroidManifest } from '../src/android/setupFirebaseNotifationIcon';
 import { ExpoConfig } from '@expo/config-types';
-import expoConfigExample from './fixtures/expo-config-example';
+import { expoConfigExample, expoConfigExampleWithExpoNotificationsPlugin } from './fixtures/expo-config-example';
 import manifestApplicationExample from './fixtures/application-example';
 import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
 
@@ -66,5 +66,48 @@ describe('Config Plugin Android Tests', function () {
     expect(called).toBeTruthy();
     // eslint-disable-next-line no-console
     console.warn = warnOrig;
+  });
+
+  it('applies changes to app/src/main/AndroidManifest.xml with expo-notifications plugin config when app.json notification is undefined', async function () {
+    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    config.notification = undefined;
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_color',
+        'android:resource': '@color/notification_icon_color',
+        'tools:replace': 'android:resource',
+      },
+    });
+  });
+
+  it('applies changes to app/src/main/AndroidManifest.xml with app.json notification config when both configs are defined', async function () {
+    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin));
+    const manifestApplication: ManifestApplication = JSON.parse(
+      JSON.stringify(manifestApplicationExample),
+    );
+    setFireBaseMessagingAndroidManifest(config, manifestApplication);
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_icon',
+        'android:resource': '@drawable/notification_icon',
+      },
+    });
+    expect(manifestApplication['meta-data']).toContainEqual({
+      $: {
+        'android:name': 'com.google.firebase.messaging.default_notification_color',
+        'android:resource': '@color/notification_icon_color',
+        'tools:replace': 'android:resource',
+      },
+    }); 
   });
 });

--- a/packages/messaging/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/messaging/plugin/__tests__/androidPlugin.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import { setFireBaseMessagingAndroidManifest } from '../src/android/setupFirebaseNotifationIcon';
 import { ExpoConfig } from '@expo/config-types';
-import { expoConfigExample, expoConfigExampleWithExpoNotificationsPlugin } from './fixtures/expo-config-example';
+import {
+  expoConfigExample,
+  expoConfigExampleWithExpoNotificationsPlugin,
+} from './fixtures/expo-config-example';
 import manifestApplicationExample from './fixtures/application-example';
 import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
 
@@ -69,7 +72,9 @@ describe('Config Plugin Android Tests', function () {
   });
 
   it('applies changes to app/src/main/AndroidManifest.xml with expo-notifications plugin config when app.json notification is undefined', async function () {
-    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin));
+    const config: ExpoConfig = JSON.parse(
+      JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin),
+    );
     const manifestApplication: ManifestApplication = JSON.parse(
       JSON.stringify(manifestApplicationExample),
     );
@@ -91,7 +96,9 @@ describe('Config Plugin Android Tests', function () {
   });
 
   it('applies changes to app/src/main/AndroidManifest.xml with app.json notification config when both configs are defined', async function () {
-    const config: ExpoConfig = JSON.parse(JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin));
+    const config: ExpoConfig = JSON.parse(
+      JSON.stringify(expoConfigExampleWithExpoNotificationsPlugin),
+    );
     const manifestApplication: ManifestApplication = JSON.parse(
       JSON.stringify(manifestApplicationExample),
     );
@@ -108,6 +115,6 @@ describe('Config Plugin Android Tests', function () {
         'android:resource': '@color/notification_icon_color',
         'tools:replace': 'android:resource',
       },
-    }); 
+    });
   });
 });

--- a/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
@@ -17,9 +17,13 @@ export const expoConfigExample: ExpoConfig = {
 /**
  * @type {import('@expo/config-types').ExpoConfig}
  */
-export const expoConfigExampleWithExpoNotificationsPlugin: ExpoConfig = {
+export const expoConfigExampleWithExpoNotificationsPlugins: ExpoConfig = {
   name: 'FirebaseMessagingTest',
   slug: 'fire-base-messaging-test',
   notification: notificationConfig,
-  plugins: [['expo-notifications', notificationConfig]],
+  plugins: [
+    ['expo-notifications', notificationConfig],
+    '../test-plugin',
+    ['expo-camera'],
+  ],
 };

--- a/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
@@ -21,9 +21,5 @@ export const expoConfigExampleWithExpoNotificationsPlugins: ExpoConfig = {
   name: 'FirebaseMessagingTest',
   slug: 'fire-base-messaging-test',
   notification: notificationConfig,
-  plugins: [
-    ['expo-notifications', notificationConfig],
-    '../test-plugin',
-    ['expo-camera'],
-  ],
+  plugins: [['expo-notifications', notificationConfig], '../test-plugin', ['expo-camera']],
 };

--- a/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
@@ -1,15 +1,26 @@
 import { ExpoConfig } from '@expo/config-types';
 
+const notificationConfig = {
+  icon: 'IconAsset',
+  color: '#1D172D',
+};
+
 /**
  * @type {import('@expo/config-types').ExpoConfig}
  */
-const expoConfigExample: ExpoConfig = {
+export const expoConfigExample: ExpoConfig = {
   name: 'FirebaseMessagingTest',
   slug: 'fire-base-messaging-test',
-  notification: {
-    icon: 'IconAsset',
-    color: '#1D172D',
-  },
+  notification: notificationConfig,
 };
 
-export default expoConfigExample;
+/**
+ * @type {import('@expo/config-types').ExpoConfig}
+ */
+export const expoConfigExampleWithExpoNotificationsPlugin: ExpoConfig = {
+  name: 'FirebaseMessagingTest',
+  slug: 'fire-base-messaging-test',
+  notification: notificationConfig,
+  plugins: [['expo-notifications', notificationConfig]],
+};
+

--- a/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
@@ -23,4 +23,3 @@ export const expoConfigExampleWithExpoNotificationsPlugin: ExpoConfig = {
   notification: notificationConfig,
   plugins: [['expo-notifications', notificationConfig]],
 };
-

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -26,12 +26,36 @@ export const withExpoPluginFirebaseNotification: ConfigPlugin = config => {
   });
 };
 
+interface NotificationConfig {
+  icon: string | null;
+  color: string | null;
+}
+
 export function setFireBaseMessagingAndroidManifest(
   config: ExpoConfig,
   application: ManifestApplication,
 ) {
+  const notificationConfig: NotificationConfig = {
+    icon: null,
+    color: null,
+  };
+
+  const notificationConfigFromPlugin = config.plugins?.find(plugin => plugin[0] === 'expo-notifications')?.[1];
+
+  // check if the notification config is defined in the expo-notifications plugin first
+  if (notificationConfigFromPlugin?.icon || notificationConfigFromPlugin?.color) {
+    notificationConfig.icon = notificationConfigFromPlugin?.icon || null;
+    notificationConfig.color = notificationConfigFromPlugin?.color || null;
+  }
+
+  // then check if the notification config is defined in the app.json notification object and override the plugin config if it is defined
+  if (config.notification) {
+    notificationConfig.icon = config.notification.icon || notificationConfig?.icon || null;
+    notificationConfig.color = config.notification.color || notificationConfig?.color || null;
+  }
+
   // If the notification object is not defined, print a friendly warning
-  if (!config.notification) {
+  if (!notificationConfig.icon && !notificationConfig.color) {
     // This warning is important because the notification icon can only use pure white on Android. By default, the system uses the app icon as the notification icon, but the app icon is usually not pure white, so you need to set the notification icon
     // eslint-disable-next-line no-console
     console.warn(
@@ -46,10 +70,10 @@ export function setFireBaseMessagingAndroidManifest(
   const metaData = application['meta-data'];
 
   if (
-    config.notification.icon &&
+    notificationConfig.icon &&
     !hasMetaData(application, 'com.google.firebase.messaging.default_notification_icon')
   ) {
-    // Expo will automatically create '@drawable/notification_icon' resource if you specify config.notification.icon.
+    // Expo will automatically create '@drawable/notification_icon' resource if you specify config.notification.icon or expo-notifications plugin.icon.
     metaData.push({
       $: {
         'android:name': 'com.google.firebase.messaging.default_notification_icon',
@@ -59,7 +83,7 @@ export function setFireBaseMessagingAndroidManifest(
   }
 
   if (
-    config.notification.color &&
+    notificationConfig.color &&
     !hasMetaData(application, 'com.google.firebase.messaging.default_notification_color')
   ) {
     metaData.push({

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -41,7 +41,7 @@ export function setFireBaseMessagingAndroidManifest(
   };
 
   const notificationConfigFromPlugin = config.plugins?.find(
-    plugin => plugin[0] === 'expo-notifications',
+    plugin => Array.isArray(plugin) && plugin[0] === 'expo-notifications',
   )?.[1];
 
   // check if the notification config is defined in the expo-notifications plugin first

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -40,7 +40,9 @@ export function setFireBaseMessagingAndroidManifest(
     color: null,
   };
 
-  const notificationConfigFromPlugin = config.plugins?.find(plugin => plugin[0] === 'expo-notifications')?.[1];
+  const notificationConfigFromPlugin = config.plugins?.find(
+    plugin => plugin[0] === 'expo-notifications',
+  )?.[1];
 
   // check if the notification config is defined in the expo-notifications plugin first
   if (notificationConfigFromPlugin?.icon || notificationConfigFromPlugin?.color) {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

When using `expo-notifications` in combination with `@react-native-firebase/messaging` for things like scheduling notifications now and other `expo-notifications` features we ran into an issue where the config wasn't being set in the [recommended plugins approach in their docs](https://docs.expo.dev/versions/latest/sdk/notifications/#configurable-properties). This meant some android devices didn't have a notification icon - e.g. like this issue here https://github.com/expo/expo/issues/24844

The goal of this is to add a check for `expo-notifications` plugin and uses the configuration for notification icon and color. If there is also a `notification.icon` and `notification.color` set then we will override with these values from the plugin.


### Related issues

As mentioned above we saw similar behaviour to this https://github.com/expo/expo/issues/24844 with mentions of this library. But we still had the problem.
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

Adds a check for `expo-notifications` plugin and uses the configuration for notification icon and color if `notification.icon` and `noticiation.color` doesn't already exist respectively

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [X] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [X] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

<img width="1154" alt="Screenshot 2025-06-09 at 22 31 03" src="https://github.com/user-attachments/assets/0ef75ad7-7143-4574-99ff-4d606f068919" />

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
