### PR TITLE
chore(messaging): deprecations for v8 API ahead of future major release

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -32,6 +32,9 @@ jest.doMock('react-native', () => {
         OS: 'android',
         select: () => {},
       },
+      AppRegistry: {
+        registerHeadlessTask: jest.fn(),
+      },
       NativeModules: {
         ...ReactNative.NativeModules,
         RNFBAnalyticsModule: {

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -374,6 +374,14 @@ export function createDeprecationProxy(instance) {
           deprecationConsoleWarning('appCheck', prop, 'statics', false);
         }
 
+        if (
+          prop === 'AuthorizationStatus' ||
+          prop === 'NotificationAndroidPriority' ||
+          prop === 'NotificationAndroidVisibility'
+        ) {
+          deprecationConsoleWarning('messaging', prop, 'statics', false);
+        }
+
         if (prop !== 'setLogLevel') {
           // we want to capture setLogLevel function call which we do below
           return Reflect.get(target, prop, receiver);

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -380,6 +380,30 @@ export function createDeprecationProxy(instance) {
         }
       }
 
+      // Check if it's a getter/setter first
+      const descriptor =
+        Object.getOwnPropertyDescriptor(target, prop) ||
+        Object.getOwnPropertyDescriptor(Object.getPrototypeOf(target), prop);
+
+      if (descriptor && (descriptor.get || descriptor.set)) {
+        const instanceName = getInstanceName(target);
+        const nameSpace = getNamespace(target);
+
+        if (descriptor.get) {
+          // Handle getter - call it and show deprecation warning
+          deprecationConsoleWarning(nameSpace, prop, instanceName, _isModularCall);
+          return descriptor.get.call(target);
+        }
+
+        if (descriptor.set) {
+          // Handle setter - return a function that calls the setter with deprecation warning
+          return function (value) {
+            deprecationConsoleWarning(nameSpace, prop, instanceName, false);
+            descriptor.set.call(target, value);
+          };
+        }
+      }
+
       if (typeof originalMethod === 'function') {
         return function (...args) {
           const isModularMethod = args.includes(MODULAR_DEPRECATION_ARG);
@@ -397,6 +421,19 @@ export function createDeprecationProxy(instance) {
 }
 
 export const MODULAR_DEPRECATION_ARG = 'react-native-firebase-modular-method-call';
+
+// Flag to track if we're currently in a modular call
+let _isModularCall = false;
+
+export function withModularFlag(fn) {
+  const previousFlag = _isModularCall;
+  _isModularCall = true;
+  try {
+    return fn();
+  } finally {
+    _isModularCall = previousFlag;
+  }
+}
 
 export function filterModularArgument(list) {
   return list.filter(arg => arg !== MODULAR_DEPRECATION_ARG);

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -406,7 +406,7 @@ export function createDeprecationProxy(instance) {
         if (descriptor.set) {
           // Handle setter - return a function that calls the setter with deprecation warning
           return function (value) {
-            deprecationConsoleWarning(nameSpace, prop, instanceName, false);
+            deprecationConsoleWarning(nameSpace, prop, instanceName, _isModularCall);
             descriptor.set.call(target, value);
           };
         }

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -107,6 +107,47 @@ export function tryJSONStringify(data) {
 const NO_REPLACEMENT = true;
 
 const mapOfDeprecationReplacements = {
+  messaging: {
+    default: {
+      isAutoInitEnabled: 'isAutoInitEnabled()',
+      isDeviceRegisteredForRemoteMessages: 'isDeviceRegisteredForRemoteMessages()',
+      isNotificationDelegationEnabled: 'isNotificationDelegationEnabled()',
+      isDeliveryMetricsExportToBigQueryEnabled: 'isDeliveryMetricsExportToBigQueryEnabled()',
+      setAutoInitEnabled: 'setAutoInitEnabled()',
+      getInitialNotification: 'getInitialNotification()',
+      getDidOpenSettingsForNotification: 'getDidOpenSettingsForNotification()',
+      getIsHeadless: 'getIsHeadless()',
+      onNotificationOpenedApp: 'onNotificationOpenedApp()',
+      onTokenRefresh: 'onTokenRefresh()',
+      requestPermission: 'requestPermission()',
+      registerDeviceForRemoteMessages: 'registerDeviceForRemoteMessages()',
+      unregisterDeviceForRemoteMessages: 'unregisterDeviceForRemoteMessages()',
+      getAPNSToken: 'getAPNSToken()',
+      setAPNSToken: 'setAPNSToken()',
+      hasPermission: 'hasPermission()',
+      onDeletedMessages: 'onDeletedMessages()',
+      onMessageSent: 'onMessageSent()',
+      onSendError: 'onSendError()',
+      setBackgroundMessageHandler: 'setBackgroundMessageHandler()',
+      setOpenSettingsForNotificationsHandler: 'setOpenSettingsForNotificationsHandler()',
+      sendMessage: 'sendMessage()',
+      subscribeToTopic: 'subscribeToTopic()',
+      unsubscribeFromTopic: 'unsubscribeFromTopic()',
+      setNotificationDelegationEnabled: 'setNotificationDelegationEnabled()',
+      // Actual firebase-js-sdk methods
+      getToken: 'getToken()',
+      deleteToken: 'deleteToken()',
+      onMessage: 'onMessage()',
+      isSupported: 'isSupported()',
+      setDeliveryMetricsExportToBigQuery:
+        'experimentalSetDeliveryMetricsExportedToBigQueryEnabled()',
+    },
+    statics: {
+      AuthorizationStatus: 'AuthorizationStatus',
+      NotificationAndroidPriority: 'NotificationAndroidPriority',
+      NotificationAndroidVisibility: 'NotificationAndroidVisibility',
+    },
+  },
   appCheck: {
     default: {
       activate: 'initializeAppCheck()',

--- a/packages/messaging/__tests__/messaging.test.ts
+++ b/packages/messaging/__tests__/messaging.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 import {
   getMessaging,
@@ -35,7 +35,15 @@ import {
   NotificationAndroidVisibility,
 } from '../lib';
 
-describe('Firestore', function () {
+import {
+  createCheckV9Deprecation,
+  CheckV9DeprecationFunction,
+} from '../../app/lib/common/unitTestUtils';
+
+// @ts-ignore test
+import FirebaseModule from '../../app/lib/internal/FirebaseModule';
+
+describe('Messaging', function () {
   describe('modular', function () {
     it('`getMessaging` function is properly exposed to end user', function () {
       expect(getMessaging).toBeDefined();
@@ -173,6 +181,191 @@ describe('Firestore', function () {
       expect(NotificationAndroidVisibility.VISIBILITY_PRIVATE).toBeDefined();
       expect(NotificationAndroidVisibility.VISIBILITY_PUBLIC).toBeDefined();
       expect(NotificationAndroidVisibility.VISIBILITY_SECRET).toBeDefined();
+    });
+  });
+
+  describe('test `console.warn` is called for RNFB v8 API & not called for v9 API', function () {
+    let messagingV9Deprecation: CheckV9DeprecationFunction;
+
+    beforeEach(function () {
+      messagingV9Deprecation = createCheckV9Deprecation(['messaging']);
+
+      // @ts-ignore test
+      jest.spyOn(FirebaseModule.prototype, 'native', 'get').mockImplementation(() => {
+        return new Proxy(
+          {},
+          {
+            get: () =>
+              jest.fn().mockResolvedValue({
+                result: true,
+              } as never),
+          },
+        );
+      });
+    });
+
+    describe('Messaging', function () {
+      it('isAutoInitEnabled', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => isAutoInitEnabled(messaging),
+          () => messaging.isAutoInitEnabled,
+          'isAutoInitEnabled',
+        );
+      });
+
+      it('isDeviceRegisteredForRemoteMessages', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => isDeviceRegisteredForRemoteMessages(messaging),
+          () => messaging.isDeviceRegisteredForRemoteMessages,
+          'isDeviceRegisteredForRemoteMessages',
+        );
+      });
+
+      it('setAutoInitEnabled', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => setAutoInitEnabled(messaging, true),
+          () => messaging.setAutoInitEnabled(true),
+          'setAutoInitEnabled',
+        );
+      });
+
+      it('getInitialNotification', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getInitialNotification(messaging),
+          () => messaging.getInitialNotification(),
+          'getInitialNotification',
+        );
+      });
+
+      it('getDidOpenSettingsForNotification', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getDidOpenSettingsForNotification(messaging),
+          () => messaging.getDidOpenSettingsForNotification(),
+          'getDidOpenSettingsForNotification',
+        );
+      });
+
+      it('getIsHeadless', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getIsHeadless(messaging),
+          () => messaging.getIsHeadless(),
+          'getIsHeadless',
+        );
+      });
+
+      it('requestPermission', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => requestPermission(messaging),
+          () => messaging.requestPermission,
+          'requestPermission',
+        );
+      });
+
+      it('registerDeviceForRemoteMessages', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => registerDeviceForRemoteMessages(messaging),
+          () => messaging.registerDeviceForRemoteMessages,
+          'registerDeviceForRemoteMessages',
+        );
+      });
+
+      it('unregisterDeviceForRemoteMessages', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => unregisterDeviceForRemoteMessages(messaging),
+          () => messaging.unregisterDeviceForRemoteMessages,
+          'unregisterDeviceForRemoteMessages',
+        );
+      });
+
+      it('getAPNSToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getAPNSToken(messaging),
+          () => messaging.getAPNSToken(),
+          'getAPNSToken',
+        );
+      });
+
+      it('setAPNSToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => setAPNSToken(messaging, 'token'),
+          () => messaging.setAPNSToken('token'),
+          'setAPNSToken',
+        );
+      });
+
+      it('hasPermission', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => hasPermission(messaging),
+          () => messaging.hasPermission(),
+          'hasPermission',
+        );
+      });
+
+      it('subscribeToTopic', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => subscribeToTopic(messaging, 'topic'),
+          () => messaging.subscribeToTopic('topic'),
+          'subscribeToTopic',
+        );
+      });
+
+      it('unsubscribeFromTopic', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => unsubscribeFromTopic(messaging, 'topic'),
+          () => messaging.unsubscribeFromTopic('topic'),
+          'unsubscribeFromTopic',
+        );
+      });
+
+      it('getToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getToken(messaging),
+          () => messaging.getToken(),
+          'getToken',
+        );
+      });
+
+      it('deleteToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => deleteToken(messaging),
+          () => messaging.deleteToken(),
+          'deleteToken',
+        );
+      });
+
+      it('isSupported', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => isSupported(messaging),
+          () => messaging.isSupported(),
+          'isSupported',
+        );
+      });
+
+      it('experimentalSetDeliveryMetricsExportedToBigQueryEnabled', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, true),
+          () => messaging.setDeliveryMetricsExportToBigQuery(true),
+          'setDeliveryMetricsExportToBigQuery',
+        );
+      });
     });
   });
 });

