### PR TITLE
feat(firestore): implement withConverter

### DIFF
--- a/docs/migrating-to-v23.md
+++ b/docs/migrating-to-v23.md
@@ -2,7 +2,7 @@
 title: Migrating to v23
 description: Migrate to React Native Firebase v23.
 previous: /migrate-to-v22
-next: /typescript
+next: /migrate-to-v24
 ---
 
 # Firebase Crashlytics

--- a/docs/migrating-to-v24.md
+++ b/docs/migrating-to-v24.md
@@ -1,0 +1,41 @@
+---
+title: Migrating to v24
+description: Migrate to React Native Firebase v24.
+previous: /migrate-to-v23
+---
+
+# Firestore
+
+Version 24 introduces `withConverter` functionality from Firebase JS SDK. Due to the differences in types between references and queries in namespace vs modular API, you will need to make the following changes:
+
+### modular API
+
+Modular reference and query types have been updated to support input of two generic types (`AppModelType`, `DbModelType`). Additionally, to match the JS SDK, they are now exported separately at the root, instead of through `FirebaseFirestoreTypes`.
+
+Most commonly these types will be affected: `CollectionReference`, `DocumentReference`, `DocumentSnapshot`, `QueryDocumentSnapshot`, `QuerySnapshot`, `Query`.
+
+```js
+// Previously
+import { doc, getFirestore, onSnapshot, FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
+
+onSnapshot(doc(getFirestore(), 'foo', 'foo'), {
+  next: (snapshot: FirebaseFirestoreTypes.DocumentSnapshot) => {
+    console.log(snapshot.get('foo'));
+  },
+});
+```
+
+```js
+// Now
+import { doc, getFirestore, onSnapshot, DocumentSnapshot } from '@react-native-firebase/firestore';
+
+onSnapshot(doc(getFirestore(), 'foo', 'foo'), {
+  next: (snapshot: DocumentSnapshot) => {
+    console.log(snapshot.get('foo'));
+  },
+});
+```
+
+### namespace API
+
+No changes required for older namespace API.

--- a/docs/sidebar.yaml
+++ b/docs/sidebar.yaml
@@ -5,6 +5,8 @@
   - '/migrating-to-v22'
 - - Migration Guide to v23
   - '/migrating-to-v23'
+- - Migration Guide to v24
+  - '/migrating-to-v24'
 - - TypeScript
   - '/typescript'
 - - Platforms

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -2,7 +2,7 @@
 title: TypeScript
 description: Using TypeScript with React Native Firebase
 next: /other-platforms
-previous: /migrating-to-v22
+previous: /migrating-to-v24
 ---
 
 The React Native Firebase project comes with support for TypeScript. The project provides

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -962,6 +962,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => getCountFromServer(query),
+          // @ts-expect-error Combines modular and namespace API
           () => query.count(),
           'count',
         );
@@ -974,6 +975,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => getCountFromServer(query),
+          // @ts-expect-error Combines modular and namespace API
           () => query.countFromServer(),
           'countFromServer',
         );
@@ -986,6 +988,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => endAt('foo'),
+          // @ts-expect-error Combines modular and namespace API
           () => query.endAt('foo'),
           'endAt',
         );
@@ -998,6 +1001,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => endBefore('foo'),
+          // @ts-expect-error Combines modular and namespace API
           () => query.endBefore('foo'),
           'endBefore',
         );
@@ -1010,6 +1014,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => getDocs(query),
+          // @ts-expect-error Combines modular and namespace API
           () => query.get(),
           'get',
         );
@@ -1023,6 +1028,7 @@ describe('Firestore', function () {
         collectionRefV9Deprecation(
           // no equivalent method
           () => {},
+          // @ts-expect-error Combines modular and namespace API
           () => query.isEqual(query),
           'isEqual',
         );
@@ -1035,6 +1041,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => limit(9),
+          // @ts-expect-error Combines modular and namespace API
           () => query.limit(9),
           'limit',
         );
@@ -1047,6 +1054,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => limitToLast(9),
+          // @ts-expect-error Combines modular and namespace API
           () => query.limitToLast(9),
           'limitToLast',
         );
@@ -1059,6 +1067,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => onSnapshot(query, () => {}),
+          // @ts-expect-error Combines modular and namespace API
           () => query.onSnapshot(() => {}),
           'onSnapshot',
         );
@@ -1071,6 +1080,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => orderBy('foo', 'asc'),
+          // @ts-expect-error Combines modular and namespace API
           () => query.orderBy('foo', 'asc'),
           'orderBy',
         );
@@ -1083,6 +1093,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => startAfter('foo'),
+          // @ts-expect-error Combines modular and namespace API
           () => query.startAfter('foo'),
           'startAfter',
         );
@@ -1095,6 +1106,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => startAt('foo'),
+          // @ts-expect-error Combines modular and namespace API
           () => query.startAt('foo'),
           'startAt',
         );
@@ -1107,6 +1119,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => where('foo', '==', 'bar'),
+          // @ts-expect-error Combines modular and namespace API
           () => query.where('foo', '==', 'bar'),
           'where',
         );
@@ -1119,6 +1132,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => addDoc(query, { foo: 'bar' }),
+          // @ts-expect-error Combines modular and namespace API
           () => query.add({ foo: 'bar' }),
           'add',
         );
