### PR TITLE
fix(analytics): security_storage is no more a boolean

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -205,7 +205,7 @@ describe('Analytics', function () {
     it('throws if security_storage of consentSettings is not one of granted or denied', function () {
       // @ts-ignore test
       expect(() => firebase.analytics().setConsent({ security_storage: 'invalid' })).toThrow(
-        "'consentSettings' value for parameter 'security_storage' is invalid, expected one of 'granted', 'denied', or 'unknown'.",
+        "'consentSettings' value for parameter 'security_storage' is invalid, expected one of 'granted' or 'denied'.",
       );
     });
 

--- a/packages/analytics/lib/namespaced.ts
+++ b/packages/analytics/lib/namespaced.ts
@@ -277,7 +277,7 @@ class FirebaseAnalyticsModule extends FirebaseModule {
       if (key === 'security_storage') {
         if (!isOneOf(value, ['granted', 'denied'])) {
           throw new Error(
-            `firebase.analytics().setConsent(*) 'consentSettings' value for parameter '${key}' is invalid, expected one of 'granted', 'denied', or 'unknown'.`,
+            `firebase.analytics().setConsent(*) 'consentSettings' value for parameter '${key}' is invalid, expected one of 'granted' or 'denied'.`,
           );
         }
         continue;


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

In the version 23.8.3 of @react-native-firebase/analytics, `security_storage` has been modified from boolean to 'granted' or 'denied' string

so it raises the issue:
`firebase.analytics().setConsent(*) 'consentSettings' value for parameter 'security_storage' is invalid, expected a boolean.`


### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

I have added a jest test case

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
