### PR TITLE
fix(app-distribution, android): use correct app-distribution gradle version 5.1.1

### DIFF
--- a/docs/migrating-to-v23.md
+++ b/docs/migrating-to-v23.md
@@ -61,7 +61,7 @@ Please refer to the official deprecation FAQ for complete migration guidance and
 - Auth play services has been bumped from `21.3.0` to `21.4.0`.
 - Crashlytics gradle plugin has been bumped from `3.0.4` to `3.0.5`.
 - Performance gradle plugin has been bumped from `1.4.2` to `2.0.0`.
-- App distribution gradle plugin has been bumped from `5.1.1` to `5.1.2`.
+- App distribution gradle plugin has been bumped from `5.1.0` to `5.1.1`.
 
 # iOS platform
 

--- a/packages/app-distribution/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/app-distribution/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-appdistribution-gradle:5.1.2'
+        classpath 'com.google.firebase:firebase-appdistribution-gradle:5.1.1'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -88,7 +88,7 @@
       "firebasePerfGradle": "2.0.1",
       "gmsGoogleServicesGradle": "4.4.3",
       "playServicesAuth": "21.4.0",
-      "firebaseAppDistributionGradle": "5.1.2"
+      "firebaseAppDistributionGradle": "5.1.1"
     }
   }
 }


### PR DESCRIPTION
closes https://github.com/invertase/react-native-firebase/issues/8689 

### Description

https://firebase.google.com/support/release-notes/android
https://mvnrepository.com/artifact/com.google.firebase.appdistribution/com.google.firebase.appdistribution.gradle.plugin

Latest version of App-Distribution-Gradle-Plugin is 5.1.1 and we were using a non-existent version 5.1.2
### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
