### PR TITLE
test(ios): pin xcode to older version / fix perf issue in simulators

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -212,11 +212,14 @@ jobs:
         run: yarn tests:emulator:start-ci
 
       # https://bitrise.io/blog/post/xcode-15-performance-regressions
-      - name: Install yeetd
+      # https://developer.apple.com/forums/thread/805625?answerId=865340022#865340022
+      - name: Install yeetd and fix iOS perf issues
         run: |
           wget https://github.com/biscuitehh/yeetd/releases/download/1.0/yeetd-normal.pkg
           sudo installer -pkg yeetd-normal.pkg -target /
           yeetd &
+          launchctl unload -w /System/Library/LaunchAgents/com.apple.ReportCrash.plist
+          sudo launchctl unload -w /System/Library/LaunchDaemons/com.apple.ReportCrash.Root.plist
 
       - name: Install brew utilities
         uses: nick-fields/retry@v3


### PR DESCRIPTION
### Description

This fixes a CI error with new Xcode present in new github workflow hosted images

For a compatibility reason the macOS 15 image (which are using instead of macos-26 because it had performance issues...) has no simulators defined for xcode-26.1 (currently `xcode-latest`). See https://github.com/actions/runner-images/issues/13275

When the workflows started using xcode-26.1 instead of xcode-26.0.1 as the "latest-stable" tag moved, this caused xcodebuild to fail since there was no valid destination

https://github.com/actions/runner-images/blob/0b19ddce5a417c6624ece7db87263a40b8b9aac6/images/macos/macos-15-arm64-Readme.md?plain=1#L247

### Related issues

Not logged, but visible in CI failures, e.g.

- https://github.com/invertase/react-native-firebase/actions/runs/19244015530/job/55013361809#step:21:37
- and item 3 here https://github.com/invertase/react-native-firebase/pull/8744#issuecomment-3508324731

### Release Summary

test only

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

If this works, tests_e2e_ios will begin passing again
It fails currently

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
