### PR TITLE
fix(analytics, ios): correct hex string to NSData conversion for hashed conversion methods

### DIFF
--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -176,7 +176,7 @@ RCT_EXPORT_METHOD(initiateOnDeviceConversionMeasurementWithHashedEmailAddress
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
   @try {
-    NSData *emailAddress = [hashedEmailAddress dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *emailAddress = [self dataFromHexString:hashedEmailAddress];
     [FIRAnalytics initiateOnDeviceConversionMeasurementWithHashedEmailAddress:emailAddress];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
@@ -203,7 +203,7 @@ RCT_EXPORT_METHOD(initiateOnDeviceConversionMeasurementWithHashedPhoneNumber
                   : (RCTPromiseResolveBlock)resolve rejecter
                   : (RCTPromiseRejectBlock)reject) {
   @try {
-    NSData *phoneNumber = [hashedPhoneNumber dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *phoneNumber = [self dataFromHexString:hashedPhoneNumber];
     [FIRAnalytics initiateOnDeviceConversionMeasurementWithHashedPhoneNumber:phoneNumber];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
@@ -263,6 +263,22 @@ RCT_EXPORT_METHOD(setConsent
 /// @param value Nullable string value
 - (NSString *)convertNSNullToNil:(NSString *)value {
   return [value isEqual:[NSNull null]] ? nil : value;
+}
+
+/// Converts a hex string to NSData
+/// @param hexString A hex string (e.g., SHA256 hash as 64-character hex string)
+/// @return NSData containing the decoded bytes (e.g., 32 bytes for SHA256)
+- (NSData *)dataFromHexString:(NSString *)hexString {
+  NSMutableData *data = [NSMutableData dataWithCapacity:hexString.length / 2];
+  unsigned char wholeByte;
+  char byteChars[3] = {'\0', '\0', '\0'};
+  for (NSUInteger i = 0; i < hexString.length; i += 2) {
+    byteChars[0] = [hexString characterAtIndex:i];
+    byteChars[1] = [hexString characterAtIndex:i + 1];
+    wholeByte = strtol(byteChars, NULL, 16);
+    [data appendBytes:&wholeByte length:1];
+  }
+  return data;
 }
 
 @end


### PR DESCRIPTION
## Description

Fixes incorrect handling of SHA256 hex strings in `initiateOnDeviceConversionMeasurementWithHashedEmailAddress` and `initiateOnDeviceConversionMeasurementWithHashedPhoneNumber` methods.

### Problem

The current implementation uses `dataUsingEncoding:NSUTF8StringEncoding` which treats the hex string as a regular string:

```objc
// Before (incorrect) - produces 64 bytes
NSData *emailAddress = [hashedEmailAddress dataUsingEncoding:NSUTF8StringEncoding];
```

For a SHA256 hex string like `"a1b2c3d4..."`:
- **Current output:** 64 bytes - UTF-8 encoded `[0x61, 0x31, 0x62, 0x32, ...]`
- **Expected output:** 32 bytes - hex-decoded `[0xa1, 0xb2, 0xc3, 0xd4, ...]`

### Solution

Added a helper method `dataFromHexString:` that properly converts hex strings to binary NSData:

```objc
// After (correct) - produces 32 bytes
NSData *emailAddress = [self dataFromHexString:hashedEmailAddress];
```

---

## Related Issues

- Fixes #8869
- Related discussion https://github.com/invertase/react-native-firebase/discussions/8764

---

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective

---

## Testing

### Manual Testing
1. Enable on-device conversion measurement in Podfile:
   ```ruby
   $RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
   ```
2. Call `initiateOnDeviceConversionMeasurementWithHashedEmailAddress` with a SHA256 hex string
3. Verify the native module correctly converts to 32-byte binary data

### Reference
- [Firebase On-Device Conversion Documentation](https://firebase.google.com/docs/tutorials/ads-ios-on-device-measurement/step-3#use-hashed-credentials)

---

🔥