--- a/packages/messaging/__tests__/messaging.test.ts
+++ b/packages/messaging/__tests__/messaging.test.ts
@@ -223,149 +223,149 @@ describe('Messaging', function () {
         );
       });
 
-      // it('setAutoInitEnabled', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => setAutoInitEnabled(messaging, true),
-      //     () => messaging.setAutoInitEnabled(true),
-      //     'setAutoInitEnabled',
-      //   );
-      // });
+      it('setAutoInitEnabled', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => setAutoInitEnabled(messaging, true),
+          () => messaging.setAutoInitEnabled(true),
+          'setAutoInitEnabled',
+        );
+      });
 
-      // it('getInitialNotification', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => getInitialNotification(messaging),
-      //     () => messaging.getInitialNotification(),
-      //     'getInitialNotification',
-      //   );
-      // });
+      it('getInitialNotification', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getInitialNotification(messaging),
+          () => messaging.getInitialNotification(),
+          'getInitialNotification',
+        );
+      });
 
-      // it('getDidOpenSettingsForNotification', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => getDidOpenSettingsForNotification(messaging),
-      //     () => messaging.getDidOpenSettingsForNotification(),
-      //     'getDidOpenSettingsForNotification',
-      //   );
-      // });
+      it('getDidOpenSettingsForNotification', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getDidOpenSettingsForNotification(messaging),
+          () => messaging.getDidOpenSettingsForNotification(),
+          'getDidOpenSettingsForNotification',
+        );
+      });
 
