### PR TITLE
fix(ios): use react-native podspec module infra for deps

### DIFF
--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -29,9 +29,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/app-check/RNFBAppCheck.podspec
+++ b/packages/app-check/RNFBAppCheck.podspec
@@ -29,9 +29,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/app-distribution/RNFBAppDistribution.podspec
+++ b/packages/app-distribution/RNFBAppDistribution.podspec
@@ -27,9 +27,14 @@ Pod::Spec.new do |s|
   s.macos.deployment_target = firebase_macos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -25,7 +25,11 @@ Pod::Spec.new do |s|
   s.source_files        = "ios/**/*.{h,m}"
 
   # React Native dependencies
-  s.dependency          'React-Core'
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if (ENV.include?('FIREBASE_SDK_VERSION'))
     Pod::UI.puts "#{s.name}: Found Firebase SDK version in environment '#{ENV['FIREBASE_SDK_VERSION']}'"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -29,9 +29,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -31,9 +31,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -30,9 +30,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -29,9 +29,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m,mm}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -32,15 +32,14 @@ Pod::Spec.new do |s|
   # Turbo modules require these compiler flags
   s.compiler_flags      = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
-  # Turbo module code generated podspecs
-  s.dependency          'ReactCodegen'
-  s.dependency          'ReactAppDependencyProvider'
-  # Turbo modules requires these dependencies
-  s.dependency          'RCT-Folly'
-  s.dependency          'React-Fabric'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -30,9 +30,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/installations/RNFBInstallations.podspec
+++ b/packages/installations/RNFBInstallations.podspec
@@ -30,9 +30,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -27,10 +27,14 @@ Pod::Spec.new do |s|
   s.macos.deployment_target = firebase_macos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/ml/RNFBML.podspec
+++ b/packages/ml/RNFBML.podspec
@@ -31,9 +31,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -30,9 +30,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -30,9 +30,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -29,9 +29,14 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.source_files        = 'ios/**/*.{h,m}'
 
-  # React Native dependencies
-  s.dependency          'React-Core'
   s.dependency          'RNFBApp'
+
+  # React Native dependencies
+  if defined?(install_modules_dependencies()) != nil
+    install_modules_dependencies(s);
+  else
+    s.dependency "React-Core"
+  end
 
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -1804,76 +1804,376 @@ PODS:
     - Yoga
   - RNDeviceInfo (15.0.1):
     - React-Core
-  - RNFBAnalytics (23.8.1):
+  - RNFBAnalytics (23.8.2):
+    - DoubleConversion
     - FirebaseAnalytics/Core (= 12.8.0)
     - FirebaseAnalytics/IdentitySupport (= 12.8.0)
+    - glog
     - GoogleAdsOnDeviceConversion
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBApp (23.8.1):
+    - Yoga
+  - RNFBApp (23.8.2):
+    - DoubleConversion
     - Firebase/CoreOnly (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
-  - RNFBAppCheck (23.8.1):
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - RNFBAppCheck (23.8.2):
+    - DoubleConversion
     - Firebase/AppCheck (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBAppDistribution (23.8.1):
+    - Yoga
+  - RNFBAppDistribution (23.8.2):
+    - DoubleConversion
     - Firebase/AppDistribution (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBAuth (23.8.1):
+    - Yoga
+  - RNFBAuth (23.8.2):
+    - DoubleConversion
     - Firebase/Auth (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBCrashlytics (23.8.1):
+    - Yoga
+  - RNFBCrashlytics (23.8.2):
+    - DoubleConversion
     - Firebase/Crashlytics (= 12.8.0)
     - FirebaseCoreExtension
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
-    - RNFBApp
-  - RNFBDatabase (23.8.1):
-    - Firebase/Database (= 12.8.0)
-    - React-Core
-    - RNFBApp
-  - RNFBFirestore (23.8.1):
-    - Firebase/Firestore (= 12.8.0)
-    - React-Core
-    - RNFBApp
-  - RNFBFunctions (23.8.1):
-    - Firebase/Functions (= 12.8.0)
-    - RCT-Folly
-    - React-Core
+    - React-debug
     - React-Fabric
-    - ReactAppDependencyProvider
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
     - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBInAppMessaging (23.8.1):
+    - Yoga
+  - RNFBDatabase (23.8.2):
+    - DoubleConversion
+    - Firebase/Database (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNFBApp
+    - Yoga
+  - RNFBFirestore (23.8.2):
+    - DoubleConversion
+    - Firebase/Firestore (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNFBApp
+    - Yoga
+  - RNFBFunctions (23.8.2):
+    - DoubleConversion
+    - Firebase/Functions (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNFBApp
+    - Yoga
+  - RNFBInAppMessaging (23.8.2):
+    - DoubleConversion
     - Firebase/InAppMessaging (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBInstallations (23.8.1):
+    - Yoga
+  - RNFBInstallations (23.8.2):
+    - DoubleConversion
     - Firebase/Installations (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBMessaging (23.8.1):
+    - Yoga
+  - RNFBMessaging (23.8.2):
+    - DoubleConversion
     - Firebase/Messaging (= 12.8.0)
     - FirebaseCoreExtension
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBML (23.8.1):
+    - Yoga
+  - RNFBML (23.8.2):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBPerf (23.8.1):
+    - Yoga
+  - RNFBPerf (23.8.2):
+    - DoubleConversion
     - Firebase/Performance (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBRemoteConfig (23.8.1):
+    - Yoga
+  - RNFBRemoteConfig (23.8.2):
+    - DoubleConversion
     - Firebase/RemoteConfig (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
-  - RNFBStorage (23.8.1):
+    - Yoga
+  - RNFBStorage (23.8.2):
+    - DoubleConversion
     - Firebase/Storage (= 12.8.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - RNFBApp
+    - Yoga
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2300,22 +2600,22 @@ SPEC CHECKSUMS:
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   RNCAsyncStorage: 6a8127b6987dc9fbce778669b252b14c8355c7ce
   RNDeviceInfo: 36d7f232bfe7c9b5c494cb7793230424ed32c388
-  RNFBAnalytics: aa853c9777e919aed30799f32e9942f0df49b31b
-  RNFBApp: 0714f4bf6f309647c61222f5e4281cfc02adefaf
-  RNFBAppCheck: 209fab360e4f07e401605145cde7a1e6c0550d3f
-  RNFBAppDistribution: 29f209f4c949b92d561c587218ac92abf07e411a
-  RNFBAuth: 9695dc9e676ed91ba43a0bcfba45121688cc485c
-  RNFBCrashlytics: e21ba19868de250aae41c3e10e6828f1dc6e73ba
-  RNFBDatabase: f3c731c35161174a46b63bad1c139b3ca4bfe4b2
-  RNFBFirestore: d3728bea3d206815251ffaa46235974ec1bd6aab
-  RNFBFunctions: 241dd16561cc527d4353089bf3118aae39328011
-  RNFBInAppMessaging: ba9df71bc744a16d950fb32d7392f28e2a170814
-  RNFBInstallations: 4598b8eceea7a73e9bfbd211a7fb04ef022f96ae
-  RNFBMessaging: 8b93eab795d79ceec89215fff8d8d5d4d230e594
-  RNFBML: 38034b44067f732977a9b544c28d98c3605fd193
-  RNFBPerf: dc6958b64c6166a31487a930a7d876c4ba06203a
-  RNFBRemoteConfig: cbbd2b7e68a29601dac3e1ce1b3bb8ce3c9b7ad7
-  RNFBStorage: 6409a9507ab74b35ef2303e8c62844c25095d0e4
+  RNFBAnalytics: 6f52cb67a7a7e6d4a9bababd4e3544ff480016b4
+  RNFBApp: 8cfdfb73d4073f9ca83ce1cb53750480652cca64
+  RNFBAppCheck: 5564b6ee1232d554201ae53eea0fbc4455b767c9
+  RNFBAppDistribution: 8a95a968bc5e7053e70c87b6b8f89cd7a267414d
+  RNFBAuth: 35a2d0379b369225514ee4cea7935f498e9ebd24
+  RNFBCrashlytics: a170250e2b35aedd93cb7dbd69b56ae6fff67f74
+  RNFBDatabase: cfcbd1f35df1c0edecc79e3143260ed3963f0c5a
+  RNFBFirestore: d7f9e3b3547608a8fd11aa09237d23f5b7efd5f8
+  RNFBFunctions: 683176a3f3a780f207f365a67f23099468fdb291
+  RNFBInAppMessaging: acfb60bacb29a18e2d0c418287893f797edbbe01
+  RNFBInstallations: 1c4a4a0be5ee1a720b8a8efd94d44ea5de256379
+  RNFBMessaging: a07f01a589fe43ed7995d0d707953adc934905dc
+  RNFBML: 282151ed10cb79998b68196886b0805eef3765c2
+  RNFBPerf: d592301b90bb1a1448bb31fded843a4193187d28
+  RNFBRemoteConfig: 33080141a2d8675fd359f50394893feb185bd033
+  RNFBStorage: e50a8905143fb9ab21f8ab25f68e91fd7c8a0aeb
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 3bb1ee33b5133befbd33872601fa46efdd48e841
 


### PR DESCRIPTION
### Description

the `install_modules_dependencies` method has existed since much longer (specifically, [react-native 0.71](https://github.com/facebook/react-native/commit/82e9c6ad611f1fb816de056ff031716f8cb24b4e)) than our lowest supported react-native version so should be safe to add a call to it in a non-breaking change

the important thing it does is include the correct pods for modules that have been converted to TurboModules, and this fixes compile errors that do not show up on react-native 0.78 but do show up on current react-native

### Related issues

Noticed this while testing fixes for the following related issue - no one else had noticed it there yet, but it was something that broke between 23.7.0 and 23.8.0 with functions converting to TurboModules

- Related #8829 
- Related #8603 

### Release Summary

it is a fix commit, it should generate a new fix version

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

This shows up in https://github.com/mikehardy/rnfbdemo/blob/main/make-demo.sh if you set the react-native-firebase version to 23.8.0 through 23.8.2, but does not show up when using 23.7.0 - indicating it was TurboModules conversion that did it

Some credit to the folks at react-native-gesture-handler (and @j-piasecki @cipolleschi) - search for my compile failure led me to that repo, and as a popular new architecture module it was a good reference to examine their podspec and see their solutions back in time as well as current state of the art

- https://github.com/software-mansion/react-native-gesture-handler/commit/2300af719edd6297ad0c9436fbd6b5d9b4837e02
- https://github.com/software-mansion/react-native-gesture-handler/pull/2653

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
