### PR TITLE
docs(auth): update phone-auth verifyPhoneNumber link

### DIFF
--- a/docs/auth/phone-auth.md
+++ b/docs/auth/phone-auth.md
@@ -29,7 +29,7 @@ For reliable automated testing, you may want to disable both automatic and fallb
 
 Ensure that all parts of step 1 and 2 from [the official firebase Android phone auth docs](https://firebase.google.com/docs/auth/android/phone-auth#enable-phone-number-sign-in-for-your-firebase-project) have been followed.
 
-To bypass Play Integrity for manual testing, you may [force reCAPTCHA to be used](https://rnfirebase.io/reference/auth/authsettings#appVerificationDisabledForTesting) prior to calling [`verifyPhoneNumber`](https://rnfirebase.io/reference/auth/phoneauthprovider#verifyPhoneNumber).
+To bypass Play Integrity for manual testing, you may [force reCAPTCHA to be used](https://rnfirebase.io/reference/auth/authsettings#appVerificationDisabledForTesting) prior to calling [`verifyPhoneNumber`](https://rnfirebase.io/reference/auth#verifyPhoneNumber).
 
 # Expo Setup
 


### PR DESCRIPTION
### Description

This PR updates a broken or outdated documentation link in the **Phone Auth** guide.  
The existing link for `verifyPhoneNumber` pointed to the old `phoneauthprovider` path.  
It now correctly links to the consolidated Auth reference section:  
[`https://rnfirebase.io/reference/auth#verifyPhoneNumber`](https://rnfirebase.io/reference/auth#verifyPhoneNumber).

### Related issues

None — this is a minor documentation fix.

### Release Summary

docs(auth): update verifyPhoneNumber link in phone-auth documentation

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.  
  - [x] Yes  
- My change supports the following platforms;  
  - [x] `Android`  
  - [x] `iOS`  
  - [x] `Other` (macOS, web)  
- My change includes tests;  
  - [ ] `e2e` tests added or updated in `packages/**/e2e`  
  - [ ] `jest` tests added or updated in `packages/**/__tests__`  
- [ ] I have updated TypeScript types that are affected by my change.  
- This is a breaking change;  
  - [ ] Yes  
  - [x] No  

### Test Plan

Documentation-only change.  
Verified that the new link correctly opens the `verifyPhoneNumber` section in the Auth reference.  
