### PR TITLE
test(functions): longer delay and function logging for streaming callable

### DIFF
--- a/.github/workflows/scripts/functions/src/testStreamingCallable.ts
+++ b/.github/workflows/scripts/functions/src/testStreamingCallable.ts
@@ -20,7 +20,7 @@ export const testStreamingCallable = onCall(
     for (let i = 0; i < count; i++) {
       // Wait for the specified delay
       await new Promise(resolve => setTimeout(resolve, delay));
-      
+
       if (response) {
         await response.sendChunk({
           index: i,
@@ -31,6 +31,7 @@ export const testStreamingCallable = onCall(
             isEven: i % 2 === 0,
           },
         });
+        logger.info(`testStreamingCallable send chunk ${i + 1}`);
       }
     }
 
@@ -43,10 +44,7 @@ export const testStreamingCallable = onCall(
  * Test streaming callable that sends progressive updates
  */
 export const testProgressStream = onCall(
-  async (
-    req: CallableRequest<{ task?: string }>,
-    response?: CallableResponse<any>,
-  ) => {
+  async (req: CallableRequest<{ task?: string }>, response?: CallableResponse<any>) => {
     const task = req.data.task || 'Processing';
 
     logger.info('testProgressStream called', { task });

--- a/tests/local-tests/functions/streaming-callable.tsx
+++ b/tests/local-tests/functions/streaming-callable.tsx
@@ -26,7 +26,7 @@ export function StreamingCallableTestComponent(): React.JSX.Element {
       addOutput('Starting basic stream test...');
 
       const callable = httpsCallable(functions, 'testStreamingCallable');
-      const { stream, data } = await callable.stream({ count: 5, delay: 500 });
+      const { stream, data } = await callable.stream({ count: 5, delay: 5000 });
 
       for await (const chunk of stream) {
         addOutput(`Chunk: ${JSON.stringify(chunk)}`);


### PR DESCRIPTION

this sets up a reproduction for an issue where streaming callables seem to batch chunks of stream output at the native layer on iOS such that a user of streaming callables on iOS may not get chunks when expected if the chunks are small
