### PR TITLE
chore: adjust stale issue labels and timing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,14 +25,14 @@ jobs:
 
             Thank you for your contributions.
           stale-pr-message: |
-            Hello 👋, this PR has been opened for more than 2 months with no activity on it.
+            Hello 👋, this PR has been opened for more than 14 days with no activity on it.
 
             If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing!
 
-            You have 15 days until this gets closed automatically
-          exempt-issue-labels: 'Keep Open,Help: Good First Issue,Workflow: Needs Review'
-          exempt-pr-labels: 'Keep Open,Help: Good First Issue,Workflow: Needs Review'
+            You have 7 days until this gets closed automatically
+          exempt-issue-labels: 'Keep Open,Help: Good First Issue,Workflow: Needs Review,Needs Attention'
+          exempt-pr-labels: 'Keep Open,Help: Good First Issue,Workflow: Needs Review,Needs Attention'
           close-issue-reason: not_planned
-          days-before-stale: 28
-          days-before-close: 15
+          days-before-stale: 14
+          days-before-close: 21
           stale-issue-label: 'Stale'


### PR DESCRIPTION

### Description

Updated stale.yml to change inactivity thresholds for PRs and issues.

### Release Summary

`chore` commits do not trigger a release

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Can only see if it works 35 minutes after the hour the first time it runs...

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
