### PR TITLE
feat(auth): support TOTP enroll and unenroll

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -198,6 +198,7 @@ TFUA
 thenable
 ThreadPoolExecutor
 timezones
+TOTP
 triaging
 TurboModule
 TurboModules

--- a/docs/auth/multi-factor-auth.md
+++ b/docs/auth/multi-factor-auth.md
@@ -5,16 +5,24 @@ next: /firestore/usage
 previous: /auth/oidc-auth
 ---
 
-# iOS Setup
+> Before a user can enroll a second factor they need to verify their email. See
+> [`User`](/reference/auth/user#sendEmailVerification) interface is returned.
+
+# TOTP MFA
+
+The [official guide for Firebase web TOTP authentication](https://firebase.google.com/docs/auth/web/totp-mfa) explains the TOTP process well, including project prerequisites to enable the feature, as well as code examples.
+
+The API details and usage examples may be combined with the full Phone auth example below to give you an MFA solution that fully supports TOTP or SMS MFA.
+
+# Phone MFA
+
+## iOS Setup
 
 Make sure to follow [the official Identity Platform
 documentation](https://cloud.google.com/identity-platform/docs/ios/mfa#enabling_multi-factor_authentication)
 to enable multi-factor authentication for your project and verify your app.
 
-# Enroll a new factor
-
-> Before a user can enroll a second factor they need to verify their email. See
-> [`User`](/reference/auth/user#sendEmailVerification) interface is returned.
+## Enroll a new factor
 
 Begin by obtaining a [`MultiFactorUser`](/reference/auth/multifactoruser)
 instance for the current user. This is the entry point for most multi-factor
@@ -57,7 +65,7 @@ await multiFactorUser.enroll(multiFactorAssertion, 'Optional display name for th
 You can inspect [`User#multiFactor`](/reference/auth/user#multiFactor) for
 information about the user's enrolled factors.
 
-# Sign-in flow using multi-factor
+## Sign-in flow using phone multi-factor
 
 Ensure the account has already enrolled a second factor. Begin by calling the
 default sign-in methods, for example email and password. If the account requires
@@ -103,7 +111,6 @@ if (resolver.hints.length > 1) {
   // Use resolver.hints to display a list of second factors to the user
 }
 
-// Currently only phone based factors are supported
 if (resolver.hints[0].factorId === PhoneMultiFactorGenerator.FACTOR_ID) {
   // Continue with the sign-in flow
 }
@@ -163,7 +170,6 @@ signInWithEmailAndPassword(getAuth(), email, password)
         // Use resolver.hints to display a list of second factors to the user
       }
 
-      // Currently only phone based factors are supported
       if (resolver.hints[0].factorId === PhoneMultiFactorGenerator.FACTOR_ID) {
         const hint = resolver.hints[0];
 
@@ -185,7 +191,7 @@ signInWithEmailAndPassword(getAuth(), email, password)
   });
 ```
 
-# Testing
+## Testing
 
 You can define test phone numbers and corresponding verification codes. The
 official[official

--- a/packages/app/lib/internal/NativeFirebaseError.js
+++ b/packages/app/lib/internal/NativeFirebaseError.js
@@ -49,6 +49,18 @@ export default class NativeFirebaseError extends Error {
       value: userInfo,
     });
 
+    // Needed for MFA processing of errors on web
+    Object.defineProperty(this, 'customData', {
+      enumerable: false,
+      value: nativeError.customData || null,
+    });
+
+    // Needed for MFA processing of errors on web
+    Object.defineProperty(this, 'operationType', {
+      enumerable: false,
+      value: nativeError.operationType || null,
+    });
+
     Object.defineProperty(this, 'nativeErrorCode', {
       enumerable: false,
       value: userInfo.nativeErrorCode || null,

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -66,6 +66,9 @@ import com.google.firebase.auth.PhoneAuthProvider;
 import com.google.firebase.auth.PhoneMultiFactorAssertion;
 import com.google.firebase.auth.PhoneMultiFactorGenerator;
 import com.google.firebase.auth.PhoneMultiFactorInfo;
+import com.google.firebase.auth.TotpMultiFactorAssertion;
+import com.google.firebase.auth.TotpMultiFactorGenerator;
+import com.google.firebase.auth.TotpSecret;
 import com.google.firebase.auth.TwitterAuthProvider;
 import com.google.firebase.auth.UserInfo;
 import com.google.firebase.auth.UserProfileChangeRequest;
@@ -107,6 +110,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
 
   private final HashMap<String, MultiFactorResolver> mCachedResolvers = new HashMap<>();
   private final HashMap<String, MultiFactorSession> mMultiFactorSessions = new HashMap<>();
+  private final HashMap<String, TotpSecret> mTotpSecrets = new HashMap<>();
 
   // storage for anonymous phone auth credentials, used for linkWithCredentials
   // https://github.com/invertase/react-native-firebase/issues/4911
@@ -154,6 +158,7 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
 
     mCachedResolvers.clear();
     mMultiFactorSessions.clear();
+    mTotpSecrets.clear();
   }
 
   @ReactMethod
@@ -1131,6 +1136,26 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
+  public void unenrollMultiFactor(
+      final String appName, final String factorUID, final Promise promise) {
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+    firebaseAuth
+        .getCurrentUser()
+        .getMultiFactor()
+        .unenroll(factorUID)
+        .addOnCompleteListener(
+            task -> {
+              if (!task.isSuccessful()) {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+                return;
+              }
+
+              promise.resolve(null);
+            });
+  }
+
+  @ReactMethod
   public void verifyPhoneNumberWithMultiFactorInfo(
       final String appName, final String hintUid, final String sessionKey, final Promise promise) {
     final MultiFactorResolver resolver = mCachedResolvers.get(sessionKey);
@@ -1280,6 +1305,42 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
             });
   }
 
+  @ReactMethod
+  public void finalizeTotpEnrollment(
+      final String appName,
+      final String totpSecret,
+      final String verificationCode,
+      @Nullable final String displayName,
+      final Promise promise) {
+
+    TotpSecret secret = mTotpSecrets.get(totpSecret);
+    if (secret == null) {
+      rejectPromiseWithCodeAndMessage(
+          promise, "invalid-multi-factor-secret", "can't find secret for provided key");
+      return;
+    }
+
+    TotpMultiFactorAssertion assertion =
+        TotpMultiFactorGenerator.getAssertionForEnrollment(secret, verificationCode);
+
+    FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
+    FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);
+
+    firebaseAuth
+        .getCurrentUser()
+        .getMultiFactor()
+        .enroll(assertion, displayName)
+        .addOnCompleteListener(
+            task -> {
+              if (!task.isSuccessful()) {
+                rejectPromiseWithExceptionMap(promise, task.getException());
+                return;
+              }
+
+              promise.resolve(null);
+            });
+  }
+
   /**
    * This method is intended to resolve a {@link PhoneAuthCredential} obtained through a
    * multi-factor authentication flow. A credential can either be obtained using:
@@ -1333,6 +1394,70 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     final PhoneAuthCredential credential =
         PhoneAuthProvider.getCredential(verificationId, verificationCode);
     resolveMultiFactorCredential(credential, session, promise);
+  }
+
+  @ReactMethod
+  public void resolveTotpSignIn(
+      final String appName,
+      final String sessionKey,
+      final String uid,
+      final String oneTimePassword,
+      final Promise promise) {
+
+    final MultiFactorAssertion assertion =
+        TotpMultiFactorGenerator.getAssertionForSignIn(uid, oneTimePassword);
+
+    final MultiFactorResolver resolver = mCachedResolvers.get(sessionKey);
+    if (resolver == null) {
+      // See https://firebase.google.com/docs/reference/node/firebase.auth.multifactorresolver for
+      // the error code
+      rejectPromiseWithCodeAndMessage(
+          promise,
+          "invalid-multi-factor-session",
+          "No resolver for session found. Is the session id correct?");
+      return;
+    }
+
+    resolver
+        .resolveSignIn(assertion)
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                AuthResult authResult = task.getResult();
+                promiseWithAuthResult(authResult, promise);
+              } else {
+                promiseRejectAuthException(promise, task.getException());
+              }
+            });
+  }
+
+  @ReactMethod
+  public void generateTotpSecret(
+      final String appName, final String sessionKey, final Promise promise) {
+
+    final MultiFactorSession session = mMultiFactorSessions.get(sessionKey);
+    if (session == null) {
+      rejectPromiseWithCodeAndMessage(
+          promise,
+          "invalid-multi-factor-session",
+          "No resolver for session found. Is the session id correct?");
+      return;
+    }
+
+    TotpMultiFactorGenerator.generateSecret(session)
+        .addOnCompleteListener(
+            task -> {
+              if (task.isSuccessful()) {
+                TotpSecret totpSecret = task.getResult();
+                String totpSecretKey = totpSecret.getSharedSecretKey();
+                mTotpSecrets.put(totpSecretKey, totpSecret);
+                WritableMap result = Arguments.createMap();
+                result.putString("secretKey", totpSecretKey);
+                promise.resolve(result);
+              } else {
+                promiseRejectAuthException(promise, task.getException());
+              }
+            });
   }
 
   @ReactMethod

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1323,6 +1323,14 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
+  public void openInOtpApp(final String appName, final String secretKey, final String qrCodeUri) {
+    TotpSecret secret = mTotpSecrets.get(secretKey);
+    if (secret != null) {
+      secret.openInOtpApp(qrCodeUri);
+    }
+  }
+
+  @ReactMethod
   public void finalizeTotpEnrollment(
       final String appName,
       final String totpSecret,

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -1306,6 +1306,23 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
   }
 
   @ReactMethod
+  public void generateQrCodeUrl(
+      final String appName,
+      final String secretKey,
+      final String account,
+      final String issuer,
+      final Promise promise) {
+
+    TotpSecret secret = mTotpSecrets.get(secretKey);
+    if (secret == null) {
+      rejectPromiseWithCodeAndMessage(
+          promise, "invalid-multi-factor-secret", "can't find secret for provided key");
+      return;
+    }
+    promise.resolve(secret.generateQrCodeUrl(account, issuer));
+  }
+
+  @ReactMethod
   public void finalizeTotpEnrollment(
       final String appName,
       final String totpSecret,

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1026,6 +1026,21 @@ RCT_EXPORT_METHOD(generateTotpSecret
                                 }];
 }
 
+RCT_EXPORT_METHOD(generateQrCodeUrl
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)secretKey
+                  : (NSString *)accountName
+                  : (NSString *)issuer
+                  : (RCTPromiseResolveBlock)resolve
+                  : (RCTPromiseRejectBlock)reject) {
+  DLog(@"generateQrCodeUrl using instance resolve generateQrCodeUrl: %@", firebaseApp.name);
+  DLog(@"generateQrCodeUrl using secretKey: %@", secretKey);
+  FIRTOTPSecret *totpSecret = cachedTotpSecrets[secretKey];
+  NSString *url = [totpSecret generateQRCodeURLWithAccountName:accountName issuer:issuer];
+  DLog(@"generateQrCodeUrl got QR Code URL %@", url);
+  resolve(url);
+}
+
 RCT_EXPORT_METHOD(getSession
                   : (FIRApp *)firebaseApp
                   : (RCTPromiseResolveBlock)resolve

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1041,6 +1041,16 @@ RCT_EXPORT_METHOD(generateQrCodeUrl
   resolve(url);
 }
 
+RCT_EXPORT_METHOD(openInOtpApp
+                  : (FIRApp *)firebaseApp
+                  : (NSString *)secretKey
+                  : (NSString *)qrCodeUri) {
+  DLog(@"generateQrCodeUrl using secretKey: %@", secretKey);
+  FIRTOTPSecret *totpSecret = cachedTotpSecrets[secretKey];
+  DLog(@"openInOtpApp using qrCodeUri: %@", qrCodeUri);
+  [totpSecret openInOTPAppWithQRCodeURL:qrCodeUri];
+}
+
 RCT_EXPORT_METHOD(getSession
                   : (FIRApp *)firebaseApp
                   : (RCTPromiseResolveBlock)resolve

--- a/packages/auth/lib/MultiFactorResolver.js
+++ b/packages/auth/lib/MultiFactorResolver.js
@@ -9,7 +9,12 @@ export default class MultiFactorResolver {
   }
 
   resolveSignIn(assertion) {
-    const { token, secret } = assertion;
-    return this._auth.resolveMultiFactorSignIn(this.session, token, secret);
+    const { token, secret, uid, verificationCode } = assertion;
+
+    if (token && secret) {
+      return this._auth.resolveMultiFactorSignIn(this.session, token, secret);
+    }
+
+    return this._auth.resolveTotpSignIn(this.session, uid, verificationCode);
   }
 }

--- a/packages/auth/lib/TotpMultiFactorGenerator.js
+++ b/packages/auth/lib/TotpMultiFactorGenerator.js
@@ -15,7 +15,9 @@
  *
  */
 
+import { isOther } from '@react-native-firebase/app/lib/common';
 import { TotpSecret } from './TotpSecret';
+import { getAuth } from './modular';
 
 export default class TotpMultiFactorGenerator {
   static FACTOR_ID = 'totp';
@@ -27,6 +29,11 @@ export default class TotpMultiFactorGenerator {
   }
 
   static assertionForSignIn(uid, verificationCode) {
+    if (isOther) {
+      // we require the web native assertion when using firebase-js-sdk
+      // as it has functions used by the SDK, a shim won't do
+      return getAuth().native.assertionForSignIn(uid, verificationCode);
+    }
     return { uid, verificationCode };
   }
 

--- a/packages/auth/lib/TotpMultiFactorGenerator.js
+++ b/packages/auth/lib/TotpMultiFactorGenerator.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { TotpSecret } from './TotpSecret';
+
+export default class TotpMultiFactorGenerator {
+  static FACTOR_ID = 'totp';
+
+  constructor() {
+    throw new Error(
+      '`new TotpMultiFactorGenerator()` is not supported on the native Firebase SDKs.',
+    );
+  }
+
+  static assertionForSignIn(uid, verificationCode) {
+    return { uid, verificationCode };
+  }
+
+  static assertionForEnrollment(totpSecret, verificationCode) {
+    return { totpSecret: totpSecret.secretKey, verificationCode };
+  }
+
+  static async generateSecret(session, auth) {
+    if (!session) {
+      throw new Error('Session is required to generate a TOTP secret.');
+    }
+    const {
+      secretKey,
+      // Other properties are not publicly exposed in native APIs
+      // hashingAlgorithm, codeLength, codeIntervalSeconds, enrollmentCompletionDeadline
+    } = await auth.native.generateTotpSecret(session);
+
+    return new TotpSecret(secretKey, auth);
+  }
+}

--- a/packages/auth/lib/TotpSecret.js
+++ b/packages/auth/lib/TotpSecret.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class TotpSecret {
+  constructor(secretKey, auth) {
+    // The native TotpSecret has many more properties, but they are
+    // internal to the native SDKs, we only maintain the secret in JS layer
+    this.secretKey = secretKey;
+
+    // we do need a handle to the correct auth instance to generate QR codes etc
+    this.auth = auth;
+  }
+
+  /**
+   * Shared secret key/seed used for enrolling in TOTP MFA and generating OTPs.
+   */
+  secretKey = null;
+
+  /**
+   * Returns a QR code URL as described in
+   * https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+   * This can be displayed to the user as a QR code to be scanned into a TOTP app like Google Authenticator.
+   * If the optional parameters are unspecified, an accountName of <userEmail> and issuer of <firebaseAppName> are used.
+   *
+   * @param accountName the name of the account/app along with a user identifier.
+   * @param issuer issuer of the TOTP (likely the app name).
+   * @returns A QR code URL string.
+   */
+  generateQrCodeUrl(_accountName, _issuer) {
+    throw new Error('`generateQrCodeUrl` is not supported on the native Firebase SDKs.');
+    // if (!this.hashingAlgorithm || !this.codeLength) {
+    //   return "";
+    // }
+
+    // return (
+    //   `otpauth://totp/${issuer}:${accountName}?secret=${this.secretKey}&issuer=${issuer}` +
+    //   `&algorithm=${this.hashingAlgorithm}&digits=${this.codeLength}`
+    // );
+  }
+}

--- a/packages/auth/lib/TotpSecret.js
+++ b/packages/auth/lib/TotpSecret.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { isString } from '@react-native-firebase/app/lib/common';
+
 export class TotpSecret {
   constructor(secretKey, auth) {
     // The native TotpSecret has many more properties, but they are
@@ -37,17 +39,14 @@ export class TotpSecret {
    *
    * @param accountName the name of the account/app along with a user identifier.
    * @param issuer issuer of the TOTP (likely the app name).
-   * @returns A QR code URL string.
+   * @returns A Promise that resolves to a QR code URL string.
    */
-  generateQrCodeUrl(_accountName, _issuer) {
-    throw new Error('`generateQrCodeUrl` is not supported on the native Firebase SDKs.');
-    // if (!this.hashingAlgorithm || !this.codeLength) {
-    //   return "";
-    // }
-
-    // return (
-    //   `otpauth://totp/${issuer}:${accountName}?secret=${this.secretKey}&issuer=${issuer}` +
-    //   `&algorithm=${this.hashingAlgorithm}&digits=${this.codeLength}`
-    // );
+  async generateQrCodeUrl(accountName, issuer) {
+    // accountName and issure are nullable in the API specification but are
+    // required by tha native SDK. The JS SDK returns '' if they are missing/empty.
+    if (!isString(accountName) || !isString(issuer) || accountName === '' || issuer === '') {
+      return '';
+    }
+    return this.auth.native.generateQrCodeUrl(this.secretKey, accountName, issuer);
   }
 }

--- a/packages/auth/lib/TotpSecret.js
+++ b/packages/auth/lib/TotpSecret.js
@@ -49,4 +49,19 @@ export class TotpSecret {
     }
     return this.auth.native.generateQrCodeUrl(this.secretKey, accountName, issuer);
   }
+
+  /**
+   * Opens the specified QR Code URL in an OTP authenticator app on the device.
+   * The shared secret key and account name will be populated in the OTP authenticator app.
+   * The URL uses the otpauth:// scheme and will be opened on an app that handles this scheme,
+   * if it exists on the device, possibly opening the ecocystem-specific app store with a generic
+   * query for compatible apps if no app exists on the device.
+   *
+   * @param qrCodeUrl the URL to open in the app, from generateQrCodeUrl
+   */
+  openInOtpApp(qrCodeUrl) {
+    if (isString(qrCodeUrl) && !qrCodeUrl !== '') {
+      return this.auth.native.openInOtpApp(this.secretKey, qrCodeUrl);
+    }
+  }
 }

--- a/packages/auth/lib/getMultiFactorResolver.js
+++ b/packages/auth/lib/getMultiFactorResolver.js
@@ -1,3 +1,4 @@
+import { isOther } from '@react-native-firebase/app/lib/common';
 import MultiFactorResolver from './MultiFactorResolver.js';
 
 /**
@@ -7,6 +8,9 @@ import MultiFactorResolver from './MultiFactorResolver.js';
  * Returns null if no resolver object can be found on the error.
  */
 export function getMultiFactorResolver(auth, error) {
+  if (isOther) {
+    return auth.native.getMultiFactorResolver(error);
+  }
   if (
     error.hasOwnProperty('userInfo') &&
     error.userInfo.hasOwnProperty('resolver') &&

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -275,6 +275,52 @@ export namespace FirebaseAuthTypes {
     assertion(credential: AuthCredential): MultiFactorAssertion;
   }
 
+  /**
+   * Represents a TOTP secret that is used for enrolling a TOTP second factor.
+   * Contains the shared secret key and other parameters to generate time-based
+   * one-time passwords. Implements methods to retrieve the shared secret key,
+   * generate a QR code URL, and open the QR code URL in an OTP authenticator app.
+   *
+   * Differs from standard firebase JS implementation in three ways:
+   * 1- there is no visibility into ony properties other than the secretKey
+   * 2- there is an added `openInOtpApp` method supported by native SDKs
+   * 3- the return value of generateQrCodeUrl is a Promise because react-native bridge is async
+   * @public
+   */
+  export declare class TotpSecret {
+    /** used internally to support non-default auth instances */
+    private readonly auth;
+    /**
+     * Shared secret key/seed used for enrolling in TOTP MFA and generating OTPs.
+     */
+    readonly secretKey: string;
+
+    private constructor();
+
+    /**
+     * Returns a QR code URL as described in
+     * https://github.com/google/google-authenticator/wiki/Key-Uri-Format
+     * This can be displayed to the user as a QR code to be scanned into a TOTP app like Google Authenticator.
+     * If the optional parameters are unspecified, an accountName of userEmail and issuer of firebaseAppName are used.
+     *
+     * @param accountName the name of the account/app along with a user identifier.
+     * @param issuer issuer of the TOTP (likely the app name).
+     * @returns A Promise that resolves to a QR code URL string.
+     */
+    async generateQrCodeUrl(accountName?: string, issuer?: string): Promise<string>;
+
+    /**
+     * Opens the specified QR Code URL in an OTP authenticator app on the device.
+     * The shared secret key and account name will be populated in the OTP authenticator app.
+     * The URL uses the otpauth:// scheme and will be opened on an app that handles this scheme,
+     * if it exists on the device, possibly opening the ecocystem-specific app store with a generic
+     * query for compatible apps if no app exists on the device.
+     *
+     * @param qrCodeUrl the URL to open in the app, from generateQrCodeUrl
+     */
+    openInOtpApp(qrCodeUrl: string): string;
+  }
+
   export interface TotpMultiFactorGenerator {
     FACTOR_ID: FactorId.TOTP;
 

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -275,6 +275,32 @@ export namespace FirebaseAuthTypes {
     assertion(credential: AuthCredential): MultiFactorAssertion;
   }
 
+  export interface TotpMultiFactorGenerator {
+    FACTOR_ID: FactorId.TOTP;
+
+    assertionForSignIn(uid: string, totpSecret: string): MultiFactorAssertion;
+
+    assertionForEnrollment(secret: TotpSecret, code: string): MultiFactorAssertion;
+
+    /**
+     * @param auth - The Auth instance. Only used for native platforms, should be ignored on web.
+     */
+    generateSecret(
+      session: FirebaseAuthTypes.MultiFactorSession,
+      auth: FirebaseAuthTypes.Auth,
+    ): Promise<TotpSecret>;
+  }
+
+  export declare interface MultiFactorError extends AuthError {
+    /** Details about the MultiFactorError. */
+    readonly customData: AuthError['customData'] & {
+      /**
+       * The type of operation (sign-in, linking, or re-authentication) that raised the error.
+       */
+      readonly operationType: (typeof OperationType)[keyof typeof OperationType];
+    };
+  }
+
   /**
    * firebase.auth.X
    */
@@ -476,6 +502,7 @@ export namespace FirebaseAuthTypes {
    */
   export enum FactorId {
     PHONE = 'phone',
+    TOTP = 'totp',
   }
 
   /**
@@ -596,6 +623,12 @@ export namespace FirebaseAuthTypes {
      * The method will ensure the user state is reloaded after successfully enrolling a factor.
      */
     enroll(assertion: MultiFactorAssertion, displayName?: string): Promise<void>;
+
+    /**
+     * Unenroll a previously enrolled multi-factor authentication factor.
+     * @param option The multi-factor option to unenroll.
+     */
+    unenroll(option: MultiFactorInfo | string): Promise<void>;
   }
 
   /**

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -34,6 +34,7 @@ import {
 import ConfirmationResult from './ConfirmationResult';
 import PhoneAuthListener from './PhoneAuthListener';
 import PhoneMultiFactorGenerator from './PhoneMultiFactorGenerator';
+import TotpMultiFactorGenerator from './TotpMultiFactorGenerator';
 import Settings from './Settings';
 import User from './User';
 import { getMultiFactorResolver } from './getMultiFactorResolver';
@@ -66,6 +67,7 @@ export {
   TwitterAuthProvider,
   FacebookAuthProvider,
   PhoneMultiFactorGenerator,
+  TotpMultiFactorGenerator,
   OAuthProvider,
   OIDCAuthProvider,
   PhoneAuthState,
@@ -80,6 +82,7 @@ const statics = {
   TwitterAuthProvider,
   FacebookAuthProvider,
   PhoneMultiFactorGenerator,
+  TotpMultiFactorGenerator,
   OAuthProvider,
   OIDCAuthProvider,
   PhoneAuthState,
@@ -322,6 +325,12 @@ class FirebaseAuthModule extends FirebaseModule {
       .then(userCredential => {
         return this._setUserCredential(userCredential);
       });
+  }
+
+  resolveTotpSignIn(session, uid, totpSecret) {
+    return this.native.resolveTotpSignIn(session, uid, totpSecret).then(userCredential => {
+      return this._setUserCredential(userCredential);
+    });
   }
 
   createUserWithEmailAndPassword(email, password) {

--- a/packages/auth/lib/multiFactor.js
+++ b/packages/auth/lib/multiFactor.js
@@ -36,6 +36,7 @@ export class MultiFactorUser {
     }
 
     // We need to reload the user otherwise the changes are not visible
+    // TODO reload not working on Other platform
     return reload(this._auth.currentUser);
   }
 

--- a/packages/auth/lib/multiFactor.js
+++ b/packages/auth/lib/multiFactor.js
@@ -26,14 +26,24 @@ export class MultiFactorUser {
    * profile, which is necessary to see the multi-factor changes.
    */
   async enroll(multiFactorAssertion, displayName) {
-    const { token, secret } = multiFactorAssertion;
-    await this._auth.native.finalizeMultiFactorEnrollment(token, secret, displayName);
+    const { token, secret, totpSecret, verificationCode } = multiFactorAssertion;
+    if (token && secret) {
+      await this._auth.native.finalizeMultiFactorEnrollment(token, secret, displayName);
+    } else if (totpSecret && verificationCode) {
+      await this._auth.native.finalizeTotpEnrollment(totpSecret, verificationCode, displayName);
+    } else {
+      throw new Error('Invalid multi-factor assertion provided for enrollment.');
+    }
 
     // We need to reload the user otherwise the changes are not visible
     return reload(this._auth.currentUser);
   }
 
-  unenroll() {
-    return Promise.reject(new Error('No implemented yet.'));
+  async unenroll(enrollmentId) {
+    await this._auth.native.unenrollMultiFactor(enrollmentId);
+
+    if (this._auth.currentUser) {
+      return reload(this._auth.currentUser);
+    }
   }
 }

--- a/packages/auth/lib/web/RNFBAuthModule.js
+++ b/packages/auth/lib/web/RNFBAuthModule.js
@@ -8,6 +8,8 @@ import {
   sendSignInLinkToEmail,
   getAdditionalUserInfo,
   multiFactor,
+  getMultiFactorResolver,
+  TotpMultiFactorGenerator,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
   isSignInWithEmailLink,
@@ -70,6 +72,15 @@ function rejectPromiseWithCodeAndMessage(code, message) {
   return rejectPromise(getWebError({ code: `auth/${code}`, message }));
 }
 
+function rejectWithCodeAndMessage(code, message) {
+  return Promise.reject(
+    getWebError({
+      code,
+      message,
+    }),
+  );
+}
+
 /**
  * Returns a structured error object.
  * @param {error} error The error object.
@@ -102,7 +113,9 @@ function userToObject(user) {
     tenantId: user.tenantId !== null && user.tenantId !== '' ? user.tenantId : null,
     providerData: user.providerData.map(userInfoToObject),
     metadata: userMetadataToObject(user.metadata),
-    multiFactor: multiFactor(user).enrolledFactors.map(multiFactorInfoToObject),
+    multiFactor: {
+      enrolledFactors: multiFactor(user).enrolledFactors.map(multiFactorInfoToObject),
+    },
   };
 }
 
@@ -222,6 +235,7 @@ const instances = {};
 const authStateListeners = {};
 const idTokenListeners = {};
 const sessionMap = new Map();
+const totpSecretMap = new Map();
 let sessionId = 0;
 
 // Returns a cached Firestore instance.
@@ -441,11 +455,28 @@ export default {
    * @returns {Promise<object>} - The result of the sign in.
    */
   async signInWithEmailAndPassword(appName, email, password) {
-    return guard(async () => {
-      const auth = getCachedAuthInstance(appName);
-      const credential = await signInWithEmailAndPassword(auth, email, password);
+    // The default guard / getWebError process doesn't work well here,
+    // since it creates a new error object that is then passed through
+    // a native module proxy and gets processed again.
+    // We need lots of information from the error so that MFA will work
+    // later if needed. So we handle the error custom here.
+    // return guard(async () => {
+    try {
+      const credential = await signInWithEmailAndPassword(
+        getCachedAuthInstance(appName),
+        email,
+        password,
+      );
       return authResultToObject(credential);
-    });
+    } catch (e) {
+      e.userInfo = {
+        code: e.code.split('/')[1],
+        message: e.message,
+        customData: e.customData,
+      };
+      throw e;
+    }
+    // });
   },
 
   /**
@@ -989,6 +1020,104 @@ export default {
         token: result.token,
       };
     });
+  },
+
+  /**
+   * Get a MultiFactorResolver from the underlying SDK
+   * @param {*} _appName the name of the app to get the auth instance for
+   * @param {*} uid the uid of the TOTP MFA attempt
+   * @param {*} code the code from the user TOTP app
+   * @return TotpMultiFactorAssertion to use for resolving
+   */
+  assertionForSignIn(_appName, uid, code) {
+    return TotpMultiFactorGenerator.assertionForSignIn(uid, code);
+  },
+
+  /**
+   * Get a MultiFactorResolver from the underlying SDK
+   * @param {*} appName the name of the app to get the auth instance for
+   * @param {*} error the MFA error returned from initial factor login attempt
+   * @return MultiFactorResolver to use for verifying the second factor
+   */
+  getMultiFactorResolver(appName, error) {
+    return getMultiFactorResolver(getCachedAuthInstance(appName), error);
+  },
+
+  /**
+   * generate a TOTP secret
+   * @param {*} _appName - The name of the app to get the auth instance for.
+   * @param {*} session - The MultiFactorSession to associate with the secret
+   * @returns object with secretKey to associate with TotpSecret
+   */
+  async generateTotpSecret(_appName, session) {
+    return guard(async () => {
+      const totpSecret = await TotpMultiFactorGenerator.generateSecret(sessionMap.get(session));
+      totpSecretMap.set(totpSecret.secretKey, totpSecret);
+      return { secretKey: totpSecret.secretKey };
+    });
+  },
+
+  /**
+   * unenroll from TOTP
+   * @param {*} appName - The name of the app to get the auth instance for.
+   * @param {*} enrollmentId - The ID to associate with the enrollment
+   * @returns
+   */
+  async unenrollMultiFactor(appName, enrollmentId) {
+    return guard(async () => {
+      const auth = getCachedAuthInstance(appName);
+      if (auth.currentUser === null) {
+        return promiseNoUser(true);
+      }
+      await multiFactor(auth.currentUser).unenroll(enrollmentId);
+    });
+  },
+
+  /**
+   * finalize a TOTP enrollment
+   * @param {*} appName - The name of the app to get the auth instance for.
+   * @param {*} secretKey - The secretKey to associate native TotpSecret
+   * @param {*} verificationCode - The TOTP to verify
+   * @param {*} displayName - The name to associate as a hint
+   * @returns
+   */
+  async finalizeTotpEnrollment(appName, secretKey, verificationCode, displayName) {
+    return guard(async () => {
+      const auth = getCachedAuthInstance(appName);
+      if (auth.currentUser === null) {
+        return promiseNoUser(true);
+      }
+      const multiFactorAssertion = TotpMultiFactorGenerator.assertionForEnrollment(
+        totpSecretMap.get(secretKey),
+        verificationCode,
+      );
+      await multiFactor(auth.currentUser).enroll(multiFactorAssertion, displayName);
+    });
+  },
+
+  /**
+   * generate a TOTP QR Code URL
+   * @param {*} _appName - The name of the app to get the auth instance for.
+   * @param {*} secretKey - The secretKey to associate with the TotpSecret
+   * @param {*} accountName - The account name to use in auth app
+   * @param {*} issuer - The issuer to use in auth app
+   * @returns QR Code URL
+   */
+  generateQrCodeUrl(_appName, secretKey, accountName, issuer) {
+    return totpSecretMap.get(secretKey).generateQrCodeUrl(accountName, issuer);
+  },
+
+  /**
+   * open a QR Code URL in an app directly
+   * @param {*} appName - The name of the app to get the auth instance for.
+   * @param {*} qrCodeUrl the URL to open in the app, from generateQrCodeUrl
+   * @throws Error not supported in this environment
+   */
+  openInOtpApp() {
+    return rejectWithCodeAndMessage(
+      'unsupported',
+      'This operation is not supported in this environment.',
+    );
   },
 
   /* ----------------------

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -202,7 +202,7 @@ PODS:
     - GTMSessionFetcher/Core (< 6.0, >= 3.4)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - GoogleAdsOnDeviceConversion (2.2.1):
+  - GoogleAdsOnDeviceConversion (2.3.0):
     - GoogleUtilities/Logger (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - nanopb (~> 3.30910.0)
@@ -1803,69 +1803,69 @@ PODS:
     - Yoga
   - RNDeviceInfo (14.0.4):
     - React-Core
-  - RNFBAnalytics (23.1.1):
+  - RNFBAnalytics (23.1.2):
     - FirebaseAnalytics/Core (= 12.1.0)
     - FirebaseAnalytics/IdentitySupport (= 12.1.0)
     - GoogleAdsOnDeviceConversion
     - React-Core
     - RNFBApp
-  - RNFBApp (23.1.1):
+  - RNFBApp (23.1.2):
     - Firebase/CoreOnly (= 12.1.0)
     - React-Core
-  - RNFBAppCheck (23.1.1):
+  - RNFBAppCheck (23.1.2):
     - Firebase/AppCheck (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBAppDistribution (23.1.1):
+  - RNFBAppDistribution (23.1.2):
     - Firebase/AppDistribution (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (23.1.1):
+  - RNFBAuth (23.1.2):
     - Firebase/Auth (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (23.1.1):
+  - RNFBCrashlytics (23.1.2):
     - Firebase/Crashlytics (= 12.1.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (23.1.1):
+  - RNFBDatabase (23.1.2):
     - Firebase/Database (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBFirestore (23.1.1):
+  - RNFBFirestore (23.1.2):
     - Firebase/Firestore (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (23.1.1):
+  - RNFBFunctions (23.1.2):
     - Firebase/Functions (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (23.1.1):
+  - RNFBInAppMessaging (23.1.2):
     - Firebase/InAppMessaging (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (23.1.1):
+  - RNFBInstallations (23.1.2):
     - Firebase/Installations (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBMessaging (23.1.1):
+  - RNFBMessaging (23.1.2):
     - Firebase/Messaging (= 12.1.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (23.1.1):
+  - RNFBML (23.1.2):
     - React-Core
     - RNFBApp
-  - RNFBPerf (23.1.1):
+  - RNFBPerf (23.1.2):
     - Firebase/Performance (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (23.1.1):
+  - RNFBRemoteConfig (23.1.2):
     - Firebase/RemoteConfig (= 12.1.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (23.1.1):
+  - RNFBStorage (23.1.2):
     - Firebase/Storage (= 12.1.0)
     - React-Core
     - RNFBApp
@@ -2224,7 +2224,7 @@ SPEC CHECKSUMS:
   FirebaseStorage: 91432ddfb31e83de1e9fa5833b4399b39bc722f7
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  GoogleAdsOnDeviceConversion: 7978b3761ee627e42edbb47d44906a0fa43ed448
+  GoogleAdsOnDeviceConversion: 9090c435cde08903e8dd1ba2c77fbec9e46d9afe
   GoogleAppMeasurement: 61605c4152a142d797383a713ecfa5df98fe46ca
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
@@ -2295,22 +2295,22 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 6a8127b6987dc9fbce778669b252b14c8355c7ce
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNFBAnalytics: 778643c319990e6fa2401a699315200b4a6cdcbe
-  RNFBApp: 053f79dccb3e34415dac9a5167bd33094d8a1441
-  RNFBAppCheck: e865a44d72f3bbbb746cfffae8f44bfa0ed7f076
-  RNFBAppDistribution: b5fcf12da3fbb4f62489725e8179dc641148507c
-  RNFBAuth: 21913e0f41fa4359d648c6bffda24aa75fcd0a1a
-  RNFBCrashlytics: 345d14c2a3ae0594f29a17aad4ce5b1f6d8bcfbb
-  RNFBDatabase: c1bd44fad79cfb6e919cc8e1d20751eeb0b64728
-  RNFBFirestore: 505a793d9c9ad1e66c7e179d8aeab4ad2c1cba18
-  RNFBFunctions: e40b25d21478c0aef09b5c70cbbf1d4f062660ed
-  RNFBInAppMessaging: 23aaf12834e1216672294a5cbcb8aa688bb3507e
-  RNFBInstallations: 5402ac25b1bf934a151afa2bdcdbb85d9bf4d653
-  RNFBMessaging: 0fec4854dc48e377b80e1e9bc54841ed390fef3c
-  RNFBML: fbcd9b5b93d438b6649c6e7b491d455e28d9654b
-  RNFBPerf: cfcd0458f5e400cc373f3514792a2ae427157f62
-  RNFBRemoteConfig: b4f483801fd650397832f30c3f3b25c8d83fc6ae
-  RNFBStorage: 111d84a8df90a707a29072b2001dc32734e09680
+  RNFBAnalytics: e3ebf6d227ba4afad82067b6cc09c39c2d7ca71c
+  RNFBApp: 3155b54dc88e7bf8d7aad86c014bed54747f4e0f
+  RNFBAppCheck: 8e49eaea8e57041f8954918db8c6c3c8c19e358a
+  RNFBAppDistribution: 2a8bfdb330900cd72feabffcb91e6ef791068cb1
+  RNFBAuth: 955c9df234ad94774b03c37d2911ec35620b8c24
+  RNFBCrashlytics: e877918706631e3533c2fdedc97b54f5f8956f14
+  RNFBDatabase: 1c6b04165029efdf3773d4595c4d173505c8db67
+  RNFBFirestore: 29a4ec6fb76277b868dcea87e60cb8009000df58
+  RNFBFunctions: 0f2bd0fe886b708f95c5a5eddd372d7aebbc0273
+  RNFBInAppMessaging: 89ed4c1a1207a5323a7d947b1447108c9a08fccf
+  RNFBInstallations: 47a81452a2f2973c7ed756a008742dd785c72232
+  RNFBMessaging: 1d82bba6185f157386c6d023079b812e02ced46f
+  RNFBML: ad2affe812fb1942c5b3715cf1b32e66e0206f32
+  RNFBPerf: 5a5c86e3208e136183cfbd0611cb04925b476663
+  RNFBRemoteConfig: 0b39796712481bf6cc3cc963c416738a02650148
+  RNFBStorage: a1e04aed7c2c53d30c7fa345d789d5208c332bf5
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 6eb60fc2c0eef63e7d2ef4a56e0a3353534143a2
 

--- a/tests/local-tests/auth/auth-totp-demonstrator.tsx
+++ b/tests/local-tests/auth/auth-totp-demonstrator.tsx
@@ -1,0 +1,586 @@
+/* eslint-disable no-console */
+/* eslint-disable react/react-in-jsx-scope */
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import QRCode from 'qrcode-generator';
+
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+  ViewStyle,
+} from 'react-native';
+
+import {
+  createUserWithEmailAndPassword,
+  FirebaseAuthTypes,
+  getAuth,
+  getMultiFactorResolver,
+  multiFactor,
+  onAuthStateChanged,
+  reload,
+  sendEmailVerification,
+  signInWithEmailAndPassword,
+  signOut,
+  TotpMultiFactorGenerator,
+  TotpSecret,
+} from '@react-native-firebase/auth';
+import { useEffect, useState } from 'react';
+
+const Button = (props: {
+  style?: ViewStyle;
+  onPress: () => void;
+  isLoading?: boolean;
+  children: string;
+}) => {
+  return (
+    <Pressable style={[styles.button, props.style]} onPress={props.onPress}>
+      {props.isLoading && <ActivityIndicator />}
+
+      {!props.isLoading && <Text style={styles.buttonText}>{props.children}</Text>}
+    </Pressable>
+  );
+};
+
+export function AuthTOTPDemonstrator() {
+  const [authReady, setAuthReady] = useState(false);
+  const [user, setUser] = useState<FirebaseAuthTypes.User | null>(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(getAuth(), user => {
+      setUser(user);
+      setAuthReady(true);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  if (!authReady) {
+    return (
+      <View style={styles.container}>
+        <Text>Loading...</Text>
+      </View>
+    );
+  }
+
+  if (!user) {
+    return <Login />;
+  }
+
+  if (!user.emailVerified) {
+    return (
+      <VerifyEmail
+        onComplete={() => {
+          setUser(getAuth().currentUser);
+        }}
+      />
+    );
+  }
+
+  return <Home />;
+}
+
+const VerifyEmail = ({ onComplete }: { onComplete: () => void }) => {
+  const [loading, setIsLoading] = useState(false);
+
+  const handleSendVerification = async () => {
+    setIsLoading(true);
+    console.log('should send verification email');
+    try {
+      await sendEmailVerification(getAuth().currentUser!);
+    } catch (error) {
+      console.error('error sending verification email', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleReloadingUser = async () => {
+    setIsLoading(true);
+    console.log('should reload user to see if verified now');
+    try {
+      await reload(getAuth().currentUser!);
+      onComplete();
+      console.log('done reloading. verification status ' + getAuth().currentUser?.emailVerified);
+    } catch (error) {
+      console.error('error reloading user', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Welcome Back</Text>
+        <Text style={styles.subtitle}>{getAuth().currentUser?.email}</Text>
+        <Text style={styles.subtitle}>Please Verify Your Email</Text>
+        <Text style={styles.subtitle}>(check spam for the email if you do not see it)</Text>
+
+        <Button onPress={handleSendVerification} isLoading={loading}>
+          Send Verification Email
+        </Button>
+        <Button onPress={handleReloadingUser} isLoading={loading}>
+          Check Verification Status
+        </Button>
+
+        <Pressable style={styles.secondaryButton} onPress={() => signOut(getAuth())}>
+          <Text style={styles.secondaryButtonText}>Sign Out</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const Login = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isLoading, setLoading] = useState(false);
+
+  const [mfaError, setMfaError] = useState<FirebaseAuthTypes.MultiFactorError>();
+
+  const handleLogin = async () => {
+    try {
+      setLoading(true);
+      await signInWithEmailAndPassword(getAuth(), email, password);
+      console.log('Login successful');
+    } catch (error) {
+      if ((error as { code: string }).code === 'auth/multi-factor-auth-required') {
+        return setMfaError(error as FirebaseAuthTypes.MultiFactorError);
+      }
+
+      console.error('Error during login:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSignUp = async () => {
+    try {
+      setLoading(true);
+      await createUserWithEmailAndPassword(getAuth(), email, password);
+      console.log('Sign up successful');
+    } catch (error) {
+      console.error('Error during signup:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (mfaError) {
+    return <MfaLogin error={mfaError} />;
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Welcome Back</Text>
+        <Text style={styles.subtitle}>Please log in to continue</Text>
+
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            onChangeText={setEmail}
+            value={email}
+            placeholder="Email"
+            placeholderTextColor="#9CA3AF"
+            keyboardType="email-address"
+            autoCapitalize="none"
+          />
+          <TextInput
+            style={styles.input}
+            onChangeText={setPassword}
+            value={password}
+            placeholder="Password"
+            placeholderTextColor="#9CA3AF"
+            secureTextEntry
+          />
+        </View>
+        <Button onPress={handleLogin} isLoading={isLoading}>
+          Log in
+        </Button>
+        <Button style={{ marginTop: 20 }} onPress={handleSignUp} isLoading={isLoading}>
+          Sign Up
+        </Button>
+      </View>
+    </View>
+  );
+};
+
+const MfaLogin = ({ error }: { error: FirebaseAuthTypes.MultiFactorError }) => {
+  const [resolver, setResolver] = useState<FirebaseAuthTypes.MultiFactorResolver>();
+  const [activeFactor, setActiveFactor] = useState<FirebaseAuthTypes.MultiFactorInfo>();
+
+  const [code, setCode] = useState<string>('');
+  const [isLoading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const resolver = getMultiFactorResolver(getAuth(), error);
+    setResolver(resolver);
+    setActiveFactor(resolver.hints[0]);
+    if (resolver.hints.length === 1) {
+      const hint = resolver.hints[0];
+      setActiveFactor(hint);
+    }
+  }, [error]);
+
+  const handleConfirm = async () => {
+    if (!resolver) return;
+
+    try {
+      setLoading(true);
+      // For demo, assume only 1 hint and it's totp
+      const multiFactorAssertion = TotpMultiFactorGenerator.assertionForSignIn(
+        activeFactor!.uid,
+        code,
+      );
+      return await resolver.resolveSignIn(multiFactorAssertion);
+    } catch (error) {
+      console.error('Error during MFA sign in:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!resolver) {
+    return null;
+  }
+
+  // For demo, assume only 1 hint and it's totp
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Two-Factor Authentication</Text>
+        <Text style={styles.subtitle}>
+          Please enter the verification code from your authenticator app
+        </Text>
+
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            onChangeText={setCode}
+            value={code}
+            placeholder="Verification Code"
+            placeholderTextColor="#9CA3AF"
+            keyboardType="number-pad"
+            textAlign="center"
+            maxLength={6}
+          />
+        </View>
+
+        <Button onPress={handleConfirm} isLoading={isLoading}>
+          Verify
+        </Button>
+      </View>
+    </View>
+  );
+};
+
+const Home = () => {
+  const [factors, setFactors] = useState(getAuth().currentUser?.multiFactor?.enrolledFactors);
+  const [addingFactor, setAddingFactor] = useState(false);
+  const [removingFactor, setRemovingFactor] = useState(false);
+
+  const [totpSecret, setTotpSecret] = useState<TotpSecret | null>(null);
+
+  const handleRemoveFactor = async (factor: FirebaseAuthTypes.MultiFactorInfo) => {
+    try {
+      const user = getAuth().currentUser;
+      if (!user) return;
+      setRemovingFactor(true);
+
+      const multiFactorUser = multiFactor(user);
+      await multiFactorUser.unenroll(factor.uid);
+      console.log(`Factor ${factor.factorId} removed successfully`);
+    } catch (error) {
+      console.error('Error removing factor:', error);
+    } finally {
+      setRemovingFactor(false);
+    }
+
+    setFactors(getAuth().currentUser?.multiFactor?.enrolledFactors);
+  };
+
+  const generateTotpSecret = async () => {
+    console.log('in generateTotpSecret');
+    setAddingFactor(true);
+    const currentUser = getAuth().currentUser!;
+    console.log(`got currentUser ${currentUser.email}`);
+    try {
+      const multiFactorSession = await multiFactor(currentUser).getSession();
+      console.log(`got multiFactorSession`);
+      setTotpSecret(await TotpMultiFactorGenerator.generateSecret(multiFactorSession, getAuth()));
+    } catch (error) {
+      console.error('Error generating TOTP Secret', error);
+    } finally {
+      setAddingFactor(false);
+    }
+  };
+
+  if (totpSecret) {
+    return (
+      <EnrollTotp
+        totpSecret={totpSecret}
+        // totpUriQRBase64={totpUriQRBase64}
+        onComplete={() => {
+          setFactors(getAuth().currentUser?.multiFactor?.enrolledFactors);
+          setTotpSecret(null);
+        }}
+      />
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Welcome!</Text>
+        <Text style={styles.subtitle}>Logged in as {getAuth().currentUser?.email}</Text>
+
+        <Text style={[styles.subtitle, { marginBottom: 10 }]}>
+          Enrolled factors: {factors?.length || 0}
+        </Text>
+
+        {factors?.map(factor => (
+          <Button
+            key={factor.uid}
+            onPress={() => handleRemoveFactor(factor)}
+            isLoading={removingFactor}
+          >
+            {`${factor.displayName || factor.factorId} (${factor.factorId}) Remove`}
+          </Button>
+        ))}
+
+        <Button style={{ marginTop: 20 }} isLoading={addingFactor} onPress={generateTotpSecret}>
+          Add TOTP Factor
+        </Button>
+
+        <Pressable style={styles.secondaryButton} onPress={() => signOut(getAuth())}>
+          <Text style={styles.secondaryButtonText}>Sign Out</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const EnrollTotp = ({
+  totpSecret,
+  onComplete,
+}: {
+  totpSecret: TotpSecret;
+  onComplete: () => void;
+}) => {
+  const [verificationCode, setVerificationCode] = useState('');
+  const [qrCodeUrl, setQrCodeUrl] = useState('');
+  const [qrCodeBase64, setQrCodeBase64] = useState('');
+  const [isLoading, setLoading] = useState(false);
+
+  useEffect(() => {
+    totpSecret
+      .generateQrCodeUrl(getAuth().currentUser?.email, 'RNFB TOTP Demonstrator')
+      .then(qrURL => {
+        setQrCodeUrl(qrURL);
+        const qr = QRCode(0, 'L');
+        qr.addData(qrURL);
+        qr.make();
+        const qrDataURL = qr.createDataURL();
+        setQrCodeBase64(qrDataURL);
+      })
+      .catch(e => console.error('error generating qa code url ' + e));
+  }, []);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      const user = getAuth().currentUser;
+      if (!user) return;
+
+      const multiFactorAssertion = TotpMultiFactorGenerator.assertionForEnrollment(
+        totpSecret,
+        verificationCode,
+      );
+      await multiFactor(user).enroll(multiFactorAssertion, 'Authenticator App');
+      onComplete();
+    } catch (error) {
+      console.error('Error enrolling TOTP:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.card}>
+        <Text style={styles.title}>Enroll Options</Text>
+        {qrCodeBase64 !== '' && (
+          <>
+            <Text style={styles.text}>a) Scan the QR code</Text>
+            <Image
+              style={{
+                width: 175,
+                height: 175,
+                resizeMode: 'contain',
+                // borderWidth: 1,
+                // borderColor: 'black',
+              }}
+              source={{ uri: qrCodeBase64 }}
+            />
+          </>
+        )}
+
+        <Text style={styles.text}>b) Open in app directly.</Text>
+        <Button onPress={() => totpSecret.openInOtpApp(qrCodeUrl)} isLoading={isLoading}>
+          Open In App
+        </Button>
+
+        <Text style={styles.subtitle}>c) Enter the secret manually</Text>
+
+        <TextInput
+          style={styles.input}
+          value={totpSecret.secretKey}
+          placeholder="TOTP Secret"
+          placeholderTextColor="#9CA3AF"
+        />
+        <Text style={styles.subtitle}>
+          Then enter the verification code from your authenticator app.
+        </Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Verification Code"
+          placeholderTextColor="#9CA3AF"
+          keyboardType="number-pad"
+          textAlign="center"
+          maxLength={6}
+          onChangeText={setVerificationCode}
+          value={verificationCode}
+        />
+        <Button onPress={handleConfirm} isLoading={isLoading}>
+          Confirm
+        </Button>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F8FAFC',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 20,
+    padding: 40,
+    width: '100%',
+    maxWidth: 400,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 8,
+    },
+    shadowOpacity: 0.12,
+    shadowRadius: 24,
+    elevation: 8,
+    borderWidth: 1,
+    borderColor: '#F1F5F9',
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#0F172A',
+    textAlign: 'center',
+    marginBottom: 12,
+    letterSpacing: -0.5,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#64748B',
+    textAlign: 'center',
+    marginBottom: 20,
+    lineHeight: 24,
+    fontWeight: '400',
+  },
+  text: {
+    fontSize: 16,
+    color: '#64748B',
+    textAlign: 'center',
+    fontWeight: '400',
+  },
+  inputContainer: {
+    marginBottom: 32,
+  },
+  input: {
+    backgroundColor: '#FAFBFC',
+    borderWidth: 2,
+    borderColor: '#E2E8F0',
+    borderRadius: 16,
+    padding: 18,
+    fontSize: 16,
+    color: '#0F172A',
+    marginBottom: 20,
+    fontWeight: '500',
+  },
+  button: {
+    backgroundColor: '#2563EB',
+    borderRadius: 16,
+    padding: 18,
+    alignItems: 'center',
+    shadowColor: '#2563EB',
+    shadowOffset: {
+      width: 0,
+      height: 6,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 17,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
+  secondaryButton: {
+    backgroundColor: '#F8FAFC',
+    borderWidth: 2,
+    borderColor: '#E2E8F0',
+    borderRadius: 16,
+    padding: 18,
+    alignItems: 'center',
+    marginTop: 20,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.05,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  secondaryButtonText: {
+    color: '#475569',
+    fontSize: 17,
+    fontWeight: '600',
+  },
+});

--- a/tests/local-tests/auth/gcloud-enable-totp-in-project.sh
+++ b/tests/local-tests/auth/gcloud-enable-totp-in-project.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright (c) 2016-present Invertase Limited & Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this library except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script will enable TOTP in your project
+#
+# It assumes:
+# - curl is in PATH (should be installed by default on macOS)
+# - gcloud is in PATH and you are authenticated (brew install google-cloud-sdk...)
+# - you have set PROJECT_ID (otherwise it will use "react-native-firebase-testing")
+
+if [ -z ${PROJECT_ID+x} ]; then
+  PROJECT_ID="react-native-firebase-testing"
+fi
+
+if [ -z ${NUM_ADJ_INTERVALS+x} ]; then
+  NUM_ADJ_INTERVALS=5
+fi
+
+echo "Enabling MFA and TOTP in gcloud project $PROJECT_ID"
+echo "...using ${NUM_ADJ_INTERVALS} as number of adjacent intervals to accept."
+
+curl -X PATCH "https://identitytoolkit.googleapis.com/admin/v2/projects/${PROJECT_ID}/config?updateMask=mfa" \
+    -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+    -H "Content-Type: application/json" \
+    -H "X-Goog-User-Project: ${PROJECT_ID}" \
+    -d \
+    "{
+        \"mfa\": {
+          \"state\": \"ENABLED\",
+          \"providerConfigs\": [{
+            \"state\": \"ENABLED\",
+            \"totpProviderConfig\": {
+              \"adjacentIntervals\": ${NUM_ADJ_INTERVALS}
+            }
+          }]
+       }
+    }"

--- a/tests/local-tests/crash-test.jsx
+++ b/tests/local-tests/crash-test.jsx
@@ -1,4 +1,21 @@
 /* eslint-disable react/react-in-jsx-scope */
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import { Button, StyleSheet, Text, View } from 'react-native';
 import { crash, getCrashlytics } from '@react-native-firebase/crashlytics';
 

--- a/tests/local-tests/database/index.js
+++ b/tests/local-tests/database/index.js
@@ -13,9 +13,10 @@ import {
   connectDatabaseEmulator,
 } from '@react-native-firebase/database';
 
-connectDatabaseEmulator(getDatabase(), '127.0.0.1', 9000);
-
 export function DatabaseOnChildMovedTest() {
+  // Defer connecting to the emulator until we display
+  connectDatabaseEmulator(getDatabase(), '127.0.0.1', 9000);
+
   return (
     <View>
       <Text>text text text</Text>

--- a/tests/local-tests/database/index.js
+++ b/tests/local-tests/database/index.js
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import React from 'react';
 import { Button, Text, View } from 'react-native';
 

--- a/tests/local-tests/firestore/onSnapshotInSync.js
+++ b/tests/local-tests/firestore/onSnapshotInSync.js
@@ -1,4 +1,21 @@
 /* eslint-disable no-console */
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import React, { useEffect } from 'react';
 import { Button, Text, View } from 'react-native';
 

--- a/tests/local-tests/index.js
+++ b/tests/local-tests/index.js
@@ -9,6 +9,7 @@ import { AITestComponent } from './ai/ai';
 import { DatabaseOnChildMovedTest } from './database';
 import { FirestoreOnSnapshotInSyncTest } from './firestore/onSnapshotInSync';
 import { VertexAITestComponent } from './vertexai/vertexai';
+import { AuthTOTPDemonstrator } from './auth/auth-totp-demonstrator';
 
 const testComponents = {
   // List your imported components here...
@@ -17,6 +18,7 @@ const testComponents = {
   'Database onChildMoved Test': DatabaseOnChildMovedTest,
   'Firestore onSnapshotInSync Test': FirestoreOnSnapshotInSyncTest,
   'VertexAI Generation Example': VertexAITestComponent,
+  'Auth TOTP Demonstrator': AuthTOTPDemonstrator,
 };
 
 export function TestComponents() {

--- a/tests/local-tests/index.js
+++ b/tests/local-tests/index.js
@@ -1,4 +1,21 @@
 /* eslint-disable react/react-in-jsx-scope */
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import { Button } from 'react-native';
 
 import { useState } from 'react';

--- a/tests/local-tests/vertexai/vertexai.js
+++ b/tests/local-tests/vertexai/vertexai.js
@@ -1,4 +1,21 @@
 /* eslint-disable no-console */
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import React, { useState } from 'react';
 import { Button, View, Text, Pressable } from 'react-native';
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -30,6 +30,7 @@
     "@react-native-firebase/remote-config": "23.1.2",
     "@react-native-firebase/storage": "23.1.2",
     "postinstall-postinstall": "2.1.0",
+    "qrcode-generator": "^2.0.4",
     "react": "19.0.0",
     "react-native": "0.78.2",
     "react-native-device-info": "^14.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19650,6 +19650,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qrcode-generator@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "qrcode-generator@npm:2.0.4"
+  checksum: 10/c488558bca2869d8837300da299a9653030dbb486ce6113153585b117fa0ab6822a03c8312cc794d41c2e3f8353dc64b950e8a3ffe90f89022593c4e7060cd53
+  languageName: node
+  linkType: hard
+
 "qrcode-terminal@npm:0.11.0":
   version: 0.11.0
   resolution: "qrcode-terminal@npm:0.11.0"
@@ -19949,6 +19956,7 @@ __metadata:
     nyc: "npm:^17.1.0"
     patch-package: "npm:^8.0.0"
     postinstall-postinstall: "npm:2.1.0"
+    qrcode-generator: "npm:^2.0.4"
     react: "npm:19.0.0"
     react-native: "npm:0.78.2"
     react-native-device-info: "npm:^14.0.4"


### PR DESCRIPTION
### Description
The aim of these changes is to enable TOTP MFA and the ability to un-enroll from either SMS or TOTP MFA.

The motivation behind doing this was to migrate away from Firebase JS SDK implementation on our existing Expo application which extensively uses multi-factor authentication.

This is my first time ever changing native code like this. My workflow at the moment for making these changes have simply been editing the native modules in the respective code editors (Xcode and Android Studio), then using patch-package and building new development builds each time and testing live against our development environment, so nothing has been emulated.

I tried to link my forked repo locally using `npm/yarn link` and build off that instead but I couldn't get it to work so I had to go the patch-package route and copy across all of my changes to my fork manually. If you're aware of a better way to do this please let me know!

I am aware that there is a blocking issue (https://github.com/firebase/firebase-tools/issues/6224) which prevents TOTP being tested within emulation, so I guess proper tests cannot be written just yet for this feature (unsure about unenroll feature).
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues
https://github.com/invertase/react-native-firebase/issues/7483
Abandoned related PR: https://github.com/invertase/react-native-firebase/pull/7718
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary
Add support for enrolling TOTP multi-factor authentication, authentication using TOTP and un-enrolling multi-factor authentication.
<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web) (NOTE: When using shims replacing imports with firebase js sdk, this should work as the APIs are exactly the same as the web sdk - https://github.com/invertase/react-native-firebase/issues/7921#issuecomment-3102680871)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan
I currently only have this working in our product application which won't be possible to post videos or screenshots of on a public PR, but I can create a minimum repro app soon enough (probably in my free time over the weekend) and post videos and screenshots from that instead.

Update:
As promised, here is a demo of the changes in action along with a demo repo: https://github.com/jamespb97/firebase-totp-demo
To run just change the app.json accordingly and copy across your firebase service files and it should all work.

Android:

https://github.com/user-attachments/assets/468e3195-7ba2-4f6d-b925-d3de01aeeef9

iOS:

https://github.com/user-attachments/assets/fd349366-bfab-4bbf-98c1-818872590936

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥 🔥 🔥 
