### PR TITLE
fix(expo): export app.plugin.js entry points for typescript packages

### DIFF
--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -56,6 +56,7 @@
         "default": "./dist/commonjs/index.js"
       }
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "react-native-builder-bob": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -109,6 +109,7 @@
         "default": "./dist/commonjs/common/*"
       }
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "peerDependencies": {

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -63,6 +63,7 @@
         "default": "./dist/commonjs/index.js"
       }
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "react-native-builder-bob": {

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -55,6 +55,7 @@
         "default": "./dist/commonjs/index.js"
       }
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "react-native-builder-bob": {


### PR DESCRIPTION
### Description

The packages migrated to typescript have explicit `exports` statements in package.json which restrict what entry points may be accessed when standard node module resolution rules are followed

Expo config plugins uses a resolver that follows those rules, so it was following the exports declarations that are new in the typescript-migrated packages

Ergo, if we are going to specify exports, we must also specify the expo plugin export, or it can't be resolved via module resolution rules used by expo and the plugin fails to load

### Related issues

- Related #8829 

Not marking it as a "fix" yet because there is still an outstanding issue for other/web reported by a user, but this should fix expo users on android / ios

### Release Summary

fix release commit, should generate a fix release

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No


### Test Plan

I have an almost-completely-working expo build demo of react-native-firebase working now:

https://github.com/mikehardy/rnfbdemo/blob/rnfb-expo-demo/make-expo-demo.sh

Most importantly for this PR, when I got it working to the point where it configured the config plugins, I reproduced the error (as hoped!) that was reported in #8829 

I was able to track it down to the exports fields in the package.json of the migrated packages and verify `expo prebuild` worked correctly via directly manipulating the package.json files in node_modules there, then carried that fix here to this PR

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
