### PR TITLE
docs: fix assignment operator in RNFB_MODULAR_DEPRECATION_STRICT_MODE example

### DIFF
--- a/docs/migrating-to-v22.md
+++ b/docs/migrating-to-v22.md
@@ -22,7 +22,7 @@ This is useful to help you quickly locate any remaining usage of the deprecated 
 Note that there may be modular API implementation errors within the react-native-firebase modules, this may still be useful as a troubleshooting aid when collaborating with the maintainers to correct these errors.
 
 ```js
-globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE === true;
+globalThis.RNFB_MODULAR_DEPRECATION_STRICT_MODE = true;
 ```
 
 # Migrating to React Native modular API


### PR DESCRIPTION
### Description

Fixed incorrect operator in the documentation example. The code was using a comparison operator (`===`) instead of an assignment operator (`=`) for setting `RNFB_MODULAR_DEPRECATION_STRICT_MODE`.

### Related issues

N/A

### Release Summary

Fix documentation example for RNFB_MODULAR_DEPRECATION_STRICT_MODE assignment

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

This is a documentation-only change fixing a typo in the code example. No functional changes were made.

