### PR TITLE
test(ci): extract local package creation script

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -59,24 +59,15 @@ jobs:
           # yarn3+ by default disables lockfile alteration in CI. We want it.
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
         run: |
-          PACKAGE_LIST=`find packages -maxdepth 1 -mindepth 1 -type d -exec basename {} \; | egrep -v 'template|invites'`
-          mkdir $HOME/packages
-          for PACKAGE in $PACKAGE_LIST; do
-            echo "Packing PR version of package $PACKAGE"
-            pushd packages/$PACKAGE;
-            yarn pack;
-            mv package.tgz $HOME/packages/react-native-firebase-${PACKAGE}.tgz;
-            ls -la $HOME/packages/*${PACKAGE}*
-            popd;
-          done
-          ls -la $HOME/packages/
+          ./.github/workflows/scripts/create_npm_packages.sh ./packages $HOME/packages
           cd $HOME
           npx @react-native-community/cli init template --skip-install --skip-git-init
           cd template
           yarn
           yarn add patch-package --dev
           mkdir patches || true
-          for PACKAGE in $PACKAGE_LIST; do
+          PACKED_PACKAGE_LIST=`find $HOME/packages/ -maxdepth 1 -mindepth 1 -type f -exec basename -s .tgz {} \; | cut -d'-' -f4-10 | sort`
+          for PACKAGE in $PACKED_PACKAGE_LIST; do
             echo "Installing package $PACKAGE into fresh template app, then clobbering with PR version"
             yarn add @react-native-firebase/$PACKAGE || true
             if [ -d node_modules/@react-native-firebase/$PACKAGE ]; then

--- a/.github/workflows/scripts/create_npm_packages.sh
+++ b/.github/workflows/scripts/create_npm_packages.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+SOURCE_PACKAGE_DIR="$1"
+TARGET_PACKAGE_DIR="$2"
+
+echo "Creating local npm packages from source '${SOURCE_PACKAGE_DIR}' in '${TARGET_PACKAGE_DIR}'..."
+
+# Make sure our target directory exists and is clean from previous runs
+if ! [ -d "${TARGET_PACKAGE_DIR}" ]; then
+  mkdir "${TARGET_PACKAGE_DIR}"
+else
+  rm -f "${TARGET_PACKAGE_DIR}"/*.tgz
+fi
+
+if ! [ -d "${SOURCE_PACKAGE_DIR}" ]; then
+  echo "Source package dir '${SOURCE_PACKAGE_DIR} not found."
+  exit 1;
+fi
+
+# Get our full list of packages, except any we specifically ignore
+IGNORED_PACKAGE_NAMES='template|invites'
+PACKAGE_LIST=`find ${SOURCE_PACKAGE_DIR} -maxdepth 1 -mindepth 1 -type d -exec basename {} \; | egrep -v "${IGNORED_PACKAGE_NAMES}"`
+
+# Pack up each package
+for PACKAGE in $PACKAGE_LIST; do
+  echo "Creating package for $PACKAGE from local source"
+  pushd "${SOURCE_PACKAGE_DIR}/${PACKAGE}";
+  yarn pack;
+  mv package.tgz "${TARGET_PACKAGE_DIR}/react-native-firebase-${PACKAGE}.tgz";
+  ls -la "${TARGET_PACKAGE_DIR}/react-native-firebase-${PACKAGE}.tgz"
+  popd;
+done
+ls -la "${TARGET_PACKAGE_DIR}"


### PR DESCRIPTION
### Description

When we released 23.8.0 we had several problems related to packaging that would have been visible if we ran our tests against locally created packages (as if they were from npmjs.com the way library users consume them) vs our development-style of symlinking the code into the live source tree

This PR will enable us to run tests in sing locally created packages so we should see those problems pre-publish instead of when users notice them and file issues - it is just the first step, the extraction of the local package creation script we already have - for use in local testing

### Related issues

- Related #8829 

### Release Summary

This is a testing PR, no release should happen

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- ✅  test patch-package generation result after abstract the script that creates locally created packages from the patch-package flow by comparing downloaded patches.zip vs expectations
- ❓ either convert all test workflows to run against local packages, or add a matrix where some is symlinked and some is locally created packages, need to check how each work first but not there yet

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
