### PR TITLE
🔥 Fix: emit messaging_notification_opened only for default notification action on iOS.

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -153,23 +153,15 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
-  if (![[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]){
-    if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
-      [_originalDelegate userNotificationCenter:center
-                 didReceiveNotificationResponse:response
-                          withCompletionHandler:completionHandler];
-    } else {
-      completionHandler();
+  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]) {
+    NSDictionary *remoteNotification = response.notification.request.content.userInfo;
+    if (remoteNotification[@"gcm.message_id"]) {
+      NSDictionary *notificationDict =
+          [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
+      [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
+                                                 body:notificationDict];
+      _initialNotification = notificationDict;
     }
-    return;
-  }
-  NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-  if (remoteNotification[@"gcm.message_id"]) {
-    NSDictionary *notificationDict =
-        [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
-    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
-                                               body:notificationDict];
-    _initialNotification = notificationDict;
   }
 
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {


### PR DESCRIPTION
### Description 

🔥 Fix: emit messaging_notification_opened only for default notification action on iOS.

## Summary

Ensure `messaging_notification_opened` is emitted only when the default notification action is triggered on iOS.

Previously the event could be emitted for all `UNNotificationResponse` actions, including custom notification actions.

This change restricts the event emission to `UNNotificationDefaultActionIdentifier`, ensuring `onNotificationOpenedApp` is invoked only when the user taps the notification body.

---

## Why

When notifications include custom actions (e.g. **Reply**, **Mark as Read**), selecting those actions previously triggered `messaging_notification_opened`.

This caused `onNotificationOpenedApp` to fire and often resulted in unintended navigation or redirection in apps that rely on the default notification tap behavior for routing.

By emitting the event only for `UNNotificationDefaultActionIdentifier`, custom actions no longer trigger `onNotificationOpenedApp`, aligning the behavior with expected iOS notification interaction patterns.

---

### Related issues

N/A

---

### Release Summary

Fix iOS behavior where `messaging_notification_opened` could be emitted for custom notification actions. The event is now emitted only for the default notification tap.

---

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

### Test Plan

1. Send a push notification via Firebase Cloud Messaging with custom actions (e.g. Reply).
2. Tap the notification body → `onNotificationOpenedApp` is triggered.
3. Tap a custom action → `onNotificationOpenedApp` is **not triggered**.
4. Verified behavior on a physical iOS device.

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
