### PR TITLE
fix(firestore): remove inequality filter with orderBy limitation

### DIFF
--- a/packages/firestore/e2e/Query/query.e2e.js
+++ b/packages/firestore/e2e/Query/query.e2e.js
@@ -66,20 +66,88 @@ describe('FirestoreQuery/FirestoreQueryModifiers', function () {
       }
     });
 
-    it('throws if where inequality operator is invoked, and the where fieldPath does not match initial orderBy parameter', async function () {
-      try {
-        firebase
-          .firestore()
-          .collection(COLLECTION)
-          .where('foo', '>', 'bar')
-          .orderBy('bar')
-          .orderBy('foo')
-          .limit(1)
-          .endAt(2);
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql('Invalid query');
-      }
+    it('should allow inequality where fieldPath that does not match initial orderBy parameter', async function () {
+      const colRef = firebase
+        .firestore()
+        // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+        // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+        .collection(`${COLLECTION}/${Utils.randString(12, '#aA')}/order-asc`);
+
+      await colRef.add({ value: 1, foo: 'baz' });
+      await colRef.add({ value: 2, foo: 'bar' });
+      await colRef.add({ value: 3, foo: 'baz' });
+      await colRef.add({ value: 4, foo: 'bar' });
+      await colRef.add({ value: 5, foo: 'baz' });
+
+      const snapshot = await colRef.where('foo', '!=', 'bar').orderBy('value', 'desc').get();
+      const expected = [5, 3, 1];
+
+      snapshot.forEach((docSnap, i) => {
+        docSnap.data().value.should.eql(expected[i]);
+      });
+    });
+
+    it('should allow inequality where fieldPath that does not match initial orderBy parameter - multiple where filters', async function () {
+      const colRef = firebase
+        .firestore()
+        // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+        // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+        .collection(`${COLLECTION}/${Utils.randString(12, '#aA')}/order-asc`);
+
+      await colRef.add({ value: 1, foo: 'baz' });
+      await colRef.add({ value: 2, foo: 'bar' });
+      await colRef.add({ value: 3, foo: 'baz' });
+      await colRef.add({ value: 4, foo: 'bar' });
+      await colRef.add({ value: 5, foo: 'baz' });
+
+      let snapshot = await colRef
+        .where('foo', '!=', 'bar')
+        .where('value', '>', 2)
+        .orderBy('value', 'desc')
+        .get();
+      let expected = [5, 3];
+
+      snapshot.forEach((docSnap, i) => {
+        docSnap.data().value.should.eql(expected[i]);
+      });
+
+      // flipped where order
+      snapshot = await colRef
+        .where('value', '>', 2)
+        .where('foo', '!=', 'bar')
+        .orderBy('value', 'desc')
+        .get();
+      const expected2 = [5, 3];
+
+      snapshot.forEach((docSnap, i) => {
+        docSnap.data().value.should.eql(expected2[i]);
+      });
+    });
+
+    it('should allow multiple inequality where fieldPath with orderBy filters', async function () {
+      const colRef = firebase
+        .firestore()
+        // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+        // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+        .collection(`${COLLECTION}/${Utils.randString(12, '#aA')}/order-asc`);
+
+      await colRef.add({ value: 1, value2: 4 });
+      await colRef.add({ value: 2, value2: 3 });
+      await colRef.add({ value: 3, value2: 2 });
+      await colRef.add({ value: 3, value2: 1 });
+
+      const snapshot = await colRef
+        .where('value', '>', 1)
+        .where('value2', '<', 4)
+        .orderBy('value', 'desc')
+        .orderBy('value2', 'desc')
+        .get();
+
+      const expected = [2, 1, 3];
+
+      snapshot.forEach((docSnap, i) => {
+        docSnap.data().value2.should.eql(expected[i]);
+      });
     });
   });
 
@@ -126,21 +194,100 @@ describe('FirestoreQuery/FirestoreQueryModifiers', function () {
       }
     });
 