@@ -1131,6 +1145,7 @@ describe('Firestore', function () {
 
         collectionRefV9Deprecation(
           () => doc(query, 'bar'),
+          // @ts-expect-error Combines modular and namespace API
           () => query.doc('foo'),
           'doc',
         );

--- a/packages/firestore/e2e/withConverter.e2e.js
+++ b/packages/firestore/e2e/withConverter.e2e.js
@@ -1,0 +1,615 @@
+/*
+ * Copyright (c) 2021-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+const COLLECTION = 'firestore';
+const { wipe } = require('./helpers');
+
+const {
+  getFirestore,
+  doc,
+  collection,
+  refEqual,
+  addDoc,
+  setDoc,
+  getDoc,
+  query,
+  where,
+  getDocs,
+  writeBatch,
+  increment,
+  initializeFirestore,
+} = firestoreModular;
+
+// Used for testing the FirestoreDataConverter.
+class Post {
+  constructor(title, author, id = 1) {
+    this.title = title;
+    this.author = author;
+    this.id = id;
+  }
+  byline() {
+    return this.title + ', by ' + this.author;
+  }
+}
+
+const postConverter = {
+  toFirestore(post) {
+    return { title: post.title, author: post.author };
+  },
+  fromFirestore(snapshot) {
+    const data = snapshot.data();
+    return new Post(data.title, data.author);
+  },
+};
+
+const postConverterMerge = {
+  toFirestore(post, options) {
+    if (
+      options &&
+      ((options && options.merge === true) ||
+        (options && Array.isArray(options.mergeFields) && options.mergeFields.length > 0))
+    ) {
+      post.should.not.be.an.instanceof(Post);
+    } else {
+      post.should.be.an.instanceof(Post);
+    }
+    const result = {};
+    if (post.title) {
+      result.title = post.title;
+    }
+    if (post.author) {
+      result.author = post.author;
+    }
+    return result;
+  },
+  fromFirestore(snapshot) {
+    const data = snapshot.data();
+    return new Post(data.title, data.author);
+  },
+};
+
+// v8 compatibility helper functions
+function modifyIgnoreUndefinedProperties(db, value) {
+  // JS SDK settings can only be called once
+  if (Platform.other) {
+    db._settings.ignoreUndefinedProperties = value;
+  } else {
+    db.settings({ ignoreUndefinedProperties: value });
+  }
+}
+
+// modular helper functions
+function withTestDb(fn) {
+  return fn(getFirestore());
+}
+
+async function withModifiedUndefinedPropertiesTestDb(fn) {
+  const db = getFirestore();
+  const previousValue = db._settings.ignoreUndefinedProperties;
+  initializeFirestore(db.app, { ignoreUndefinedProperties: false });
+  await fn(db);
+  initializeFirestore(db.app, { ignoreUndefinedProperties: previousValue });
+}
+
+function withTestCollection(fn) {
+  return withTestDb(db => fn(collection(db, COLLECTION)));
+}
+function withTestDoc(fn) {
+  return withTestDb(db => fn(doc(db, `${COLLECTION}/doc`)));
+}
+
+function withTestCollectionAndInitialData(data, fn) {
+  return withTestDb(async db => {
+    const coll = collection(db, COLLECTION);
+    for (const element of data) {
+      const ref = doc(coll);
+      await setDoc(ref, element);
+    }
+    return fn(coll);
+  });
+}
+
+describe('firestore.withConverter', function () {
+  describe('v8 compatibility', function () {
+    beforeEach(async function beforeEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = true;
+    });
+
+    afterEach(async function afterEachTest() {
+      // @ts-ignore
+      globalThis.RNFB_SILENCE_MODULAR_DEPRECATION_WARNINGS = false;
+    });
+
+    before(function () {
+      return wipe();
+    });
+
+    it('for collection references', function () {
+      const firestore = firebase.firestore();
+      const coll1a = firestore.collection('a');
+      const coll1b = firestore.doc('a/b').parent;
+      const coll2 = firestore.collection('c');
+
+      coll1a.isEqual(coll1b).should.be.true();
+      coll1a.isEqual(coll2).should.be.false();
+
+      const coll1c = firestore.collection('a').withConverter({
+        toFirestore: data => data,
+        fromFirestore: snap => snap.data(),
+      });
+      coll1a.isEqual(coll1c).should.be.false();
+
+      try {
+        coll1a.isEqual(firestore.doc('a/b'));
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql('expected a Query instance.');
+        return Promise.resolve();
+      }
+    });
+
+    it('for document references', function () {
+      const firestore = firebase.firestore();
+      const doc1a = firestore.doc('a/b');
+      const doc1b = firestore.collection('a').doc('b');
+      const doc2 = firestore.doc('a/c');
+
+      doc1a.isEqual(doc1b).should.be.true();
+      doc1a.isEqual(doc2).should.be.false();
+
+      try {
+        const doc1c = firestore.collection('a').withConverter({
+          toFirestore: data => data,
+          fromFirestore: snap => snap.data(),
+        });
+        doc1a.isEqual(doc1c);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql('expected a DocumentReference instance.');
+      }
+
+      try {
+        doc1a.isEqual(firestore.collection('a'));
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql('expected a DocumentReference instance.');
+      }
+      return Promise.resolve();
+    });
+
+    it('for DocumentReference.withConverter()', async function () {
+      const firestore = firebase.firestore();
+      let docRef = firestore.doc(`${COLLECTION}/doc`);
+      docRef = docRef.withConverter(postConverter);
+      await docRef.set(new Post('post', 'author'));
+      const postData = await docRef.get();
+      const post = postData.data();
+      post.should.not.be.undefined();
+      post.byline().should.equal('post, by author');
+    });
+
+    it('for DocumentReference.withConverter(null) applies default converter', function () {
+      const firestore = firebase.firestore();
+      const coll = firestore
+        .collection(COLLECTION)
+        .withConverter(postConverter)
+        .withConverter(null);
+      try {
+        return coll
+          .doc('post1')
+          .set(10)
+          .then(() => Promise.reject(new Error('Did not throw an Error.')));
+      } catch (error) {
+        error.message.should.containEql(
+          `firebase.firestore().doc().set(*) 'data' must be an object.`,
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('for CollectionReference.withConverter()', async function () {
+      const firestore = firebase.firestore();
+      let coll = firestore.collection(COLLECTION);
+      coll = coll.withConverter(postConverter);
+      const docRef = await coll.add(new Post('post', 'author'));
+      const postData = await docRef.get();
+      const post = postData.data();
+      post.should.not.be.undefined();
+      post.byline().should.equal('post, by author');
+    });
+
+    it('for CollectionReference.withConverter(null) applies default converter', function () {
+      const firestore = firebase.firestore();
+      let docRef = firestore.doc(`${COLLECTION}/doc`);
+      try {
+        docRef = docRef.withConverter(postConverter).withConverter(null);
+        return docRef.set(10).then(() => Promise.reject(new Error('Did not throw an Error.')));
+      } catch (error) {
+        error.message.should.containEql(
+          `firebase.firestore().doc().set(*) 'data' must be an object.`,
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('for Query.withConverter()', async function () {
+      const firestore = firebase.firestore();
+      const collRef = firestore.collection(COLLECTION);
+      await collRef.add({ title: 'post', author: 'author' });
+      let query1 = collRef.where('title', '==', 'post');
+      query1 = query1.withConverter(postConverter);
+      const result = await query1.get();
+      result.docs[0].data().should.be.an.instanceOf(Post);
+      result.docs[0].data().byline().should.equal('post, by author');
+    });
+
+    it('for Query.withConverter(null) applies default converter', async function () {
+      const firestore = firebase.firestore();
+      const collRef = firestore.collection(COLLECTION);
+      await collRef.add({ title: 'post', author: 'author' });
+      let query1 = collRef.where('title', '==', 'post');
+      query1 = query1.withConverter(postConverter).withConverter(null);
+      const result = await query1.get();
+      result.docs[0].should.not.be.an.instanceOf(Post);
+    });
+
+    it('keeps the converter when calling parent() with a DocumentReference', function () {
+      const db = firebase.firestore();
+      const coll = db.doc('root/doc').withConverter(postConverter);
+      const typedColl = coll.parent;
+      typedColl.isEqual(db.collection('root').withConverter(postConverter)).should.be.true();
+    });
+
+    it('drops the converter when calling parent() with a CollectionReference', function () {
+      const db = firebase.firestore();
+      const coll = db.collection('root/doc/parent').withConverter(postConverter);
+      const untypedDoc = coll.parent;
+      untypedDoc.isEqual(db.doc('root/doc')).should.be.true();
+    });
+
+    it('checks converter when comparing with isEqual()', function () {
+      const db = firebase.firestore();
+      const postConverter2 = { ...postConverter };
+
+      const postsCollection = db.collection('users/user1/posts').withConverter(postConverter);
+      const postsCollection2 = db.collection('users/user1/posts').withConverter(postConverter2);
+      postsCollection.isEqual(postsCollection2).should.be.false();
+
+      const docRef = db.doc('some/doc').withConverter(postConverter);
+      const docRef2 = db.doc('some/doc').withConverter(postConverter2);
+      docRef.isEqual(docRef2).should.be.false();
+    });
+
+    it('requires the correct converter for Partial usage', async function () {
+      const db = firebase.firestore();
+      const previousValue = db._settings.ignoreUndefinedProperties;
+      modifyIgnoreUndefinedProperties(db, false);
+
+      const coll = db.collection('posts');
+      const ref = coll.doc('post').withConverter(postConverter);
+      const batch = db.batch();
+
+      try {
+        batch.set(ref, { title: 'olive' }, { merge: true });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql('Unsupported field value: undefined');
+      }
+      modifyIgnoreUndefinedProperties(db, previousValue);
+      return Promise.resolve();
+    });
+
+    it('supports primitive types with valid converter', async function () {
+      const firestore = firebase.firestore();
+      const primitiveConverter = {
+        toFirestore(value) {
+          return { value };
+        },
+        fromFirestore(snapshot) {
+          const data = snapshot.data();
+          return data.value;
+        },
+      };
+
+      const arrayConverter = {
+        toFirestore(value) {
+          return { values: value };
+        },
+        fromFirestore(snapshot) {
+          const data = snapshot.data();
+          return data.values;
+        },
+      };
+
+      const coll = firestore.collection(COLLECTION);
+      const ref = coll.doc('number').withConverter(primitiveConverter);
+      await ref.set(3);
+      const result = await ref.get();
+      result.data().should.equal(3);
+
+      const ref2 = coll.doc('array').withConverter(arrayConverter);
+      await ref2.set([1, 2, 3]);
+      const result2 = await ref2.get();
+      result2.data().should.deepEqual([1, 2, 3]);
+    });
+
+    it('supports partials with merge', async function () {
+      const firestore = firebase.firestore();
+      const coll = firestore.collection(COLLECTION);
+      const ref = coll.doc('post').withConverter(postConverterMerge);
+      await ref.set(new Post('walnut', 'author'));
+      await ref.set(
+        { title: 'olive', id: firebase.firestore.FieldValue.increment(2) },
+        { merge: true },
+      );
+      const postDoc = await ref.get();
+      postDoc.get('title').should.equal('olive');
+      postDoc.get('author').should.equal('author');
+    });
+
+    it('supports partials with mergeFields', async function () {
+      const firestore = firebase.firestore();
+      const coll = firestore.collection(COLLECTION);
+      const ref = coll.doc('post').withConverter(postConverterMerge);
+      await ref.set(new Post('walnut', 'author'));
+      await ref.set({ title: 'olive' }, { mergeFields: ['title'] });
+      const postDoc = await ref.get();
+      postDoc.get('title').should.equal('olive');
+      postDoc.get('author').should.equal('author');
+    });
+  });
+
+  describe('modular', function () {
+    before(function () {
+      return wipe();
+    });
+
+    it('for collection references', function () {
+      return withTestDb(firestore => {
+        const coll1a = collection(firestore, 'a');
+        const coll1b = doc(firestore, 'a/b').parent;
+        const coll2 = collection(firestore, 'c');
+
+        refEqual(coll1a, coll1b).should.be.true();
+        refEqual(coll1a, coll2).should.be.false();
+
+        const coll1c = collection(firestore, 'a').withConverter({
+          toFirestore: data => data,
+          fromFirestore: snap => snap.data(),
+        });
+        refEqual(coll1a, coll1c).should.be.false();
+
+        try {
+          refEqual(coll1a, doc(firestore, 'a/b'));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('expected a Query instance.');
+          return Promise.resolve();
+        }
+      });
+    });
+
+    it('for document references', function () {
+      return withTestDb(firestore => {
+        const doc1a = doc(firestore, 'a/b');
+        const doc1b = doc(collection(firestore, 'a'), 'b');
+        const doc2 = doc(firestore, 'a/c');
+
+        refEqual(doc1a, doc1b).should.be.true();
+        refEqual(doc1a, doc2).should.be.false();
+
+        try {
+          const doc1c = collection(firestore, 'a').withConverter({
+            toFirestore: data => data,
+            fromFirestore: snap => snap.data(),
+          });
+          refEqual(doc1a, doc1c);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('expected a DocumentReference instance.');
+        }
+
+        try {
+          refEqual(doc1a, collection(firestore, 'a'));
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('expected a DocumentReference instance.');
+        }
+        return Promise.resolve();
+      });
+    });
+
+    it('for DocumentReference.withConverter()', function () {
+      return withTestDoc(async docRef => {
+        docRef = docRef.withConverter(postConverter);
+        await setDoc(docRef, new Post('post', 'author'));
+        const postData = await getDoc(docRef);
+        const post = postData.data();
+        post.should.not.be.undefined();
+        post.byline().should.equal('post, by author');
+      });
+    });
+
+    it('for DocumentReference.withConverter(null) applies default converter', function () {
+      return withTestCollection(async coll => {
+        coll = coll.withConverter(postConverter).withConverter(null);
+        try {
+          await setDoc(doc(coll, 'post1'), 10);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            `firebase.firestore().doc().set(*) 'data' must be an object.`,
+          );
+          return Promise.resolve();
+        }
+      });
+    });
+
+    it('for CollectionReference.withConverter()', function () {
+      return withTestCollection(async coll => {
+        coll = coll.withConverter(postConverter);
+        const docRef = await addDoc(coll, new Post('post', 'author'));
+        const postData = await getDoc(docRef);
+        const post = postData.data();
+        post.should.not.be.undefined();
+        post.byline().should.equal('post, by author');
+      });
+    });
+
+    it('for CollectionReference.withConverter(null) applies default converter', function () {
+      return withTestDoc(async doc => {
+        try {
+          doc = doc.withConverter(postConverter).withConverter(null);
+          await setDoc(doc, 10);
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql(
+            `firebase.firestore().doc().set(*) 'data' must be an object.`,
+          );
+          return Promise.resolve();
+        }
+      });
+    });
+
+    it('for Query.withConverter()', function () {
+      return withTestCollectionAndInitialData(
+        [{ title: 'post', author: 'author' }],
+        async collRef => {
+          let query1 = query(collRef, where('title', '==', 'post'));
+          query1 = query1.withConverter(postConverter);
+          const result = await getDocs(query1);
+          result.docs[0].data().should.be.an.instanceOf(Post);
+          result.docs[0].data().byline().should.equal('post, by author');
+        },
+      );
+    });
+
+    it('for Query.withConverter(null) applies default converter', function () {
+      return withTestCollectionAndInitialData(
+        [{ title: 'post', author: 'author' }],
+        async collRef => {
+          let query1 = query(collRef, where('title', '==', 'post'));
+          query1 = query1.withConverter(postConverter).withConverter(null);
+          const result = await getDocs(query1);
+          result.docs[0].should.not.be.an.instanceOf(Post);
+        },
+      );
+    });
+
+    it('keeps the converter when calling parent() with a DocumentReference', function () {
+      return withTestDb(async db => {
+        const coll = doc(db, 'root/doc').withConverter(postConverter);
+        const typedColl = coll.parent;
+        refEqual(typedColl, collection(db, 'root').withConverter(postConverter)).should.be.true();
+      });
+    });
+
+    it('drops the converter when calling parent() with a CollectionReference', function () {
+      return withTestDb(async db => {
+        const coll = collection(db, 'root/doc/parent').withConverter(postConverter);
+        const untypedDoc = coll.parent;
+        refEqual(untypedDoc, doc(db, 'root/doc')).should.be.true();
+      });
+    });
+
+    it('checks converter when comparing with isEqual()', function () {
+      return withTestDb(async db => {
+        const postConverter2 = { ...postConverter };
+
+        const postsCollection = collection(db, 'users/user1/posts').withConverter(postConverter);
+        const postsCollection2 = collection(db, 'users/user1/posts').withConverter(postConverter2);
+        refEqual(postsCollection, postsCollection2).should.be.false();
+
+        const docRef = doc(db, 'some/doc').withConverter(postConverter);
+        const docRef2 = doc(db, 'some/doc').withConverter(postConverter2);
+        refEqual(docRef, docRef2).should.be.false();
+      });
+    });
+
+    it('requires the correct converter for Partial usage', async function () {
+      return withModifiedUndefinedPropertiesTestDb(async db => {
+        const coll = collection(db, 'posts');
+        const ref = doc(coll, 'post').withConverter(postConverter);
+        const batch = writeBatch(db);
+
+        try {
+          batch.set(ref, { title: 'olive' }, { merge: true });
+          return Promise.reject(new Error('Did not throw an Error.'));
+        } catch (error) {
+          error.message.should.containEql('Unsupported field value: undefined');
+        }
+        return Promise.resolve();
+      });
+    });
+
+    it('supports primitive types with valid converter', function () {
+      const primitiveConverter = {
+        toFirestore(value) {
+          return { value };
+        },
+        fromFirestore(snapshot) {
+          const data = snapshot.data();
+          return data.value;
+        },
+      };
+
+      const arrayConverter = {
+        toFirestore(value) {
+          return { values: value };
+        },
+        fromFirestore(snapshot) {
+          const data = snapshot.data();
+          return data.values;
+        },
+      };
+
+      return withTestCollection(async coll => {
+        const ref = doc(coll, 'number').withConverter(primitiveConverter);
+        await setDoc(ref, 3);
+        const result = await getDoc(ref);
+        result.data().should.equal(3);
+
+        const ref2 = doc(coll, 'array').withConverter(arrayConverter);
+        await setDoc(ref2, [1, 2, 3]);
+        const result2 = await getDoc(ref2);
+        result2.data().should.deepEqual([1, 2, 3]);
+      });
+    });
+
+    it('supports partials with merge', async function () {
+      return withTestCollection(async coll => {
+        const ref = doc(coll, 'post').withConverter(postConverterMerge);
+        await setDoc(ref, new Post('walnut', 'author'));
+        await setDoc(ref, { title: 'olive', id: increment(2) }, { merge: true });
+        const postDoc = await getDoc(ref);
+        postDoc.get('title').should.equal('olive');
+        postDoc.get('author').should.equal('author');
+      });
+    });
+
+    it('supports partials with mergeFields', async function () {
+      return withTestCollection(async coll => {
+        const ref = doc(coll, 'post').withConverter(postConverterMerge);
+        await setDoc(ref, new Post('walnut', 'author'));
+        await setDoc(ref, { title: 'olive' }, { mergeFields: ['title'] });
+        const postDoc = await getDoc(ref);
+        postDoc.get('title').should.equal('olive');
+        postDoc.get('author').should.equal('author');
+      });
+    });
+  });
+});

--- a/packages/firestore/lib/FirestoreCollectionReference.js
+++ b/packages/firestore/lib/FirestoreCollectionReference.js
@@ -15,16 +15,22 @@
  *
  */
 
-import { generateFirestoreId, isObject } from '@react-native-firebase/app/dist/module/common';
+import {
+  generateFirestoreId,
+  isObject,
+  isNull,
+  isUndefined,
+} from '@react-native-firebase/app/dist/module/common';
 import FirestoreDocumentReference, {
   provideCollectionReferenceClass,
 } from './FirestoreDocumentReference';
 import FirestoreQuery from './FirestoreQuery';
 import FirestoreQueryModifiers from './FirestoreQueryModifiers';
+import { validateWithConverter } from './utils';
 
 export default class FirestoreCollectionReference extends FirestoreQuery {
-  constructor(firestore, collectionPath) {
-    super(firestore, collectionPath, new FirestoreQueryModifiers());
+  constructor(firestore, collectionPath, converter) {
+    super(firestore, collectionPath, new FirestoreQueryModifiers(), undefined, converter);
   }
 
   get id() {
@@ -62,7 +68,21 @@ export default class FirestoreCollectionReference extends FirestoreQuery {
       );
     }
 
-    return new FirestoreDocumentReference(this._firestore, path);
+    return new FirestoreDocumentReference(this._firestore, path, this._converter);
+  }
+
+  withConverter(converter) {
+    if (isUndefined(converter) || isNull(converter)) {
+      return new FirestoreCollectionReference(this._firestore, this._collectionPath, null);
+    }
+
+    try {
+      validateWithConverter(converter);
+    } catch (e) {
+      throw new Error(`firebase.firestore().collection().withConverter() ${e.message}`);
+    }
+
+    return new FirestoreCollectionReference(this._firestore, this._collectionPath, converter);
   }
 }
 

--- a/packages/firestore/lib/FirestoreDocumentChange.js
+++ b/packages/firestore/lib/FirestoreDocumentChange.js
@@ -24,15 +24,16 @@ const TYPE_MAP = {
 };
 
 export default class FirestoreDocumentChange {
-  constructor(firestore, nativeData) {
+  constructor(firestore, nativeData, converter) {
     this._firestore = firestore;
     this._nativeData = nativeData;
     this._isMetadataChange = nativeData.isMetadataChange;
+    this._converter = converter;
   }
 
   get doc() {
     return createDeprecationProxy(
-      new FirestoreDocumentSnapshot(this._firestore, this._nativeData.doc),
+      new FirestoreDocumentSnapshot(this._firestore, this._nativeData.doc, this._converter),
     );
   }
 

--- a/packages/firestore/lib/FirestoreQuerySnapshot.js
+++ b/packages/firestore/lib/FirestoreQuerySnapshot.js
@@ -16,24 +16,26 @@
  */
 
 import {
+  createDeprecationProxy,
   isBoolean,
   isFunction,
   isObject,
   isUndefined,
-  createDeprecationProxy,
 } from '@react-native-firebase/app/dist/module/common';
 import FirestoreDocumentChange from './FirestoreDocumentChange';
 import FirestoreDocumentSnapshot from './FirestoreDocumentSnapshot';
 import FirestoreSnapshotMetadata from './FirestoreSnapshotMetadata';
 
 export default class FirestoreQuerySnapshot {
-  constructor(firestore, query, nativeData) {
+  constructor(firestore, query, nativeData, converter) {
     this._query = query;
     this._source = nativeData.source;
     this._excludesMetadataChanges = nativeData.excludesMetadataChanges;
-    this._changes = nativeData.changes.map($ => new FirestoreDocumentChange(firestore, $));
+    this._changes = nativeData.changes.map(
+      $ => new FirestoreDocumentChange(firestore, $, converter),
+    );
     this._docs = nativeData.documents.map($ =>
-      createDeprecationProxy(new FirestoreDocumentSnapshot(firestore, $)),
+      createDeprecationProxy(new FirestoreDocumentSnapshot(firestore, $, converter)),
     );
     this._metadata = new FirestoreSnapshotMetadata(nativeData.metadata);
   }

--- a/packages/firestore/lib/modular/index.d.ts
+++ b/packages/firestore/lib/modular/index.d.ts
@@ -1,19 +1,28 @@
 import { ReactNativeFirebase } from '@react-native-firebase/app';
 import { FirebaseFirestoreTypes } from '../index';
+import { FieldValue } from './FieldValue';
+import { FieldPath } from './FieldPath';
 
 import FirebaseApp = ReactNativeFirebase.FirebaseApp;
 import Firestore = FirebaseFirestoreTypes.Module;
-import CollectionReference = FirebaseFirestoreTypes.CollectionReference;
-import DocumentReference = FirebaseFirestoreTypes.DocumentReference;
-import DocumentData = FirebaseFirestoreTypes.DocumentData;
-import Query = FirebaseFirestoreTypes.Query;
-import FieldValue = FirebaseFirestoreTypes.FieldValue;
-import FieldPath = FirebaseFirestoreTypes.FieldPath;
-import PersistentCacheIndexManager = FirebaseFirestoreTypes.PersistentCacheIndexManager;
-import AggregateQuerySnapshot = FirebaseFirestoreTypes.AggregateQuerySnapshot;
+
+export type PersistentCacheIndexManager = FirebaseFirestoreTypes.PersistentCacheIndexManager;
+export type AggregateQuerySnapshot = FirebaseFirestoreTypes.AggregateQuerySnapshot;
+export type SetOptions = FirebaseFirestoreTypes.SetOptions;
+export type SnapshotListenOptions = FirebaseFirestoreTypes.SnapshotListenOptions;
+export type WhereFilterOp = FirebaseFirestoreTypes.WhereFilterOp;
+export type QueryCompositeFilterConstraint = FirebaseFirestoreTypes.QueryCompositeFilterConstraint;
 
 /** Primitive types. */
 export type Primitive = string | number | boolean | undefined | null;
+
+/**
+ * A `DocumentData` object represents the data in a document.
+ * - Same as {@link FirebaseFirestoreTypes.DocumentData}
+ */
+export interface DocumentData {
+  [key: string]: any;
+}
 
 /**
  * Similar to Typescript's `Partial<T>`, but allows nested fields to be
@@ -152,6 +161,626 @@ export declare function connectFirestoreEmulator(
     mockUserToken?: EmulatorMockTokenOptions | string;
   },
 ): void;
+
+/**
+ * Converter used by `withConverter()` to transform user objects of type
+ * `AppModelType` into Firestore data of type `DbModelType`.
+ *
+ * Using the converter allows you to specify generic type arguments when
+ * storing and retrieving objects from Firestore.
+ *
+ * In this context, an "AppModel" is a class that is used in an application to
+ * package together related information and functionality. Such a class could,
+ * for example, have properties with complex, nested data types, properties used
+ * for memoization, properties of types not supported by Firestore (such as
+ * `symbol` and `bigint`), and helper functions that perform compound
+ * operations. Such classes are not suitable and/or possible to store into a
+ * Firestore database. Instead, instances of such classes need to be converted
+ * to "plain old JavaScript objects" (POJOs) with exclusively primitive
+ * properties, potentially nested inside other POJOs or arrays of POJOs. In this
+ * context, this type is referred to as the "DbModel" and would be an object
+ * suitable for persisting into Firestore. For convenience, applications can
+ * implement `FirestoreDataConverter` and register the converter with Firestore
+ * objects, such as `DocumentReference` or `Query`, to automatically convert
+ * `AppModel` to `DbModel` when storing into Firestore, and convert `DbModel`
+ * to `AppModel` when retrieving from Firestore.
+ *
+ * @example
+ *
+ * Simple Example
+ *
+ * ```typescript
+ * const numberConverter = {
+ *     toFirestore(value: WithFieldValue<number>) {
+ *         return { value };
+ *     },
+ *     fromFirestore(snapshot: QueryDocumentSnapshot, options: SnapshotOptions) {
+ *         return snapshot.data(options).value as number;
+ *     }
+ * };
+ *
+ * async function simpleDemo(db: Firestore): Promise<void> {
+ *     const documentRef = doc(db, 'values/value123').withConverter(numberConverter);
+ *
+ *     // converters are used with `setDoc`, `addDoc`, and `getDoc`
+ *     await setDoc(documentRef, 42);
+ *     const snapshot1 = await getDoc(documentRef);
+ *     assertEqual(snapshot1.data(), 42);
+ *
+ *     // converters are not used when writing data with `updateDoc`
+ *     await updateDoc(documentRef, { value: 999 });
+ *     const snapshot2 = await getDoc(documentRef);
+ *     assertEqual(snapshot2.data(), 999);
+ * }
+ * ```
+ *
+ * Advanced Example
+ *
+ * ```typescript
+ * // The Post class is a model that is used by our application.
+ * // This class may have properties and methods that are specific
+ * // to our application execution, which do not need to be persisted
+ * // to Firestore.
+ * class Post {
+ *     constructor(
+ *         readonly title: string,
+ *         readonly author: string,
+ *         readonly lastUpdatedMillis: number
+ *     ) {}
+ *     toString(): string {
+ *         return `${this.title} by ${this.author}`;
+ *     }
+ * }
+ *
+ * // The PostDbModel represents how we want our posts to be stored
+ * // in Firestore. This DbModel has different properties (`ttl`,
+ * // `aut`, and `lut`) from the Post class we use in our application.
+ * interface PostDbModel {
+ *     ttl: string;
+ *     aut: { firstName: string; lastName: string };
+ *     lut: Timestamp;
+ * }
+ *
+ * // The `PostConverter` implements `FirestoreDataConverter` and specifies
+ * // how the Firestore SDK can convert `Post` objects to `PostDbModel`
+ * // objects and vice versa.
+ * class PostConverter implements FirestoreDataConverter<Post, PostDbModel> {
+ *     toFirestore(post: WithFieldValue<Post>): WithFieldValue<PostDbModel> {
+ *         return {
+ *             ttl: post.title,
+ *             aut: this._autFromAuthor(post.author),
+ *             lut: this._lutFromLastUpdatedMillis(post.lastUpdatedMillis)
+ *         };
+ *     }
+ *
+ *     fromFirestore(snapshot: QueryDocumentSnapshot, options: SnapshotOptions): Post {
+ *         const data = snapshot.data(options) as PostDbModel;
+ *         const author = `${data.aut.firstName} ${data.aut.lastName}`;
+ *         return new Post(data.ttl, author, data.lut.toMillis());
+ *     }
+ *
+ *     _autFromAuthor(
+ *         author: string | FieldValue
+ *     ): { firstName: string; lastName: string } | FieldValue {
+ *         if (typeof author !== 'string') {
+ *             // `author` is a FieldValue, so just return it.
+ *             return author;
+ *         }
+ *         const [firstName, lastName] = author.split(' ');
+ *         return {firstName, lastName};
+ *     }
+ *
+ *     _lutFromLastUpdatedMillis(
+ *         lastUpdatedMillis: number | FieldValue
+ *     ): Timestamp | FieldValue {
+ *         if (typeof lastUpdatedMillis !== 'number') {
+ *             // `lastUpdatedMillis` must be a FieldValue, so just return it.
+ *             return lastUpdatedMillis;
+ *         }
+ *         return Timestamp.fromMillis(lastUpdatedMillis);
+ *     }
+ * }
+ *
+ * async function advancedDemo(db: Firestore): Promise<void> {
+ *     // Create a `DocumentReference` with a `FirestoreDataConverter`.
+ *     const documentRef = doc(db, 'posts/post123').withConverter(new PostConverter());
+ *
+ *     // The `data` argument specified to `setDoc()` is type checked by the
+ *     // TypeScript compiler to be compatible with `Post`. Since the `data`
+ *     // argument is typed as `WithFieldValue<Post>` rather than just `Post`,
+ *     // this allows properties of the `data` argument to also be special
+ *     // Firestore values that perform server-side mutations, such as
+ *     // `arrayRemove()`, `deleteField()`, and `serverTimestamp()`.
+ *     await setDoc(documentRef, {
+ *         title: 'My Life',
+ *         author: 'Foo Bar',
+ *         lastUpdatedMillis: serverTimestamp()
+ *     });
+ *
+ *     // The TypeScript compiler will fail to compile if the `data` argument to
+ *     // `setDoc()` is _not_ compatible with `WithFieldValue<Post>`. This
+ *     // type checking prevents the caller from specifying objects with incorrect
+ *     // properties or property values.
+ *     // @ts-expect-error "Argument of type { ttl: string; } is not assignable
+ *     // to parameter of type WithFieldValue<Post>"
+ *     await setDoc(documentRef, { ttl: 'The Title' });
+ *
+ *     // When retrieving a document with `getDoc()` the `DocumentSnapshot`
+ *     // object's `data()` method returns a `Post`, rather than a generic object,
+ *     // which would have been returned if the `DocumentReference` did _not_ have a
+ *     // `FirestoreDataConverter` attached to it.
+ *     const snapshot1: DocumentSnapshot<Post> = await getDoc(documentRef);
+ *     const post1: Post = snapshot1.data()!;
+ *     if (post1) {
+ *         assertEqual(post1.title, 'My Life');
+ *         assertEqual(post1.author, 'Foo Bar');
+ *     }
+ *
+ *     // The `data` argument specified to `updateDoc()` is type checked by the
+ *     // TypeScript compiler to be compatible with `PostDbModel`. Note that
+ *     // unlike `setDoc()`, whose `data` argument must be compatible with `Post`,
+ *     // the `data` argument to `updateDoc()` must be compatible with
+ *     // `PostDbModel`. Similar to `setDoc()`, since the `data` argument is typed
+ *     // as `WithFieldValue<PostDbModel>` rather than just `PostDbModel`, this
+ *     // allows properties of the `data` argument to also be those special
+ *     // Firestore values, like `arrayRemove()`, `deleteField()`, and
+ *     // `serverTimestamp()`.
+ *     await updateDoc(documentRef, {
+ *         'aut.firstName': 'NewFirstName',
+ *         lut: serverTimestamp()
+ *     });
+ *
+ *     // The TypeScript compiler will fail to compile if the `data` argument to
+ *     // `updateDoc()` is _not_ compatible with `WithFieldValue<PostDbModel>`.
+ *     // This type checking prevents the caller from specifying objects with
+ *     // incorrect properties or property values.
+ *     // @ts-expect-error "Argument of type { title: string; } is not assignable
+ *     // to parameter of type WithFieldValue<PostDbModel>"
+ *     await updateDoc(documentRef, { title: 'New Title' });
+ *     const snapshot2: DocumentSnapshot<Post> = await getDoc(documentRef);
+ *     const post2: Post = snapshot2.data()!;
+ *     if (post2) {
+ *         assertEqual(post2.title, 'My Life');
+ *         assertEqual(post2.author, 'NewFirstName Bar');
+ *     }
+ * }
+ * ```
+ */
+export interface FirestoreDataConverter<
+  AppModelType,
+  DbModelType extends DocumentData = DocumentData,
+> {
+  /**
+   * Called by the Firestore SDK to convert a custom model object of type
+   * `AppModelType` into a plain JavaScript object (suitable for writing
+   * directly to the Firestore database) of type `DbModelType`. To use `set()`
+   * with `merge` and `mergeFields`, `toFirestore()` must be defined with
+   * `PartialWithFieldValue<AppModelType>`.
+   *
+   * The `WithFieldValue<T>` type extends `T` to also allow FieldValues such as
+   * {@link (deleteField:1)} to be used as property values.
+   */
+  toFirestore(modelObject: WithFieldValue<AppModelType>): WithFieldValue<DbModelType>;
+
+  /**
+   * Called by the Firestore SDK to convert a custom model object of type
+   * `AppModelType` into a plain JavaScript object (suitable for writing
+   * directly to the Firestore database) of type `DbModelType`. Used with
+   * {@link (setDoc:1)}, {@link (WriteBatch.set:1)} and
+   * {@link (Transaction.set:1)} with `merge:true` or `mergeFields`.
+   *
+   * The `PartialWithFieldValue<T>` type extends `Partial<T>` to allow
+   * FieldValues such as {@link (arrayUnion:1)} to be used as property values.
+   * It also supports nested `Partial` by allowing nested fields to be
+   * omitted.
+   */
+  toFirestore(
+    modelObject: PartialWithFieldValue<AppModelType>,
+    options: SetOptions,
+  ): PartialWithFieldValue<DbModelType>;
+
+  /**
+   * Called by the Firestore SDK to convert Firestore data into an object of
+   * type `AppModelType`. You can access your data by calling:
+   * `snapshot.data(options)`.
+   *
+   * Generally, the data returned from `snapshot.data()` can be cast to
+   * `DbModelType`; however, this is not guaranteed because Firestore does not
+   * enforce a schema on the database. For example, writes from a previous
+   * version of the application or writes from another client that did not use a
+   * type converter could have written data with different properties and/or
+   * property types. The implementation will need to choose whether to
+   * gracefully recover from non-conforming data or throw an error.
+   *
+   * To override this method, see {@link (FirestoreDataConverter.fromFirestore:1)}.
+   *
+   * @param snapshot - A `QueryDocumentSnapshot` containing your data and metadata.
+   * @param options - The `SnapshotOptions` from the initial call to `data()`.
+   */
+  fromFirestore(
+    snapshot: QueryDocumentSnapshot<DocumentData, DocumentData>,
+    options?: SnapshotOptions,
+  ): AppModelType;
+}
+
+/**
+ * A Query refers to a `Query` which you can read or listen to. You can also construct refined `Query` objects by
+ * adding filters and ordering.
+ */
+export interface Query<
+  AppModelType = DocumentData,
+  DbModelType extends DocumentData = DocumentData,
+> {
+  /**
+   * The Firestore instance the document is in. This is useful for performing transactions, for example.
+   */
+  firestore: Firestore;
+
+  /**
+   * If provided, the {@link FirestoreDataConverter} associated with this instance.
+   */
+  converter: FirestoreDataConverter<AppModelType, DbModelType> | null;
+
+  /**
+   * Removes the current converter.
+   *
+   * @param converter - `null` removes the current converter.
+   * @returns A `Query<DocumentData, DocumentData>` that does not use a
+   * converter.
+   */
+  withConverter(converter: null): Query<DocumentData, DocumentData>;
+  /**
+   * Applies a custom data converter to this query, allowing you to use your own
+   * custom model objects with Firestore. When you call {@link getDocs} with
+   * the returned query, the provided converter will convert between Firestore
+   * data of type `NewDbModelType` and your custom type `NewAppModelType`.
+   *z
+   * @param converter - Converts objects to and from Firestore.
+   * @returns A `Query` that uses the provided converter.
+   */
+  withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(
+    converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>,
+  ): Query<NewAppModelType, NewDbModelType>;
+}
+
+/**
+ * A `CollectionReference` object can be used for adding documents, getting document references, and querying for
+ * documents (using the methods inherited from `Query`).
+ */
+export interface CollectionReference<
+  AppModelType = DocumentData,
+  DbModelType extends DocumentData = DocumentData,
+> extends Query<AppModelType, DbModelType> {
+  /**
+   * The collection's identifier.
+   */
+  id: string;
+
+  /**
+   * A reference to the containing `DocumentReference` if this is a subcollection. If this isn't a
+   * subcollection, the reference is null.
+   */
+  parent: DocumentReference<DocumentData, DocumentData> | null;
+
+  /**
+   * A string representing the path of the referenced collection (relative to the root of the database).
+   */
+  path: string;
+
+  /**
+   * Removes the current converter.
+   *
+   * @param converter - `null` removes the current converter.
+   * @returns A `CollectionReference<DocumentData, DocumentData>` that does not
+   * use a converter.
+   */
+  withConverter(converter: null): CollectionReference<DocumentData, DocumentData>;
+  /**
+   * Applies a custom data converter to this `CollectionReference`, allowing you
+   * to use your own custom model objects with Firestore. When you call {@link
+   * addDoc} with the returned `CollectionReference` instance, the provided
+   * converter will convert between Firestore data of type `NewDbModelType` and
+   * your custom type `NewAppModelType`.
+   *
+   * @param converter - Converts objects to and from Firestore.
+   * @returns A `CollectionReference` that uses the provided converter.
+   */
+  withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(
+    converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>,
+  ): CollectionReference<NewAppModelType, NewDbModelType>;
+}
+
+/**
+ * A `DocumentReference` refers to a document location in a Firestore database and can be used to write, read, or listen
+ * to the location. The document at the referenced location may or may not exist. A `DocumentReference` can also be used
+ * to create a `CollectionReference` to a subcollection.
+ */
+export interface DocumentReference<
+  AppModelType = DocumentData,
+  DbModelType extends DocumentData = DocumentData,
+> {
+  /**
+   * The Firestore instance the document is in. This is useful for performing transactions, for example.
+   */
+  firestore: Firestore;
+
+  /**
+   * If provided, the {@link FirestoreDataConverter} associated with this instance.
+   */
+  converter: FirestoreDataConverter<AppModelType, DbModelType> | null;
+
+  /**
+   * The document's identifier within its collection.
+   */
+  id: string;
+
+  /**
+   * The Collection this `DocumentReference` belongs to.
+   */
+  parent: CollectionReference<AppModelType, DbModelType>;
+
+  /**
+   * A string representing the path of the referenced document (relative to the root of the database).
+   */
+  path: string;
+
+  /**
+   * Removes the current converter.
+   *
+   * @param converter - `null` removes the current converter.
+   * @returns A `DocumentReference<DocumentData, DocumentData>` that does not
+   * use a converter.
+   */
+  withConverter(converter: null): DocumentReference<DocumentData, DocumentData>;
+  /**
+   * Applies a custom data converter to this `DocumentReference`, allowing you
+   * to use your own custom model objects with Firestore. When you call
+   * {@link setDoc:1}, {@link getDoc:1}, etc. with the returned `DocumentReference`
+   * instance, the provided converter will convert between Firestore data of
+   * type `NewDbModelType` and your custom type `NewAppModelType`.
+   *
+   * @param converter - Converts objects to and from Firestore.
+   * @returns A `DocumentReference` that uses the provided converter.
+   */
+  withConverter<NewAppModelType, NewDbModelType extends DocumentData = DocumentData>(
+    converter: FirestoreDataConverter<NewAppModelType, NewDbModelType>,
+  ): DocumentReference<NewAppModelType, NewDbModelType>;
+}
+
+/**
+ * A write batch, used to perform multiple writes as a single atomic unit.
+ *
+ * A `WriteBatch` object can be acquired by calling {@link writeBatch}. It
+ * provides methods for adding writes to the write batch. None of the writes
+ * will be committed (or visible locally) until {@link WriteBatch.commit} is
+ * called.
+ */
+export class WriteBatch {
+  /**
+   * Writes to the document referred to by the provided {@link
+   * DocumentReference}. If the document does not exist yet, it will be created.
+   *
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
+   */
+  set<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    data: WithFieldValue<AppModelType>,
+  ): WriteBatch;
+  /**
+   * Writes to the document referred to by the provided {@link
+   * DocumentReference}. If the document does not exist yet, it will be created.
+   * If you provide `merge` or `mergeFields`, the provided data can be merged
+   * into an existing document.
+   *
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @param options - An object to configure the set behavior.
+   * @throws Error - If the provided input is not a valid Firestore document.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
+   */
+  set<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    data: PartialWithFieldValue<AppModelType>,
+    options: SetOptions,
+  ): WriteBatch;
+  /**
+   * Updates fields in the document referred to by the provided {@link
+   * DocumentReference}. The update will fail if applied to a document that does
+   * not exist.
+   *
+   * @param documentRef - A reference to the document to be updated.
+   * @param data - An object containing the fields and values with which to
+   * update the document. Fields can contain dots to reference nested fields
+   * within the document.
+   * @throws Error - If the provided input is not valid Firestore data.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
+   */
+  update<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    data: UpdateData<DbModelType>,
+  ): WriteBatch;
+  /**
+   * Updates fields in the document referred to by this {@link
+   * DocumentReference}. The update will fail if applied to a document that does
+   * not exist.
+   *
+   * Nested fields can be update by providing dot-separated field path strings
+   * or by providing `FieldPath` objects.
+   *
+   * @param documentRef - A reference to the document to be updated.
+   * @param field - The first field to update.
+   * @param value - The first value.
+   * @param moreFieldsAndValues - Additional key value pairs.
+   * @throws Error - If the provided input is not valid Firestore data.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
+   */
+  update<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    field: string | FieldPath,
+    value: unknown,
+    ...moreFieldsAndValues: unknown[]
+  ): WriteBatch;
+  update<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    fieldOrUpdateData: string | FieldPath | UpdateData<DbModelType>,
+    value?: unknown,
+    ...moreFieldsAndValues: unknown[]
+  ): WriteBatch;
+
+  /**
+   * Deletes the document referred to by the provided {@link DocumentReference}.
+   *
+   * @param documentRef - A reference to the document to be deleted.
+   * @returns This `WriteBatch` instance. Used for chaining method calls.
+   */
+  delete<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+  ): WriteBatch;
+  /**
+   * Commits all of the writes in this write batch as a single atomic unit.
+   *
+   * The result of these writes will only be reflected in document reads that
+   * occur after the returned promise resolves. If the client is offline, the
+   * write fails. If you would like to see local modifications or buffer writes
+   * until the client is online, use the full Firestore SDK.
+   *
+   * @returns A `Promise` resolved once all of the writes in the batch have been
+   * successfully written to the backend as an atomic unit (note that it won't
+   * resolve while you're offline).
+   */
+  commit(): Promise<void>;
+}
+
+/**
+ * A reference to a transaction.
+ *
+ * The `Transaction` object passed to a transaction's `updateFunction` provides
+ * the methods to read and write data within the transaction context. See
+ * {@link runTransaction}.
+ */
+export class Transaction extends LiteTransaction {
+  /**
+   * Reads the document referenced by the provided {@link DocumentReference}.
+   *
+   * @param documentRef - A reference to the document to be read.
+   * @returns A `DocumentSnapshot` with the read data.
+   */
+  get<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+  ): Promise<DocumentSnapshot<AppModelType, DbModelType>>;
+
+  /**
+   * Writes to the document referred to by the provided {@link
+   * DocumentReference}. If the document does not exist yet, it will be created.
+   *
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @throws Error - If the provided input is not a valid Firestore document.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
+  set<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    data: WithFieldValue<AppModelType>,
+  ): this;
+  /**
+   * Writes to the document referred to by the provided {@link
+   * DocumentReference}. If the document does not exist yet, it will be created.
+   * If you provide `merge` or `mergeFields`, the provided data can be merged
+   * into an existing document.
+   *
+   * @param documentRef - A reference to the document to be set.
+   * @param data - An object of the fields and values for the document.
+   * @param options - An object to configure the set behavior.
+   * @throws Error - If the provided input is not a valid Firestore document.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
+  set<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    data: PartialWithFieldValue<AppModelType>,
+    options: SetOptions,
+  ): this;
+
+  /**
+   * Updates fields in the document referred to by the provided {@link
+   * DocumentReference}. The update will fail if applied to a document that does
+   * not exist.
+   *
+   * @param documentRef - A reference to the document to be updated.
+   * @param data - An object containing the fields and values with which to
+   * update the document. Fields can contain dots to reference nested fields
+   * within the document.
+   * @throws Error - If the provided input is not valid Firestore data.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
+  update<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    data: UpdateData<DbModelType>,
+  ): this;
+  /**
+   * Updates fields in the document referred to by the provided {@link
+   * DocumentReference}. The update will fail if applied to a document that does
+   * not exist.
+   *
+   * Nested fields can be updated by providing dot-separated field path
+   * strings or by providing `FieldPath` objects.
+   *
+   * @param documentRef - A reference to the document to be updated.
+   * @param field - The first field to update.
+   * @param value - The first value.
+   * @param moreFieldsAndValues - Additional key/value pairs.
+   * @throws Error - If the provided input is not valid Firestore data.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
+  update<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    field: string | FieldPath,
+    value: unknown,
+    ...moreFieldsAndValues: unknown[]
+  ): this;
+  update<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+    fieldOrUpdateData: string | FieldPath | UpdateData<DbModelType>,
+    value?: unknown,
+    ...moreFieldsAndValues: unknown[]
+  ): this;
+  /**
+   * Deletes the document referred to by the provided {@link DocumentReference}.
+   *
+   * @param documentRef - A reference to the document to be deleted.
+   * @returns This `Transaction` instance. Used for chaining method calls.
+   */
+  delete<AppModelType, DbModelType extends DocumentData>(
+    documentRef: DocumentReference<AppModelType, DbModelType>,
+  ): this;
+}
+
+/**
+ * Executes the given `updateFunction` and then attempts to commit the changes
+ * applied within the transaction. If any document read within the transaction
+ * has changed, Cloud Firestore retries the `updateFunction`. If it fails to
+ * commit after 5 attempts, the transaction fails.
+ *
+ * The maximum number of writes allowed in a single transaction is 500.
+ *
+ * @param firestore - A reference to the Firestore database to run this
+ * transaction against.
+ * @param updateFunction - The function to execute within the transaction
+ * context.
+ * @param options - An options object to configure maximum number of attempts to
+ * commit.
+ * @returns If the transaction completed successfully or was explicitly aborted
+ * (the `updateFunction` returned a failed promise), the promise returned by the
+ * `updateFunction `is returned here. Otherwise, if the transaction failed, a
+ * rejected promise with the corresponding failure error is returned.
+ */
+export function runTransaction<T>(
+  firestore: Firestore,
+  updateFunction: (transaction: Transaction) => Promise<T>,
+  options?: TransactionOptions,
+): Promise<T>;
+
 /**
  * Gets a `DocumentReference` instance that refers to the document at the
  * specified absolute path.
@@ -168,7 +797,7 @@ export function doc(
   firestore: Firestore,
   path: string,
   ...pathSegments: string[]
-): DocumentReference<DocumentData>;
+): DocumentReference<DocumentData, DocumentData>;
 
 /**
  * Gets a `DocumentReference` instance that refers to a document within
@@ -208,12 +837,6 @@ export declare function doc<AppModelType, DbModelType extends DocumentData>(
   path: string,
   ...pathSegments: string[]
 ): DocumentReference<DocumentData, DocumentData>;
-
-export function doc<T>(
-  parent: Firestore | CollectionReference<T> | DocumentReference<unknown>,
-  path?: string,
-  ...pathSegments: string[]
-): DocumentReference;
 
 /**
  * Gets a `CollectionReference` instance that refers to the collection at
@@ -287,12 +910,6 @@ export function collection(
   ...pathSegments: string[]
 ): CollectionReference<DocumentData>;
 
-export function collection(
-  parent: Firestore | DocumentReference<unknown> | CollectionReference<unknown>,
-  path: string,
-  ...pathSegments: string[]
-): CollectionReference<DocumentData>;
-
 /**
  *Returns true if the provided references are equal.
  *
@@ -334,7 +951,10 @@ export function collectionGroup(
  * @returns A `Promise` resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
-export function setDoc<T>(reference: DocumentReference<T>, data: WithFieldValue<T>): Promise<void>;
+export function setDoc<AppModelType, DbModelType extends DocumentData>(
+  reference: DocumentReference<AppModelType, DbModelType>,
+  data: WithFieldValue<AppModelType>,
+): Promise<void>;
 
 /**
  * Writes to the document referred to by the specified `DocumentReference`. If
@@ -347,18 +967,11 @@ export function setDoc<T>(reference: DocumentReference<T>, data: WithFieldValue<
  * @returns A Promise resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
-export function setDoc<T>(
-  reference: DocumentReference<T>,
-  data: PartialWithFieldValue<T>,
-  options: FirebaseFirestoreTypes.SetOptions,
+export function setDoc<AppModelType, DbModelType extends DocumentData>(
+  reference: DocumentReference<AppModelType, DbModelType>,
+  data: PartialWithFieldValue<AppModelType>,
+  options: SetOptions,
 ): Promise<void>;
-
-export function setDoc<T>(
-  reference: DocumentReference<T>,
-  data: PartialWithFieldValue<T>,
-  options?: FirebaseFirestoreTypes.SetOptions,
-): Promise<void>;
-
 /**
  * Updates fields in the document referred to by the specified
  * `DocumentReference`. The update will fail if applied to a document that does
@@ -371,7 +984,10 @@ export function setDoc<T>(
  * @returns A `Promise` resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
-export function updateDoc<T>(reference: DocumentReference<T>, data: UpdateData<T>): Promise<void>;
+export function updateDoc<AppModelType, DbModelType extends DocumentData>(
+  reference: DocumentReference<AppModelType, DbModelType>,
+  data: UpdateData<DbModelType>,
+): Promise<void>;
 /**
  * Updates fields in the document referred to by the specified
  * `DocumentReference` The update will fail if applied to a document that does
@@ -387,13 +1003,12 @@ export function updateDoc<T>(reference: DocumentReference<T>, data: UpdateData<T
  * @returns A `Promise` resolved once the data has been successfully written
  * to the backend (note that it won't resolve while you're offline).
  */