-      // it('getIsHeadless', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => getIsHeadless(messaging),
-      //     () => messaging.getIsHeadless(),
-      //     'getIsHeadless',
-      //   );
-      // });
+      it('getIsHeadless', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getIsHeadless(messaging),
+          () => messaging.getIsHeadless(),
+          'getIsHeadless',
+        );
+      });
 
-      // it('requestPermission', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => requestPermission(messaging),
-      //     () => messaging.requestPermission,
-      //     'requestPermission',
-      //   );
-      // });
+      it('requestPermission', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => requestPermission(messaging),
+          () => messaging.requestPermission(),
+          'requestPermission',
+        );
+      });
 
-      // it('registerDeviceForRemoteMessages', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => registerDeviceForRemoteMessages(messaging),
-      //     () => messaging.registerDeviceForRemoteMessages,
-      //     'registerDeviceForRemoteMessages',
-      //   );
-      // });
+      it('registerDeviceForRemoteMessages', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => registerDeviceForRemoteMessages(messaging),
+          () => messaging.registerDeviceForRemoteMessages(),
+          'registerDeviceForRemoteMessages',
+        );
+      });
 
-      // it('unregisterDeviceForRemoteMessages', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => unregisterDeviceForRemoteMessages(messaging),
-      //     () => messaging.unregisterDeviceForRemoteMessages,
-      //     'unregisterDeviceForRemoteMessages',
-      //   );
-      // });
+      it('unregisterDeviceForRemoteMessages', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => unregisterDeviceForRemoteMessages(messaging),
+          () => messaging.unregisterDeviceForRemoteMessages(),
+          'unregisterDeviceForRemoteMessages',
+        );
+      });
 
-      // it('getAPNSToken', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => getAPNSToken(messaging),
-      //     () => messaging.getAPNSToken(),
-      //     'getAPNSToken',
-      //   );
-      // });
+      it('getAPNSToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getAPNSToken(messaging),
+          () => messaging.getAPNSToken(),
+          'getAPNSToken',
+        );
+      });
 
-      // it('setAPNSToken', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => setAPNSToken(messaging, 'token'),
-      //     () => messaging.setAPNSToken('token'),
-      //     'setAPNSToken',
-      //   );
-      // });
+      it('setAPNSToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => setAPNSToken(messaging, 'token'),
+          () => messaging.setAPNSToken('token'),
+          'setAPNSToken',
+        );
+      });
 
-      // it('hasPermission', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => hasPermission(messaging),
-      //     () => messaging.hasPermission(),
-      //     'hasPermission',
-      //   );
-      // });
+      it('hasPermission', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => hasPermission(messaging),
+          () => messaging.hasPermission(),
+          'hasPermission',
+        );
+      });
 
-      // it('subscribeToTopic', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => subscribeToTopic(messaging, 'topic'),
-      //     () => messaging.subscribeToTopic('topic'),
-      //     'subscribeToTopic',
-      //   );
-      // });
+      it('subscribeToTopic', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => subscribeToTopic(messaging, 'topic'),
+          () => messaging.subscribeToTopic('topic'),
+          'subscribeToTopic',
+        );
+      });
 
-      // it('unsubscribeFromTopic', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => unsubscribeFromTopic(messaging, 'topic'),
-      //     () => messaging.unsubscribeFromTopic('topic'),
-      //     'unsubscribeFromTopic',
-      //   );
-      // });
+      it('unsubscribeFromTopic', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => unsubscribeFromTopic(messaging, 'topic'),
+          () => messaging.unsubscribeFromTopic('topic'),
+          'unsubscribeFromTopic',
+        );
+      });
 
-      // it('getToken', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => getToken(messaging),
-      //     () => messaging.getToken(),
-      //     'getToken',
-      //   );
-      // });
+      it('getToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => getToken(messaging),
+          () => messaging.getToken(),
+          'getToken',
+        );
+      });
 
-      // it('deleteToken', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => deleteToken(messaging),
-      //     () => messaging.deleteToken(),
-      //     'deleteToken',
-      //   );
-      // });
+      it('deleteToken', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => deleteToken(messaging),
+          () => messaging.deleteToken(),
+          'deleteToken',
+        );
+      });
 
-      // it('isSupported', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => isSupported(messaging),
-      //     () => messaging.isSupported(),
-      //     'isSupported',
-      //   );
-      // });
+      it('isSupported', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => isSupported(messaging),
+          () => messaging.isSupported(),
+          'isSupported',
+        );
+      });
 
-      // it('experimentalSetDeliveryMetricsExportedToBigQueryEnabled', function () {
-      //   const messaging = getMessaging();
-      //   messagingV9Deprecation(
-      //     () => experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, true),
-      //     () => messaging.setDeliveryMetricsExportToBigQuery(true),
-      //     'setDeliveryMetricsExportToBigQuery',
-      //   );
-      // });
+      it('experimentalSetDeliveryMetricsExportedToBigQueryEnabled', function () {
+        const messaging = getMessaging();
+        messagingV9Deprecation(
+          () => experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, true),
+          () => messaging.setDeliveryMetricsExportToBigQuery(true),
+          'setDeliveryMetricsExportToBigQuery',
+        );
+      });
     });
   });
 });

