### PR TITLE
feat(firestore): make persistence configuration available in Modular API

### DIFF
--- a/packages/firestore/lib/modular/index.d.ts
+++ b/packages/firestore/lib/modular/index.d.ts
@@ -778,6 +778,75 @@ export function deleteAllPersistentCacheIndexes(
   indexManager: PersistentCacheIndexManager,
 ): Promise<void>;
 
+ /**
+     * Specifies custom settings to be used to configure the Firestore instance. Must be set before invoking any other methods.
+     *
+     * #### Example
+     *
+     * ```js
+     * const settings = {
+     *   cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED,
+     * };
+     *
+     * await firebase.firestore().settings(settings);
+     * ```
+     *
+     * @param settings A `Settings` object.
+     */
+export function settings(settings: Settings): Promise<void>;
+
+export interface Settings {
+  /**
+   * Enables or disables local persistent storage.
+   */
+  persistence?: boolean;
+
+  /**
+   * An approximate cache size threshold for the on-disk data. If the cache grows beyond this size, Firestore will start
+   * removing data that hasn't been recently used. The size is not a guarantee that the cache will stay below that size,
+   * only that if the cache exceeds the given size, cleanup will be attempted.
+   *
+   * To disable garbage collection and set an unlimited cache size, use `firebase.firestore.CACHE_SIZE_UNLIMITED`.
+   */
+  cacheSizeBytes?: number;
+
+  /**
+   * The hostname to connect to.
+   *
+   * Note: on android, hosts 'localhost' and '127.0.0.1' are automatically remapped to '10.0.2.2' (the
+   * "host" computer IP address for android emulators) to make the standard development experience easy.
+   * If you want to use the emulator on a real android device, you will need to specify the actual host
+   * computer IP address. Use of this property for emulator connection is deprecated. Use useEmulator instead
+   */
+  host?: string;
+
+  /**
+   * Whether to use SSL when connecting. A true value is incompatible with the firestore emulator.
+   */
+  ssl?: boolean;
+
+  /**
+   * Whether to skip nested properties that are set to undefined during object serialization.
+   * If set to true, these properties are skipped and not written to Firestore.
+   * If set to false or omitted, the SDK throws an exception when it encounters properties of type undefined.
+   */
+  ignoreUndefinedProperties?: boolean;
+
+  /**
+   * If set, controls the return value for server timestamps that have not yet been set to their final value.
+   *
+   * By specifying 'estimate', pending server timestamps return an estimate based on the local clock.
+   * This estimate will differ from the final value and cause these values to change once the server result becomes available.
+   *
+   * By specifying 'previous', pending timestamps will be ignored and return their previous value instead.
+   *
+   * If omitted or set to 'none', null will be returned by default until the server value becomes available.
+   *
+   */
+  serverTimestampBehavior?: 'estimate' | 'previous' | 'none';
+}
+
+
 export * from './query';
 export * from './snapshot';
 export * from './Bytes';

--- a/packages/firestore/lib/modular/index.d.ts
+++ b/packages/firestore/lib/modular/index.d.ts
@@ -778,21 +778,21 @@ export function deleteAllPersistentCacheIndexes(
   indexManager: PersistentCacheIndexManager,
 ): Promise<void>;
 
- /**
-     * Specifies custom settings to be used to configure the Firestore instance. Must be set before invoking any other methods.
-     *
-     * #### Example
-     *
-     * ```js
-     * const settings = {
-     *   cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED,
-     * };
-     *
-     * await firebase.firestore().settings(settings);
-     * ```
-     *
-     * @param settings A `Settings` object.
-     */
+/**
+ * Specifies custom settings to be used to configure the Firestore instance. Must be set before invoking any other methods.
+ *
+ * #### Example
+ *
+ * ```js
+ * const settings = {
+ *   cacheSizeBytes: firebase.firestore.CACHE_SIZE_UNLIMITED,
+ * };
+ *
+ * await firebase.firestore().settings(settings);
+ * ```
+ *
+ * @param settings A `Settings` object.
+ */
 export function settings(settings: Settings): Promise<void>;
 
 export interface Settings {
@@ -845,7 +845,6 @@ export interface Settings {
    */
   serverTimestampBehavior?: 'estimate' | 'previous' | 'none';
 }
-
 
 export * from './query';
 export * from './snapshot';

--- a/packages/firestore/lib/modular/index.js
+++ b/packages/firestore/lib/modular/index.js
@@ -400,6 +400,10 @@ export function deleteAllPersistentCacheIndexes(indexManager) {
   return indexManager.deleteAllIndexes.call(indexManager, MODULAR_DEPRECATION_ARG);
 }
 
+export function settings(firestore, settings) {
+  return firestore.settings.call(firestore, settings, MODULAR_DEPRECATION_ARG);
+}
+
 export * from './query';
 export * from './snapshot';
 export * from './Bytes';


### PR DESCRIPTION
### Description

fixes https://github.com/invertase/react-native-firebase/issues/8309

Deprecation message for firestore().settings() tells us to use settings() but it was not implemented.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
