### PR TITLE
fix(analytics): fix the typing for screen_view event logging

### DIFF
--- a/packages/analytics/lib/modular/index.d.ts
+++ b/packages/analytics/lib/modular/index.d.ts
@@ -105,8 +105,8 @@ export declare function logEvent(
   analytics: Analytics,
   name: 'screen_view',
   params?: {
-    firebase_screen: EventParams['firebase_screen'];
-    firebase_screen_class: EventParams['firebase_screen_class'];
+    screen_name: EventParams['firebase_screen'];
+    screen_class: EventParams['firebase_screen_class'];
     [key: string]: any;
   },
   options?: AnalyticsCallOptions,


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

Motivation:
Since migrating from logScreenView to logging screen_view events we lost the screen tracking in our project. To prevent this from happening to other developers only the typing information has to be fixed.
Without the change developers are encouraged to use faulty parameter names, leading to errors in the firebase backend and dropped events due to reserved property names. If the names `screen_name` and `screen class` are used the issue does not exist and screen views are tracked as before via logScreenView

See issue https://github.com/invertase/react-native-firebase/issues/8609 for more details on this.

It is likely that the EventParams `firebase_screen` and `firebase_screen_class` are not needed any more.

### Related issues
Fixes #8609 

### Release Summary

This changes the names you need to supply to logEvent(analytics, 'screen_view') to what it should have been already. Without a change to parameter names your screen tracking will not work!

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [X] Yes
- My change supports the following platforms;
  - [X] `Android`
  - [X] `iOS`
  - [X] `Other` (macOS, web)
- My change includes tests;
  - [-] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [-] `jest` tests added or updated in `packages/\*\*/__tests__`
- [X] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [X] Yes (it will require changes to the passed in parameters, but it is more fixing than breaking)
  - [-] No



### Test Plan

I only changed typings and validated the change in my own Project since it requires checks on the firebase debugging backend.

And since I read the whole guide I am allowed to add some flames in the end :) :fire: