### PR TITLE
fix(app-check): remove ReactNativeFirebaseAppCheckProvider from type-only export

### DIFF
--- a/packages/app-check/lib/index.ts
+++ b/packages/app-check/lib/index.ts
@@ -33,7 +33,6 @@ export type {
   ReactNativeFirebaseAppCheckProviderWebOptions,
   ReactNativeFirebaseAppCheckProviderAppleOptions,
   ReactNativeFirebaseAppCheckProviderAndroidOptions,
-  ReactNativeFirebaseAppCheckProvider,
   AppCheck,
   FirebaseAppCheckTypes,
 } from './types/appcheck';


### PR DESCRIPTION
## Problem

When importing `ReactNativeFirebaseAppCheckProvider` as documented:

```typescript
import { ReactNativeFirebaseAppCheckProvider } from '@react-native-firebase/app-check';

const provider = new ReactNativeFirebaseAppCheckProvider(); // ❌ TS2693
```

TypeScript throws:
> 'ReactNativeFirebaseAppCheckProvider' only refers to a type, but is being used as a value here. (TS2693)

**Note:** This is a different issue from #8512 (TS2614: "has no exported member"), which was fixed by #8529. That PR added the modular exports but kept `ReactNativeFirebaseAppCheckProvider` in the `export type {}` block, causing this new conflict.

## Root Cause

In `packages/app-check/lib/index.ts`:

```typescript
export type {
  // ...
  ReactNativeFirebaseAppCheckProvider,  // ← exported as TYPE
} from './types/appcheck';

export * from './modular';  // ← also exports as VALUE (class)
```

When the same name is exported as both a type (via `export type`) and a value (via `export *`), TypeScript prioritizes the type-only export, making it impossible to use as a constructor.

## Solution

Remove `ReactNativeFirebaseAppCheckProvider` from the `export type {}` block.

The class will still be exported via `export * from './modular'`, and type inference will work correctly.

## Affected Versions

- Tested on `@react-native-firebase/app-check@23.8.5`