### PR TITLE
fix: Root tsconfig doesn't include anything useful and all type-tests in the repository are broken

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["packages/**/lib/*.d.ts", "packages/**/type-test.ts"],
+  "include": ["packages/**/lib/**/*.d.ts", "packages/**/type-test.ts"],
   "compilerOptions": {
     "noEmit": true,
     "target": "es5",
@@ -18,7 +18,10 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
-    "lib": ["es2015", "es2016", "esnext", "dom"]
+    "lib": ["es2015", "es2016", "esnext", "dom"],
+    "paths": {
+      "@react-native-firebase/*": ["./packages/*/lib/index.d.ts"]
+    }
   },
   "exclude": ["node_modules", "**/*.spec.ts"]
 }


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

I found that all type tests (type-test.ts) in the repository are currently broken and do not test anything useful. I noticed this via intellisense when installing the repo locally to fix some other types: nearly everything is typed as `any`.

### Analysing the problem

Current tsconfig only includes `packages/**/lib/*.d.ts`. (Insight: this doesn't include nested folders underneath lib/) For all the packages I looked at, this only includes the index.d.ts but does not include other type declarations in nested folders. For example, the firestore package has a lot of *.d.ts within the `firestore/lib/modular/` directory.

In most cases, the `lib/index.d.ts` file will import types from those nested directories in the module. `firestore/lib/index.d.ts` imports from `firestore/lib/modular/index.d.ts` for example. However, because those nested directories are not part of the tsconfig, they are treated as external dependencies. This is an issue because skipLibCheck is enabled. skipLibCheck ignores type errors in any external dependency, and changes the errored types to any. Oops, that includes all types from nested files within our modules!

FInally, packages attempt to import each other's types. For example, all modules have `import { ReactNativeFirebase } from '@react-native-firebase/app'` at the top. When installed as a dependency from NPM this is OK, as the imported module will be in node_modules and resolved correctly. However, when running tsc against the repo there's no way for the type checker to resolve these as they are not found in node_modules. You can verify this by checking intellisense in vscode after installing this repo, any time that a package's index.d.ts imports from `@react-native-firebase/*` you will see all the imported types become `any`.

### Solution

I have made these changes:

1. Include *all* .d.ts files nested within each package's lib directory, not only the root.
2. Add a tsconfig `paths` definition to allow the modules to resolve each other when running tsc in the repo.

After this change, the type-test.ts in most packages are broken. That's not caused by this change, in fact the tests are already wrong for many years and have just been masked by the `skipLibCheck` issue (Since #5590 in 2021!!!). For example, most type-tests treat `import firebase from '.'` as both a default import and as a star import, which is likely incorrect.

The bottom line is: if `skipLibCheck` is enabled, it is critically important to include all files you actually want to type check within the scope of a tsconfig.json which is used to run `tsc`. Otherwise they are treated as external deps and aren't checked at all, with all their types silently becoming `any` when unresolved.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

Does not affect any user-facing code. tsc is not used anywhere to compile code (noEmit is set). Just makes the type tests in the repository actually functional. They should be fixed individually later.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