--- a/packages/messaging/__tests__/messaging.test.ts
+++ b/packages/messaging/__tests__/messaging.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-import {
+import messaging, {
   getMessaging,
   deleteToken,
   getToken,
@@ -186,9 +186,11 @@ describe('Messaging', function () {
 
   describe('test `console.warn` is called for RNFB v8 API & not called for v9 API', function () {
     let messagingV9Deprecation: CheckV9DeprecationFunction;
+    let staticsV9Deprecation: CheckV9DeprecationFunction;
 
     beforeEach(function () {
       messagingV9Deprecation = createCheckV9Deprecation(['messaging']);
+      staticsV9Deprecation = createCheckV9Deprecation(['messaging', 'statics']);
 
       // @ts-ignore test
       jest.spyOn(FirebaseModule.prototype, 'native', 'get').mockImplementation(() => {
@@ -365,6 +367,32 @@ describe('Messaging', function () {
           () => messaging.setDeliveryMetricsExportToBigQuery(true),
           'setDeliveryMetricsExportToBigQuery',
         );
+      });
+
+      describe('statics', function () {
+        it('AuthorizationStatus', function () {
+          staticsV9Deprecation(
+            () => AuthorizationStatus,
+            () => messaging.AuthorizationStatus,
+            'AuthorizationStatus',
+          );
+        });
+
+        it('NotificationAndroidPriority', function () {
+          staticsV9Deprecation(
+            () => NotificationAndroidPriority,
+            () => messaging.NotificationAndroidPriority,
+            'NotificationAndroidPriority',
+          );
+        });
+
+        it('NotificationAndroidVisibility', function () {
+          staticsV9Deprecation(
+            () => NotificationAndroidVisibility,
+            () => messaging.NotificationAndroidVisibility,
+            'NotificationAndroidVisibility',
+          );
+        });
       });
     });
   });

--- a/packages/messaging/__tests__/messaging.test.ts
+++ b/packages/messaging/__tests__/messaging.test.ts
@@ -223,149 +223,149 @@ describe('Messaging', function () {
         );
       });
 
-      it('setAutoInitEnabled', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => setAutoInitEnabled(messaging, true),
-          () => messaging.setAutoInitEnabled(true),
-          'setAutoInitEnabled',
-        );
-      });
+      // it('setAutoInitEnabled', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => setAutoInitEnabled(messaging, true),
+      //     () => messaging.setAutoInitEnabled(true),
+      //     'setAutoInitEnabled',
+      //   );
+      // });
 
-      it('getInitialNotification', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => getInitialNotification(messaging),
-          () => messaging.getInitialNotification(),
-          'getInitialNotification',
-        );
-      });
+      // it('getInitialNotification', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => getInitialNotification(messaging),
+      //     () => messaging.getInitialNotification(),
+      //     'getInitialNotification',
+      //   );
+      // });
 
-      it('getDidOpenSettingsForNotification', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => getDidOpenSettingsForNotification(messaging),
-          () => messaging.getDidOpenSettingsForNotification(),
-          'getDidOpenSettingsForNotification',
-        );
-      });
+      // it('getDidOpenSettingsForNotification', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => getDidOpenSettingsForNotification(messaging),
+      //     () => messaging.getDidOpenSettingsForNotification(),
+      //     'getDidOpenSettingsForNotification',
+      //   );
+      // });
 
-      it('getIsHeadless', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => getIsHeadless(messaging),
-          () => messaging.getIsHeadless(),
-          'getIsHeadless',
-        );
-      });
+      // it('getIsHeadless', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => getIsHeadless(messaging),
+      //     () => messaging.getIsHeadless(),
+      //     'getIsHeadless',
+      //   );
+      // });
 
-      it('requestPermission', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => requestPermission(messaging),
-          () => messaging.requestPermission,
-          'requestPermission',
-        );
-      });
+      // it('requestPermission', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => requestPermission(messaging),
+      //     () => messaging.requestPermission,
+      //     'requestPermission',
+      //   );
+      // });
 
-      it('registerDeviceForRemoteMessages', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => registerDeviceForRemoteMessages(messaging),
-          () => messaging.registerDeviceForRemoteMessages,
-          'registerDeviceForRemoteMessages',
-        );
-      });
+      // it('registerDeviceForRemoteMessages', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => registerDeviceForRemoteMessages(messaging),
+      //     () => messaging.registerDeviceForRemoteMessages,
+      //     'registerDeviceForRemoteMessages',
+      //   );
+      // });
 
-      it('unregisterDeviceForRemoteMessages', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => unregisterDeviceForRemoteMessages(messaging),
-          () => messaging.unregisterDeviceForRemoteMessages,
-          'unregisterDeviceForRemoteMessages',
-        );
-      });
+      // it('unregisterDeviceForRemoteMessages', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => unregisterDeviceForRemoteMessages(messaging),
+      //     () => messaging.unregisterDeviceForRemoteMessages,
+      //     'unregisterDeviceForRemoteMessages',
+      //   );
+      // });
 
-      it('getAPNSToken', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => getAPNSToken(messaging),
-          () => messaging.getAPNSToken(),
-          'getAPNSToken',
-        );
-      });
+      // it('getAPNSToken', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => getAPNSToken(messaging),
+      //     () => messaging.getAPNSToken(),
+      //     'getAPNSToken',
+      //   );
+      // });
 
-      it('setAPNSToken', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => setAPNSToken(messaging, 'token'),
-          () => messaging.setAPNSToken('token'),
-          'setAPNSToken',
-        );
-      });
+      // it('setAPNSToken', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => setAPNSToken(messaging, 'token'),
+      //     () => messaging.setAPNSToken('token'),
+      //     'setAPNSToken',
+      //   );
+      // });
 
