### PR TITLE
docs: Update App Check provider configuration example

### DIFF
--- a/docs/app-check/usage/index.md
+++ b/docs/app-check/usage/index.md
@@ -177,6 +177,7 @@ To configure the react-native-firebase custom provider, first obtain one, then c
 import { getApp } from '@react-native-firebase/app';
 
 const rnfbProvider = getApp().appCheck().newReactNativeFirebaseAppCheckProvider();
+
 rnfbProvider.configure({
   android: {
     provider: __DEV__ ? 'debug' : 'playIntegrity',


### PR DESCRIPTION
### Description

Since the modular update, the documentation was not reflecting how to instantiate a rnfb provider. 

I figured it out and want to update doc. 

I did not find a getAppCheck() method like the other modules. Was it forgotten? 

### Related issues

No related issues

### Release Summary

Edited the appcheck usage doc. 

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x ] Yes
- This is a breaking change;
  - [ ] Yes
  - [x ] No



### Test Plan
No tests only 2 line of doc. 
