### PR TITLE
feat!: bump firebase-ios-sdk to `12.0.0`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ If you do not meet these prerequisites, follow the links below:
 - [React Native - Setting up the development environment](https://reactnative.dev/docs/environment-setup)
 - [Create a new Firebase project](https://console.firebase.google.com/)
 
-Additionally, current versions of firebase-ios-sdk have a minimum Xcode requirement of 15.2, which implies a minimum macOS version of 13.5 (macOS Ventura).
+Additionally, current versions of firebase-ios-sdk have a minimum Xcode requirement of 16.2, which implies a minimum macOS version of 14.5 (macOS Sequoia).
 
 ## Installation for Expo projects
 
@@ -335,7 +335,7 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '11.15.0'
+$FirebaseSDKVersion = '12.0.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.

--- a/docs/migrating-to-v23.md
+++ b/docs/migrating-to-v23.md
@@ -21,9 +21,15 @@ const multiFactorUser = credential.user.multiFactor;
 console.log(multiFactorUser.enrolledFactors);
 ```
 
+# Firebase App
+
+- `gaMeasurementId` property from `FirebaseOptions` has been replaced with `measurementId` to match Firebase web JS SDK.
+
 # Firebase Dynamic Links
 
 ⚠️ **REMOVED** ⚠️
+
+Firebase Dynamic Links has been Removed
 
 This package has been deprecated and removed from the React Native Firebase repository.
 
@@ -56,6 +62,12 @@ Please refer to the official deprecation FAQ for complete migration guidance and
 - Crashlytics gradle plugin has been bumped from `3.0.4` to `3.0.5`.
 - Performance gradle plugin has been bumped from `1.4.2` to `2.0.0`.
 - App distribution gradle plugin has been bumped from `5.1.1` to `5.1.2`.
+
+# iOS platform
+
+- Minimum iOS deployment target has now been bumped to `15` from `13`.
+- Minimum Xcode version required for iOS development is now Xcode `16.2`, previous was Xcode `15.2`.
+- `gaMeasurementId` property from `FirebaseOptions` (now `measurementId` in React Native Firebase) has been removed from firebase-ios-sdk as it wasn't used.
 
 # Web platform
 

--- a/packages/analytics/lib/web/RNFBAnalyticsModule.js
+++ b/packages/analytics/lib/web/RNFBAnalyticsModule.js
@@ -11,7 +11,7 @@ function getAnalyticsApi(appName) {
   if (!measurementId) {
     // eslint-disable-next-line no-console
     console.warn(
-      'No measurement id found for Firebase Analytics. Analytics will be unavailable. Have you set gaTrackingId in your Firebase config?',
+      'No measurement id (`FirebaseOptions.measurementId`) found for Firebase Analytics. Analytics will be unavailable.',
     );
   }
   if (!analyticsInstances[measurementId]) {

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/RCTConvertFirebase.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/RCTConvertFirebase.java
@@ -53,7 +53,7 @@ public class RCTConvertFirebase {
     options.put("appId", appOptions.getApplicationId());
     options.put("projectId", appOptions.getProjectId());
     options.put("databaseURL", appOptions.getDatabaseUrl());
-    options.put("gaTrackingId", appOptions.getGaTrackingId());
+    options.put("measurementId", appOptions.getGaTrackingId());
     options.put("messagingSenderId", appOptions.getGcmSenderId());
     options.put("storageBucket", appOptions.getStorageBucket());
 
@@ -82,8 +82,8 @@ public class RCTConvertFirebase {
     builder.setProjectId(options.getString("projectId"));
     builder.setDatabaseUrl(options.getString("databaseURL"));
 
-    if (options.hasKey("gaTrackingId")) {
-      builder.setGaTrackingId(options.getString("gaTrackingId"));
+    if (options.hasKey("measurementId")) {
+      builder.setGaTrackingId(options.getString("measurementId"));
     }
 
     builder.setStorageBucket(options.getString("storageBucket"));

--- a/packages/app/ios/RNFBApp/RCTConvert+FIROptions.m
+++ b/packages/app/ios/RNFBApp/RCTConvert+FIROptions.m
@@ -26,11 +26,8 @@
   firOptions.APIKey = [rawOptions valueForKey:@"apiKey"];
   firOptions.projectID = [rawOptions valueForKey:@"projectId"];
   firOptions.clientID = [rawOptions valueForKey:@"clientId"];
-  firOptions.trackingID = [rawOptions valueForKey:@"gaTrackingId"];
   firOptions.databaseURL = [rawOptions valueForKey:@"databaseURL"];
   firOptions.storageBucket = [rawOptions valueForKey:@"storageBucket"];
-  firOptions.androidClientID = [rawOptions valueForKey:@"androidClientId"];
-  firOptions.deepLinkURLScheme = [rawOptions valueForKey:@"deepLinkURLScheme"];
   firOptions.bundleID = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
   return firOptions;
 }

--- a/packages/app/ios/RNFBApp/RNFBAppModule.m
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.m
@@ -190,10 +190,7 @@ RCT_EXPORT_METHOD(initializeApp
     if (![[options valueForKey:@"storageBucket"] isEqual:[NSNull null]]) {
       firOptions.storageBucket = [options valueForKey:@"storageBucket"];
     }
-    // kFirebaseOptionsDeepLinkURLScheme
-    if (![[options valueForKey:@"deepLinkURLScheme"] isEqual:[NSNull null]]) {
-      firOptions.deepLinkURLScheme = [options valueForKey:@"deepLinkURLScheme"];
-    }
+
     // kFirebaseOptionsIosBundleId
     if (![[options valueForKey:@"iosBundleId"] isEqual:[NSNull null]]) {
       firOptions.bundleID = [options valueForKey:@"iosBundleId"];

--- a/packages/app/ios/RNFBApp/RNFBSharedUtils.m
+++ b/packages/app/ios/RNFBApp/RNFBSharedUtils.m
@@ -59,13 +59,10 @@ static NSString *const RNFBErrorDomain = @"RNFBErrorDomain";
   firAppOptions[@"appId"] = firOptions.googleAppID;
   firAppOptions[@"projectId"] = firOptions.projectID;
   firAppOptions[@"databaseURL"] = firOptions.databaseURL;
-  firAppOptions[@"gaTrackingId"] = firOptions.trackingID;
   firAppOptions[@"storageBucket"] = firOptions.storageBucket;
   firAppOptions[@"messagingSenderId"] = firOptions.GCMSenderID;
   // missing from android sdk - ios only:
   firAppOptions[@"clientId"] = firOptions.clientID;
-  firAppOptions[@"androidClientID"] = firOptions.androidClientID;
-  firAppOptions[@"deepLinkUrlScheme"] = firOptions.deepLinkURLScheme;
   // not in FIROptions API but in JS SDK and project config JSON
   if ([RNFBAppModule getCustomDomain:name] != nil) {
     firAppOptions[@"authDomain"] = [RNFBAppModule getCustomDomain:name];

--- a/packages/app/lib/index.d.ts
+++ b/packages/app/lib/index.d.ts
@@ -85,8 +85,7 @@ export namespace ReactNativeFirebase {
     /**
      * The tracking ID for Google Analytics, e.g. "UA-12345678-1", used to configure Google Analytics.
      */
-    // TODO this should now be measurementId
-    gaTrackingId?: string;
+    measurementId?: string;
 
     /**
      * The Google Cloud Storage bucket name, e.g. "abc-xyz-123.storage.firebase.com".

--- a/packages/app/lib/internal/web/RNFBAppModule.js
+++ b/packages/app/lib/internal/web/RNFBAppModule.js
@@ -74,11 +74,7 @@ export default {
       newAppConfig.automaticDataCollectionEnabled = appConfig.automaticDataCollectionEnabled;
     }
     const optionsCopy = Object.assign({}, options);
-    // TODO RNFB is using the old gaTrackingId property, we should remove this in the future
-    // in favor of the measurementId property.
-    if (optionsCopy.gaTrackingId) {
-      optionsCopy.measurementId = optionsCopy.gaTrackingId;
-    }
+
     delete optionsCopy.clientId;
     initializeApp(optionsCopy, newAppConfig);
     return {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -74,10 +74,10 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "11.15.0",
-      "iosTarget": "13.0",
+      "firebase": "12.0.0",
+      "iosTarget": "15.0",
       "macosTarget": "10.15",
-      "tvosTarget": "13.0"
+      "tvosTarget": "15.0"
     },
     "android": {
       "minSdk": 23,

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -186,9 +186,7 @@ global.FirebaseHelpers = {
         projectId: 'react-native-firebase-testing',
         storageBucket: 'react-native-firebase-testing.appspot.com',
         messagingSenderId: '448618578101',
-        // TODO RNFB is using the old gaTrackingId property, we should remove this in the future
-        // in favor of the measurementId property.
-        gaTrackingId: 'G-HX0JQKHZEB',
+        measurementId: 'G-HX0JQKHZEB',
       };
     },
   },

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -7,125 +7,120 @@ PODS:
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
   - FBLazyVector (0.78.2)
-  - Firebase/AppCheck (11.15.0):
+  - Firebase/AppCheck (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseAppCheck (~> 11.15.0)
-  - Firebase/AppDistribution (11.15.0):
+    - FirebaseAppCheck (~> 12.0.0)
+  - Firebase/AppDistribution (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseAppDistribution (~> 11.15.0-beta)
-  - Firebase/Auth (11.15.0):
+    - FirebaseAppDistribution (~> 12.0.0-beta)
+  - Firebase/Auth (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseAuth (~> 11.15.0)
-  - Firebase/CoreOnly (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-  - Firebase/Crashlytics (11.15.0):
+    - FirebaseAuth (~> 12.0.0)
+  - Firebase/CoreOnly (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+  - Firebase/Crashlytics (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseCrashlytics (~> 11.15.0)
-  - Firebase/Database (11.15.0):
+    - FirebaseCrashlytics (~> 12.0.0)
+  - Firebase/Database (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseDatabase (~> 11.15.0)
-  - Firebase/DynamicLinks (11.15.0):
+    - FirebaseDatabase (~> 12.0.0)
+  - Firebase/Firestore (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 11.15.0)
-  - Firebase/Firestore (11.15.0):
+    - FirebaseFirestore (~> 12.0.0)
+  - Firebase/Functions (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseFirestore (~> 11.15.0)
-  - Firebase/Functions (11.15.0):
+    - FirebaseFunctions (~> 12.0.0)
+  - Firebase/InAppMessaging (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseFunctions (~> 11.15.0)
-  - Firebase/InAppMessaging (11.15.0):
+    - FirebaseInAppMessaging (~> 12.0.0-beta)
+  - Firebase/Installations (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseInAppMessaging (~> 11.15.0-beta)
-  - Firebase/Installations (11.15.0):
+    - FirebaseInstallations (~> 12.0.0)
+  - Firebase/Messaging (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseInstallations (~> 11.15.0)
-  - Firebase/Messaging (11.15.0):
+    - FirebaseMessaging (~> 12.0.0)
+  - Firebase/Performance (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 11.15.0)
-  - Firebase/Performance (11.15.0):
+    - FirebasePerformance (~> 12.0.0)
+  - Firebase/RemoteConfig (12.0.0):
     - Firebase/CoreOnly
-    - FirebasePerformance (~> 11.15.0)
-  - Firebase/RemoteConfig (11.15.0):
+    - FirebaseRemoteConfig (~> 12.0.0)
+  - Firebase/Storage (12.0.0):
     - Firebase/CoreOnly
-    - FirebaseRemoteConfig (~> 11.15.0)
-  - Firebase/Storage (11.15.0):
-    - Firebase/CoreOnly
-    - FirebaseStorage (~> 11.15.0)
-  - FirebaseABTesting (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-  - FirebaseAnalytics/Core (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement/Core (= 11.15.0)
+    - FirebaseStorage (~> 12.0.0)
+  - FirebaseABTesting (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+  - FirebaseAnalytics/Core (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
+    - GoogleAppMeasurement/Core (= 12.0.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAnalytics/IdentitySupport (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - GoogleAppMeasurement/IdentitySupport (= 11.15.0)
+  - FirebaseAnalytics/IdentitySupport (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
+    - GoogleAppMeasurement/IdentitySupport (= 12.0.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - FirebaseAppCheck (11.15.0):
+  - FirebaseAppCheck (12.0.0):
     - AppCheckCore (~> 11.0)
-    - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.15.0)
+    - FirebaseAppCheckInterop (~> 12.0.0)
+    - FirebaseCore (~> 12.0.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
-  - FirebaseAppCheckInterop (11.15.0)
-  - FirebaseAppDistribution (11.15.0-beta):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
+  - FirebaseAppCheckInterop (12.0.0)
+  - FirebaseAppDistribution (12.0.0-beta):
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
-  - FirebaseAuth (11.15.0):
-    - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseCoreExtension (~> 11.15.0)
+  - FirebaseAuth (12.0.0):
+    - FirebaseAppCheckInterop (~> 12.0.0)
+    - FirebaseAuthInterop (~> 12.0.0)
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseCoreExtension (~> 12.0.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/Environment (~> 8.1)
-    - GTMSessionFetcher/Core (< 5.0, >= 3.4)
+    - GTMSessionFetcher/Core (< 6.0, >= 3.4)
     - RecaptchaInterop (~> 101.0)
-  - FirebaseAuthInterop (11.15.0)
-  - FirebaseCore (11.15.0):
-    - FirebaseCoreInternal (~> 11.15.0)
+  - FirebaseAuthInterop (12.0.0)
+  - FirebaseCore (12.0.0):
+    - FirebaseCoreInternal (~> 12.0.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreExtension (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-  - FirebaseCoreInternal (11.15.0):
+  - FirebaseCoreExtension (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+  - FirebaseCoreInternal (12.0.0):
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseCrashlytics (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - FirebaseRemoteConfigInterop (~> 11.0)
-    - FirebaseSessions (~> 11.0)
-    - GoogleDataTransport (~> 10.0)
+  - FirebaseCrashlytics (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
+    - FirebaseRemoteConfigInterop (~> 12.0.0)
+    - FirebaseSessions (~> 12.0.0)
+    - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
-  - FirebaseDatabase (11.15.0):
-    - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseSharedSwift (~> 11.0)
+  - FirebaseDatabase (12.0.0):
+    - FirebaseAppCheckInterop (~> 12.0.0)
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseSharedSwift (~> 12.0.0)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - leveldb-library (~> 1.22)
-  - FirebaseDynamicLinks (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-  - FirebaseFirestore (11.15.0):
-    - FirebaseFirestoreBinary (= 11.15.0)
+  - FirebaseFirestore (12.0.0):
+    - FirebaseFirestoreBinary (= 12.0.0)
   - FirebaseFirestoreAbseilBinary (1.2024072200.0)
-  - FirebaseFirestoreBinary (11.15.0):
-    - FirebaseCore (= 11.15.0)
-    - FirebaseCoreExtension (= 11.15.0)
-    - FirebaseFirestoreInternalBinary (= 11.15.0)
-    - FirebaseSharedSwift (= 11.15.0)
+  - FirebaseFirestoreBinary (12.0.0):
+    - FirebaseCore (= 12.0.0)
+    - FirebaseCoreExtension (= 12.0.0)
+    - FirebaseFirestoreInternalBinary (= 12.0.0)
+    - FirebaseSharedSwift (= 12.0.0)
   - FirebaseFirestoreGRPCBoringSSLBinary (1.69.0)
   - FirebaseFirestoreGRPCCoreBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
@@ -133,92 +128,92 @@ PODS:
   - FirebaseFirestoreGRPCCPPBinary (1.69.0):
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCoreBinary (= 1.69.0)
-  - FirebaseFirestoreInternalBinary (11.15.0):
-    - FirebaseCore (= 11.15.0)
+  - FirebaseFirestoreInternalBinary (12.0.0):
+    - FirebaseCore (= 12.0.0)
     - FirebaseFirestoreAbseilBinary (= 1.2024072200.0)
     - FirebaseFirestoreGRPCCPPBinary (= 1.69.0)
     - leveldb-library (~> 1.22)
     - nanopb (~> 3.30910.0)
-  - FirebaseFunctions (11.15.0):
-    - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseCoreExtension (~> 11.15.0)
-    - FirebaseMessagingInterop (~> 11.0)
-    - FirebaseSharedSwift (~> 11.0)
-    - GTMSessionFetcher/Core (< 5.0, >= 3.4)
-  - FirebaseInAppMessaging (11.15.0-beta):
-    - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
+  - FirebaseFunctions (12.0.0):
+    - FirebaseAppCheckInterop (~> 12.0.0)
+    - FirebaseAuthInterop (~> 12.0.0)
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseCoreExtension (~> 12.0.0)
+    - FirebaseMessagingInterop (~> 12.0.0)
+    - FirebaseSharedSwift (~> 12.0.0)
+    - GTMSessionFetcher/Core (< 6.0, >= 3.4)
+  - FirebaseInAppMessaging (12.0.0-beta):
+    - FirebaseABTesting (~> 12.0.0)
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - FirebaseInstallations (11.15.0):
-    - FirebaseCore (~> 11.15.0)
+  - FirebaseInstallations (12.0.0):
+    - FirebaseCore (~> 12.0.0)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - GoogleDataTransport (~> 10.0)
+  - FirebaseMessaging (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
+    - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/Reachability (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - FirebaseMessagingInterop (11.15.0)
-  - FirebasePerformance (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - FirebaseRemoteConfig (~> 11.0)
-    - FirebaseSessions (~> 11.0)
-    - GoogleDataTransport (~> 10.0)
+  - FirebaseMessagingInterop (12.0.0)
+  - FirebasePerformance (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
+    - FirebaseRemoteConfig (~> 12.0.0)
+    - FirebaseSessions (~> 12.0.0)
+    - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - FirebaseRemoteConfig (11.15.0):
-    - FirebaseABTesting (~> 11.0)
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - FirebaseRemoteConfigInterop (~> 11.0)
-    - FirebaseSharedSwift (~> 11.0)
+  - FirebaseRemoteConfig (12.0.0):
+    - FirebaseABTesting (~> 12.0.0)
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
+    - FirebaseRemoteConfigInterop (~> 12.0.0)
+    - FirebaseSharedSwift (~> 12.0.0)
     - GoogleUtilities/Environment (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseRemoteConfigInterop (11.15.0)
-  - FirebaseSessions (11.15.0):
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseCoreExtension (~> 11.15.0)
-    - FirebaseInstallations (~> 11.0)
-    - GoogleDataTransport (~> 10.0)
+  - FirebaseRemoteConfigInterop (12.0.0)
+  - FirebaseSessions (12.0.0):
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseCoreExtension (~> 12.0.0)
+    - FirebaseInstallations (~> 12.0.0)
+    - GoogleDataTransport (~> 10.1)
     - GoogleUtilities/Environment (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
-  - FirebaseSharedSwift (11.15.0)
-  - FirebaseStorage (11.15.0):
-    - FirebaseAppCheckInterop (~> 11.0)
-    - FirebaseAuthInterop (~> 11.0)
-    - FirebaseCore (~> 11.15.0)
-    - FirebaseCoreExtension (~> 11.15.0)
+  - FirebaseSharedSwift (12.0.0)
+  - FirebaseStorage (12.0.0):
+    - FirebaseAppCheckInterop (~> 12.0.0)
+    - FirebaseAuthInterop (~> 12.0.0)
+    - FirebaseCore (~> 12.0.0)
+    - FirebaseCoreExtension (~> 12.0.0)
     - GoogleUtilities/Environment (~> 8.1)
-    - GTMSessionFetcher/Core (< 5.0, >= 3.4)
+    - GTMSessionFetcher/Core (< 6.0, >= 3.4)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - GoogleAdsOnDeviceConversion (2.1.0):
+  - GoogleAdsOnDeviceConversion (2.2.1):
     - GoogleUtilities/Logger (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/Core (11.15.0):
+  - GoogleAppMeasurement/Core (12.0.0):
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
     - "GoogleUtilities/NSData+zlib (~> 8.1)"
     - nanopb (~> 3.30910.0)
-  - GoogleAppMeasurement/IdentitySupport (11.15.0):
-    - GoogleAppMeasurement/Core (= 11.15.0)
+  - GoogleAppMeasurement/IdentitySupport (12.0.0):
+    - GoogleAppMeasurement/Core (= 12.0.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
     - GoogleUtilities/MethodSwizzler (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
@@ -254,7 +249,7 @@ PODS:
   - GoogleUtilities/UserDefaults (8.1.0):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GTMSessionFetcher/Core (4.5.0)
+  - GTMSessionFetcher/Core (5.0.0)
   - hermes-engine (0.78.2):
     - hermes-engine/Pre-built (= 0.78.2)
   - hermes-engine/Pre-built (0.78.2)
@@ -1808,75 +1803,70 @@ PODS:
     - Yoga
   - RNDeviceInfo (14.0.4):
     - React-Core
-  - RNFBAnalytics (22.3.0):
-    - FirebaseAnalytics/Core (= 11.15.0)
-    - FirebaseAnalytics/IdentitySupport (= 11.15.0)
+  - RNFBAnalytics (22.4.0):
+    - FirebaseAnalytics/Core (= 12.0.0)
+    - FirebaseAnalytics/IdentitySupport (= 12.0.0)
     - GoogleAdsOnDeviceConversion
     - React-Core
     - RNFBApp
-  - RNFBApp (22.3.0):
-    - Firebase/CoreOnly (= 11.15.0)
+  - RNFBApp (22.4.0):
+    - Firebase/CoreOnly (= 12.0.0)
     - React-Core
-  - RNFBAppCheck (22.3.0):
-    - Firebase/AppCheck (= 11.15.0)
-    - React-Core
-    - RNFBApp
-  - RNFBAppDistribution (22.3.0):
-    - Firebase/AppDistribution (= 11.15.0)
+  - RNFBAppCheck (22.4.0):
+    - Firebase/AppCheck (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBAuth (22.3.0):
-    - Firebase/Auth (= 11.15.0)
+  - RNFBAppDistribution (22.4.0):
+    - Firebase/AppDistribution (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBCrashlytics (22.3.0):
-    - Firebase/Crashlytics (= 11.15.0)
+  - RNFBAuth (22.4.0):
+    - Firebase/Auth (= 12.0.0)
+    - React-Core
+    - RNFBApp
+  - RNFBCrashlytics (22.4.0):
+    - Firebase/Crashlytics (= 12.0.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBDatabase (22.3.0):
-    - Firebase/Database (= 11.15.0)
+  - RNFBDatabase (22.4.0):
+    - Firebase/Database (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBDynamicLinks (22.3.0):
-    - Firebase/DynamicLinks (= 11.15.0)
-    - GoogleUtilities/AppDelegateSwizzler
+  - RNFBFirestore (22.4.0):
+    - Firebase/Firestore (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBFirestore (22.3.0):
-    - Firebase/Firestore (= 11.15.0)
+  - RNFBFunctions (22.4.0):
+    - Firebase/Functions (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBFunctions (22.3.0):
-    - Firebase/Functions (= 11.15.0)
+  - RNFBInAppMessaging (22.4.0):
+    - Firebase/InAppMessaging (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInAppMessaging (22.3.0):
-    - Firebase/InAppMessaging (= 11.15.0)
+  - RNFBInstallations (22.4.0):
+    - Firebase/Installations (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBInstallations (22.3.0):
-    - Firebase/Installations (= 11.15.0)
-    - React-Core
-    - RNFBApp
-  - RNFBMessaging (22.3.0):
-    - Firebase/Messaging (= 11.15.0)
+  - RNFBMessaging (22.4.0):
+    - Firebase/Messaging (= 12.0.0)
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
-  - RNFBML (22.3.0):
+  - RNFBML (22.4.0):
     - React-Core
     - RNFBApp
-  - RNFBPerf (22.3.0):
-    - Firebase/Performance (= 11.15.0)
+  - RNFBPerf (22.4.0):
+    - Firebase/Performance (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBRemoteConfig (22.3.0):
-    - Firebase/RemoteConfig (= 11.15.0)
+  - RNFBRemoteConfig (22.4.0):
+    - Firebase/RemoteConfig (= 12.0.0)
     - React-Core
     - RNFBApp
-  - RNFBStorage (22.3.0):
-    - Firebase/Storage (= 11.15.0)
+  - RNFBStorage (22.4.0):
+    - Firebase/Storage (= 12.0.0)
     - React-Core
     - RNFBApp
   - SocketRocket (0.7.1)
@@ -1887,7 +1877,7 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native/third-party-podspecs/fast_float.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
-  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `11.15.0`)
+  - FirebaseFirestore (from `https://github.com/invertase/firestore-ios-sdk-frameworks.git`, tag `12.0.0`)
   - fmt (from `../node_modules/react-native/third-party-podspecs/fmt.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
@@ -1960,7 +1950,6 @@ DEPENDENCIES:
   - "RNFBAuth (from `../node_modules/@react-native-firebase/auth`)"
   - "RNFBCrashlytics (from `../node_modules/@react-native-firebase/crashlytics`)"
   - "RNFBDatabase (from `../node_modules/@react-native-firebase/database`)"
-  - "RNFBDynamicLinks (from `../node_modules/@react-native-firebase/dynamic-links`)"
   - "RNFBFirestore (from `../node_modules/@react-native-firebase/firestore`)"
   - "RNFBFunctions (from `../node_modules/@react-native-firebase/functions`)"
   - "RNFBInAppMessaging (from `../node_modules/@react-native-firebase/in-app-messaging`)"
@@ -1988,7 +1977,6 @@ SPEC REPOS:
     - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseDatabase
-    - FirebaseDynamicLinks
     - FirebaseFirestoreAbseilBinary
     - FirebaseFirestoreBinary
     - FirebaseFirestoreGRPCBoringSSLBinary
@@ -2029,7 +2017,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/Libraries/FBLazyVector"
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.15.0
+    :tag: 12.0.0
   fmt:
     :podspec: "../node_modules/react-native/third-party-podspecs/fmt.podspec"
   glog:
@@ -2171,8 +2159,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-firebase/crashlytics"
   RNFBDatabase:
     :path: "../node_modules/@react-native-firebase/database"
-  RNFBDynamicLinks:
-    :path: "../node_modules/@react-native-firebase/dynamic-links"
   RNFBFirestore:
     :path: "../node_modules/@react-native-firebase/firestore"
   RNFBFunctions:
@@ -2197,7 +2183,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   FirebaseFirestore:
     :git: https://github.com/invertase/firestore-ios-sdk-frameworks.git
-    :tag: 11.15.0
+    :tag: 12.0.0
 
 SPEC CHECKSUMS:
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
@@ -2205,45 +2191,44 @@ SPEC CHECKSUMS:
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: e32d34492c519a2194ec9d7f5e7a79d11b73f91c
-  Firebase: d99ac19b909cd2c548339c2241ecd0d1599ab02e
-  FirebaseABTesting: 5e9d432834aebf27ab72100d37af44dfbe8d82f7
-  FirebaseAnalytics: 6433dfd311ba78084fc93bdfc145e8cb75740eae
-  FirebaseAppCheck: 4574d7180be2a8b514f588099fc5262f032a92c7
-  FirebaseAppCheckInterop: 06fe5a3799278ae4667e6c432edd86b1030fa3df
-  FirebaseAppDistribution: 9191091eca844b85c761efd9dbb2e814a1815d19
-  FirebaseAuth: a6575e5fbf46b046c58dc211a28a5fbdd8d4c83b
-  FirebaseAuthInterop: 7087d7a4ee4bc4de019b2d0c240974ed5d89e2fd
-  FirebaseCore: efb3893e5b94f32b86e331e3bd6dadf18b66568e
-  FirebaseCoreExtension: edbd30474b5ccf04e5f001470bdf6ea616af2435
-  FirebaseCoreInternal: 9afa45b1159304c963da48addb78275ef701c6b4
-  FirebaseCrashlytics: e09d0bc19aa54a51e45b8039c836ef73f32c039a
-  FirebaseDatabase: 954eb5613d01573ea50ef839e380edcb68db3707
-  FirebaseDynamicLinks: 639fc743dc9c9f01709139bf74319536a674f012
-  FirebaseFirestore: 736c2099af30aed7728d5789059fee1914b4d213
+  Firebase: 800d487043c0557d9faed71477a38d9aafb08a41
+  FirebaseABTesting: 2cad22e464cd7ef4589ae29f897bc71ff83ce83b
+  FirebaseAnalytics: 6d790cd1b159b4eb61a99948df0934ce505a34f7
+  FirebaseAppCheck: b91ab9185b0192dabe7efe83d4b66de33f0d83b0
+  FirebaseAppCheckInterop: c848d06a04030c9858ef0ae555b82035dbe470d0
+  FirebaseAppDistribution: e6764880c66baad80ab1c3d3e4f06f4e43667b35
+  FirebaseAuth: 654e4de84787c45d7265599a651038e854ccb439
+  FirebaseAuthInterop: 002da671896af5e8879ae117dc604ed240b86e80
+  FirebaseCore: 055f4ab117d5964158c833f3d5e7ec6d91648d4a
+  FirebaseCoreExtension: 639afb3de6abd611952be78a794c54a47fa0f361
+  FirebaseCoreInternal: dedc28e569a4be85f38f3d6af1070a2e12018d55
+  FirebaseCrashlytics: db75aa0cab8d00f68406fa247c32fe17ade884d7
+  FirebaseDatabase: a460e05127716ea17671f07241d4725b6dde7c6d
+  FirebaseFirestore: e91d2b8a03399f154fdd3782d2435d2769e8baf8
   FirebaseFirestoreAbseilBinary: 4cfa8823cedc1b774843e04fe578ad279b387f97
-  FirebaseFirestoreBinary: 43abe19da1cb39a10171786e5a2e18fa9d57b6af
+  FirebaseFirestoreBinary: 95ad0b144bb28e14ceca0f29aeb03f7444eb1ff1
   FirebaseFirestoreGRPCBoringSSLBinary: c3dfef3ff448ae2c1c85f9baf9fac5afc4db99fa
   FirebaseFirestoreGRPCCoreBinary: 565534e160a0415d12185f7f171c52a567382fbd
   FirebaseFirestoreGRPCCPPBinary: 6c0134e8d230ee58b9d51dec2a30a48efd6d5dc7
-  FirebaseFirestoreInternalBinary: ea89c368772c8fa4c9550a464b36c25796f6182c
-  FirebaseFunctions: 86062a3ba8c7420e6b6fe22c8a1e1150332286de
-  FirebaseInAppMessaging: 684b346d8cea49531b9dcaca2c1dbbfa82516fb5
-  FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
-  FirebaseMessaging: 3b26e2cee503815e01c3701236b020aa9b576f09
-  FirebaseMessagingInterop: 63e504b147a7206cfe64cbe2f40c2ddd009945bd
-  FirebasePerformance: 8710877e6ba0f6ca4940d10624f5302431b406ea
-  FirebaseRemoteConfig: b496646b82855e174a7f1e354c65e0e913085168
-  FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
-  FirebaseSessions: b9a92c1c51bbb81e78fc3142cda6d925d700f8e7
-  FirebaseSharedSwift: e17c654ef1f1a616b0b33054e663ad1035c8fd40
-  FirebaseStorage: 50fc9ee147392943e492467db6b52759b0447037
+  FirebaseFirestoreInternalBinary: 3a19506d88eecbafae8e639a0ec5769e2eddba27
+  FirebaseFunctions: a5d47653ed6262ba76d215e3097f105dcabc652c
+  FirebaseInAppMessaging: cbbc4ce0fc8a78bf87ba2c15803438748cf6de23
+  FirebaseInstallations: d4c7c958f99c8860d7fcece786314ae790e2f988
+  FirebaseMessaging: af49f8d7c0a3d2a017d9302c80946f45a7777dde
+  FirebaseMessagingInterop: 30024b4793b4876fa1e104e42949eb0273257e38
+  FirebasePerformance: 58e48464297c539c0a75c4c3411a5fba442b4553
+  FirebaseRemoteConfig: 4cbbe0083474359025e7bb334b9d0cff16b78d3a
+  FirebaseRemoteConfigInterop: bfa0ea72ba3dc5af739777296424e46bd6f42613
+  FirebaseSessions: 4e784acda213108aafef536535cdfc03504acc42
+  FirebaseSharedSwift: 59266c22ccfcef604d725c034c568fa666ea9bda
+  FirebaseStorage: 5603c913805b0eacc8e6853395e837ca5742e5f7
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64
-  GoogleAppMeasurement: 700dce7541804bec33db590a5c496b663fbe2539
+  GoogleAdsOnDeviceConversion: 7978b3761ee627e42edbb47d44906a0fa43ed448
+  GoogleAppMeasurement: 8f6ab04ad6ae493b53fcf56bd26323fb2f1384f3
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  GTMSessionFetcher: fc75fc972958dceedee61cb662ae1da7a83a91cf
+  GTMSessionFetcher: 02d6e866e90bc236f48a703a041dfe43e6221a29
   hermes-engine: 2771b98fb813fdc6f92edd7c9c0035ecabf9fee7
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
@@ -2310,23 +2295,22 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 5321442ed26760d7581b26effab82399ea5ff18b
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNFBAnalytics: 5cfe8c05a01dad18f089af3df0a4af5057330761
-  RNFBApp: f4375dd56d5cca3c47af4cff25e9a801a7405729
-  RNFBAppCheck: 8ec4e9283afb3d7828c6e26843a080d0c9dea39f
-  RNFBAppDistribution: 7e6cdc3d05f1549b68d039f253f33d70661dc96e
-  RNFBAuth: 4107c9889a628967fddd394c02cfca0410bb9218
-  RNFBCrashlytics: b101c80707727d0044a0b55fad0b8b952a200855
-  RNFBDatabase: f76d9006c51ad211efe36c6d79e2908dd547934d
-  RNFBDynamicLinks: d461e99c1905d17d1d528da745f0f2cbad253a06
-  RNFBFirestore: 942e343c06e3cefcb08742fc14991674e565882c
-  RNFBFunctions: 3ba97516c05e96ea4cedee384896d0aa954fb4d7
-  RNFBInAppMessaging: d96c7ab07c94917d04837d8d6ac26386f7c2bc0c
-  RNFBInstallations: 01a8a5d9f9197be5c09d5da276d5e8a82c09609f
-  RNFBMessaging: d7a9b3652402d9a210bcf8bb535834874a676e6f
-  RNFBML: f9d89ae71931ded81fdc9996a77b80eea708c6a4
-  RNFBPerf: e18283b6a2fc29105d2d044c097aa32d134808cd
-  RNFBRemoteConfig: ef8a9a28dc18e48467d6a323f06a9b4c52ba3790
-  RNFBStorage: b8c0715145a453bb2aeb110e1b134ae3627babdd
+  RNFBAnalytics: 0cce3ee742c3645422f343c89894696d4036b6ce
+  RNFBApp: 41da95b42ed82fb9570b3dce0da1e167c0869a0e
+  RNFBAppCheck: 54fee056dd3d546400acdd11b00862bb99b0cc94
+  RNFBAppDistribution: d83c2f85e9b13a300f635cdf36f9385f00d5caeb
+  RNFBAuth: dc41c0755d85b7ca8beaba80b147aec2e4383dc2
+  RNFBCrashlytics: 0e8d36c0e3e6900fcc470e37c4ee4afc95c4bc63
+  RNFBDatabase: bb42f27eca3a3ce45cea25f97ad5832e356aa281
+  RNFBFirestore: adc60036101790b22590704cb70c4dc8954454cc
+  RNFBFunctions: e209503d23883d5cb9114dcaf638f8bca43835ed
+  RNFBInAppMessaging: f594277fde91e8889035a86d3d237b3e5f8a0aca
+  RNFBInstallations: 8a1ce6660fa338604d821fe663b6cf2ab2c8866a
+  RNFBMessaging: 509a068efffa75522b76e0b7ca4b7aad55ddeafa
+  RNFBML: 93997896dd4ca03ed8adb95f92ebce4ccc8be31e
+  RNFBPerf: 6613fbd6f6bb3b8199611c783eb4ae76b00c5259
+  RNFBRemoteConfig: 2c1513240ed283492911c92e6ff6a1f25e8ce328
+  RNFBStorage: 8aa0a9f2ddafdba9d25d20fafafee221aaa4a6ab
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 6eb60fc2c0eef63e7d2ef4a56e0a3353534143a2
 


### PR DESCRIPTION
### Description

`trackingId` has been removed from firebase-ios-sdk: https://firebase.google.com/support/release-notes/ios#version_1200_-_july_15_2025

I've kept the `gaTrackingId` API in the JS code because it appears android still uses it: https://firebase.google.com/docs/reference/android/com/google/firebase/FirebaseOptions?_gl=1*dtmd6b*_up*MQ..*_ga*MzIzOTI0NDg4LjE3NTM5NjIwMjM.*_ga_CW55HF8NVT*czE3NTM5NjQxOTMkbzIkZzAkdDE3NTM5NjQxOTMkajYwJGwwJGgw#gaTrackingId()

Although we could possibly update it to match firebase-js-sdk which would be `measurementId`?

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
