### PR TITLE
chore(ci): if new comment posted on closed item, handle differently

### DIFF
--- a/.github/workflows/issue-labels.yaml
+++ b/.github/workflows/issue-labels.yaml
@@ -20,17 +20,29 @@ jobs:
             echo "op_comment=false" >> $GITHUB_ENV
           fi
 
-      - name: Add 'Needs Attention' label if OP responded
-        if: env.op_comment == 'true'
+      - name: Add 'Needs Attention' label if OP responded and it was open
+        if: env.op_comment == 'true' && github.event.issue.state == 'open'
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: 'Needs Attention'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      - name: Remove 'blocked customer-response' label if OP responded
-        if: env.op_comment == 'true'
+
+      - name: Remove 'blocked customer-response' label if OP responded and it was open
+        if: env.op_comment == 'true' && github.event.issue.state == 'open'
         uses: actions-ecosystem/action-remove-labels@v1
         with:
           labels: 'blocked: customer-response'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Add comment if OP responded but issue was closed
+        if: env.op_comment == 'true' && github.event.issue.state == 'closed'
+        uses: actions-ecosystem/action-create-comment@v1
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          body: |
+            In order to prioritize work in this repository, closed issues and pull requests do not regularly receive attention.
+
+            If the underlying issue or pull request still requires attention, opening a new issue with a reproduction
+            after testing with current versions, or reposting the pull request as a new PR may be the most effective way forward.


### PR DESCRIPTION
### Description

If a comment is posted on an issue or pull request that is already closed:

- do not add needs attention label
- note in a comment that closed items may not receive attention


the state of the issue that created the comment should be available at this property reference per https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=created#issue_comment

I believe this is the correct syntax for a multi-part `if:` conditional for a workflow step but needs testing live

### Test Plan

have to merge this to main then add a comment to an issue or PR that I am OP on - one closed and one open in order to observe behavior