### PR TITLE
fix(analytics, ios): reject getSessionId call if id is zero

### DIFF
--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -129,6 +129,13 @@ RCT_EXPORT_METHOD(getSessionId
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
   [FIRAnalytics sessionIDWithCompletion:^(int64_t sessionID, NSError *_Nullable error) {
+    // Occasionally sessionID is 0 despite nil error, reject as if it were an error
+    // https://github.com/firebase/firebase-ios-sdk/issues/15258
+    if (!error && [NSNumber numberWithLongLong:sessionID] == 0) {
+      DLog(@"Error getting session ID: sessionID is zero despite nil error");
+      return resolve([NSNull null]);
+    }
+
     if (error) {
       DLog(@"Error getting session ID: %@", error);
       return resolve([NSNull null]);


### PR DESCRIPTION

### Description

firebase-ios-sdk sometimes returns a zero session ID with a nil error, leading us to return zero as a session ID

I assert this is not a valid session ID so I'm going to reject for API callers in this case

Issue logged upstream


Detected in flake hammer parallel CI runs with a roughly 7% incidence in full e2e runs, example:

https://github.com/invertase/react-native-firebase/actions/runs/17225729926/job/48869796433#step:25:4846

### Related issues

- https://github.com/firebase/firebase-ios-sdk/issues/15258

### Release Summary

single conventional commit ready for rebase

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

This issue was detected via e2e runs, manual iOS e2e workflow set to run 15 instances (so it ends up running 15x debug + release, for 30 total, expect 1-3 failures on this without the patch.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
