### PR TITLE
docs: remove no-longer-present signatures graphql

### DIFF
--- a/website/src/templates/entity.tsx
+++ b/website/src/templates/entity.tsx
@@ -165,16 +165,6 @@ export const pageQuery = graphql`
         hash
         mdx
         source
-
-        signatures {
-          name
-          description
-          type
-          parameters {
-            type
-            name
-          }
-        }
       }
 
       entities {


### PR DESCRIPTION

### Description

after merge of firestore conversion it appears there are no more typescript types that have the signatures block for use in the old graphql used to build reference docs via gatsby

remove the block and the website builds again

### Related issues

- This PR is where it broke #8892 

### Release Summary

shouldn't trigger a release but looking at the generated reference docs on the PR build in vercel will be instructive

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Check the Vercel deployment to see if it still looks "okay", where "okay" is not that great since the old reference site generator finds the new typescript modules impenetrable, c.f.:

- #8858 

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
