### PR TITLE
fix: validate listenerOrObserver callbacks in auth, app-check, remote-config

### DIFF
--- a/packages/ai/e2e/fetch.e2e.js
+++ b/packages/ai/e2e/fetch.e2e.js
@@ -32,37 +32,39 @@ const fakeVertexAI = {
 globalThis.RNFB_VERTEXAI_EMULATOR_URL = true;
 
 // It calls firebase functions emulator that mimics responses from VertexAI server
-describe('fetch requests()', function () {
-  it('should fetch', async function () {
-    const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-1.5-flash' });
-    const result = await model.generateContent("What is google's mission statement?");
-    const text = result.response.text();
-    // See vertexAI function emulator for response
-    text.should.containEql(
-      'Google\'s mission is to "organize the world\'s information and make it universally accessible and useful."',
-    );
-  });
+describe('ai()', function () {
+  describe('fetch requests', function () {
+    it('should fetch', async function () {
+      const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-1.5-flash' });
+      const result = await model.generateContent("What is google's mission statement?");
+      const text = result.response.text();
+      // See vertexAI function emulator for response
+      text.should.containEql(
+        'Google\'s mission is to "organize the world\'s information and make it universally accessible and useful."',
+      );
+    });
 
-  it('should fetch stream', async function () {
-    const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-1.5-flash' });
-    // See vertexAI function emulator for response
-    const poem = [
-      'The wind whispers secrets through the trees,',
-      'Rustling leaves in a gentle breeze.',
-      'Sunlight dances on the grass,',
-      'A fleeting moment, sure to pass.',
-      'Birdsong fills the air so bright,',
-      'A symphony of pure delight.',
-      'Time stands still, a peaceful pause,',
-      "In nature's beauty, no flaws.",
-    ];
-    const result = await model.generateContentStream('Write me a short poem');
+    it('should fetch stream', async function () {
+      const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-1.5-flash' });
+      // See vertexAI function emulator for response
+      const poem = [
+        'The wind whispers secrets through the trees,',
+        'Rustling leaves in a gentle breeze.',
+        'Sunlight dances on the grass,',
+        'A fleeting moment, sure to pass.',
+        'Birdsong fills the air so bright,',
+        'A symphony of pure delight.',
+        'Time stands still, a peaceful pause,',
+        "In nature's beauty, no flaws.",
+      ];
+      const result = await model.generateContentStream('Write me a short poem');
 
-    const text = [];
-    for await (const chunk of result.stream) {
-      const chunkText = chunk.text();
-      text.push(chunkText);
-    }
-    text.should.deepEqual(poem);
+      const text = [];
+      for await (const chunk of result.stream) {
+        const chunkText = chunk.text();
+        text.push(chunkText);
+      }
+      text.should.deepEqual(poem);
+    });
   });
 });

--- a/packages/app-check/lib/index.js
+++ b/packages/app-check/lib/index.js
@@ -23,6 +23,7 @@ import {
   isFunction,
   isUndefined,
   isOther,
+  parseListenerOrObserver,
 } from '@react-native-firebase/app/lib/common';
 import {
   createModuleNamespace,
@@ -179,12 +180,6 @@ class FirebaseAppCheckModule extends FirebaseModule {
     return this.native.getLimitedUseToken();
   }
 
-  _parseListener(listenerOrObserver) {
-    return typeof listenerOrObserver === 'object'
-      ? listenerOrObserver.next.bind(listenerOrObserver)
-      : listenerOrObserver;
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onTokenChanged(onNextOrObserver, onError, onCompletion) {
     // iOS does not provide any native listening feature
@@ -193,7 +188,7 @@ class FirebaseAppCheckModule extends FirebaseModule {
       console.warn('onTokenChanged is not implemented on IOS, only for Android');
       return () => {};
     }
-    const nextFn = this._parseListener(onNextOrObserver);
+    const nextFn = parseListenerOrObserver(onNextOrObserver);
     // let errorFn = function () { };
     // if (onNextOrObserver.error != null) {
     //   errorFn = onNextOrObserver.error.bind(onNextOrObserver);

--- a/packages/app/lib/common/index.js
+++ b/packages/app/lib/common/index.js
@@ -16,7 +16,7 @@
  */
 import { Platform } from 'react-native';
 import Base64 from './Base64';
-import { isString } from './validate';
+import { isFunction, isObject, isString } from './validate';
 
 export * from './id';
 export * from './path';
@@ -101,6 +101,19 @@ export function tryJSONStringify(data) {
   } catch (_) {
     return null;
   }
+}
+
+export function parseListenerOrObserver(listenerOrObserver) {
+  if (!isFunction(listenerOrObserver) && !isObject(listenerOrObserver)) {
+  }
+  if (isFunction(listenerOrObserver)) {
+    return listenerOrObserver;
+  }
+  if (isObject(listenerOrObserver) && isFunction(listenerOrObserver.next)) {
+    return listenerOrObserver.next.bind(listenerOrObserver);
+  }
+
+  throw new Error("'listenerOrObserver' expected a function or an object with 'next' function.");
 }
 
 // Used to indicate if there is no corresponding modular function

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -23,6 +23,7 @@ import {
   isOther,
   isString,
   isValidUrl,
+  parseListenerOrObserver,
 } from '@react-native-firebase/app/lib/common';
 import { setReactNativeModule } from '@react-native-firebase/app/lib/internal/nativeModule';
 import {
@@ -225,14 +226,8 @@ class FirebaseAuthModule extends FirebaseModule {
     await this.native.setTenantId(tenantId);
   }
 
-  _parseListener(listenerOrObserver) {
-    return typeof listenerOrObserver === 'object'
-      ? listenerOrObserver.next.bind(listenerOrObserver)
-      : listenerOrObserver;
-  }
-
   onAuthStateChanged(listenerOrObserver) {
-    const listener = this._parseListener(listenerOrObserver);
+    const listener = parseListenerOrObserver(listenerOrObserver);
     const subscription = this.emitter.addListener(
       this.eventNameForApp('onAuthStateChanged'),
       listener,
@@ -247,7 +242,7 @@ class FirebaseAuthModule extends FirebaseModule {
   }
 
   onIdTokenChanged(listenerOrObserver) {
-    const listener = this._parseListener(listenerOrObserver);
+    const listener = parseListenerOrObserver(listenerOrObserver);
     const subscription = this.emitter.addListener(
       this.eventNameForApp('onIdTokenChanged'),
       listener,
@@ -262,7 +257,7 @@ class FirebaseAuthModule extends FirebaseModule {
   }
 
   onUserChanged(listenerOrObserver) {
-    const listener = this._parseListener(listenerOrObserver);
+    const listener = parseListenerOrObserver(listenerOrObserver);
     const subscription = this.emitter.addListener(this.eventNameForApp('onUserChanged'), listener);
     if (this._authResult) {
       Promise.resolve().then(() => {

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -781,11 +781,29 @@ describe('remoteConfig()', function () {
       });
     });
 
-    describe('onConfigUpdated on un-supported platforms', function () {
-      it('returns a descriptive error message if called', async function () {
+    describe('onConfigUpdated parameter verification', function () {
+      it('throws an error if no callback provided', async function () {
         const { getRemoteConfig, onConfigUpdated } = remoteConfigModular;
         try {
           onConfigUpdated(getRemoteConfig());
+        } catch (error) {
+          error.message.should.containEql(
+            "'listenerOrObserver' expected a function or an object with 'next' function.",
+          );
+        }
+      });
+    });
+
+    describe('onConfigUpdated on un-supported platforms', function () {
+      if (!Platform.other) {
+        // Supported on non-other, tests are in the following describe block
+        return;
+      }
+
+      it('returns a descriptive error message if called', async function () {
+        const { getRemoteConfig, onConfigUpdated } = remoteConfigModular;
+        try {
+          onConfigUpdated(getRemoteConfig(), () => {});
         } catch (error) {
           error.message.should.containEql('Not supported by the Firebase Javascript SDK');
         }
@@ -794,7 +812,7 @@ describe('remoteConfig()', function () {
 
     xdescribe('onConfigUpdated on supported platforms', function () {
       if (Platform.other) {
-        // Not supported on Web, verify we get a nice error
+        // Not supported on Web
         return;
       }
 

--- a/packages/remote-config/lib/index.js
+++ b/packages/remote-config/lib/index.js
@@ -22,6 +22,7 @@ import {
   isString,
   isUndefined,
   isIOS,
+  parseListenerOrObserver,
 } from '@react-native-firebase/app/lib/common';
 import Value from './RemoteConfigValue';
 import {
@@ -247,7 +248,7 @@ class FirebaseConfigModule extends FirebaseModule {
    * @returns {function} unsubscribe listener
    */
   onConfigUpdated(listenerOrObserver) {
-    const listener = this._parseListener(listenerOrObserver);
+    const listener = parseListenerOrObserver(listenerOrObserver);
     let unsubscribed = false;
     const subscription = this.emitter.addListener(
       this.eventNameForApp('on_config_updated'),
@@ -285,12 +286,6 @@ class FirebaseConfigModule extends FirebaseModule {
         this.native.removeConfigUpdateRegistration();
       }
     };
-  }
-
-  _parseListener(listenerOrObserver) {
-    return typeof listenerOrObserver === 'object'
-      ? listenerOrObserver.next.bind(listenerOrObserver)
-      : listenerOrObserver;
   }
 
   _updateFromConstants(constants) {


### PR DESCRIPTION
### Description


#### The Error

I noticed my last merge to main had a crash failure, and it appeared to be near remote-config but not exactly in it, it was in an unknown block?

https://github.com/invertase/react-native-firebase/actions/runs/17158027065/job/48679779113#step:18:3686

```
Fri, 22 Aug 2025 14:45:10 GMT        onConfigUpdated on supported platforms
Fri, 22 Aug 2025 14:45:10 GMT          - adds a listener and receives updates
Fri, 22 Aug 2025 14:45:10 GMT          - manages multiple listeners
Fri, 22 Aug 2025 14:45:10 GMT          - handles react-native reload
Fri, 22 Aug 2025 14:45:10 GMT        setCustomSignals()
Fri, 22 Aug 2025 14:45:10 GMT          ✔ should resolve with valid signal value; `string`, `number` or `null`
Fri, 22 Aug 2025 14:45:10 GMT          ✔ should reject with invalid signal value
Fri, 22 Aug 2025 14:45:10 GMT    fetch requests()
Fri, 22 Aug 2025 14:45:10 GMT[🟨] Jet client disconnected - for no particular reason (code = 1006).
Fri, 22 Aug 2025 14:45:10 GMT[🟥] Exiting after an abnormal disconnect.
Fri, 22 Aug 2025 14:45:10 GMT
```

#### The investigation

When I looked at the emulator log from the CI run, I could see something about an undefined listener:

```

08-22 14:45:10.427  4929 16967 E FA      : Invalid public event name. Event will not be logged (FE): app_exception
08-22 14:45:10.428  4929  6050 W System.err: io.invertase.firebase.crashlytics.JavaScriptError: listener is not a function (it is undefined)
08-22 14:45:10.428  4929  6050 W System.err: 	at .anonymous(http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.invertase.testing&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server:276477:21)
08-22 14:45:10.428  4929  6050 W System.err: 	at .apply((native):0:0)
08-22 14:45:10.429  4929  6050 W System.err: 	at .emit(http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.invertase.testing&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server:20735:40)
08-22 14:45:10.429  4929  6050 W System.err: 	at .anonymous(http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.invertase.testing&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server:133103:45)
08-22 14:45:10.429  4929  6050 W System.err: 	at .apply((native):0:0)
08-22 14:45:10.429  4929  6050 W System.err: 	at .listenerDebugger(http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.invertase.testing&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server:134833:32)
08-22 14:45:10.429  4929  6050 W System.err: 	at .apply((native):0:0)
08-22 14:45:10.429  4929  6050 W System.err: 	at .emit(http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.invertase.testing&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server:20735:40)
08-22 14:45:10.429  4929  6050 W System.err: 	at .apply((native):0:0)
08-22 14:45:10.429  4929  6050 W System.err: 	at .anonymous(http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.invertase.testing&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server:20643:200)
08-22 14:45:10.429  4929  6050 W System.err: 	at .emit(http://10.0.2.2:8081/index.bundle//&platform=android&dev=true&lazy=true&minify=false&app=com.invertase.testing&modulesOnly=false&runModule=true&excludeSource=true&sourcePaths=url-server:20659:62)
```

Loading the bundle locally in ReactNative DevTools allowed me to find that line number in the bundle, and it was the remote-config listener subscription!

#### The root cause

I had not properly skipped an e2e test I added on un-supported platforms, and I had not configured a listener since I was just checking an error message:

https://github.com/invertase/react-native-firebase/commit/959c4cf98496e6e6f25416d33fa794007bd34119#diff-082cd0f3e3f8e1b47c7f2ec9b75d4bfd15ab6ca8b8d4baa64fd086ce2c058d73R784-R788

So on supported platforms this was really attempting to register an undefined listener and other tests triggered an update so it crashed later, in an unidentified testing block.

The proximate cause is that there is no validation of the callback param when registering it, and this is true for all these listener or observer callbacks. The root cause is I wasn't registering a callback.

#### The Repair

1) I refactored whole codebase registration of listenerOrObserver registration since none were doing validation and all were susceptible to crashes like this. They all validate now. Added a test for that and fixed the first test.

2) I formatted the AI tests better so it is more obvious when they are executing

### Release Summary

Conventional commits, semantic release will get them fine

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

e2e test found the problem, repaired package code and added another e2e test.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
