### PR TITLE
perf(ci): only save ccache on main branch

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -163,6 +163,7 @@ jobs:
         name: Xcode Compile Cache
         with:
           key: ${{ runner.os }}-${{ matrix.buildmode }}-ios-v3 # makes a unique key w/related restore key internally
+          save: "${{ github.ref == 'refs/heads/main' }}"
           create-symlink: true
           max-size: 1500M
 

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -148,6 +148,7 @@ jobs:
         name: Xcode Compile Cache
         with:
           key: ${{ runner.os }}-macos-v2
+          save: "${{ github.ref == 'refs/heads/main' }}"
           create-symlink: true
           max-size: 1500M
 


### PR DESCRIPTION
### Description

prevents LRU eviction thrashing of caches since we are near the limit on useful caches for a single CI run

This is a follow-on to the CI perf tuning PR from a few days back, it was the only thing I noticed that wasn't perfect after merging that one - we are saving lots of ccache's, mostly from branches, and it LRUs out useful main-branch caches

### Related issues

- #8820

### Release Summary

test only, and just perf on test even - no release

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Look at the caches page after this is implemented, and we should no longer see caches from non-branch that start with ccache https://github.com/invertase/react-native-firebase/actions/caches

Additionally, after other branches update to this workflow or run them and it has been a while, we will hopefully stop seeing our cacches expire so frequently - many of them should be pretty long-lived (weeks+, not just hours/days)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