-    it('throws if where inequality operator is invoked, and the where fieldPath does not match initial orderBy parameter', async function () {
-      const { getFirestore, collection, query, where, orderBy, limit, endAt } = firestoreModular;
-      try {
-        query(
-          collection(getFirestore(), COLLECTION),
-          where('foo', '>', 'bar'),
-          orderBy('bar'),
-          orderBy('foo'),
-          limit(1),
-          endAt(2),
-        );
-        return Promise.reject(new Error('Did not throw an Error.'));
-      } catch (error) {
-        error.message.should.containEql('Invalid query');
-      }
+    it('should allow inequality where fieldPath that does not match initial orderBy parameter', async function () {
+      const { getFirestore, collection, addDoc, query, where, orderBy, getDocs } = firestoreModular;
+      // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+      // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+      const colRef = collection(
+        getFirestore(),
+        `${COLLECTION}/${Utils.randString(12, '#aA')}/order-asc`,
+      );
+
+      await addDoc(colRef, { value: 1, foo: 'baz' });
+      await addDoc(colRef, { value: 2, foo: 'bar' });
+      await addDoc(colRef, { value: 3, foo: 'baz' });
+      await addDoc(colRef, { value: 4, foo: 'bar' });
+      await addDoc(colRef, { value: 5, foo: 'baz' });
+
+      const q = query(colRef, where('foo', '!=', 'bar'), orderBy('value', 'desc'));
+      const snapshot = await getDocs(q);
+      const expected = [5, 3, 1];
+
+      snapshot.forEach((docSnap, i) => {
+        docSnap.data().value.should.eql(expected[i]);
+      });
+    });
+
+    it('should allow inequality where fieldPath that does not match initial orderBy parameter - multiple where filters', async function () {
+      const { getFirestore, collection, addDoc, query, where, orderBy, getDocs } = firestoreModular;
+      // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+      // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+      const colRef = collection(
+        getFirestore(),
+        `${COLLECTION}/${Utils.randString(12, '#aA')}/order-asc`,
+      );
+
+      await addDoc(colRef, { value: 1, foo: 'baz' });
+      await addDoc(colRef, { value: 2, foo: 'bar' });
+      await addDoc(colRef, { value: 3, foo: 'baz' });
+      await addDoc(colRef, { value: 4, foo: 'bar' });
+      await addDoc(colRef, { value: 5, foo: 'baz' });
+
+      const q = query(
+        colRef,
+        where('foo', '!=', 'bar'),
+        where('value', '>', 2),
+        orderBy('value', 'desc'),
+      );
+      const snapshot = await getDocs(q);
+      const expected = [5, 3];
+
+      snapshot.forEach((docSnap, i) => {
+        docSnap.data().value.should.eql(expected[i]);
+      });
+
+      // flipped where order
+      const q2 = query(
+        colRef,
+        where('value', '>', 2),
+        where('foo', '!=', 'bar'),
+        orderBy('value', 'desc'),
+      );
+      const snapshot2 = await getDocs(q2);
+      const expected2 = [5, 3];
+
+      snapshot2.forEach((docSnap, i) => {
+        docSnap.data().value.should.eql(expected2[i]);
+      });
+    });
+
+    it('should allow multiple inequality where fieldPath with orderBy filters', async function () {
+      const { getFirestore, collection, addDoc, query, where, orderBy, getDocs } = firestoreModular;
+      // Firestore caches aggressively, even if you wipe the emulator, local documents are cached
+      // between runs, so use random collections to make sure `tests:*:test-reuse` works while iterating
+      const colRef = collection(
+        getFirestore(),
+        `${COLLECTION}/${Utils.randString(12, '#aA')}/order-asc`,
+      );
+
+      await addDoc(colRef, { value: 1, value2: 4 });
+      await addDoc(colRef, { value: 2, value2: 3 });
+      await addDoc(colRef, { value: 3, value2: 2 });
+      await addDoc(colRef, { value: 3, value2: 1 });
+
+      const q = query(
+        colRef,
+        where('value', '>', 1),
+        where('value2', '<', 4),
+        orderBy('value', 'desc'),
+        orderBy('value2', 'desc'),
+      );
+      const snapshot = await getDocs(q);
+      const expected = [2, 1, 3];
+
+      snapshot.forEach((docSnap, i) => {
+        docSnap.data().value2.should.eql(expected[i]);
+      });
     });
   });
 });

--- a/packages/firestore/lib/FirestoreQueryModifiers.js
+++ b/packages/firestore/lib/FirestoreQueryModifiers.js
@@ -398,15 +398,6 @@ export default class FirestoreQueryModifiers {
             "Invalid query. Query.where() fieldPath parameter: 'FirestoreFieldPath' cannot be used in conjunction with a different Query.orderBy() parameter",
           );
         }
-
-        if (INEQUALITY[filter.operator]) {
-          // Initial orderBy() parameter has to match every where() fieldPath parameter when inequality operator is invoked
-          if (filterFieldPath !== this._orders[0].fieldPath._toPath()) {
-            throw new Error(
-              `Invalid query. Initial Query.orderBy() parameter: ${orderFieldPath} has to be the same as the Query.where() fieldPath parameter(s): ${filterFieldPath} when an inequality operator is invoked `,
-            );
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
### Description

This PR removes a query modifiers check that is no longer necessary. This check is preventing inequality filters from being combined with `orderBy` filters if they are applied to a different field.

### Related issues

- Fixes #8534
- Fixes #8161

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. 
- This is a breaking change;
  - [ ] Yes
  - [x] No




Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter

🔥 