-      it('hasPermission', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => hasPermission(messaging),
-          () => messaging.hasPermission(),
-          'hasPermission',
-        );
-      });
+      // it('hasPermission', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => hasPermission(messaging),
+      //     () => messaging.hasPermission(),
+      //     'hasPermission',
+      //   );
+      // });
 
-      it('subscribeToTopic', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => subscribeToTopic(messaging, 'topic'),
-          () => messaging.subscribeToTopic('topic'),
-          'subscribeToTopic',
-        );
-      });
+      // it('subscribeToTopic', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => subscribeToTopic(messaging, 'topic'),
+      //     () => messaging.subscribeToTopic('topic'),
+      //     'subscribeToTopic',
+      //   );
+      // });
 
-      it('unsubscribeFromTopic', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => unsubscribeFromTopic(messaging, 'topic'),
-          () => messaging.unsubscribeFromTopic('topic'),
-          'unsubscribeFromTopic',
-        );
-      });
+      // it('unsubscribeFromTopic', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => unsubscribeFromTopic(messaging, 'topic'),
+      //     () => messaging.unsubscribeFromTopic('topic'),
+      //     'unsubscribeFromTopic',
+      //   );
+      // });
 
-      it('getToken', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => getToken(messaging),
-          () => messaging.getToken(),
-          'getToken',
-        );
-      });
+      // it('getToken', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => getToken(messaging),
+      //     () => messaging.getToken(),
+      //     'getToken',
+      //   );
+      // });
 
-      it('deleteToken', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => deleteToken(messaging),
-          () => messaging.deleteToken(),
-          'deleteToken',
-        );
-      });
+      // it('deleteToken', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => deleteToken(messaging),
+      //     () => messaging.deleteToken(),
+      //     'deleteToken',
+      //   );
+      // });
 
-      it('isSupported', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => isSupported(messaging),
-          () => messaging.isSupported(),
-          'isSupported',
-        );
-      });
+      // it('isSupported', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => isSupported(messaging),
+      //     () => messaging.isSupported(),
+      //     'isSupported',
+      //   );
+      // });
 
-      it('experimentalSetDeliveryMetricsExportedToBigQueryEnabled', function () {
-        const messaging = getMessaging();
-        messagingV9Deprecation(
-          () => experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, true),
-          () => messaging.setDeliveryMetricsExportToBigQuery(true),
-          'setDeliveryMetricsExportToBigQuery',
-        );
-      });
+      // it('experimentalSetDeliveryMetricsExportedToBigQueryEnabled', function () {
+      //   const messaging = getMessaging();
+      //   messagingV9Deprecation(
+      //     () => experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, true),
+      //     () => messaging.setDeliveryMetricsExportToBigQuery(true),
+      //     'setDeliveryMetricsExportToBigQuery',
+      //   );
+      // });
     });
   });
 });

--- a/packages/messaging/lib/modular/index.js
+++ b/packages/messaging/lib/modular/index.js
@@ -1,5 +1,6 @@
 import { getApp } from '@react-native-firebase/app';
 import { withModularFlag } from '@react-native-firebase/app/lib/common';
