### PR TITLE
fix(remote-config): type error in callback for modular `onConfigUpdated`

### DIFF
--- a/packages/remote-config/lib/index.d.ts
+++ b/packages/remote-config/lib/index.d.ts
@@ -540,6 +540,17 @@ export namespace FirebaseRemoteConfigTypes {
      */
     reset(): Promise<void>;
   }
+
+  export type CallbackOrObserver<T extends (...args: any[]) => any> = T | { next: T };
+
+  export type OnConfigUpdatedListenerCallback = (
+    event?: { updatedKeys: string[] },
+    error?: {
+      code: string;
+      message: string;
+      nativeErrorMessage: string;
+    },
+  ) => void;
 }
 
 declare const defaultExport: ReactNativeFirebase.FirebaseModuleWithStatics<
@@ -553,17 +564,6 @@ export const firebase: ReactNativeFirebase.Module & {
     name?: string,
   ): ReactNativeFirebase.FirebaseApp & { remoteConfig(): FirebaseRemoteConfigTypes.Module };
 };
-
-type CallbackOrObserver<T extends (...args: any[]) => any> = T | { next: T };
-
-type OnConfigUpdatedListenerCallback = (
-  event?: { updatedKeys: string[] },
-  error?: {
-    code: string;
-    message: string;
-    nativeErrorMessage: string;
-  },
-) => void;
 
 export default defaultExport;
 

--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -27,6 +27,8 @@ import RemoteConfigLogLevel = FirebaseRemoteConfigTypes.RemoteConfigLogLevel;
 import FirebaseApp = ReactNativeFirebase.FirebaseApp;
 import LastFetchStatusInterface = FirebaseRemoteConfigTypes.LastFetchStatus;
 import ValueSourceInterface = FirebaseRemoteConfigTypes.ValueSource;
+import CallbackOrObserver = FirebaseRemoteConfigTypes.CallbackOrObserver;
+import OnConfigUpdatedListenerCallback = FirebaseRemoteConfigTypes.OnConfigUpdatedListenerCallback;
 
 export const LastFetchStatus: LastFetchStatusInterface;
 export const ValueSource: ValueSourceInterface;
@@ -210,7 +212,7 @@ export function setDefaultsFromResource(
  */
 export function onConfigUpdated(
   remoteConfig: RemoteConfig,
-  callback: Parameters<RemoteConfig['onConfigUpdated']>[0],
+  callback: CallbackOrObserver<OnConfigUpdatedListenerCallback>,
 ): () => void;
 
 /**

--- a/packages/remote-config/lib/modular/index.js
+++ b/packages/remote-config/lib/modular/index.js
@@ -243,7 +243,7 @@ export function setDefaultsFromResource(remoteConfig, resourceName) {
  * Registers a listener to changes in the configuration.
  *
  * @param {RemoteConfig} remoteConfig - RemoteConfig instance
- * @param {Parameters<RemoteConfig['onConfigUpdated']>[0]} callback - function called on config change
+ * @param {CallbackOrObserver<OnConfigUpdatedListenerCallback>} callback - function called on config change
  * @returns {function} unsubscribe listener
  */
 export function onConfigUpdated(remoteConfig, callback) {


### PR DESCRIPTION
### Description

Update the type for the modular `onConfigUpdated` callback to match the existing type in the namespaced export


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

Fixes #8613

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary



<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->


before:
> <img width="1493" height="404" alt="image" src="https://github.com/user-attachments/assets/ae2ea237-ddc9-4f9f-879f-1551aa2c24b7" />

after:
> <img width="739" height="415" alt="image" src="https://github.com/user-attachments/assets/252c4bd8-3d79-428e-88c0-834695f67938" />


---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥
