### PR TITLE
test: ignore errors related to workflow screen recording

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -103,11 +103,13 @@ jobs:
     steps:
       - name: Setup Environment for Screen Recording
         uses: guidepup/setup-action@0.17.3
+        continue-on-error: true
         with:
           record: true
 
       - name: Upload Screen Recording Environment Setup
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         if: always()
         with:
           name: screenrecording-setup-${{ matrix.buildmode }}-${{ matrix.iteration }}.mov

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -98,11 +98,13 @@ jobs:
     steps:
       - name: Setup Environment for Screen Recording
         uses: guidepup/setup-action@0.17.3
+        continue-on-error: true
         with:
           record: true
 
       - name: Upload Screen Recording Environment Setup
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         if: always()
         with:
           name: screenrecording-setup-${{ matrix.iteration }}.mov
@@ -235,6 +237,7 @@ jobs:
           echo "...javascript bundle ready"
 
       - name: Start Screen Recording and System Logging
+        continue-on-error: true
         run: |
           nohup sh -c "sleep 314159265 | screencapture -v -C -k -T0 -g screenrecording.mov > screenrecording.log 2>&1 &"
           nohup sh -c "log stream --backtrace --color none --style syslog > syslog.log 2>&1 &"


### PR DESCRIPTION
### Description

the screen recordings are nice to have for forensics, but not an indicator of whether the test run itself is succeeding

at same time screen recording setup apperas to fail 3-4% of the time and is now one of the most significant sources of flakiness, so continue if that's the only problem

This should take our iOS CI flakiness down from approx 3/30 or 10% to approx 2/30 or 6-7%, a worthwhile win

### Related issues

- See #8650 

### Release Summary

test only

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

it's all determined via iterative / flake-hammer style runs on iOS and Other, but here is the most recent example of this failure: https://github.com/invertase/react-native-firebase/actions/runs/17370625894/job/49305461304



---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
