### PR TITLE
fix: misinformation for default firebase function timeout

### DIFF
--- a/packages/functions/lib/index.d.ts
+++ b/packages/functions/lib/index.d.ts
@@ -149,14 +149,14 @@ export namespace FirebaseFunctionsTypes {
    **/
   export interface HttpsCallableOptions {
     /**
-     * The timeout property is the time in milliseconds after which to cancel if there is no response. Default is 7000 milliseconds (7 seconds).
+     * The timeout property is the time in milliseconds after which to cancel if there is no response. Default is 70000 milliseconds (70 seconds).
      *
      * #### Example
      *
      *```js
-     * // The below will wait 7 seconds for a response from the cloud function before an error is thrown.
+     * // The below will wait 90 seconds for a response from the cloud function before an error is thrown.
      * try {
-     *  const instance = firebase.functions().httpsCallable('order', { timeout: 7000 });
+     *  const instance = firebase.functions().httpsCallable('order', { timeout: 90000 });
      *  const response = await instance({
      *    id: '12345',
      *  });


### PR DESCRIPTION
Description

This PR corrects the documented default timeout for Callable Cloud Functions in the React Native Firebase docs.
	•	Current docs (incorrect): default timeout is 7 seconds
	•	Correct behavior: default timeout is 70,000 ms (70 seconds) []
	•	Rationale: React Native Firebase defers to the upstream Firebase SDKs for callable timeouts and does not override the default in native code. The upstream SDK default for client callable functions is 70 seconds.

This change updates the documentation to reflect the actual default and avoids confusion for developers who observe requests continuing past 7 seconds without timing out.

And also this page from Firebase’s docs confirms it:
[HttpsCallableOptions](https://rnfirebase.io/reference/functions/httpscallableoptions) — “Default is 70000”  ￼
⸻

Related issues

https://github.com/invertase/react-native-firebase/issues/8708



⸻




