### PR TITLE
fix(app, android): adopt firebase-android-sdk 34.1.0

### DIFF
--- a/docs/crashlytics/android-setup.md
+++ b/docs/crashlytics/android-setup.md
@@ -40,7 +40,7 @@ buildscript {
   // ..
   dependencies {
     // ..
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.4'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
   }
   // ..
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -320,7 +320,7 @@ project.ext {
       // Overriding Library SDK Versions
       firebase: [
         // Override Firebase SDK Version
-        bom           : "34.0.0"
+        bom           : "34.1.0"
       ],
     ],
   ])

--- a/docs/perf/usage/index.md
+++ b/docs/perf/usage/index.md
@@ -38,7 +38,7 @@ Add the plugin to your `/android/build.gradle` file as a dependency:
 buildscript {
     dependencies {
         // ...
-        classpath 'com.google.firebase:perf-plugin:1.4.2'
+        classpath 'com.google.firebase:perf-plugin:2.0.1'
     }
 ```
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -83,9 +83,9 @@
       "minSdk": 23,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "34.0.0",
-      "firebaseCrashlyticsGradle": "3.0.5",
-      "firebasePerfGradle": "2.0.0",
+      "firebase": "34.1.0",
+      "firebaseCrashlyticsGradle": "3.0.6",
+      "firebasePerfGradle": "2.0.1",
       "gmsGoogleServicesGradle": "4.4.3",
       "playServicesAuth": "21.4.0",
       "firebaseAppDistributionGradle": "5.1.2"

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.5'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/perf/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/perf/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:perf-plugin:2.0.0'
+        classpath 'com.google.firebase:perf-plugin:2.0.1'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -35,8 +35,8 @@ buildscript {
     classpath 'com.android.tools.build:gradle:8.9.2' // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
     classpath("com.facebook.react:react-native-gradle-plugin")
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-    classpath 'com.google.firebase:perf-plugin:1.4.2'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.4'
+    classpath 'com.google.firebase:perf-plugin:2.0.1'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.6'
     classpath 'com.google.firebase:firebase-appdistribution-gradle:5.1.1'
   }
 }


### PR DESCRIPTION

Adopts the latest firebase-android-sdk 34.1.0 release - appears to be a bugfix-only release

- updated a couple docs spots that were missed in the last android SDK bump for gradle plugin versions