### PR TITLE
Update glob paths for internal and common modules

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -80,11 +80,11 @@
       "source": "./lib/internal/*.ts",
       "import": {
         "types": "./dist/typescript/module/lib/internal/*.d.ts",
-        "default": "./dist/module/internal/*"
+        "default": "./dist/module/internal/*.js"
       },
       "require": {
         "types": "./dist/typescript/commonjs/lib/internal/*.d.ts",
-        "default": "./dist/commonjs/internal/*"
+        "default": "./dist/commonjs/internal/*.js"
       }
     },
     "./lib/common": {
@@ -102,11 +102,11 @@
       "source": "./lib/common/*.ts",
       "import": {
         "types": "./dist/typescript/module/lib/common/*.d.ts",
-        "default": "./dist/module/common/*"
+        "default": "./dist/module/common/*.js"
       },
       "require": {
         "types": "./dist/typescript/commonjs/lib/common/*.d.ts",
-        "default": "./dist/commonjs/common/*"
+        "default": "./dist/commonjs/common/*.js"
       }
     },
     "./app.plugin.js": "./app.plugin.js",


### PR DESCRIPTION
### Description

Fixing the exports problem:
```bash
 WARN  The package [projectURL]/node_modules/@react-native-firebase/app contains an invalid package.json configuration. Consider raising this issue with the package maintainer(s).
Reason: The resolution for "[projectURL]/node_modules/@react-native-firebase/app/lib/internal/nativeModule" defined in "exports" is [projectURL]/node_modules/@react-native-firebase/app/dist/module/internal/nativeModule, however this file does not exist. Falling back to file-based resolution.
 WARN  The package [projectURL]/node_modules/@react-native-firebase/app contains an invalid package.json configuration. Consider raising this issue with the package maintainer(s).
Reason: The resolution for "[projectURL]/node_modules/@react-native-firebase/app/lib/internal/NativeFirebaseError" defined in "exports" is [projectURL]/node_modules/@react-native-firebase/app/dist/module/internal/NativeFirebaseError, however this file does not exist. Falling back to file-based resolution.
 WARN  The package [projectURL]/node_modules/@react-native-firebase/app contains an invalid package.json configuration. Consider raising this issue with the package maintainer(s).
Reason: The resolution for "[projectURL]/node_modules/@react-native-firebase/app/lib/common/deeps" defined in "exports" is [projectURL]/node_modules/@react-native-firebase/app/dist/module/common/deeps, however this file does not exist. Falling back to file-based resolution.
 WARN  The package [projectURL]/node_modules/@react-native-firebase/app contains an invalid package.json configuration. Consider raising this issue with the package maintainer(s).
Reason: The resolution for "[projectURL]/node_modules/@react-native-firebase/app/lib/common/validate" defined in "exports" is [projectURL]/node_modules/@react-native-firebase/app/dist/module/common/validate, however this file does not exist. Falling back to file-based resolution.
 WARN  The package [projectURL]/node_modules/@react-native-firebase/app contains an invalid package.json configuration. Consider raising this issue with the package maintainer(s).
Reason: The resolution for "[projectURL]/node_modules/@react-native-firebase/app/lib/internal/SharedEventEmitter" defined in "exports" is [projectURL]/node_modules/@react-native-firebase/app/dist/module/internal/SharedEventEmitter, however this file does not exist. Falling back to file-based resolution.
```

### Related issues

- Fixes my own issue https://github.com/invertase/react-native-firebase/issues/8853 
- And maybe allows to close https://github.com/invertase/react-native-firebase/issues/8829

### Release Summary

Edition of the two glob path for the common and internal folder.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Did not test i edited the two entries package.json in my personal project directly. 

But after a made the modification I rebuilt both android and apple and all react native firebase functions works now. 

I my simulator i even have AppCheck + expo54 working without problem (problem mentionned here)
https://github.com/invertase/react-native-firebase/issues/8829#issuecomment-3779643944

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
