### PR TITLE
fix(messaging, ios): prioritize delegate call order in willPresentNotification

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -130,8 +130,9 @@ struct {
   if (notification.request.content.userInfo[@"gcm.message_id"]) {
     NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
 
-    // Don't send an event if contentAvailable is true - application:didReceiveRemoteNotification
-    // will send the event for us, we don't want to duplicate them
+    // Don't send an event if contentAvailable is true -
+    // application:didReceiveRemoteNotification will send the event for us, we
+    // don't want to duplicate them
     if (!notificationDict[@"contentAvailable"]) {
       [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
                                                  body:notificationDict];
@@ -143,8 +144,9 @@ struct {
                       willPresentNotification:notification
                         withCompletionHandler:completionHandler];
   }
-  
-  // Don't consume completionHandler before the _originalDelegate has been processed
+
+  // Don't consume completionHandler before the _originalDelegate has been
+  // processed
   completionHandler(presentationOptions);
 }
 


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

This PR fixes an issue where `completionHandler` in `userNotificationCenter:willPresentNotification:withCompletionHandler:` is called before the original delegate, preventing custom foreground notification presentation logic from working.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

- Fixes #8754

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->
Fixed iOS messaging to respect custom notification presentation logic by calling the original delegate before consuming the completionHandler.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

**Tested Scenario:**
1. Implemented custom `willPresentNotification` handler in AppDelegate to control notification presentation
2. Sent FCM notification while app is in foreground
3. Verified custom logic is now executed and controls notification display behavior

**Before Fix:**
- Custom completion handler in AppDelegate was ignored
- Notifications always displayed with library's default options

**After Fix:**
- Custom completion handler in AppDelegate is respected
- Developers can control whether/how to display foreground notifications
- Default behavior preserved when no custom delegate exists

**Code Example Tested:**
```objc
// AppDelegate.m
- (void)userNotificationCenter:(UNUserNotificationCenter *)center
willPresentNotification:(UNNotification *)notification
withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
  // Custom logic to determine notification presentation
  if (shouldShowNotification) {
    completionHandler(UNNotificationPresentationOptionBanner | 
                     UNNotificationPresentationOptionSound);
  } else {
    completionHandler(UNNotificationPresentationOptionNone);
  }
}
```
---