### PR TITLE
fix(android, firestore): detach snapshot listeners before executor shutdown

### DIFF
--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -43,14 +43,14 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
 
   @Override
   public void invalidate() {
-    super.invalidate();
-
     for (int i = 0, size = collectionSnapshotListeners.size(); i < size; i++) {
       int key = collectionSnapshotListeners.keyAt(i);
       ListenerRegistration listenerRegistration = collectionSnapshotListeners.get(key);
       listenerRegistration.remove();
     }
     collectionSnapshotListeners.clear();
+
+    super.invalidate();
   }
 
   @ReactMethod

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -44,14 +44,14 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
   @Override
   public void invalidate() {
-    super.invalidate();
-
     for (int i = 0, size = documentSnapshotListeners.size(); i < size; i++) {
       int key = documentSnapshotListeners.keyAt(i);
       ListenerRegistration listenerRegistration = documentSnapshotListeners.get(key);
       listenerRegistration.remove();
     }
     documentSnapshotListeners.clear();
+
+    super.invalidate();
   }
 
   @ReactMethod


### PR DESCRIPTION
## Summary
Removes Firestore snapshot listeners before `super.invalidate()` in `ReactNativeFirebaseFirestoreCollectionModule` and `ReactNativeFirebaseFirestoreDocumentModule`.

`ReactNativeFirebaseModule.invalidate()` shuts down `TaskExecutorService`; `sendOnSnapshotEvent` uses `Tasks.call(getTransactionalExecutor(...), ...)`. If the executor is terminated first, a late snapshot can throw `RejectedExecutionException` (terminated pool).

This matches the teardown order already used in `ReactNativeFirebaseFirestoreTransactionModule`.

## Related issue
- Fixes #8939

## Test plan
- [ ] Android: enable Firestore `onSnapshot`, trigger RN reload or scenario that invalidates native modules; confirm no crash (manual / existing e2e if any)


Made with [Cursor](https://cursor.com)