### PR TITLE
fix(auth, ios): append openURL changes only once in Expo plugin

### DIFF
--- a/packages/auth/plugin/src/ios/openUrlFix.ts
+++ b/packages/auth/plugin/src/ios/openUrlFix.ts
@@ -183,6 +183,10 @@ export function modifySwiftAppDelegate(contents: string): string | null {
       return null;
     }
   }
+  const isAlreadyModified = contents.includes(skipOpenUrlForFirebaseAuthBlockSwift);
+  if (isAlreadyModified) {
+    return null;
+  }
   return contents.replace(pattern, `${fullMatch[0]}${skipOpenUrlForFirebaseAuthBlockSwift}\n`);
 }
 


### PR DESCRIPTION

### Description

This is fix for https://github.com/invertase/react-native-firebase/issues/8720 and https://github.com/invertase/react-native-firebase/issues/8718.

Fix behavior when AppDelegate.swift pollute with @react-native-firebase/auth-openURL changes multiple times.

### Related issues

- Fixes #8720
- Fixes #8718

### Release Summary

Fix multiple addition of @react-native-firebase/auth-openURL tag string into AppDelegate.swift by authentication ios plugin.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - Yes
- My change supports the following platforms;
  - [x] `iOS`
- This is a breaking change;
  - [x] No



### Test Plan

Install react-native-firebase packages into Expo app and run npx expo prebuild two times. Check ios directory and it's AppDelegate.swift file that it contains only one copy of this string:

// @generated begin @react-native-firebase/auth-openURL - expo prebuild (DO NOT MODIFY)
    if url.host?.lowercased() == "firebaseauth" {
      // invocations for Firebase Auth are handled elsewhere and should not be forwarded to Expo Router
      return false
    }
// @generated end @react-native-firebase/auth-openURL


