### PR TITLE
fix: remove reset method's comment is above setConfigSettings method

### DIFF
--- a/packages/remote-config/lib/modular/index.d.ts
+++ b/packages/remote-config/lib/modular/index.d.ts
@@ -167,7 +167,6 @@ export function reset(remoteConfig: RemoteConfig): Promise<void>;
 /**
  * Set the Remote RemoteConfig settings, currently able to set
  * `fetchTimeMillis` & `minimumFetchIntervalMillis`
- * Android only. iOS does not reset anything.
  * @param remoteConfig - RemoteConfig instance
  * @param settings - ConfigSettings instance
  * @returns {Promise<void>}


### PR DESCRIPTION
### Description

The comment I remove exists above "reset" method, I think it's mistakenly copied and pasted above setConfigSettings method

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x ] Yes
- My change supports the following platforms;
  - [x ] `Android`
  - [x ] `iOS`
  - [ x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
