### PR TITLE
fix(app-check): use bridging header instead of Swift module import

### DIFF
--- a/packages/app-check/plugin/src/ios/appDelegate.ts
+++ b/packages/app-check/plugin/src/ios/appDelegate.ts
@@ -83,13 +83,18 @@ export function modifySwiftBridgingHeader(projectRoot: string): void {
     const bridgingHeader = path.join(iosDir, entry.name, `${entry.name}-Bridging-Header.h`);
     if (fs.existsSync(bridgingHeader)) {
       let contents = fs.readFileSync(bridgingHeader, 'utf-8');
-      if (!contents.includes('#import <RNFBAppCheckModule.h>')) {
-        contents += '\n#import <RNFBAppCheckModule.h>\n';
-        fs.writeFileSync(bridgingHeader, contents);
-      }
+      contents = modifySwiftBridgingHeaderContents(contents);
+      fs.writeFileSync(bridgingHeader, contents);
       break;
     }
   }
+}
+
+export function modifySwiftBridgingHeaderContents(contents: string): string {
+  if (!contents.includes('#import <RNFBAppCheckModule.h>')) {
+    contents += '\n#import <RNFBAppCheckModule.h>\n';
+  }
+  return contents;
 }
 
 export function modifySwiftAppDelegate(contents: string): string {


### PR DESCRIPTION
## Summary

The `RNFBAppCheck` pod is an Obj-C static library that doesn't set `DEFINES_MODULE` or include a module map. When projects use `useFrameworks: "static"` (required by `firebase-ios-sdk`), the Expo config plugin's `import RNFBAppCheck` in `AppDelegate.swift` fails with:

```
No such module 'RNFBAppCheck'
```

This is a widely reported issue:
- #8700
- #8757

## Changes

Updates the Expo config plugin (`plugin/src/ios/appDelegate.ts`) to:

1. **Remove** `import RNFBAppCheck` from `AppDelegate.swift` (including cleaning up any previously added imports)
2. **Add** `#import <RNFBAppCheckModule.h>` to the project's bridging header (`ProjectName-Bridging-Header.h`)

The `RNFBAppCheckModule` class is then available to Swift through the bridging header, which is the standard way to consume Obj-C pods without module maps from Swift.

## Why not add `DEFINES_MODULE`?

Adding `DEFINES_MODULE = YES` to the podspec would also fix the Swift import, but would be a larger change affecting all consumers. The bridging header approach is the minimal, targeted fix that matches how the Obj-C path already works (using `#import`).

## Testing

- Verified with `expo prebuild --platform ios --clean` that `import RNFBAppCheck` is removed and bridging header is updated
- Verified `xcodebuild build` succeeds
- Tested with Expo SDK 54, React Native 0.81, `@react-native-firebase/app-check` 23.8.4

Fixes #8700
Fixes #8757