### PR TITLE
feat(firestore): add support for local source snapshot listeners

### DIFF
--- a/.github/scripts/compare-types/packages/firestore/config.ts
+++ b/.github/scripts/compare-types/packages/firestore/config.ts
@@ -141,12 +141,6 @@ const config: PackageConfig = {
         'as setIndexConfiguration is not supported.',
     },
     {
-      name: 'ListenSource',
-      reason:
-        'Union type for snapshot listener source (default, server, cache). ' +
-        'Not yet implemented in RN Firebase; listeners always use default behaviour.',
-    },
-    {
       name: 'MemoryCacheSettings',
       reason:
         'Configuration interface for the memory local cache. The local cache ' +
@@ -319,12 +313,6 @@ const config: PackageConfig = {
         '`_offlineComponentProvider` members that are not part of the ' +
         'firebase-js-sdk public type. These are structural artifacts of the ' +
         'RN implementation.',
-    },
-    {
-      name: 'SnapshotListenOptions',
-      reason:
-        'The firebase-js-sdk includes an optional `source` property (of type ' +
-        '`ListenSource`) which is not yet supported in RN Firebase.',
     },
     // --- Wrapper classes (same public API, different structure: getters vs properties, readonly, toJSON/fromJSON) ---
     {

--- a/.github/scripts/compare-types/src/index.ts
+++ b/.github/scripts/compare-types/src/index.ts
@@ -9,7 +9,8 @@
  *
  * Exit codes:
  *   0 — all differences are documented in the package config files
- *   1 — undocumented differences found (or a required file is missing)
+ *   1 — undocumented differences, stale registry entries in config (resolved
+ *       APIs still listed as missing/extra/different), or a required file missing
  */
 
 import fs from 'fs';

--- a/.github/scripts/compare-types/src/report.ts
+++ b/.github/scripts/compare-types/src/report.ts
@@ -49,13 +49,70 @@ function printSection(
 }
 
 // ---------------------------------------------------------------------------
+// Stale registry (documented differences that no longer apply)
+// ---------------------------------------------------------------------------
+
+function countStale(result: ComparisonResult): number {
+  return (
+    result.staleConfigMissing.length +
+    result.staleConfigExtra.length +
+    result.staleConfigDifferentShape.length
+  );
+}
+
+/**
+ * Prints stale `config.ts` entries and returns how many were printed.
+ * These must run even when there are zero live diffs, otherwise a resolved
+ * API (e.g. an export removed from `missingInRN` in reality) would never
+ * force updating the comparison registry.
+ */
+function printStaleRegistrySection(result: ComparisonResult): number {
+  const totalStale = countStale(result);
+  if (totalStale === 0) {
+    return 0;
+  }
+
+  console.log(`\n  ${c(RED, `Stale registry / config entries`)} (${totalStale}):`);
+
+  for (const name of result.staleConfigMissing) {
+    console.log(
+      `${c(RED, '  ✗')} ${c(BOLD, name)}${c(RED, ' [STALE missingInRN]')}${c(
+        DIM,
+        `  — ${name} exists in React Native Firebase but is still listed under missingInRN in config.ts; remove it or reclassify (e.g. differentShape) if types still differ.`,
+      )}`,
+    );
+  }
+
+  for (const name of result.staleConfigExtra) {
+    console.log(
+      `${c(RED, '  ✗')} ${c(BOLD, name)}${c(RED, ' [STALE extraInRN]')}${c(
+        DIM,
+        `  — ${name} is no longer an extra export in React Native Firebase but is still listed under extraInRN; remove from config.ts.`,
+      )}`,
+    );
+  }
+
+  for (const name of result.staleConfigDifferentShape) {
+    console.log(
+      `${c(RED, '  ✗')} ${c(BOLD, name)}${c(RED, ' [STALE differentShape]')}${c(
+        DIM,
+        `  — ${name} now matches the firebase-js-sdk shape; remove from differentShape in config.ts.`,
+      )}`,
+    );
+  }
+
+  return totalStale;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
 /**
  * Print a human-readable report to stdout.
  *
- * @returns `true` if there are any undocumented differences (CI failure).
+ * @returns `true` if there are undocumented differences or stale registry
+ *          entries (CI failure).
  */
 export function printReport(results: ComparisonResult[]): boolean {
   console.log(
@@ -72,9 +129,20 @@ export function printReport(results: ComparisonResult[]): boolean {
       result.extra.length +
       result.differentShape.length;
 
-    if (totalDiffs === 0) {
+    const totalStale = countStale(result);
+
+    if (totalDiffs === 0 && totalStale === 0) {
       console.log(c(GREEN, '  ✓ No differences found'));
       continue;
+    }
+
+    if (totalDiffs === 0 && totalStale > 0) {
+      console.log(
+        c(
+          GREEN,
+          '  ✓ Exported types match the firebase-js-sdk snapshot (no live diffs)',
+        ),
+      );
     }
 
     // --- Missing ---
@@ -117,25 +185,7 @@ export function printReport(results: ComparisonResult[]): boolean {
       );
     }
 
-    // --- Stale config entries ---
-    const totalStale =
-      result.staleConfigMissing.length +
-      result.staleConfigExtra.length +
-      result.staleConfigDifferentShape.length;
-
-    if (totalStale > 0) {
-      const staleNames = [
-        ...result.staleConfigMissing,
-        ...result.staleConfigExtra,
-        ...result.staleConfigDifferentShape,
-      ];
-      console.log(`\n  ${c(RED, `Stale config entries`)} (${totalStale}):`);
-      for (const name of staleNames) {
-        console.log(
-          `${c(RED, '  ✗')} ${c(BOLD, name)}${c(RED, ' [STALE]')}${c(DIM, '  — now matches the firebase-js-sdk; remove from config.ts')}`,
-        );
-      }
-    }
+    const printedStale = printStaleRegistrySection(result);
 
     // --- Summary ---
     const totalUndoc =
@@ -143,16 +193,19 @@ export function printReport(results: ComparisonResult[]): boolean {
       result.undocumentedExtra.length +
       result.undocumentedDifferentShape.length;
 
-    if (totalUndoc > 0 || totalStale > 0) {
+    if (totalUndoc > 0 || printedStale > 0) {
       hasFailures = true;
       if (totalUndoc > 0) {
         console.log(
           `\n  ${c(RED, `✗ ${totalUndoc} undocumented difference(s) — add them to config.ts with a reason`)}`,
         );
       }
-      if (totalStale > 0) {
+      if (printedStale > 0) {
         console.log(
-          `\n  ${c(RED, `✗ ${totalStale} stale config entry/entries — remove them from config.ts`)}`,
+          `\n  ${c(
+            RED,
+            `✗ ${printedStale} stale registry entry/entries — update packages/<name>/config.ts for the type comparison tool`,
+          )}`,
         );
       }
     } else {

--- a/packages/firestore/__tests__/firestore.test.ts
+++ b/packages/firestore/__tests__/firestore.test.ts
@@ -7,6 +7,7 @@ import FirebaseModule from '../../app/lib/internal/FirebaseModule';
 import Query from '../lib/FirestoreQuery';
 // @ts-ignore test
 import FirestoreDocumentSnapshot from '../lib/FirestoreDocumentSnapshot';
+import { parseSnapshotArgs } from '../lib/utils';
 // @ts-ignore test
 import * as nativeModule from '@react-native-firebase/app/dist/module/internal/nativeModuleAndroidIos';
 
@@ -497,6 +498,35 @@ describe('Firestore', function () {
 
           expect(nullIndexManager).toBeNull();
         });
+      });
+    });
+
+    describe('onSnapshot()', function () {
+      it("accepts { source: 'cache' } listener options", function () {
+        const parsed = parseSnapshotArgs([{ source: 'cache' }, () => {}]);
+
+        expect(parsed.snapshotListenOptions).toEqual({
+          includeMetadataChanges: false,
+          source: 'cache',
+        });
+      });
+
+      it("accepts { source: 'default', includeMetadataChanges: true } listener options", function () {
+        const parsed = parseSnapshotArgs([
+          { source: 'default', includeMetadataChanges: true },
+          () => {},
+        ]);
+
+        expect(parsed.snapshotListenOptions).toEqual({
+          includeMetadataChanges: true,
+          source: 'default',
+        });
+      });
+
+      it("throws for unsupported listener source value 'server'", function () {
+        expect(() =>
+          parseSnapshotArgs([{ source: 'server' as 'default' | 'cache' }, () => {}]),
+        ).toThrow("'options' SnapshotOptions.source must be one of 'default' or 'cache'.");
       });
     });
   });

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -347,6 +347,8 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       int listenerId,
       ReadableMap listenerOptions) {
     MetadataChanges metadataChanges;
+    SnapshotListenOptions.Builder snapshotListenOptionsBuilder =
+        new SnapshotListenOptions.Builder();
 
     if (listenerOptions != null
         && listenerOptions.hasKey("includeMetadataChanges")
@@ -354,6 +356,15 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       metadataChanges = MetadataChanges.INCLUDE;
     } else {
       metadataChanges = MetadataChanges.EXCLUDE;
+    }
+    snapshotListenOptionsBuilder.setMetadataChanges(metadataChanges);
+
+    if (listenerOptions != null
+        && listenerOptions.hasKey("source")
+        && "cache".equals(listenerOptions.getString("source"))) {
+      snapshotListenOptionsBuilder.setSource(ListenSource.CACHE);
+    } else {
+      snapshotListenOptionsBuilder.setSource(ListenSource.DEFAULT);
     }
 
     final EventListener<QuerySnapshot> listener =
@@ -371,7 +382,7 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
         };
 
     ListenerRegistration listenerRegistration =
-        firestoreQuery.query.addSnapshotListener(metadataChanges, listener);
+        firestoreQuery.query.addSnapshotListener(snapshotListenOptionsBuilder.build(), listener);
 
     collectionSnapshotListeners.put(listenerId, listenerRegistration);
   }

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -78,18 +78,27 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
           }
         };
 
-    MetadataChanges metadataChanges;
+    SnapshotListenOptions.Builder snapshotListenOptionsBuilder =
+        new SnapshotListenOptions.Builder();
 
     if (listenerOptions != null
         && listenerOptions.hasKey("includeMetadataChanges")
         && listenerOptions.getBoolean("includeMetadataChanges")) {
-      metadataChanges = MetadataChanges.INCLUDE;
+      snapshotListenOptionsBuilder.setMetadataChanges(MetadataChanges.INCLUDE);
     } else {
-      metadataChanges = MetadataChanges.EXCLUDE;
+      snapshotListenOptionsBuilder.setMetadataChanges(MetadataChanges.EXCLUDE);
+    }
+
+    if (listenerOptions != null
+        && listenerOptions.hasKey("source")
+        && "cache".equals(listenerOptions.getString("source"))) {
+      snapshotListenOptionsBuilder.setSource(ListenSource.CACHE);
+    } else {
+      snapshotListenOptionsBuilder.setSource(ListenSource.DEFAULT);
     }
 
     ListenerRegistration listenerRegistration =
-        documentReference.addSnapshotListener(metadataChanges, listener);
+        documentReference.addSnapshotListener(snapshotListenOptionsBuilder.build(), listener);
 
     documentSnapshotListeners.put(listenerId, listenerRegistration);
   }

--- a/packages/firestore/e2e/DocumentReference/onSnapshot.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/onSnapshot.e2e.js
@@ -16,7 +16,7 @@
  */
 const COLLECTION = 'firestore';
 const NO_RULE_COLLECTION = 'no_rules';
-const { wipe } = require('../helpers');
+const { wipe, setDocumentOutOfBand } = require('../helpers');
 
 describe('firestore().doc().onSnapshot()', function () {
   before(function () {
@@ -302,6 +302,108 @@ describe('firestore().doc().onSnapshot()', function () {
           "'options' SnapshotOptions.includeMetadataChanges must be a boolean value",
         );
         return Promise.resolve();
+      }
+    });
+
+    it("throws if SnapshotListenerOptions.source is invalid ('server')", function () {
+      try {
+        firebase.firestore().doc(`${NO_RULE_COLLECTION}/nope`).onSnapshot({
+          source: 'server',
+        });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql(
+          "'options' SnapshotOptions.source must be one of 'default' or 'cache'",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('accepts source-only SnapshotListenerOptions', async function () {
+      if (Platform.other) {
+        return;
+      }
+      const callback = sinon.spy();
+      const unsub = firebase.firestore().doc(`${COLLECTION}/source-only`).onSnapshot(
+        {
+          source: 'cache',
+        },
+        callback,
+      );
+
+      await Utils.spyToBeCalledOnceAsync(callback);
+      unsub();
+    });
+
+    it('accepts source + includeMetadataChanges SnapshotListenerOptions', async function () {
+      if (Platform.other) {
+        return;
+      }
+      const callback = sinon.spy();
+      const unsub = firebase.firestore().doc(`${COLLECTION}/source-with-metadata`).onSnapshot(
+        {
+          source: 'default',
+          includeMetadataChanges: true,
+        },
+        callback,
+      );
+
+      await Utils.spyToBeCalledOnceAsync(callback);
+      unsub();
+    });
+
+    it('cache source listeners ignore out-of-band server writes', async function () {
+      if (Platform.other) {
+        return;
+      }
+
+      const docPath = `${COLLECTION}/${Utils.randString(12, '#aA')}`;
+      const docRef = firebase.firestore().doc(docPath);
+      await docRef.set({ value: 1 });
+      await docRef.get();
+
+      const callback = sinon.spy();
+      const unsub = docRef.onSnapshot({ source: 'cache' }, callback);
+      try {
+        await Utils.spyToBeCalledOnceAsync(callback);
+
+        await setDocumentOutOfBand(docPath, { value: 2 });
+        await Utils.sleep(1500);
+        callback.should.be.callCount(1);
+
+        await docRef.set({ value: 3 });
+        await Utils.spyToBeCalledTimesAsync(callback, 2);
+        callback.args[1][0].get('value').should.equal(3);
+      } finally {
+        unsub();
+      }
+    });
+
+    it('default source listeners receive out-of-band server writes', async function () {
+      if (Platform.other) {
+        return;
+      }
+
+      const docPath = `${COLLECTION}/${Utils.randString(12, '#aA')}`;
+      const docRef = firebase.firestore().doc(docPath);
+      await docRef.set({ value: 1 });
+      await docRef.get();
+
+      const callback = sinon.spy();
+      const unsub = docRef.onSnapshot(
+        { source: 'default', includeMetadataChanges: true },
+        callback,
+      );
+      try {
+        await Utils.spyToBeCalledOnceAsync(callback);
+
+        await setDocumentOutOfBand(docPath, { value: 2 });
+        await Utils.spyToBeCalledTimesAsync(callback, 2, 8000);
+
+        const latestSnapshot = callback.args[callback.callCount - 1][0];
+        latestSnapshot.get('value').should.equal(2);
+      } finally {
+        unsub();
       }
     });
 
@@ -614,6 +716,58 @@ describe('firestore().doc().onSnapshot()', function () {
         );
         return Promise.resolve();
       }
+    });
+
+    it("throws if SnapshotListenerOptions.source is invalid ('server')", function () {
+      const { getFirestore, doc, onSnapshot } = firestoreModular;
+      try {
+        onSnapshot(doc(getFirestore(), `${NO_RULE_COLLECTION}/nope`), {
+          source: 'server',
+        });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql(
+          "'options' SnapshotOptions.source must be one of 'default' or 'cache'",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('accepts source-only SnapshotListenerOptions', async function () {
+      if (Platform.other) {
+        return;
+      }
+      const { getFirestore, doc, onSnapshot } = firestoreModular;
+      const callback = sinon.spy();
+      const unsub = onSnapshot(
+        doc(getFirestore(), `${COLLECTION}/mod-source-only`),
+        {
+          source: 'cache',
+        },
+        callback,
+      );
+
+      await Utils.spyToBeCalledOnceAsync(callback);
+      unsub();
+    });
+
+    it('accepts source + includeMetadataChanges SnapshotListenerOptions', async function () {
+      if (Platform.other) {
+        return;
+      }
+      const { getFirestore, doc, onSnapshot } = firestoreModular;
+      const callback = sinon.spy();
+      const unsub = onSnapshot(
+        doc(getFirestore(), `${COLLECTION}/mod-source-with-metadata`),
+        {
+          source: 'default',
+          includeMetadataChanges: true,
+        },
+        callback,
+      );
+
+      await Utils.spyToBeCalledOnceAsync(callback);
+      unsub();
     });
 
     it('throws if next callback is invalid', function () {

--- a/packages/firestore/e2e/Query/onSnapshot.e2e.js
+++ b/packages/firestore/e2e/Query/onSnapshot.e2e.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-const { wipe } = require('../helpers');
+const { wipe, setDocumentOutOfBand } = require('../helpers');
 const COLLECTION = 'firestore';
 const NO_RULE_COLLECTION = 'no_rules';
 
@@ -316,6 +316,69 @@ describe('firestore().collection().onSnapshot()', function () {
           "'options' SnapshotOptions.includeMetadataChanges must be a boolean value",
         );
         return Promise.resolve();
+      }
+    });
+
+    it("throws if SnapshotListenerOptions.source is invalid ('server')", function () {
+      try {
+        firebase.firestore().collection(NO_RULE_COLLECTION).onSnapshot({
+          source: 'server',
+        });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql(
+          "'options' SnapshotOptions.source must be one of 'default' or 'cache'",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it('cache source query listeners ignore out-of-band server writes', async function () {
+      if (Platform.other) {
+        return;
+      }
+
+      const collectionPath = `${COLLECTION}/${Utils.randString(12, '#aA')}/cache-source`;
+      const colRef = firebase.firestore().collection(collectionPath);
+      await colRef.doc('one').set({ enabled: true });
+      await colRef.get();
+
+      const callback = sinon.spy();
+      const unsub = colRef.onSnapshot({ source: 'cache' }, callback);
+      try {
+        await Utils.spyToBeCalledOnceAsync(callback);
+        await setDocumentOutOfBand(`${collectionPath}/server-write`, { enabled: false });
+        await Utils.sleep(1500);
+        callback.should.be.callCount(1);
+
+        await colRef.doc('local-write').set({ enabled: true });
+        await Utils.spyToBeCalledTimesAsync(callback, 2);
+      } finally {
+        unsub();
+      }
+    });
+
+    it('default source query listeners receive out-of-band server writes', async function () {
+      if (Platform.other) {
+        return;
+      }
+
+      const collectionPath = `${COLLECTION}/${Utils.randString(12, '#aA')}/cache-source-meta`;
+      const colRef = firebase.firestore().collection(collectionPath);
+      await colRef.doc('one').set({ enabled: true });
+      await colRef.get();
+
+      const callback = sinon.spy();
+      const unsub = colRef.onSnapshot(
+        { source: 'default', includeMetadataChanges: true },
+        callback,
+      );
+      try {
+        await Utils.spyToBeCalledOnceAsync(callback);
+        await setDocumentOutOfBand(`${collectionPath}/server-write`, { enabled: false });
+        await Utils.spyToBeCalledTimesAsync(callback, 2, 8000);
+      } finally {
+        unsub();
       }
     });
 
@@ -632,6 +695,21 @@ describe('firestore().collection().onSnapshot()', function () {
       } catch (error) {
         error.message.should.containEql(
           "'options' SnapshotOptions.includeMetadataChanges must be a boolean value",
+        );
+        return Promise.resolve();
+      }
+    });
+
+    it("throws if SnapshotListenerOptions.source is invalid ('server')", function () {
+      const { getFirestore, collection, onSnapshot } = firestoreModular;
+      try {
+        onSnapshot(collection(getFirestore(), NO_RULE_COLLECTION), {
+          source: 'server',
+        });
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.message.should.containEql(
+          "'options' SnapshotOptions.source must be one of 'default' or 'cache'",
         );
         return Promise.resolve();
       }

--- a/packages/firestore/e2e/helpers.js
+++ b/packages/firestore/e2e/helpers.js
@@ -44,6 +44,73 @@ exports.wipe = async function wipe(debug = false, databaseId = '(default)') {
   }
 };
 
+function toFirestoreValue(value) {
+  if (value === null) {
+    return { nullValue: null };
+  }
+
+  if (Array.isArray(value)) {
+    return { arrayValue: { values: value.map(toFirestoreValue) } };
+  }
+
+  if (typeof value === 'boolean') {
+    return { booleanValue: value };
+  }
+
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) {
+      return { integerValue: String(value) };
+    }
+    return { doubleValue: value };
+  }
+
+  if (typeof value === 'string') {
+    return { stringValue: value };
+  }
+
+  if (typeof value === 'object') {
+    const fields = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      fields[key] = toFirestoreValue(nestedValue);
+    }
+    return { mapValue: { fields } };
+  }
+
+  throw new Error(`Unsupported Firestore REST value type: ${typeof value}`);
+}
+
+exports.setDocumentOutOfBand = async function setDocumentOutOfBand(
+  path,
+  data,
+  databaseId = '(default)',
+) {
+  const url =
+    `http://${getE2eEmulatorHost()}:8080/v1/projects/` +
+    getE2eTestProject() +
+    `/databases/${databaseId}/documents/${path}`;
+
+  const fields = {};
+  for (const [key, value] of Object.entries(data)) {
+    fields[key] = toFirestoreValue(value);
+  }
+
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: 'Bearer owner',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ fields }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Unable to set out-of-band firestore document: ${response.status} ${body}`);
+  }
+
+  return response.json();
+};
+
 exports.BUNDLE_QUERY_NAME = 'named-bundle-test';
 exports.BUNDLE_COLLECTION = 'firestore-bundle-tests';
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
@@ -23,8 +23,6 @@
 #import "RNFBFirestoreCommon.h"
 #import "RNFBFirestoreSerialize.h"
 
-static NSString *const KEY_INCLUDE_METADATA_CHANGES = @"includeMetadataChanges";
-
 @interface RNFBFirestoreCollectionModule : NSObject <RCTBridgeModule>
 
 @end

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -387,8 +387,12 @@ RCT_EXPORT_METHOD(collectionGet
                    listenerId:(nonnull NSNumber *)listenerId
               listenerOptions:(NSDictionary *)listenerOptions {
   BOOL includeMetadataChanges = NO;
+  FIRListenSource source = FIRListenSourceDefault;
   if (listenerOptions[KEY_INCLUDE_METADATA_CHANGES] != nil) {
     includeMetadataChanges = [listenerOptions[KEY_INCLUDE_METADATA_CHANGES] boolValue];
+  }
+  if ([listenerOptions[KEY_SOURCE] isEqualToString:@"cache"]) {
+    source = FIRListenSourceCache;
   }
 
   __weak RNFBFirestoreCollectionModule *weakSelf = self;
@@ -412,9 +416,11 @@ RCT_EXPORT_METHOD(collectionGet
     }
   };
 
-  id<FIRListenerRegistration> listener = [[firestoreQuery instance]
-      addSnapshotListenerWithIncludeMetadataChanges:includeMetadataChanges
-                                           listener:listenerBlock];
+  FIRSnapshotListenOptions *snapshotListenOptions = [[[[FIRSnapshotListenOptions alloc] init]
+      optionsWithIncludeMetadataChanges:includeMetadataChanges] optionsWithSource:source];
+  id<FIRListenerRegistration> listener =
+      [[firestoreQuery instance] addSnapshotListenerWithOptions:snapshotListenOptions
+                                                       listener:listenerBlock];
   collectionSnapshotListeners[listenerId] = listener;
 }
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
@@ -19,6 +19,9 @@
 #import <Firebase/Firebase.h>
 #import <React/RCTBridgeModule.h>
 
+static NSString *const KEY_INCLUDE_METADATA_CHANGES = @"includeMetadataChanges";
+static NSString *const KEY_SOURCE = @"source";
+
 @interface RNFBFirestoreCommon : NSObject
 
 + (dispatch_queue_t)getFirestoreQueue;

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -97,13 +97,19 @@ RCT_EXPORT_METHOD(documentOnSnapshot
   };
 
   BOOL includeMetadataChanges = NO;
-  if (listenerOptions[@"includeMetadataChanges"] != nil) {
-    includeMetadataChanges = [listenerOptions[@"includeMetadataChanges"] boolValue];
+  FIRListenSource source = FIRListenSourceDefault;
+  if (listenerOptions[KEY_INCLUDE_METADATA_CHANGES] != nil) {
+    includeMetadataChanges = [listenerOptions[KEY_INCLUDE_METADATA_CHANGES] boolValue];
+  }
+  if ([listenerOptions[KEY_SOURCE] isEqualToString:@"cache"]) {
+    source = FIRListenSourceCache;
   }
 
+  FIRSnapshotListenOptions *snapshotListenOptions = [[[[FIRSnapshotListenOptions alloc] init]
+      optionsWithIncludeMetadataChanges:includeMetadataChanges] optionsWithSource:source];
   id<FIRListenerRegistration> listener =
-      [documentReference addSnapshotListenerWithIncludeMetadataChanges:includeMetadataChanges
-                                                              listener:listenerBlock];
+      [documentReference addSnapshotListenerWithOptions:snapshotListenOptions
+                                               listener:listenerBlock];
   documentSnapshotListeners[listenerId] = listener;
 }
 

--- a/packages/firestore/lib/FirestoreDocumentReference.ts
+++ b/packages/firestore/lib/FirestoreDocumentReference.ts
@@ -38,7 +38,7 @@ import type DocumentSnapshot from './FirestoreDocumentSnapshot';
 import type { FirestoreInternal, FirestoreSyncEventBodyInternal } from './types/internal';
 import type { DocumentSnapshotNativeData } from './FirestoreDocumentSnapshot';
 import type FirestorePath from './FirestorePath';
-import type { DocumentData, FirestoreDataConverter } from './types/firestore';
+import type { DocumentData, FirestoreDataConverter, ListenSource } from './types/firestore';
 
 let FirestoreCollectionReference:
   | (new (
@@ -201,7 +201,7 @@ export default class DocumentReference<
   }
 
   onSnapshot(...args: unknown[]): () => void {
-    let snapshotListenOptions: { includeMetadataChanges?: boolean };
+    let snapshotListenOptions: { includeMetadataChanges?: boolean; source?: ListenSource };
     let callback: (
       snapshot: DocumentSnapshot<AppModelType, DbModelType> | null,
       error: Error | null,

--- a/packages/firestore/lib/FirestoreQuery.ts
+++ b/packages/firestore/lib/FirestoreQuery.ts
@@ -34,7 +34,7 @@ import QuerySnapshot, { type QuerySnapshotNativeData } from './FirestoreQuerySna
 import { parseSnapshotArgs, validateWithConverter } from './utils';
 
 import type FirestorePath from './FirestorePath';
-import type { DocumentData, FirestoreDataConverter } from './types/firestore';
+import type { DocumentData, FirestoreDataConverter, ListenSource } from './types/firestore';
 import type {
   FirestoreInternal,
   DocumentFieldValueInternal,
@@ -349,7 +349,7 @@ export default class Query<
   }
 
   onSnapshot(...args: unknown[]): () => void {
-    let snapshotListenOptions: { includeMetadataChanges?: boolean };
+    let snapshotListenOptions: { includeMetadataChanges?: boolean; source?: ListenSource };
     let callback: (
       snapshot: QuerySnapshot<AppModelType, DbModelType> | null,
       error: Error | null,

--- a/packages/firestore/lib/types/firestore.ts
+++ b/packages/firestore/lib/types/firestore.ts
@@ -201,8 +201,17 @@ export type QueryConstraintType =
   | 'endAt'
   | 'endBefore';
 
+/**
+ * Describe the source a query listens to.
+ *
+ * Set to `default` to listen to both cache and server changes. Set to `cache`
+ * to listen to changes in cache only.
+ */
+export type ListenSource = 'default' | 'cache';
+
 export interface SnapshotListenOptions {
   readonly includeMetadataChanges?: boolean;
+  readonly source?: ListenSource;
 }
 
 /**

--- a/packages/firestore/lib/types/internal.ts
+++ b/packages/firestore/lib/types/internal.ts
@@ -36,6 +36,7 @@ import type {
   WithFieldValue,
   AggregateType,
   PartialWithFieldValue,
+  ListenSource,
 } from './firestore';
 import type { PersistentCacheIndexManager } from '../FirestorePersistentCacheIndexManager';
 import type { QueryConstraint } from '../modular/query';
@@ -357,9 +358,10 @@ export interface FirestorePipelineSnapshotInternal {
   executionTime: FirestorePipelineTimestampInternal;
 }
 
-/** Options for snapshot listeners (includeMetadataChanges). */
+/** Options for snapshot listeners (includeMetadataChanges, source). */
 export interface FirestoreSnapshotListenOptionsInternal {
   includeMetadataChanges?: boolean;
+  source?: ListenSource;
 }
 
 /** Settings state on the Firestore module instance (ignoreUndefinedProperties, persistence). */

--- a/packages/firestore/lib/types/namespaced.ts
+++ b/packages/firestore/lib/types/namespaced.ts
@@ -16,6 +16,7 @@
  */
 
 import { ReactNativeFirebase } from '@react-native-firebase/app';
+import type { ListenSource } from './firestore';
 
 /**
  * Firebase Cloud Firestore package for React Native.
@@ -489,7 +490,7 @@ export namespace FirebaseFirestoreTypes {
      * ```js
      * const unsubscribe = firebase.firestore().doc('users/alovelace')
      *   .onSnapshot(
-     *     { includeMetadataChanges: true }, // SnapshotListenerOptions
+     *     { source: 'cache', includeMetadataChanges: true }, // SnapshotListenerOptions
      *     (documentSnapshot) => {}, // onNext
      *     (error) => console.error(error), // onError
      *   );
@@ -1354,7 +1355,7 @@ export namespace FirebaseFirestoreTypes {
      * ```js
      * const unsubscribe = firebase.firestore().collection('users')
      *   .onSnapshot(
-     *     { includeMetadataChanges: true }, // SnapshotListenerOptions
+     *     { source: 'cache', includeMetadataChanges: true }, // SnapshotListenerOptions
      *     (querySnapshot) => {}, // onNext
      *     (error) => console.error(error), // onError
      *   );
@@ -1762,7 +1763,11 @@ export namespace FirebaseFirestoreTypes {
     /**
      * Include a change even if only the metadata of the query or of a document changed. Default is false.
      */
-    includeMetadataChanges: boolean;
+    includeMetadataChanges?: boolean;
+    /**
+     * Set the source the query listens to. Default is 'default'.
+     */
+    source?: ListenSource;
   }
 
   /**

--- a/packages/firestore/lib/utils/index.ts
+++ b/packages/firestore/lib/utils/index.ts
@@ -31,6 +31,7 @@ import type {
   PartialSnapshotObserverInternal,
 } from '../types/internal';
 import FieldPath, { fromDotSeparatedString } from '../FieldPath';
+import type { ListenSource } from '../types/firestore';
 
 export function extractFieldPathData(data: unknown, segments: string[]): unknown {
   if (!isObject(data)) {
@@ -151,7 +152,10 @@ function isPartialObserver(
 }
 
 export interface ParseSnapshotArgsResult {
-  snapshotListenOptions: { includeMetadataChanges?: boolean };
+  snapshotListenOptions: {
+    includeMetadataChanges?: boolean;
+    source?: ListenSource;
+  };
   callback: (snapshot: unknown, error: Error | null) => void;
   onNext: (snapshot: unknown) => void;
   onError: (error: Error) => void;
@@ -163,7 +167,10 @@ export function parseSnapshotArgs(args: unknown[]): ParseSnapshotArgsResult {
   }
 
   const NOOP = (): void => {};
-  const snapshotListenOptions: { includeMetadataChanges?: boolean } = {};
+  const snapshotListenOptions: {
+    includeMetadataChanges?: boolean;
+    source?: ListenSource;
+  } = {};
   let callback: (snapshot: unknown, error: Error | null) => void = NOOP;
   let onError: (error: Error) => void = NOOP;
   let onNext: (snapshot: unknown) => void = NOOP;
@@ -189,9 +196,10 @@ export function parseSnapshotArgs(args: unknown[]): ParseSnapshotArgsResult {
   }
 
   if (isObject(args[0]) && !isPartialObserver(args[0])) {
-    const opts = args[0] as { includeMetadataChanges?: boolean };
+    const opts = args[0] as { includeMetadataChanges?: boolean; source?: ListenSource };
     snapshotListenOptions.includeMetadataChanges =
       opts.includeMetadataChanges == null ? false : opts.includeMetadataChanges;
+    snapshotListenOptions.source = opts.source == null ? 'default' : opts.source;
     if (isFunction(args[1])) {
       if (isFunction(args[2])) {
         onNext = args[1] as (snapshot: unknown) => void;
@@ -214,6 +222,12 @@ export function parseSnapshotArgs(args: unknown[]): ParseSnapshotArgsResult {
   if (hasOwnProperty(snapshotListenOptions, 'includeMetadataChanges')) {
     if (!isBoolean(snapshotListenOptions.includeMetadataChanges)) {
       throw new Error("'options' SnapshotOptions.includeMetadataChanges must be a boolean value.");
+    }
+  }
+
+  if (hasOwnProperty(snapshotListenOptions, 'source')) {
+    if (snapshotListenOptions.source !== 'default' && snapshotListenOptions.source !== 'cache') {
+      throw new Error("'options' SnapshotOptions.source must be one of 'default' or 'cache'.");
     }
   }
 

--- a/packages/firestore/type-test.ts
+++ b/packages/firestore/type-test.ts
@@ -310,9 +310,7 @@ const nsDocRef = nsColl.doc('alice');
 const nsQuery = nsColl.where('name', '==', 'test');
 
 nsDocRef.set({ name: 'Alice', count: 1 }).then(() => {});
-nsDocRef
-  .set({ name: 'Alice' }, { merge: true })
-  .then(() => {});
+nsDocRef.set({ name: 'Alice' }, { merge: true }).then(() => {});
 
 nsDocRef.update({ count: 2 }).then(() => {});
 nsDocRef.update('count', 3).then(() => {});
@@ -358,6 +356,10 @@ const unsubDoc2 = nsDocRef.onSnapshot(
   { includeMetadataChanges: true },
   (_snap: FirebaseFirestoreTypes.DocumentSnapshot) => {},
 );
+const unsubDoc4 = nsDocRef.onSnapshot(
+  { source: 'cache' },
+  (_snap: FirebaseFirestoreTypes.DocumentSnapshot) => {},
+);
 const unsubDoc3 = nsDocRef.onSnapshot({
   next: (_snap: FirebaseFirestoreTypes.DocumentSnapshot) => {},
   error: (_e: Error) => {},
@@ -365,6 +367,7 @@ const unsubDoc3 = nsDocRef.onSnapshot({
 unsubDoc1();
 unsubDoc2();
 unsubDoc3();
+unsubDoc4();
 
 // ----- onSnapshot (query) -----
 const unsubQuery1 = nsQuery.onSnapshot((snap: FirebaseFirestoreTypes.QuerySnapshot) => {
@@ -374,8 +377,13 @@ const unsubQuery2 = nsQuery.onSnapshot(
   { includeMetadataChanges: true },
   { next: (_snap: FirebaseFirestoreTypes.QuerySnapshot) => {}, error: (_e: Error) => {} },
 );
+const unsubQuery3 = nsQuery.onSnapshot(
+  { source: 'cache', includeMetadataChanges: true },
+  { next: (_snap: FirebaseFirestoreTypes.QuerySnapshot) => {}, error: (_e: Error) => {} },
+);
 unsubQuery1();
 unsubQuery2();
+unsubQuery3();
 
 // ----- Query: where, orderBy, limit, cursor -----
 const nsQuery2 = nsColl
@@ -397,13 +405,15 @@ console.log(nsLoadTask.then(() => {}));
 const nsNamed = nsFirestore.namedQuery('my-query');
 console.log(nsNamed);
 
-nsFirestore.runTransaction(async (tx: FirebaseFirestoreTypes.Transaction) => {
-  const snap = await tx.get(nsDocRef);
-  if (snap.exists()) {
-    tx.update(nsDocRef, { count: ((snap.data() as { count?: number })?.count ?? 0) + 1 });
-  }
-  return null;
-}).then(() => {});
+nsFirestore
+  .runTransaction(async (tx: FirebaseFirestoreTypes.Transaction) => {
+    const snap = await tx.get(nsDocRef);
+    if (snap.exists()) {
+      tx.update(nsDocRef, { count: ((snap.data() as { count?: number })?.count ?? 0) + 1 });
+    }
+    return null;
+  })
+  .then(() => {});
 
 // ----- Firestore instance: persistence and network -----
 nsFirestore.clearPersistence().then(() => {});
@@ -448,13 +458,15 @@ const nsArrayRemove = firebase.firestore.FieldValue.arrayRemove(1);
 void nsArrayRemove;
 const nsIncrement = firebase.firestore.FieldValue.increment(1);
 
-nsDocRef.set({
-  name: 'x',
-  deleted: nsDelete,
-  ts: nsServerTs,
-  arr: nsArrayUnion,
-  cnt: nsIncrement,
-}).then(() => {});
+nsDocRef
+  .set({
+    name: 'x',
+    deleted: nsDelete,
+    ts: nsServerTs,
+    arr: nsArrayUnion,
+    cnt: nsIncrement,
+  })
+  .then(() => {});
 
 // ----- withConverter (namespaced) -----
 interface User {
@@ -644,15 +656,23 @@ deleteDoc(modDoc).then(() => {});
 // ----- onSnapshot (modular) -----
 const unsubMod1 = onSnapshot(modDoc, snap => snap.data());
 const unsubMod2 = onSnapshot(modDoc, { includeMetadataChanges: true }, snap => snap.data());
+const unsubMod5 = onSnapshot(modDoc, { source: 'cache' }, snap => snap.data());
 const unsubMod3 = onSnapshot(modDoc, {
   next: _snap => {},
   error: (_e: Error) => {},
 });
 const unsubMod4 = onSnapshot(modQuery1, snap => snap.docs);
+const unsubMod6 = onSnapshot(
+  modQuery1,
+  { source: 'cache', includeMetadataChanges: true },
+  snap => snap.docs,
+);
 unsubMod1();
 unsubMod2();
 unsubMod3();
 unsubMod4();
+unsubMod5();
+unsubMod6();
 
 // ----- snapshotEqual, queryEqual -----
 getDoc(modDoc).then(s1 => {


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

### Related issues

- Fixes #8126
<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

Adds the ability to specify the source ('cache'/'default') for snapshot listeners.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

New tests added for functionality.
All tests for both platforms passing.

<img width="905" height="735" alt="Screenshot 2026-03-12 at 17 45 47" src="https://github.com/user-attachments/assets/52797c43-6985-442e-9b74-c95b8f05a657" />



🔥

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Firestore listener behavior on both Android and iOS by wiring a new `source` option into native `addSnapshotListener` APIs, which could affect realtime update delivery and caching semantics. Coverage is improved with new unit and e2e tests, but it still touches core data subscription paths.
> 
> **Overview**
> Adds support for specifying snapshot listener `source` (`'default'` or `'cache'`) for `DocumentReference.onSnapshot` and `Query.onSnapshot` across the JS, Android, and iOS layers.
> 
> Updates JS/TS types and argument parsing (`SnapshotListenOptions`, new `ListenSource`) to validate and default the option, and updates native modules to build `SnapshotListenOptions`/`FIRSnapshotListenOptions` with the requested source. Expands Jest/type tests and adds emulator e2e coverage (including out-of-band server writes) to verify cache-only vs default listener behavior, and tightens the type-compare tooling to fail on *stale* registry/config entries (with clearer reporting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7541dec0fa07ce2b3f0f513a1a62e466a20d547d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->