### PR TITLE
fix(other): a batch of fixes for the Other platform

### DIFF
--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -20,6 +20,7 @@ import {
   isAndroid,
   isBoolean,
   isNull,
+  isOther,
   isString,
   isValidUrl,
 } from '@react-native-firebase/app/lib/common';
@@ -127,7 +128,10 @@ class FirebaseAuthModule extends FirebaseModule {
     // but we need it in Auth if it exists. During app configuration we store
     // mappings from app name to authDomain, this auth constructor
     // is a reasonable time to use the mapping and set it into auth natively
-    this.native.configureAuthDomain();
+    if (!isOther) {
+      // Only supported on native platforms
+      this.native.configureAuthDomain();
+    }
   }
 
   get languageCode() {

--- a/packages/auth/lib/web/RNFBAuthModule.js
+++ b/packages/auth/lib/web/RNFBAuthModule.js
@@ -227,7 +227,7 @@ let sessionId = 0;
 // Returns a cached Firestore instance.
 function getCachedAuthInstance(appName) {
   if (!instances[appName]) {
-    if (!isMemoryStorage()) {
+    if (isMemoryStorage()) {
       // Warn auth persistence is is disabled unless Async Storage implementation is provided.
       // eslint-disable-next-line no-console
       console.warn(

--- a/packages/database/e2e/helpers.js
+++ b/packages/database/e2e/helpers.js
@@ -1,4 +1,18 @@
+// Eliminate annoying warning about double-loading firebase while
+// on Other platform - we load it, and rules-unit-testing does as well
+
+// eslint-disable-next-line no-console
+const originalConsoleWarn = console.warn;
+// eslint-disable-next-line no-console
+console.warn = function (message) {
+  if (message && typeof message === 'string' && !message.includes('@firebase/app-compat')) {
+    originalConsoleWarn(message);
+  }
+};
 const testingUtils = require('@firebase/rules-unit-testing');
+// eslint-disable-next-line no-console
+console.warn = originalConsoleWarn;
+
 const { getE2eTestProject, getE2eEmulatorHost } = require('../../app/e2e/helpers');
 
 // TODO make more unique?

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -781,9 +781,20 @@ describe('remoteConfig()', function () {
       });
     });
 
-    xdescribe('onConfigUpdated', function () {
+    describe('onConfigUpdated on un-supported platforms', function () {
+      it('returns a descriptive error message if called', async function () {
+        const { getRemoteConfig, onConfigUpdated } = remoteConfigModular;
+        try {
+          onConfigUpdated(getRemoteConfig());
+        } catch (error) {
+          error.message.should.containEql('Not supported by the Firebase Javascript SDK');
+        }
+      });
+    });
+
+    xdescribe('onConfigUpdated on supported platforms', function () {
       if (Platform.other) {
-        // Not supported on Web.
+        // Not supported on Web, verify we get a nice error
         return;
       }
 

--- a/packages/remote-config/lib/web/RNFBConfigModule.js
+++ b/packages/remote-config/lib/web/RNFBConfigModule.js
@@ -9,7 +9,7 @@ import {
   makeIDBAvailable,
   setCustomSignals,
 } from '@react-native-firebase/app/lib/internal/web/firebaseRemoteConfig';
-import { guard } from '@react-native-firebase/app/lib/internal/web/utils';
+import { guard, getWebError } from '@react-native-firebase/app/lib/internal/web/utils';
 
 let configSettingsForInstance = {
   // [APP_NAME]: RemoteConfigSettings
@@ -120,5 +120,8 @@ export default {
       await setCustomSignals(remoteConfig, customSignals);
       return resultAndConstants(remoteConfig, null);
     });
+  },
+  onConfigUpdated() {
+    return getWebError('unsupported', 'Not supported by the Firebase Javascript SDK.');
   },
 };


### PR DESCRIPTION
### Description

This was primarily meant to fix the lack of a good warning message for `onConfigUpdated` in the web module

While I was in there fixing that I fixed some unlogged things that I saw:

-  persistence detection, the detector had an inverted conditional, so persistence was set but the warning was emitted
-  an incorrect configureAuthDomain call - it's only supported on native, so I skip it on Other platform
-  and a test warning, @firebase/rules-unit-testing loads firebase-js-sdk also, so the double-load warning was emitted, I filter that out now

### Related issues

- Fixes #8665 

### Release Summary

conventional commits, rebase merge into main and it will generate the correct release (+ notes) next publish

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

I added a test for the error message I added, and all the other changes were directly related to what I saw while testing - Other platform runs that test cleanly now with `it.only` whereas without the other commits there were little errors and warnings everywhere

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