+import { MODULAR_DEPRECATION_ARG } from '@react-native-firebase/app/lib/common';
 
 /**
  * @typedef {import('..').FirebaseMessagingTypes} FirebaseMessagingTypes
@@ -34,7 +35,7 @@ export function getMessaging(app) {
  * @returns {Promise<void>}
  */
 export function deleteToken(messaging, tokenOptions) {
-  return messaging.deleteToken.call(messaging, tokenOptions);
+  return messaging.deleteToken.call(messaging, tokenOptions, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -44,7 +45,7 @@ export function deleteToken(messaging, tokenOptions) {
  * @returns {Promise<string>}
  */
 export function getToken(messaging, options) {
-  return messaging.getToken.call(messaging, options);
+  return messaging.getToken.call(messaging, options, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -55,7 +56,7 @@ export function getToken(messaging, options) {
  * @returns {() => void}
  */
 export function onMessage(messaging, listener) {
-  return messaging.onMessage.call(messaging, listener);
+  return messaging.onMessage.call(messaging, listener, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -66,7 +67,7 @@ export function onMessage(messaging, listener) {
  * @returns {() => void}
  */
 export function onNotificationOpenedApp(messaging, listener) {
-  return messaging.onNotificationOpenedApp.call(messaging, listener);
+  return messaging.onNotificationOpenedApp.call(messaging, listener, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -78,7 +79,7 @@ export function onNotificationOpenedApp(messaging, listener) {
  * @returns {() => void}
  */
 export function onTokenRefresh(messaging, listener) {
-  return messaging.onTokenRefresh.call(messaging, listener);
+  return messaging.onTokenRefresh.call(messaging, listener, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -89,7 +90,7 @@ export function onTokenRefresh(messaging, listener) {
  * @returns {Promise<AuthorizationStatus>}
  */
 export function requestPermission(messaging, iosPermissions) {
-  return messaging.requestPermission.call(messaging, iosPermissions);
+  return messaging.requestPermission.call(messaging, iosPermissions, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -108,7 +109,7 @@ export function isAutoInitEnabled(messaging) {
  * @returns {Promise<void>}
  */
 export function setAutoInitEnabled(messaging, enabled) {
-  return messaging.setAutoInitEnabled.call(messaging, enabled);
+  return messaging.setAutoInitEnabled.call(messaging, enabled, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -119,7 +120,7 @@ export function setAutoInitEnabled(messaging, enabled) {
  * @returns {Promise<RemoteMessage | null>}
  */
 export function getInitialNotification(messaging) {
-  return messaging.getInitialNotification.call(messaging);
+  return messaging.getInitialNotification.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -129,7 +130,7 @@ export function getInitialNotification(messaging) {
  * @returns {Promise<boolean>}
  */
 export function getDidOpenSettingsForNotification(messaging) {
-  return messaging.getDidOpenSettingsForNotification.call(messaging);
+  return messaging.getDidOpenSettingsForNotification.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -139,7 +140,7 @@ export function getDidOpenSettingsForNotification(messaging) {
  * @returns {Promise<boolean>}
  */
 export function getIsHeadless(messaging) {
-  return messaging.getIsHeadless.call(messaging);
+  return messaging.getIsHeadless.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -149,7 +150,7 @@ export function getIsHeadless(messaging) {
  * @returns {Promise<void>}
  */
 export function registerDeviceForRemoteMessages(messaging) {
-  return messaging.registerDeviceForRemoteMessages.call(messaging);
+  return messaging.registerDeviceForRemoteMessages.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -159,7 +160,7 @@ export function registerDeviceForRemoteMessages(messaging) {
  * @returns {boolean}
  */
 export function isDeviceRegisteredForRemoteMessages(messaging) {
-  return messaging.isDeviceRegisteredForRemoteMessages.call(messaging);
+  return withModularFlag(() => messaging.isDeviceRegisteredForRemoteMessages);
 }
 
 /**
@@ -168,7 +169,7 @@ export function isDeviceRegisteredForRemoteMessages(messaging) {
  * @returns {Promise<void>}
  */
 export function unregisterDeviceForRemoteMessages(messaging) {
-  return messaging.unregisterDeviceForRemoteMessages.call(messaging);
+  return messaging.unregisterDeviceForRemoteMessages.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -178,7 +179,7 @@ export function unregisterDeviceForRemoteMessages(messaging) {
  * @returns {Promise<string | null>}
  */
 export function getAPNSToken(messaging) {
-  return messaging.getAPNSToken.call(messaging);
+  return messaging.getAPNSToken.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -205,7 +206,7 @@ export function getAPNSToken(messaging) {
  * @returns {Promise<void>}
  */
 export function setAPNSToken(messaging, token, type) {
-  return messaging.setAPNSToken.call(messaging, token, type);
+  return messaging.setAPNSToken.call(messaging, token, type, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -214,7 +215,7 @@ export function setAPNSToken(messaging, token, type) {
  * @returns {Promise<AuthorizationStatus>}
  */
 export function hasPermission(messaging) {
-  return messaging.hasPermission.call(messaging);
+  return messaging.hasPermission.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -224,7 +225,7 @@ export function hasPermission(messaging) {
  * @returns {() => void}
  */
 export function onDeletedMessages(messaging, listener) {
-  return messaging.onDeletedMessages.call(messaging, listener);
+  return messaging.onDeletedMessages.call(messaging, listener, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -234,7 +235,7 @@ export function onDeletedMessages(messaging, listener) {
  * @returns {() => void}
  */
 export function onMessageSent(messaging, listener) {
-  return messaging.onMessageSent.call(messaging, listener);
+  return messaging.onMessageSent.call(messaging, listener, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -244,7 +245,7 @@ export function onMessageSent(messaging, listener) {
  * @returns {() => void}
  */
 export function onSendError(messaging, listener) {
-  return messaging.onSendError.call(messaging, listener);
+  return messaging.onSendError.call(messaging, listener, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -256,7 +257,7 @@ export function onSendError(messaging, listener) {
  * @returns {void}
  */
 export function setBackgroundMessageHandler(messaging, handler) {
-  return messaging.setBackgroundMessageHandler.call(messaging, handler);
+  return messaging.setBackgroundMessageHandler.call(messaging, handler, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -267,7 +268,11 @@ export function setBackgroundMessageHandler(messaging, handler) {
  * @returns {void}
  */
 export function setOpenSettingsForNotificationsHandler(messaging, handler) {
-  return messaging.setOpenSettingsForNotificationsHandler.call(messaging, handler);
+  return messaging.setOpenSettingsForNotificationsHandler.call(
+    messaging,
+    handler,
+    MODULAR_DEPRECATION_ARG,
+  );
 }
 
 /**
@@ -277,7 +282,7 @@ export function setOpenSettingsForNotificationsHandler(messaging, handler) {
  * @returns {Promise<void>}
  */
 export function sendMessage(messaging, message) {
-  return messaging.sendMessage.call(messaging, message);
+  return messaging.sendMessage.call(messaging, message, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -288,7 +293,7 @@ export function sendMessage(messaging, message) {
  * @returns {Promise<void>}
  */
 export function subscribeToTopic(messaging, topic) {
-  return messaging.subscribeToTopic.call(messaging, topic);
+  return messaging.subscribeToTopic.call(messaging, topic, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -298,7 +303,7 @@ export function subscribeToTopic(messaging, topic) {
  * @returns {Promise<void>}
  */
 export function unsubscribeFromTopic(messaging, topic) {
-  return messaging.unsubscribeFromTopic.call(messaging, topic);
+  return messaging.unsubscribeFromTopic.call(messaging, topic, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -307,7 +312,7 @@ export function unsubscribeFromTopic(messaging, topic) {
  * @returns {boolean}
  */
 export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
-  return messaging.isDeliveryMetricsExportToBigQueryEnabled.call(messaging);
+  return withModularFlag(() => messaging.isDeliveryMetricsExportToBigQueryEnabled);
 }
 
 /**
@@ -317,7 +322,7 @@ export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
  * @returns {boolean}
  */
 export function isNotificationDelegationEnabled(messaging) {
-  return messaging.isNotificationDelegationEnabled.call(messaging);
+  return withModularFlag(() => messaging.isNotificationDelegationEnabled);
 }
 
 /**
@@ -329,7 +334,11 @@ export function isNotificationDelegationEnabled(messaging) {
  * @returns {Promise<void>}
  */
 export function setNotificationDelegationEnabled(messaging, enabled) {
-  return messaging.setNotificationDelegationEnabled.call(messaging, enabled);
+  return messaging.setNotificationDelegationEnabled.call(
+    messaging,
+    enabled,
+    MODULAR_DEPRECATION_ARG,
+  );
 }
 
 /**
@@ -338,7 +347,7 @@ export function setNotificationDelegationEnabled(messaging, enabled) {
  * @returns {boolean}
  */
 export function isSupported(messaging) {
-  return messaging.isSupported.call(messaging);
+  return messaging.isSupported.call(messaging, MODULAR_DEPRECATION_ARG);
 }
 
 /**
@@ -349,7 +358,11 @@ export function isSupported(messaging) {
  * @returns {Promise<void>}
  */
 export function experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enabled) {
-  return messaging.setDeliveryMetricsExportToBigQuery.call(messaging, enabled);
+  return messaging.setDeliveryMetricsExportToBigQuery.call(
+    messaging,
+    enabled,
+    MODULAR_DEPRECATION_ARG,
+  );
 }
 
 export {

--- a/packages/messaging/lib/modular/index.js
+++ b/packages/messaging/lib/modular/index.js
@@ -1,4 +1,5 @@
 import { getApp } from '@react-native-firebase/app';
+import { withModularFlag } from '@react-native-firebase/app/lib/common';
 
 /**
  * @typedef {import('..').FirebaseMessagingTypes} FirebaseMessagingTypes
@@ -33,7 +34,7 @@ export function getMessaging(app) {
  * @returns {Promise<void>}
  */
 export function deleteToken(messaging, tokenOptions) {
-  return messaging.deleteToken(tokenOptions);
+  return messaging.deleteToken.call(messaging, tokenOptions);
 }
 
 /**
@@ -43,7 +44,7 @@ export function deleteToken(messaging, tokenOptions) {
  * @returns {Promise<string>}
  */
 export function getToken(messaging, options) {
-  return messaging.getToken(options);
+  return messaging.getToken.call(messaging, options);
 }
 
 /**
@@ -54,7 +55,7 @@ export function getToken(messaging, options) {
  * @returns {() => void}
  */
 export function onMessage(messaging, listener) {
-  return messaging.onMessage(listener);
+  return messaging.onMessage.call(messaging, listener);
 }
 
 /**
@@ -65,7 +66,7 @@ export function onMessage(messaging, listener) {
  * @returns {() => void}
  */
 export function onNotificationOpenedApp(messaging, listener) {
-  return messaging.onNotificationOpenedApp(listener);
+  return messaging.onNotificationOpenedApp.call(messaging, listener);
 }
 
 /**
@@ -77,7 +78,7 @@ export function onNotificationOpenedApp(messaging, listener) {
  * @returns {() => void}
  */
 export function onTokenRefresh(messaging, listener) {
-  return messaging.onTokenRefresh(listener);
+  return messaging.onTokenRefresh.call(messaging, listener);
 }
 
 /**
@@ -88,7 +89,7 @@ export function onTokenRefresh(messaging, listener) {
  * @returns {Promise<AuthorizationStatus>}
  */
 export function requestPermission(messaging, iosPermissions) {
-  return messaging.requestPermission(iosPermissions);
+  return messaging.requestPermission.call(messaging, iosPermissions);
 }
 
 /**
@@ -97,7 +98,7 @@ export function requestPermission(messaging, iosPermissions) {
  * @returns {boolean}
  */
 export function isAutoInitEnabled(messaging) {
-  return messaging.isAutoInitEnabled;
+  return withModularFlag(() => messaging.isAutoInitEnabled);
 }
 
 /**
@@ -107,7 +108,7 @@ export function isAutoInitEnabled(messaging) {
  * @returns {Promise<void>}
  */
 export function setAutoInitEnabled(messaging, enabled) {
-  return messaging.setAutoInitEnabled(enabled);
+  return messaging.setAutoInitEnabled.call(messaging, enabled);
 }
 
 /**
@@ -118,7 +119,7 @@ export function setAutoInitEnabled(messaging, enabled) {
  * @returns {Promise<RemoteMessage | null>}
  */
 export function getInitialNotification(messaging) {
-  return messaging.getInitialNotification();
+  return messaging.getInitialNotification.call(messaging);
 }
 
 /**
@@ -128,7 +129,7 @@ export function getInitialNotification(messaging) {
  * @returns {Promise<boolean>}
  */
 export function getDidOpenSettingsForNotification(messaging) {
-  return messaging.getDidOpenSettingsForNotification();
+  return messaging.getDidOpenSettingsForNotification.call(messaging);
 }
 
 /**
@@ -138,7 +139,7 @@ export function getDidOpenSettingsForNotification(messaging) {
  * @returns {Promise<boolean>}
  */
 export function getIsHeadless(messaging) {
-  return messaging.getIsHeadless();
+  return messaging.getIsHeadless.call(messaging);
 }
 
 /**
@@ -148,7 +149,7 @@ export function getIsHeadless(messaging) {
  * @returns {Promise<void>}
  */
 export function registerDeviceForRemoteMessages(messaging) {
-  return messaging.registerDeviceForRemoteMessages();
+  return messaging.registerDeviceForRemoteMessages.call(messaging);
 }
 
 /**
@@ -158,7 +159,7 @@ export function registerDeviceForRemoteMessages(messaging) {
  * @returns {boolean}
  */
 export function isDeviceRegisteredForRemoteMessages(messaging) {
-  return messaging.isDeviceRegisteredForRemoteMessages;
+  return messaging.isDeviceRegisteredForRemoteMessages.call(messaging);
 }
 
 /**
@@ -167,7 +168,7 @@ export function isDeviceRegisteredForRemoteMessages(messaging) {
  * @returns {Promise<void>}
  */
 export function unregisterDeviceForRemoteMessages(messaging) {
-  return messaging.unregisterDeviceForRemoteMessages();
+  return messaging.unregisterDeviceForRemoteMessages.call(messaging);
 }
 
 /**
@@ -177,7 +178,7 @@ export function unregisterDeviceForRemoteMessages(messaging) {
  * @returns {Promise<string | null>}
  */
 export function getAPNSToken(messaging) {
-  return messaging.getAPNSToken();
+  return messaging.getAPNSToken.call(messaging);
 }
 
 /**
@@ -204,7 +205,7 @@ export function getAPNSToken(messaging) {
  * @returns {Promise<void>}
  */
 export function setAPNSToken(messaging, token, type) {
-  return messaging.setAPNSToken(token, type);
+  return messaging.setAPNSToken.call(messaging, token, type);
 }
 
 /**
@@ -213,7 +214,7 @@ export function setAPNSToken(messaging, token, type) {
  * @returns {Promise<AuthorizationStatus>}
  */
 export function hasPermission(messaging) {
-  return messaging.hasPermission();
+  return messaging.hasPermission.call(messaging);
 }
 
 /**
@@ -223,7 +224,7 @@ export function hasPermission(messaging) {
  * @returns {() => void}
  */
 export function onDeletedMessages(messaging, listener) {
-  return messaging.onDeletedMessages(listener);
+  return messaging.onDeletedMessages.call(messaging, listener);
 }
 
 /**
@@ -233,7 +234,7 @@ export function onDeletedMessages(messaging, listener) {
  * @returns {() => void}
  */
 export function onMessageSent(messaging, listener) {
-  return messaging.onMessageSent(listener);
+  return messaging.onMessageSent.call(messaging, listener);
 }
 
 /**
@@ -243,7 +244,7 @@ export function onMessageSent(messaging, listener) {
  * @returns {() => void}
  */
 export function onSendError(messaging, listener) {
-  return messaging.onSendError(listener);
+  return messaging.onSendError.call(messaging, listener);
 }
 
 /**
@@ -255,7 +256,7 @@ export function onSendError(messaging, listener) {
  * @returns {void}
  */
 export function setBackgroundMessageHandler(messaging, handler) {
-  return messaging.setBackgroundMessageHandler(handler);
+  return messaging.setBackgroundMessageHandler.call(messaging, handler);
 }
 
 /**
@@ -266,7 +267,7 @@ export function setBackgroundMessageHandler(messaging, handler) {
  * @returns {void}
  */
 export function setOpenSettingsForNotificationsHandler(messaging, handler) {
-  return messaging.setOpenSettingsForNotificationsHandler(handler);
+  return messaging.setOpenSettingsForNotificationsHandler.call(messaging, handler);
 }
 
 /**
@@ -276,7 +277,7 @@ export function setOpenSettingsForNotificationsHandler(messaging, handler) {
  * @returns {Promise<void>}
  */
 export function sendMessage(messaging, message) {
-  return messaging.sendMessage(message);
+  return messaging.sendMessage.call(messaging, message);
 }
 
 /**
@@ -287,7 +288,7 @@ export function sendMessage(messaging, message) {
  * @returns {Promise<void>}
  */
 export function subscribeToTopic(messaging, topic) {
-  return messaging.subscribeToTopic(topic);
+  return messaging.subscribeToTopic.call(messaging, topic);
 }
 
 /**
@@ -297,7 +298,7 @@ export function subscribeToTopic(messaging, topic) {
  * @returns {Promise<void>}
  */
 export function unsubscribeFromTopic(messaging, topic) {
-  return messaging.unsubscribeFromTopic(topic);
+  return messaging.unsubscribeFromTopic.call(messaging, topic);
 }
 
 /**
@@ -306,7 +307,7 @@ export function unsubscribeFromTopic(messaging, topic) {
  * @returns {boolean}
  */
 export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
-  return messaging.isDeliveryMetricsExportToBigQueryEnabled;
+  return messaging.isDeliveryMetricsExportToBigQueryEnabled.call(messaging);
 }
 
 /**
@@ -316,7 +317,7 @@ export function isDeliveryMetricsExportToBigQueryEnabled(messaging) {
  * @returns {boolean}
  */
 export function isNotificationDelegationEnabled(messaging) {
-  return messaging.isNotificationDelegationEnabled;
+  return messaging.isNotificationDelegationEnabled.call(messaging);
 }
 
 /**
@@ -328,7 +329,7 @@ export function isNotificationDelegationEnabled(messaging) {
  * @returns {Promise<void>}
  */
 export function setNotificationDelegationEnabled(messaging, enabled) {
-  return messaging.setNotificationDelegationEnabled(enabled);
+  return messaging.setNotificationDelegationEnabled.call(messaging, enabled);
 }
 
 /**
@@ -337,7 +338,7 @@ export function setNotificationDelegationEnabled(messaging, enabled) {
  * @returns {boolean}
  */
 export function isSupported(messaging) {
-  return messaging.isSupported();
+  return messaging.isSupported.call(messaging);
 }
 
 /**
@@ -348,7 +349,7 @@ export function isSupported(messaging) {
  * @returns {Promise<void>}
  */
 export function experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, enabled) {
-  return messaging.setDeliveryMetricsExportToBigQuery(enabled);
+  return messaging.setDeliveryMetricsExportToBigQuery.call(messaging, enabled);
 }
 
 export {


### PR DESCRIPTION
### Description

There are a lot of messaging helper methods that are out of scope from all other Firebase SDKs (JS messaging has only 5, RNFB messaging has 31). I wonder if they should remain or should some be deprecated & removed during next major release. You can see them all listed here: [`messaging-deprecations?expand=1`#diff-312fbb9aca](https://github.com/invertase/react-native-firebase/compare/messaging-deprecations?expand=1#diff-312fbb9acaebf425cb655707b7d92bf231fc1c5e338b6d029603af8c6a1d7e03R112-R143)

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](../CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
