### PR TITLE
fix(docs): add a necessary await operator to the example code for initializeAppCheck()

### DIFF
--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -201,7 +201,7 @@ Once you have the custom provider configured, install it in app-check using the 
 import { getApp } from '@react-native-firebase/app';
 import { initializeAppCheck } from '@react-native-firebase/app-check';
 
-const appCheck = initializeAppCheck(getApp(), {
+const appCheck = await initializeAppCheck(getApp(), {
   provider: rnfbProvider,
   isTokenAutoRefreshEnabled: true,
 });


### PR DESCRIPTION
Something else, the link to the Contributor Guide that is in the template when you create a pull request gives a 404: [Contributor Guide](../CONTRIBUTING.md)

https://github.com/invertase/react-native-firebase/CONTRIBUTING.md