-export function updateDoc(
-  reference: DocumentReference<unknown>,
+export function updateDoc<AppModelType, DbModelType extends DocumentData>(
+  reference: DocumentReference<AppModelType, DbModelType>,
   field: string | FieldPath,
   value: unknown,
   ...moreFieldsAndValues: unknown[]
 ): Promise<void>;
-
 /**
  * Add a new document to specified `CollectionReference` with the given data,
  * assigning it a document ID automatically.
@@ -529,7 +1144,7 @@ export function setLogLevel(logLevel: LogLevel): void;
  */
 export function runTransaction<T>(
   firestore: Firestore,
-  updateFunction: (transaction: FirebaseFirestoreTypes.Transaction) => Promise<T>,
+  updateFunction: (transaction: Transaction) => Promise<T>,
 ): Promise<T>;
 
 /**
@@ -737,7 +1352,7 @@ export function namedQuery(firestore: Firestore, name: string): Promise<Query | 
  * @returns A `WriteBatch` that can be used to atomically execute multiple
  * writes.
  */
-export function writeBatch(firestore: Firestore): FirebaseFirestoreTypes.WriteBatch;
+export function writeBatch(firestore: Firestore): WriteBatch;
 
 /**
  * Gets the `PersistentCacheIndexManager` instance used by this Cloud Firestore instance.

--- a/packages/firestore/lib/modular/index.js
+++ b/packages/firestore/lib/modular/index.js
@@ -1,14 +1,17 @@
 /**
- * @typedef {import('..').FirebaseFirestoreTypes} FirebaseFirestoreTypes
- * @typedef {import('..').FirebaseFirestoreTypes.CollectionReference} CollectionReference
- * @typedef {import('..').FirebaseFirestoreTypes.DocumentData} DocumentData
- * @typedef {import('..').FirebaseFirestoreTypes.DocumentReference} DocumentReference
- * @typedef {import('..').FirebaseFirestoreTypes.FieldPath} FieldPath
  * @typedef {import('..').FirebaseFirestoreTypes.Module} Firestore
- * @typedef {import('..').FirebaseFirestoreTypes.Query} Query
- * @typedef {import('..').FirebaseFirestoreTypes.SetOptions} SetOptions
  * @typedef {import('..').FirebaseFirestoreTypes.Settings} FirestoreSettings
- * @typedef {import('..').FirebaseFirestoreTypes.PersistentCacheIndexManager} PersistentCacheIndexManager
+ * @typedef {import('.').AggregateQuerySnapshot} AggregateQuerySnapshot
+ * @typedef {import('.').CollectionReference} CollectionReference
+ * @typedef {import('.').DocumentData} DocumentData
+ * @typedef {import('.').DocumentReference} DocumentReference
+ * @typedef {import('.').FieldPath} FieldPath
+ * @typedef {import('.').PersistentCacheIndexManager} PersistentCacheIndexManager
+ * @typedef {import('.').Query} Query
+ * @typedef {import('.').SetOptions} SetOptions
+ * @typedef {import('.').Transaction} Transaction
+ * @typedef {import('.').WriteBatch} WriteBatch
+
  * @typedef {import('@firebase/app').FirebaseApp} FirebaseApp
  */
 
@@ -43,7 +46,7 @@ export function getFirestore(app, databaseId) {
 }
 
 /**
- * @param {Firestore | CollectionReference | DocumentReference<unknown>} parent
+ * @param {Firestore | CollectionReference | DocumentReference} parent
  * @param {string?} path
  * @param {string?} pathSegments
  * @returns {DocumentReference}
@@ -57,7 +60,7 @@ export function doc(parent, path, ...pathSegments) {
 }
 
 /**
- * @param {Firestore | DocumentReference<unknown> | CollectionReference<unknown>} parent
+ * @param {Firestore | DocumentReference | CollectionReference} parent
  * @param {string} path
  * @param {string?} pathSegments
  * @returns {CollectionReference<DocumentData>}
@@ -230,7 +233,7 @@ export function setLogLevel(logLevel) {
 
 /**
  * @param {Firestore} firestore
- * @param {(transaction: FirebaseFirestoreTypes.Transaction) => Promise} updateFunction
+ * @param {(transaction: Transaction) => Promise} updateFunction
  * @returns {Promise}
  */
 export function runTransaction(firestore, updateFunction) {
@@ -239,7 +242,7 @@ export function runTransaction(firestore, updateFunction) {
 
 /**
  * @param {Query} query
- * @returns {Promise<FirebaseFirestoreTypes.AggregateQuerySnapshot>}
+ * @returns {Promise<AggregateQuerySnapshot>}
  */
 export function getCountFromServer(query) {
   return query.count.call(query, MODULAR_DEPRECATION_ARG).get();
@@ -350,7 +353,7 @@ export function namedQuery(firestore, name) {
 
 /**
  * @param {Firestore} firestore
- * @returns {FirebaseFirestoreTypes.WriteBatch}
+ * @returns {WriteBatch}
  */
 export function writeBatch(firestore) {
   return firestore.batch.call(firestore, MODULAR_DEPRECATION_ARG);

--- a/packages/firestore/lib/modular/query.js
+++ b/packages/firestore/lib/modular/query.js
@@ -1,13 +1,13 @@
 /**
- * @typedef {import('..').FirebaseFirestoreTypes.DocumentReference} DocumentReference
- * @typedef {import('..').FirebaseFirestoreTypes.DocumentSnapshot} DocumentSnapshot
- * @typedef {import('..').FirebaseFirestoreTypes.FieldPath} FieldPath
- * @typedef {import('..').FirebaseFirestoreTypes.QueryCompositeFilterConstraint} QueryCompositeFilterConstraint
- * @typedef {import('..').FirebaseFirestoreTypes.QuerySnapshot} QuerySnapshot
- * @typedef {import('..').FirebaseFirestoreTypes.Query} Query
- * @typedef {import('..').FirebaseFirestoreTypes.WhereFilterOp} WhereFilterOp
  * @typedef {import('../FirestoreFilter')._Filter} _Filter
- * @typedef {import('./query').IQueryConstraint} IQueryConstraint
+ * @typedef {import('.').FieldPath} FieldPath
+ * @typedef {import('.').QueryCompositeFilterConstraint} QueryCompositeFilterConstraint
+ * @typedef {import('.').WhereFilterOp} WhereFilterOp
+ * @typedef {import('.').DocumentReference} DocumentReference
+ * @typedef {import('.').Query} Query
+ * @typedef {import('./snapshot').QuerySnapshot} QuerySnapshot
+ * @typedef {import('./snapshot').DocumentSnapshot} DocumentSnapshot
+ * @typedef {import('./query').QueryConstraint} IQueryConstraint
  * @typedef {import('./query').OrderByDirection} OrderByDirection
  * @typedef {import('./query').QueryFieldFilterConstraint} QueryFieldFilterConstraint
  * @typedef {import('./query').QueryLimitConstraint} QueryLimitConstraint
@@ -168,7 +168,7 @@ export function limitToLast(limit) {
 }
 
 /**
- * @param {DocumentReference} query
+ * @param {DocumentReference} reference
  * @returns {Promise<DocumentSnapshot>}
  */
 export function getDoc(reference) {
@@ -176,7 +176,7 @@ export function getDoc(reference) {
 }
 
 /**
- * @param {DocumentReference} query
+ * @param {DocumentReference} reference
  * @returns {Promise<DocumentSnapshot>}
  */
 export function getDocFromCache(reference) {
@@ -184,7 +184,7 @@ export function getDocFromCache(reference) {
 }
 
 /**
- * @param {DocumentReference} query
+ * @param {DocumentReference} reference
  * @returns {Promise<DocumentSnapshot>}
  */
 export function getDocFromServer(reference) {

--- a/packages/firestore/lib/modular/snapshot.js
+++ b/packages/firestore/lib/modular/snapshot.js
@@ -1,7 +1,6 @@
 /**
- * @typedef {import('../..').FirebaseFirestoreTypes.Query} Query
- * @typedef {import('../..').FirebaseFirestoreTypes.DocumentReference} DocumentReference
- * @typedef {import('snapshot').Unsubscribe} Unsubscribe
+ * @typedef {import('.').Query} Query
+ * @typedef {import('.').DocumentReference} DocumentReference
  */
 
 import { MODULAR_DEPRECATION_ARG } from '@react-native-firebase/app/dist/module/common';

--- a/packages/firestore/lib/utils/index.js
+++ b/packages/firestore/lib/utils/index.js
@@ -130,6 +130,21 @@ export function parseSetOptions(options) {
   return out;
 }
 
+/**
+ * Applies a FirestoreDataConverter to the data object, if converter is provided.
+ *
+ * @param data
+ * @param converter
+ * @param options
+ * @returns Converted data.
+ */
+export function applyFirestoreDataConverter(data, converter, options) {
+  if (converter && converter.toFirestore) {
+    return converter.toFirestore(data, options);
+  }
+  return data;
+}
+
 // function buildFieldPathData(segments, value) {
 //   if (segments.length === 1) {
 //     return {
@@ -242,4 +257,23 @@ export function parseSnapshotArgs(args) {
   }
 
   return { snapshotListenOptions, callback, onNext, onError };
+}
+
+/**
+ * Validates a withConverter object contains both required functions
+ *
+ * @param converter
+ */
+export function validateWithConverter(converter) {
+  if (isUndefined(converter) || !isObject(converter)) {
+    throw new Error('expected an object value.');
+  }
+
+  if (!isFunction(converter.toFirestore)) {
+    throw new Error("'toFirestore' expected a function.");
+  }
+
+  if (!isFunction(converter.fromFirestore)) {
+    throw new Error("'fromFirestore' expected a function.");
+  }
 }


### PR DESCRIPTION
### Description

Hello! I'm sorry for introducing such a large PR, but I hope it's gonna be worth it. 

This PR adds the withCoverter functionality to both the namespace and modular APIs and updates types accordingly.

Both type and e2e tests are a 1:1 copy of the Firebase JS SDK to ensure feature parity.

### Related issues

- Closes #8611 
- Closes #8698 
- Closes #8672
- Closes #8834

### Release Summary

Implements `withConverter` from Firebase JS SDK

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No


:fire:
