### PR TITLE
feat(ios): add SPM dependency resolution support alongside CocoaPods

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -75,9 +75,13 @@ jobs:
             // we want to test debug and release - they generate different code
             let buildmode = ['debug', 'release'];
 
+            // Test both SPM and CocoaPods dependency resolution modes
+            let depResolution = ['spm', 'cocoapods'];
+
             return {
               "iteration": iterationArray,
-              "buildmode": buildmode
+              "buildmode": buildmode,
+              "dep-resolution": depResolution
             }
       - name: Debug Output
         run: echo "${{ steps.build-matrix.outputs.result }}"
@@ -85,7 +89,7 @@ jobs:
   # This uses the matrix generated from the matrix-prep stage
   # it will run unit tests on whatever OS combinations are desired
   ios:
-    name: iOS (${{ matrix.buildmode }}, ${{ matrix.iteration }})
+    name: iOS (${{ matrix.buildmode }}, ${{ matrix.dep-resolution }}, ${{ matrix.iteration }})
     runs-on: macos-15
     needs: matrix_prep
     # TODO matrix across APIs, at least 11 and 15 (lowest to highest)
@@ -182,7 +186,7 @@ jobs:
       - uses: hendrikmuhs/ccache-action@v1
         name: Xcode Compile Cache
         with:
-          key: ${{ runner.os }}-${{ matrix.buildmode }}-ios-v3 # makes a unique key w/related restore key internally
+          key: ${{ runner.os }}-${{ matrix.buildmode }}-${{ matrix.dep-resolution }}-ios-v3 # makes a unique key w/related restore key internally
           save: "${{ github.ref == 'refs/heads/main' }}"
           create-symlink: true
           max-size: 1500M
@@ -214,8 +218,24 @@ jobs:
         continue-on-error: true
         with:
           path: tests/ios/Pods
-          key: ${{ runner.os }}-ios-pods-v3-${{ hashFiles('tests/ios/Podfile.lock') }}
-          restore-keys: ${{ runner.os }}-ios-pods-v3
+          key: ${{ runner.os }}-ios-pods-v3-${{ matrix.dep-resolution }}-${{ hashFiles('tests/ios/Podfile.lock') }}
+          restore-keys: ${{ runner.os }}-ios-pods-v3-${{ matrix.dep-resolution }}
+
+      - name: Configure Dependency Resolution Mode
+        run: |
+          if [[ "${{ matrix.dep-resolution }}" == "cocoapods" ]]; then
+            echo "Configuring CocoaPods-only mode (disabling SPM)"
+            # Insert $RNFirebaseDisableSPM flag and switch to static linkage
+            cd tests/ios
+            sed -i '' "s/^linkage = 'dynamic'/linkage = 'static'/" Podfile
+            sed -i '' "/^platform :ios/i\\
+            \$RNFirebaseDisableSPM = true" Podfile
+            # Remove SWIFT_ENABLE_EXPLICIT_MODULES override (not needed without SPM)
+            sed -i '' "/SWIFT_ENABLE_EXPLICIT_MODULES/d" Podfile
+            echo "Podfile configured for CocoaPods-only mode"
+          else
+            echo "Using default SPM mode (dynamic linkage)"
+          fi
 
       - name: Pod Install
         uses: nick-fields/retry@v3

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -52,6 +52,8 @@ jobs:
           retry_wait_seconds: 60
           max_attempts: 3
           command: yarn
+      - name: Test Firebase SPM Helper
+        run: ruby packages/app/__tests__/firebase_spm_test.rb
       - name: Jest
         run: yarn tests:jest-coverage
       - uses: codecov/codecov-action@v5

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -45,24 +46,31 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'FirebaseAnalytics/Core', firebase_sdk_version
-  if defined?($RNFirebaseAnalyticsWithoutAdIdSupport) && ($RNFirebaseAnalyticsWithoutAdIdSupport == true)
-    Pod::UI.puts "#{s.name}: Not installing FirebaseAnalytics/IdentitySupport Pod, no IDFA will be collected."
-  else
-    if !defined?($RNFirebaseAnalyticsWithoutAdIdSupport)
-      Pod::UI.puts "#{s.name}: Using FirebaseAnalytics/IdentitySupport with Ad Ids. May require App Tracking Transparency. Not allowed for Kids apps."
-      Pod::UI.puts "#{s.name}: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids."
-    end
-    s.dependency          'FirebaseAnalytics/IdentitySupport', firebase_sdk_version
+  # Analytics has conditional dependencies that vary between SPM and CocoaPods.
+  # SPM: FirebaseAnalytics includes ad ID support by default.
+  # CocoaPods: IdentitySupport is a separate subspec controlled by $RNFirebaseAnalyticsWithoutAdIdSupport.
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseAnalytics'], 'FirebaseAnalytics/Core')
 
-    # Special pod for on-device conversion
-    if defined?($RNFirebaseAnalyticsEnableAdSupport) && ($RNFirebaseAnalyticsEnableAdSupport == true)
-      Pod::UI.puts "#{s.name}: Adding Apple AdSupport.framework dependency for optional analytics features"
-      s.frameworks =       'AdSupport'
+  unless defined?(spm_dependency)
+    # CocoaPods-only: conditional IdentitySupport subspec
+    if defined?($RNFirebaseAnalyticsWithoutAdIdSupport) && ($RNFirebaseAnalyticsWithoutAdIdSupport == true)
+      Pod::UI.puts "#{s.name}: Not installing FirebaseAnalytics/IdentitySupport Pod, no IDFA will be collected."
+    else
+      if !defined?($RNFirebaseAnalyticsWithoutAdIdSupport)
+        Pod::UI.puts "#{s.name}: Using FirebaseAnalytics/IdentitySupport with Ad Ids. May require App Tracking Transparency. Not allowed for Kids apps."
+        Pod::UI.puts "#{s.name}: You may set variable `$RNFirebaseAnalyticsWithoutAdIdSupport=true` in Podfile to use analytics without ad ids."
+      end
+      s.dependency          'FirebaseAnalytics/IdentitySupport', firebase_sdk_version
     end
   end
 
-  # Special pod for on-device conversion
+  # AdSupport framework (works with both SPM and CocoaPods)
+  if defined?($RNFirebaseAnalyticsEnableAdSupport) && ($RNFirebaseAnalyticsEnableAdSupport == true)
+    Pod::UI.puts "#{s.name}: Adding Apple AdSupport.framework dependency for optional analytics features"
+    s.frameworks =       'AdSupport'
+  end
+
+  # GoogleAdsOnDeviceConversion (CocoaPods only, not available in firebase-ios-sdk SPM)
   if defined?($RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion) && ($RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion == true)
     Pod::UI.puts "#{s.name}: GoogleAdsOnDeviceConversion pod added"
     s.dependency          'GoogleAdsOnDeviceConversion'

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseAnalytics;
+#endif
 #import <React/RCTUtils.h>
 
 #if __has_include(<RNFBAnalytics/RNFBAnalytics-Swift.h>)

--- a/packages/app-check/RNFBAppCheck.podspec
+++ b/packages/app-check/RNFBAppCheck.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -44,7 +45,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/AppCheck', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseAppCheck'], 'Firebase/AppCheck')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
@@ -15,8 +15,15 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
-#import <FirebaseAppCheck/FIRAppCheck.h>
+#elif __has_include(<FirebaseAppCheck/FirebaseAppCheck.h>)
+#import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseAppCheck/FirebaseAppCheck.h>
+#else
+@import FirebaseCore;
+@import FirebaseAppCheck;
+#endif
 
 #import <React/RCTUtils.h>
 

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.h
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.h
@@ -15,8 +15,15 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
-#import <FirebaseAppCheck/FIRAppCheck.h>
+#elif __has_include(<FirebaseAppCheck/FirebaseAppCheck.h>)
+#import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseAppCheck/FirebaseAppCheck.h>
+#else
+@import FirebaseCore;
+@import FirebaseAppCheck;
+#endif
 
 @interface RNFBAppCheckProvider : NSObject <FIRAppCheckProvider>
 

--- a/packages/app-distribution/RNFBAppDistribution.podspec
+++ b/packages/app-distribution/RNFBAppDistribution.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -42,7 +43,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/AppDistribution', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseAppDistribution-Beta'], 'Firebase/AppDistribution')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
+++ b/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseAppDistribution;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -36,6 +36,64 @@ yarn add @react-native-firebase/app
 
 - [Utils](https://rnfirebase.io/app/utils)
 
+## iOS Dependency Resolution: SPM vs CocoaPods
+
+Starting with React Native >= 0.75, `@react-native-firebase` supports **Swift Package Manager (SPM)** for resolving Firebase iOS SDK dependencies. SPM is enabled by default — no configuration needed.
+
+### How it works
+
+Each RNFB module uses `firebase_dependency()` (defined in `firebase_spm.rb`) to declare its Firebase dependencies. This helper automatically chooses between:
+
+| Condition | Resolution | When to use |
+|-----------|-----------|-------------|
+| React Native >= 0.75 and `$RNFirebaseDisableSPM` **not set** | **SPM** (default) | Dynamic linkage (`use_frameworks! :linkage => :dynamic`) |
+| `$RNFirebaseDisableSPM = true` in Podfile | **CocoaPods** | Static linkage or projects that need CocoaPods-only resolution |
+| React Native < 0.75 | **CocoaPods** (automatic fallback) | Older React Native versions without `spm_dependency` support |
+
+### Configuration
+
+**Option A — SPM (default, recommended for Xcode 26+)**
+
+No changes needed. Just make sure your Podfile uses dynamic linkage:
+
+```ruby
+# Podfile
+use_frameworks! :linkage => :dynamic
+```
+
+> **Xcode 26 note:** If you see build errors about `FirebaseCoreInternal` or `FirebaseSharedSwift`
+> module resolution, add this to your Podfile `post_install`:
+> ```ruby
+> config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
+> ```
+> This does NOT disable SPM — it only tells the Swift compiler to use implicit module discovery
+> (the Xcode 16 default) so transitive SPM targets are resolved automatically.
+
+**Option B — CocoaPods only**
+
+Add this line at the top of your Podfile (before any `target` block):
+
+```ruby
+# Podfile
+$RNFirebaseDisableSPM = true
+```
+
+This forces all RNFB modules to use traditional `s.dependency` CocoaPods declarations.
+You can use either static or dynamic linkage with this option.
+
+### How to verify
+
+During `pod install`, you will see messages indicating which resolution mode is active:
+
+```
+# SPM mode:
+[react-native-firebase] RNFBApp: Using SPM for Firebase dependency resolution (products: FirebaseCore)
+[react-native-firebase] RNFBAuth: Using SPM for Firebase dependency resolution (products: FirebaseAuth)
+
+# CocoaPods mode:
+[react-native-firebase] RNFBApp: SPM disabled ($RNFirebaseDisableSPM = true), using CocoaPods for Firebase dependencies
+```
+
 ## License
 
 - See [LICENSE](/LICENSE)

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -1,5 +1,6 @@
 require 'json'
 require './firebase_json'
+require './firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 firebase_sdk_version = package['sdkVersions']['ios']['firebase']
 firebase_ios_target = package['sdkVersions']['ios']['iosTarget']
@@ -61,7 +62,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/CoreOnly', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseCore'], 'Firebase/CoreOnly')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/app/__tests__/README.md
+++ b/packages/app/__tests__/README.md
@@ -1,0 +1,29 @@
+## Firebase SPM dependency tests
+
+Unit tests for `firebase_spm.rb` — the shared helper that declares Firebase dependencies with SPM support and CocoaPods fallback.
+
+### How to run
+
+```bash
+ruby __tests__/firebase_spm_test.rb
+```
+
+### What is `Pod::Specification` and why is it mocked?
+
+`Pod::Specification` is the core CocoaPods class — it's the `s` object used inside every `.podspec` file to declare things like `s.dependency`, `s.name`, `s.version`, etc. We mock it with a simple class that records `dependency` calls, so we can run the tests without installing CocoaPods.
+
+### Test flow
+
+1. A mock `Pod::Specification` captures `dependency` calls.
+2. `firebase_dependency()` is called with known inputs (version, SPM products, CocoaPods pods).
+3. Assertions verify which path executed and with what arguments.
+
+### Tests
+
+| Test | What it verifies | Path | Flow |
+|------|-----------------|------|------|
+| `test_cocoapods_single_pod` | When SPM is not available, a single Firebase pod (like Auth) is added as a CocoaPods dependency with the correct name and version. | CocoaPods | `spm_dependency` undefined → `spec.dependency('Firebase/Auth', '12.10.0')` called once |
+| `test_cocoapods_multiple_pods` | When SPM is not available and a module needs multiple pods (like Crashlytics + CoreExtension), all of them are added as CocoaPods dependencies. | CocoaPods | `spm_dependency` undefined → `spec.dependency` called twice (Crashlytics + CoreExtension) |
+| `test_spm_single_product` | When SPM is available, the Firebase dependency is declared via Swift Package Manager instead of CocoaPods, using the correct URL, version, and product name. | SPM | `spm_dependency` defined → called with `['FirebaseAuth']`, `spec.dependency` not called |
+| `test_spm_multiple_products_ignores_cocoapods_extras` | When SPM is available, only the SPM product names are used. Extra CocoaPods-only dependencies (like FirebaseCoreExtension) are correctly ignored because SPM resolves them automatically as transitive dependencies. | SPM | `spm_dependency` defined → called with `['FirebaseCrashlytics']` only, ignores CocoaPods extras |
+| `test_reads_spm_url_from_package_json` | The Firebase SPM repository URL is read from `package.json` instead of being hardcoded, ensuring a single source of truth for the SDK location. | Config | `$firebase_spm_url` reads from `package.json` → `https://github.com/firebase/firebase-ios-sdk.git` |

--- a/packages/app/__tests__/firebase_spm_test.rb
+++ b/packages/app/__tests__/firebase_spm_test.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'json'
+
+# Mock Pod::Specification to capture dependency calls
+class MockSpec
+  attr_reader :dependencies
+
+  def initialize
+    @dependencies = []
+  end
+
+  def dependency(name, version)
+    @dependencies << { name: name, version: version }
+  end
+end
+
+class FirebaseSpmTest < Minitest::Test
+  def setup
+    # Reset global state before each test
+    $firebase_spm_url = nil
+    # Remove spm_dependency if defined from a previous test
+    if defined?(spm_dependency)
+      Object.send(:remove_method, :spm_dependency)
+    end
+  end
+
+  def load_firebase_spm
+    # Force re-evaluation of the file
+    load File.join(__dir__, '..', 'firebase_spm.rb')
+  end
+
+  # ── CocoaPods path (spm_dependency NOT defined) ──
+
+  def test_cocoapods_single_pod
+    load_firebase_spm
+
+    spec = MockSpec.new
+    firebase_dependency(spec, '12.10.0', ['FirebaseAuth'], 'Firebase/Auth')
+
+    assert_equal 1, spec.dependencies.length
+    assert_equal 'Firebase/Auth', spec.dependencies[0][:name]
+    assert_equal '12.10.0', spec.dependencies[0][:version]
+  end
+
+  def test_cocoapods_multiple_pods
+    load_firebase_spm
+
+    spec = MockSpec.new
+    firebase_dependency(spec, '12.10.0',
+      ['FirebaseCrashlytics'],
+      ['Firebase/Crashlytics', 'FirebaseCoreExtension']
+    )
+
+    assert_equal 2, spec.dependencies.length
+    assert_equal 'Firebase/Crashlytics', spec.dependencies[0][:name]
+    assert_equal 'FirebaseCoreExtension', spec.dependencies[1][:name]
+    spec.dependencies.each do |dep|
+      assert_equal '12.10.0', dep[:version]
+    end
+  end
+
+  # ── SPM path (spm_dependency IS defined) ──
+
+  def test_spm_single_product
+    # Define spm_dependency mock to capture the call
+    spm_calls = []
+    Object.define_method(:spm_dependency) do |spec, **kwargs|
+      spm_calls << { spec: spec, **kwargs }
+    end
+
+    load_firebase_spm
+
+    spec = MockSpec.new
+    firebase_dependency(spec, '12.10.0', ['FirebaseAuth'], 'Firebase/Auth')
+
+    # CocoaPods dependency should NOT be called
+    assert_equal 0, spec.dependencies.length
+
+    # SPM dependency should be called with correct params
+    assert_equal 1, spm_calls.length
+    call = spm_calls[0]
+    assert_equal spec, call[:spec]
+    assert_equal 'https://github.com/firebase/firebase-ios-sdk.git', call[:url]
+    assert_equal({ kind: 'upToNextMajorVersion', minimumVersion: '12.10.0' }, call[:requirement])
+    assert_equal ['FirebaseAuth'], call[:products]
+  end
+
+  def test_spm_multiple_products_ignores_cocoapods_extras
+    spm_calls = []
+    Object.define_method(:spm_dependency) do |spec, **kwargs|
+      spm_calls << { spec: spec, **kwargs }
+    end
+
+    load_firebase_spm
+
+    spec = MockSpec.new
+    # Crashlytics: SPM only needs FirebaseCrashlytics, CocoaPods needs 2 pods
+    firebase_dependency(spec, '12.10.0',
+      ['FirebaseCrashlytics'],
+      ['Firebase/Crashlytics', 'FirebaseCoreExtension']
+    )
+
+    # CocoaPods not called
+    assert_equal 0, spec.dependencies.length
+
+    # SPM called with only the SPM products (no FirebaseCoreExtension)
+    assert_equal 1, spm_calls.length
+    assert_equal ['FirebaseCrashlytics'], spm_calls[0][:products]
+  end
+
+  # ── URL from package.json ──
+
+  def test_reads_spm_url_from_package_json
+    load_firebase_spm
+
+    assert_equal 'https://github.com/firebase/firebase-ios-sdk.git', $firebase_spm_url
+  end
+end

--- a/packages/app/firebase_spm.rb
+++ b/packages/app/firebase_spm.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+#
+# Copyright (c) 2016-present Invertase Limited & Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this library except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'json'
+
+# Read Firebase SPM URL from app package.json (single source of truth)
+$firebase_spm_url ||= begin
+  app_package_path = File.join(__dir__, 'package.json')
+  app_package = JSON.parse(File.read(app_package_path))
+  app_package['sdkVersions']['ios']['firebaseSpmUrl']
+end
+
+# Helper to declare Firebase dependencies with SPM support and CocoaPods fallback.
+#
+# When `spm_dependency` is available (React Native >= 0.75), it declares the
+# Firebase iOS SDK as a Swift Package dependency. Otherwise, it falls back to
+# the traditional CocoaPods `s.dependency` declaration.
+#
+# Set `$RNFirebaseDisableSPM = true` in your Podfile to force CocoaPods-only
+# dependency resolution. This is required when using `use_frameworks! :linkage => :static`
+# because static frameworks cause each pod to embed Firebase SPM products,
+# resulting in duplicate symbol linker errors.
+#
+# @param spec [Pod::Specification] The podspec object (the `s` in podspec DSL)
+# @param version [String] Firebase SDK version (e.g., '12.10.0')
+# @param spm_products [Array<String>] SPM product names (e.g., ['FirebaseAuth'])
+# @param pods [Array<String>, String] CocoaPods dependency names with optional version
+#   Can be a single string like 'Firebase/Auth' or an array like ['Firebase/Messaging', 'FirebaseCoreExtension']
+def firebase_dependency(spec, version, spm_products, pods)
+  if defined?(spm_dependency) && !defined?($RNFirebaseDisableSPM)
+    Pod::UI.puts "[react-native-firebase] #{spec.name}: ".yellow +
+      "Using SPM for Firebase dependency resolution (products: #{spm_products.join(', ')})"
+    spm_dependency(spec,
+      url: $firebase_spm_url,
+      requirement: { kind: 'upToNextMajorVersion', minimumVersion: version },
+      products: spm_products
+    )
+  else
+    if defined?($RNFirebaseDisableSPM)
+      Pod::UI.puts "[react-native-firebase] #{spec.name}: ".yellow +
+        "SPM disabled ($RNFirebaseDisableSPM = true), using CocoaPods for Firebase dependencies"
+    elsif !defined?(spm_dependency)
+      Pod::UI.puts "[react-native-firebase] #{spec.name}: ".yellow +
+        "SPM not available (React Native < 0.75), using CocoaPods for Firebase dependencies"
+    end
+    pods = [pods] unless pods.is_a?(Array)
+    pods.each do |pod|
+      spec.dependency pod, version
+    end
+  end
+end

--- a/packages/app/ios/RNFBApp/RCTConvert+FIRApp.h
+++ b/packages/app/ios/RNFBApp/RCTConvert+FIRApp.h
@@ -15,7 +15,11 @@
  *
  */
 
+#if __has_include(<FirebaseCore/FirebaseCore.h>)
 #import <FirebaseCore/FirebaseCore.h>
+#else
+@import FirebaseCore;
+#endif
 #import <React/RCTConvert.h>
 
 @interface RCTConvert (FIRApp)

--- a/packages/app/ios/RNFBApp/RCTConvert+FIROptions.h
+++ b/packages/app/ios/RNFBApp/RCTConvert+FIROptions.h
@@ -15,7 +15,11 @@
  *
  */
 
+#if __has_include(<FirebaseCore/FirebaseCore.h>)
 #import <FirebaseCore/FirebaseCore.h>
+#else
+@import FirebaseCore;
+#endif
 #import <React/RCTConvert.h>
 
 @interface RCTConvert (FIROptions)

--- a/packages/app/ios/RNFBApp/RNFBAppModule.m
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.m
@@ -15,7 +15,11 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBAppModule.h"

--- a/packages/app/ios/RNFBApp/RNFBSharedUtils.h
+++ b/packages/app/ios/RNFBApp/RNFBSharedUtils.h
@@ -18,7 +18,11 @@
 #ifndef RNFBSharedUtils_h
 #define RNFBSharedUtils_h
 
+#if __has_include(<FirebaseCore/FirebaseCore.h>)
 #import <FirebaseCore/FirebaseCore.h>
+#else
+@import FirebaseCore;
+#endif
 #import <React/RCTBridgeModule.h>
 
 #ifdef DEBUG

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -106,6 +106,7 @@
   "sdkVersions": {
     "ios": {
       "firebase": "12.10.0",
+      "firebaseSpmUrl": "https://github.com/firebase/firebase-ios-sdk.git",
       "iosTarget": "15.0",
       "macosTarget": "10.15",
       "tvosTarget": "15.0"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -44,7 +45,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Auth', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseAuth'], 'Firebase/Auth')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.h
@@ -15,7 +15,13 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseAuth;
+@import FirebaseAuthInternal;
+#endif
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
 

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -15,7 +15,13 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseAuth;
+@import FirebaseAuthInternal;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RCTConvert+FIRApp.h"

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -46,8 +47,12 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Crashlytics', firebase_sdk_version
-  s.dependency          'FirebaseCoreExtension'
+  # FirebaseCoreExtension is a transitive dependency of FirebaseCrashlytics in SPM,
+  # so it only needs to be declared explicitly for CocoaPods.
+  firebase_dependency(s, firebase_sdk_version,
+    ['FirebaseCrashlytics'],
+    ['Firebase/Crashlytics', 'FirebaseCoreExtension']
+  )
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.h
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<FirebaseCoreExtension/FIRLibrary.h>)
 #import <FirebaseCoreExtension/FIRLibrary.h>
+#else
+@import FirebaseCore;
+@import FirebaseCoreExtension;
+#endif
 #import <Foundation/Foundation.h>
 
 @interface RNFBCrashlyticsInitProvider : NSObject <FIRLibrary>

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsInitProvider.m
@@ -16,13 +16,25 @@
  */
 
 #import "RNFBCrashlyticsInitProvider.h"
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+#endif
+#if __has_include(<FirebaseCoreExtension/FIRAppInternal.h>)
 #import <FirebaseCoreExtension/FIRAppInternal.h>
 #import <FirebaseCoreExtension/FIRComponent.h>
 #import <FirebaseCoreExtension/FIRComponentContainer.h>
 #import <FirebaseCoreExtension/FIRComponentType.h>
 #import <FirebaseCoreExtension/FIRLibrary.h>
+#else
+@import FirebaseCoreExtension;
+#endif
+#if __has_include(<FirebaseCrashlytics/FIRCrashlytics.h>)
 #import <FirebaseCrashlytics/FIRCrashlytics.h>
+#else
+@import FirebaseCrashlytics;
+#endif
 #import "RNFBJSON.h"
 #import "RNFBMeta.h"
 #import "RNFBPreferences.h"

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -22,7 +22,12 @@
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseCrashlytics;
+#endif
 #import "RNFBApp/RNFBSharedUtils.h"
 #import "RNFBCrashlyticsInitProvider.h"
 #import "RNFBCrashlyticsModule.h"

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsNativeHelper.m
@@ -17,7 +17,12 @@
  */
 
 #import "RNFBCrashlyticsNativeHelper.h"
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseCrashlytics;
+#endif
 
 @implementation RNFBCrashlyticsNativeHelper
 

--- a/packages/crashlytics/ios_config.sh
+++ b/packages/crashlytics/ios_config.sh
@@ -16,10 +16,19 @@
 #
 set -e
 
-if [[ ${PODS_ROOT} ]]; then
+if [[ ${PODS_ROOT} && -f "${PODS_ROOT}/FirebaseCrashlytics/run" ]]; then
   echo "info: Exec FirebaseCrashlytics Run from Pods"
   "${PODS_ROOT}/FirebaseCrashlytics/run"
-else
+elif [[ -f "${PROJECT_DIR}/FirebaseCrashlytics.framework/run" ]]; then
   echo "info: Exec FirebaseCrashlytics Run from framework"
   "${PROJECT_DIR}/FirebaseCrashlytics.framework/run"
+else
+  # SPM: upload-symbols is in the SourcePackages checkout
+  SPM_UPLOAD_SYMBOLS=$(find "${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics" -name "upload-symbols" -type f 2>/dev/null | head -1)
+  if [[ -n "${SPM_UPLOAD_SYMBOLS}" ]]; then
+    echo "info: Exec FirebaseCrashlytics upload-symbols from SPM"
+    "${SPM_UPLOAD_SYMBOLS}" -gsp "${PROJECT_DIR}/GoogleService-Info.plist" -p ios "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}"
+  else
+    echo "warning: FirebaseCrashlytics run script not found, skipping dSYM upload"
+  fi
 fi

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -45,7 +46,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Database', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseDatabase'], 'Firebase/Database')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseCommon.h
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseCommon.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseDatabaseInternal;
+#endif
 #import <React/RCTBridgeModule.h>
 
 @interface RNFBDatabaseCommon : NSObject

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseDatabaseInternal;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseOnDisconnectModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseOnDisconnectModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseDatabaseInternal;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseQuery.h
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseQuery.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseDatabaseInternal;
+#endif
 #import <React/RCTBridgeModule.h>
 
 @interface RNFBDatabaseQuery : NSObject

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseQueryModule.h
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseQueryModule.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseDatabaseInternal;
+#endif
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
 

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseDatabaseInternal;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseTransactionModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseTransactionModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseDatabaseInternal;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -44,7 +45,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Firestore', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseFirestore'], 'Firebase/Firestore')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/firestore/ios/RNFBFirestore/RCTConvert+FIRLoggerLevel.h
+++ b/packages/firestore/ios/RNFBFirestore/RCTConvert+FIRLoggerLevel.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <React/RCTConvert.h>
 
 @interface RCTConvert (FIRLoggerLevel)

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <Foundation/Foundation.h>
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <RNFBFirestoreQuery.h>

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCommon.h
@@ -16,7 +16,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <React/RCTBridgeModule.h>
 
 @interface RNFBFirestoreCommon : NSObject

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <Foundation/Foundation.h>
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <React/RCTBridgeModule.h>

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <Foundation/Foundation.h>
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <React/RCTBridgeModule.h>

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreQuery.h
@@ -16,7 +16,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <RNFBFirestoreSerialize.h>
 #import <React/RCTBridgeModule.h>
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.h
@@ -16,7 +16,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <React/RCTBridgeModule.h>
 
 @interface RNFBFirestoreSerialize : NSObject

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreSerialize.m
@@ -16,7 +16,11 @@
  *
  */
 
+#if __has_include("FirebaseFirestore/FIRVectorValue.h")
 #import "FirebaseFirestore/FIRVectorValue.h"
+#elif __has_include(<FirebaseFirestore/FIRVectorValue.h>)
+#import <FirebaseFirestore/FIRVectorValue.h>
+#endif
 
 #import "RNFBFirestoreCommon.h"
 #import "RNFBFirestoreSerialize.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseFirestore;
+#endif
 #import <Foundation/Foundation.h>
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <RNFBFirestoreQuery.h>

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -48,7 +49,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Functions', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseFunctions'], 'Firebase/Functions')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/functions/ios/RNFBFunctions/RNFBFunctionsCallHandler.swift
+++ b/packages/functions/ios/RNFBFunctions/RNFBFunctionsCallHandler.swift
@@ -22,7 +22,31 @@ import FirebaseCore
 /// Swift wrapper for Firebase Functions callable methods that's accessible from Objective-C
 /// This encapsulates the logic for calling Firebase Functions (both by name and URL)
 @objcMembers public class RNFBFunctionsCallHandler: NSObject {
-  
+
+  // MARK: - Factory method for FIRFunctions (used by ObjC++ to avoid @import FirebaseFunctions)
+
+  /// Creates and configures a Functions instance.
+  /// This factory exists because FirebaseFunctions is a pure-Swift SPM module
+  /// and cannot be imported from .mm files without -fcxx-modules (which breaks JSI).
+  @objc public static func createFunctions(
+    forApp app: FirebaseApp,
+    customUrlOrRegion: String,
+    emulatorHost: String?,
+    emulatorPort: Int
+  ) -> Functions {
+    let functions: Functions
+    if let url = URL(string: customUrlOrRegion),
+       url.scheme != nil, url.host != nil {
+      functions = Functions.functions(app: app, customDomain: customUrlOrRegion)
+    } else {
+      functions = Functions.functions(app: app, region: customUrlOrRegion)
+    }
+    if let host = emulatorHost {
+      functions.useEmulator(withHost: host, port: emulatorPort)
+    }
+    return functions
+  }
+
   /// Call a Firebase Function by name
   /// - Parameters:
   ///   - app: Firebase App instance

--- a/packages/functions/ios/RNFBFunctions/RNFBFunctionsModule.mm
+++ b/packages/functions/ios/RNFBFunctions/RNFBFunctionsModule.mm
@@ -15,7 +15,18 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#elif __has_include(<FirebaseFunctions/FirebaseFunctions.h>)
+#import <FirebaseCore/FirebaseCore.h>
+#import <FirebaseFunctions/FirebaseFunctions.h>
+#elif __has_include(<FirebaseCore/FirebaseCore.h>)
+#import <FirebaseCore/FirebaseCore.h>
+// SPM: FirebaseFunctions is a pure-Swift module — no ObjC headers available.
+// FIRFunctions instances are created via RNFBFunctionsCallHandler.createFunctions() factory.
+#else
+@import FirebaseCore;
+#endif
 #import <React/RCTUtils.h>
 
 #import "NativeRNFBTurboFunctions.h"
@@ -82,13 +93,14 @@ RCT_EXPORT_MODULE(NativeRNFBTurboFunctions)
               options:(JS::NativeRNFBTurboFunctions::SpecHttpsCallableOptions &)options
               resolve:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject {
-  NSURL *url = [NSURL URLWithString:customUrlOrRegion];
   FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
 
-  FIRFunctions *functions =
-      (url && url.scheme && url.host)
-          ? [FIRFunctions functionsForApp:firebaseApp customDomain:customUrlOrRegion]
-          : [FIRFunctions functionsForApp:firebaseApp region:customUrlOrRegion];
+  // Use Swift factory — FirebaseFunctions is a pure-Swift SPM module,
+  // cannot be imported directly from .mm files.
+  id functions = [RNFBFunctionsCallHandler createFunctionsForApp:firebaseApp
+                                              customUrlOrRegion:customUrlOrRegion
+                                                   emulatorHost:emulatorHost
+                                                   emulatorPort:(int)emulatorPort];
 
   id callableData = data.data();
 
@@ -101,10 +113,6 @@ RCT_EXPORT_MODULE(NativeRNFBTurboFunctions)
   }
 
   std::optional<double> timeout = options.timeout();
-
-  if (emulatorHost != nil) {
-    [functions useEmulatorWithHost:emulatorHost port:(int)emulatorPort];
-  }
 
   RNFBFunctionsCallHandler *handler = [[RNFBFunctionsCallHandler alloc] init];
 
@@ -140,13 +148,12 @@ RCT_EXPORT_MODULE(NativeRNFBTurboFunctions)
                          (JS::NativeRNFBTurboFunctions::SpecHttpsCallableFromUrlOptions &)options
                      resolve:(RCTPromiseResolveBlock)resolve
                       reject:(RCTPromiseRejectBlock)reject {
-  NSURL *customUrl = [NSURL URLWithString:customUrlOrRegion];
   FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
 
-  FIRFunctions *functions =
-      (customUrl && customUrl.scheme && customUrl.host)
-          ? [FIRFunctions functionsForApp:firebaseApp customDomain:customUrlOrRegion]
-          : [FIRFunctions functionsForApp:firebaseApp region:customUrlOrRegion];
+  id functions = [RNFBFunctionsCallHandler createFunctionsForApp:firebaseApp
+                                              customUrlOrRegion:customUrlOrRegion
+                                                   emulatorHost:emulatorHost
+                                                   emulatorPort:(int)emulatorPort];
 
   id callableData = data.data();
 
@@ -160,10 +167,6 @@ RCT_EXPORT_MODULE(NativeRNFBTurboFunctions)
 
   std::optional<double> timeout = options.timeout();
   std::optional<bool> limitedUseAppCheckToken = options.limitedUseAppCheckTokens();
-
-  if (emulatorHost != nil) {
-    [functions useEmulatorWithHost:emulatorHost port:(int)emulatorPort];
-  }
 
   RNFBFunctionsCallHandler *handler = [[RNFBFunctionsCallHandler alloc] init];
 
@@ -246,20 +249,15 @@ RCT_EXPORT_MODULE(NativeRNFBTurboFunctions)
   NSNumber *listenerIdNumber = @((int)listenerId);
 
   if (@available(iOS 15.0, macOS 12.0, *)) {
-    NSURL *customUrl = [NSURL URLWithString:customUrlOrRegion];
     FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
 
-    FIRFunctions *functions =
-        (customUrl && customUrl.scheme && customUrl.host)
-            ? [FIRFunctions functionsForApp:firebaseApp customDomain:customUrlOrRegion]
-            : [FIRFunctions functionsForApp:firebaseApp region:customUrlOrRegion];
+    id functions = [RNFBFunctionsCallHandler createFunctionsForApp:firebaseApp
+                                                customUrlOrRegion:customUrlOrRegion
+                                                     emulatorHost:emulatorHost
+                                                     emulatorPort:(int)emulatorPort];
 
     if (data == nil) {
       data = [NSNull null];
-    }
-
-    if (emulatorHost != nil) {
-      [functions useEmulatorWithHost:emulatorHost port:(int)emulatorPort];
     }
 
     RNFBFunctionsStreamHandler *handler = [[RNFBFunctionsStreamHandler alloc] init];

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -45,7 +46,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/InAppMessaging', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseInAppMessaging-Beta'], 'Firebase/InAppMessaging')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
+++ b/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseInAppMessagingInternal;
+#endif
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/installations/RNFBInstallations.podspec
+++ b/packages/installations/RNFBInstallations.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -45,7 +46,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Installations', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseInstallations'], 'Firebase/Installations')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/installations/ios/RNFBInstallations/RNFBInstallationsModule.m
+++ b/packages/installations/ios/RNFBInstallations/RNFBInstallationsModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseInstallations;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -42,8 +43,12 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Messaging', firebase_sdk_version
-  s.dependency          'FirebaseCoreExtension'
+  # FirebaseCoreExtension is a transitive dependency of FirebaseMessaging in SPM,
+  # so it only needs to be declared explicitly for CocoaPods.
+  firebase_dependency(s, firebase_sdk_version,
+    ['FirebaseMessaging'],
+    ['Firebase/Messaging', 'FirebaseCoreExtension']
+  )
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseMessaging;
+#endif
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <objc/runtime.h>
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseMessaging;
+#endif
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
@@ -14,7 +14,12 @@
  * limitations under the License.
  *
  */
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseMessaging;
+#endif
 #import <RNFBApp/RNFBJSON.h>
 #import <RNFBApp/RNFBRCTEventEmitter.h>
 #import <React/RCTConvert.h>

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseMessaging;
+#endif
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.h
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseMessaging;
+#endif
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
 

--- a/packages/ml/RNFBML.podspec
+++ b/packages/ml/RNFBML.podspec
@@ -1,5 +1,6 @@
 require 'json'
 require '../app/firebase_json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -46,6 +47,9 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
+  # NOTE: Firebase/MLModelDownloader dependency is currently disabled
+  # When re-enabled, use: firebase_dependency(s, firebase_sdk_version,
+  #   ['FirebaseMLModelDownloader'], 'Firebase/MLModelDownloader')
   # s.dependency          'Firebase/MLModelDownloader', firebase_sdk_version
 
   if defined?($RNFirebaseAsStaticFramework)

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -45,7 +46,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Performance', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebasePerformance'], 'Firebase/Performance')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/perf/ios/RNFBPerf/RNFBPerfModule.m
+++ b/packages/perf/ios/RNFBPerf/RNFBPerfModule.m
@@ -18,7 +18,12 @@
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebasePerformance;
+#endif
 #import "RNFBPerfModule.h"
 
 static __strong NSMutableDictionary *traces;

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -45,7 +46,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/RemoteConfig', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseRemoteConfig'], 'Firebase/RemoteConfig')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseRemoteConfigInternal;
+#endif
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -1,4 +1,5 @@
 require 'json'
+require '../app/firebase_spm'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 appPackage = JSON.parse(File.read(File.join('..', 'app', 'package.json')))
 
@@ -44,7 +45,7 @@ Pod::Spec.new do |s|
   end
 
   # Firebase dependencies
-  s.dependency          'Firebase/Storage', firebase_sdk_version
+  firebase_dependency(s, firebase_sdk_version, ['FirebaseStorage'], 'Firebase/Storage')
 
   if defined?($RNFirebaseAsStaticFramework)
     Pod::UI.puts "#{s.name}: Using overridden static_framework value of '#{$RNFirebaseAsStaticFramework}'"

--- a/packages/storage/ios/RNFBStorage/RNFBStorageCommon.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageCommon.m
@@ -16,7 +16,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseStorage;
+#endif
 #import <MobileCoreServices/MobileCoreServices.h>
 
 #import "RNFBSharedUtils.h"

--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -15,7 +15,12 @@
  *
  */
 
+#if __has_include(<Firebase/Firebase.h>)
 #import <Firebase/Firebase.h>
+#else
+@import FirebaseCore;
+@import FirebaseStorage;
+#endif
 #import <React/RCTUtils.h>
 
 #import "RNFBRCTEventEmitter.h"

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -14,12 +14,16 @@ Pod::UI.puts "react-native-firebase/tests: Using Firebase SDK version '#{$Fireba
 # Everything will be static with `use_frameworks!`, but you can set it manually for testing if desired
 # $RNFirebaseAsStaticFramework = true # toggle this to true (and set 'use_frameworks!' below to test static frameworks)
 
+# SPM mode: SPM dependency resolution enabled (no $RNFirebaseDisableSPM flag)
+# Works with dynamic linkage. For static linkage, set $RNFirebaseDisableSPM = true
+
 # Toggle this to true for the no-ad-tracking Analytics subspec. Useful at minimum for Kids category apps.
 # See: https://firebase.google.com/support/release-notes/ios#analytics - requires firebase-ios-sdk 7.11.0+
 #$RNFirebaseAnalyticsWithoutAdIdSupport = true # toggle this to true for the no-ad-tracking Analytics subspec
 
 # Toggle this to true if you want to include support for on device conversion measurement APIs
-$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
+# Disabled for SPM test: GoogleAdsOnDeviceConversion is a static xcframework incompatible with dynamic linkage
+# $RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
 
 # Toggle this to true if you want to include optional support for extended analytics features
 $RNFirebaseAnalyticsEnableAdSupport = true
@@ -41,7 +45,7 @@ platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
 # set this to static and toggle '$RNFirebaseAsStaticFramework' above to test static frameworks)
-linkage = 'static' # ENV['USE_FRAMEWORKS']
+linkage = 'dynamic' # SPM test: dynamic linkage avoids duplicate symbols
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
   use_frameworks! :linkage => linkage.to_sym
@@ -93,10 +97,15 @@ target 'testing' do
     end
 
     # Bumps minimum deploy target to ours (which is >12.4): https://github.com/facebook/react-native/issues/34106
+    # Xcode 26 enables explicit modules by default, but Firebase SPM internal targets
+    # (FirebaseCoreInternal, FirebaseSharedSwift) are not exposed as public products.
+    # This does NOT disable SPM — it only tells the Swift compiler to use implicit module
+    # discovery (the Xcode 16 default) so transitive SPM targets are found automatically.
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
         config.build_settings["GCC_WARN_INHIBIT_ALL_WARNINGS"] = "YES"
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = min_ios_version_supported
+        config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
       end
     end
   end

--- a/tests/local-tests/index.js
+++ b/tests/local-tests/index.js
@@ -30,9 +30,11 @@ import { VertexAITestComponent } from './vertexai/vertexai';
 import { AuthMFADemonstrator } from './auth/auth-mfa-demonstrator';
 import { HttpsCallableTestComponent } from './functions/https-callable';
 import { StreamingCallableTestComponent } from './functions/streaming-callable';
+import { SPMVerificationComponent } from './spm-verification';
 
 const testComponents = {
   // List your imported components here...
+  'SPM Dependency Verification': SPMVerificationComponent,
   'Crashlytics Test Crash': CrashTestComponent,
   'AI Generation Example': AITestComponent,
   'Database onChildMoved Test': DatabaseOnChildMovedTest,

--- a/tests/local-tests/spm-verification.jsx
+++ b/tests/local-tests/spm-verification.jsx
@@ -1,0 +1,131 @@
+/* eslint-disable react/react-in-jsx-scope */
+import { useState } from 'react';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { getApp, SDK_VERSION } from '@react-native-firebase/app';
+import { getAuth } from '@react-native-firebase/auth';
+import { getFirestore } from '@react-native-firebase/firestore';
+import { getDatabase } from '@react-native-firebase/database';
+import { getFunctions } from '@react-native-firebase/functions';
+import { getStorage } from '@react-native-firebase/storage';
+import { getCrashlytics, setAttribute } from '@react-native-firebase/crashlytics';
+import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
+import { getRemoteConfig } from '@react-native-firebase/remote-config';
+import { getInstallations } from '@react-native-firebase/installations';
+import { getPerformance } from '@react-native-firebase/perf';
+
+const MODULES_TO_CHECK = [
+  { name: 'App', check: () => getApp().name },
+  { name: 'Auth', check: () => getAuth().app.name },
+  { name: 'Firestore', check: () => getFirestore().app.name },
+  { name: 'Database', check: () => getDatabase().app.name },
+  { name: 'Functions', check: () => getFunctions().app.name },
+  { name: 'Storage', check: () => getStorage().app.name },
+  { name: 'Crashlytics', check: () => getCrashlytics().app.name },
+  { name: 'Analytics', check: () => getAnalytics().app.name },
+  { name: 'RemoteConfig', check: () => getRemoteConfig().app.name },
+  { name: 'Installations', check: () => getInstallations().app.name },
+  { name: 'Perf', check: () => getPerformance().app.name },
+];
+
+export function SPMVerificationComponent() {
+  const [results, setResults] = useState(null);
+  const [running, setRunning] = useState(false);
+
+  const runVerification = async () => {
+    setRunning(true);
+    const moduleResults = [];
+
+    const sdkVersion = SDK_VERSION;
+
+    for (const mod of MODULES_TO_CHECK) {
+      try {
+        const result = mod.check();
+        moduleResults.push({ name: mod.name, status: 'OK', detail: String(result) });
+      } catch (e) {
+        moduleResults.push({ name: mod.name, status: 'FAIL', detail: e.message });
+      }
+    }
+
+    // Verify app options are populated (proves native initialization worked)
+    try {
+      const app = getApp();
+      const opts = app.options;
+      moduleResults.push({
+        name: 'App Options',
+        status: opts.appId ? 'OK' : 'FAIL',
+        detail: opts.appId ? `appId: ${opts.appId.substring(0, 15)}...` : 'No appId',
+      });
+    } catch (e) {
+      moduleResults.push({ name: 'App Options', status: 'FAIL', detail: e.message });
+    }
+
+    // Verify Crashlytics setAttribute (proves native bridge works)
+    try {
+      await setAttribute(getCrashlytics(), 'spm_test', 'true');
+      moduleResults.push({ name: 'Crashlytics setAttribute', status: 'OK', detail: 'Set OK' });
+    } catch (e) {
+      moduleResults.push({ name: 'Crashlytics setAttribute', status: 'FAIL', detail: e.message });
+    }
+
+    // Verify Analytics logEvent (proves native bridge works)
+    try {
+      await logEvent(getAnalytics(), 'spm_verification_test', { timestamp: Date.now() });
+      moduleResults.push({ name: 'Analytics logEvent', status: 'OK', detail: 'Logged OK' });
+    } catch (e) {
+      moduleResults.push({ name: 'Analytics logEvent', status: 'FAIL', detail: e.message });
+    }
+
+    const passed = moduleResults.filter(r => r.status === 'OK').length;
+    const failed = moduleResults.filter(r => r.status === 'FAIL').length;
+
+    setResults({ sdkVersion, modules: moduleResults, passed, failed });
+    setRunning(false);
+  };
+
+  return (
+    <ScrollView style={styles.container}>
+      <Text style={styles.title}>SPM Dependency Verification</Text>
+      <Text style={styles.subtitle}>
+        Verifies all Firebase native modules are loaded and functional.
+      </Text>
+
+      <Button
+        title={running ? 'Running...' : 'Run SPM Verification'}
+        onPress={runVerification}
+        disabled={running}
+      />
+
+      {results && (
+        <View style={styles.resultsContainer}>
+          <Text style={styles.sdkVersion}>Firebase SDK: {results.sdkVersion}</Text>
+          <Text style={[styles.summary, results.failed > 0 ? styles.fail : styles.pass]}>
+            {results.passed}/{results.passed + results.failed} modules OK
+            {results.failed > 0 ? ` — ${results.failed} FAILED` : ' — All Passed'}
+          </Text>
+
+          {results.modules.map((mod, i) => (
+            <View key={i} style={styles.row}>
+              <Text style={mod.status === 'OK' ? styles.pass : styles.fail}>
+                {mod.status === 'OK' ? '✅' : '❌'} {mod.name}
+              </Text>
+              <Text style={styles.detail}>{mod.detail}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 10 },
+  title: { fontSize: 18, fontWeight: 'bold', textAlign: 'center', marginBottom: 4 },
+  subtitle: { fontSize: 12, color: '#666', textAlign: 'center', marginBottom: 12 },
+  resultsContainer: { marginTop: 12 },
+  sdkVersion: { fontSize: 14, textAlign: 'center', marginBottom: 8, color: '#333' },
+  summary: { fontSize: 16, fontWeight: 'bold', textAlign: 'center', marginBottom: 12 },
+  row: { paddingVertical: 4, borderBottomWidth: 0.5, borderBottomColor: '#eee' },
+  detail: { fontSize: 11, color: '#888', marginLeft: 28 },
+  pass: { color: 'green' },
+  fail: { color: 'red' },
+});


### PR DESCRIPTION
## Summary

- Add `firebase_spm.rb` helper that enables dual SPM/CocoaPods dependency resolution for all Firebase modules
- Update all 16 podspecs to use `firebase_dependency()` instead of direct `s.dependency` calls — transparently resolves via SPM (default on RN >= 0.75) or CocoaPods
- Add `#if __has_include` guards in 43 native iOS files (`.h`, `.m`, `.mm`, `.swift`) for compatible imports in both modes
- Add `SWIFT_ENABLE_EXPLICIT_MODULES=NO` in test Podfile for Xcode 26 compatibility (does not disable SPM — only uses implicit module discovery)
- Add SPM/CocoaPods matrix dimension to CI E2E iOS pipeline
- Add `firebase_spm_test.rb` execution to Jest CI pipeline

## Motivation

Xcode 26 enables explicit modules (`SWIFT_ENABLE_EXPLICIT_MODULES=YES`) by default. This causes build failures because `FirebaseCoreInternal` and `FirebaseSharedSwift` are internal SPM targets (not public products) and cannot be resolved explicitly. SPM dependency resolution via `spm_dependency()` (available in React Native >= 0.75) resolves these transitive dependencies correctly.

## How it works

### For users (zero config required for SPM)
- **SPM (default)**: Works automatically with dynamic linkage on RN >= 0.75. No changes needed.
- **CocoaPods**: Add `$RNFirebaseDisableSPM = true` before `platform :ios` in Podfile.

### Technical details
- `firebase_dependency(spec, version, spm_products, pods)` checks if `spm_dependency` is available and `$RNFirebaseDisableSPM` is not set
- Native files use `#if __has_include(<Firebase/Firebase.h>)` to detect CocoaPods umbrella header vs SPM module imports
- Special handling for `FirebaseFunctions` (pure Swift module in SPM — uses Swift factory for ObjC++ interop)

## CI changes
- E2E iOS pipeline now tests matrix: `buildmode × dep-resolution × iteration` where `dep-resolution: ['spm', 'cocoapods']`
- CocoaPods mode in CI: sets `$RNFirebaseDisableSPM = true`, switches to static linkage, removes explicit modules override
- Jest pipeline now runs `firebase_spm_test.rb` unit tests

## Test plan

- [x] Manual test: 14/14 Firebase modules OK on iPhone 16e (iOS 26.2, Firebase SDK 12.10.0)
- [ ] CI E2E: SPM mode (debug + release)
- [ ] CI E2E: CocoaPods mode (debug + release)  
- [ ] CI Jest: firebase_spm_test.rb passes