### PR TITLE
fix: emit messaging_notification_opened only for default notification action on iOS.

### DIFF
--- a/docs/messaging/notifications.mdx
+++ b/docs/messaging/notifications.mdx
@@ -107,6 +107,10 @@ could open a specific screen for example). The API provides two APIs for handlin
 - `getInitialNotification`: When the application is opened from a quit state.
 - `onNotificationOpenedApp`: When the application is running, but in the background.
 
+These fire for the **default notification open** (user taps the notification body). They do **not** fire for
+custom notification-category actions or dismiss; those interactions need a dedicated response API (tracked
+internally — do not route custom-action navigation through opened/initial).
+
 To handle both scenarios, the code can be executed during setup. For example, using [React Navigation](https://reactnavigation.org/)
 we can set an initial route when the app is opened from a quit state, and push to a new screen when the app is in a background state:
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -153,23 +153,15 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
-  if (![[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]){
-    if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
-      [_originalDelegate userNotificationCenter:center
-                 didReceiveNotificationResponse:response
-                          withCompletionHandler:completionHandler];
-    } else {
-      completionHandler();
+  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]) {
+    NSDictionary *remoteNotification = response.notification.request.content.userInfo;
+    if (remoteNotification[@"gcm.message_id"]) {
+      NSDictionary *notificationDict =
+          [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
+      [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
+                                                 body:notificationDict];
+      _initialNotification = notificationDict;
     }
-    return;
-  }
-  NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-  if (remoteNotification[@"gcm.message_id"]) {
-    NSDictionary *notificationDict =
-        [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
-    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
-                                               body:notificationDict];
-    _initialNotification = notificationDict;
   }
 
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -153,6 +153,16 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
+  if (![[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]){
+    if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
+      [_originalDelegate userNotificationCenter:center
+                 didReceiveNotificationResponse:response
+                          withCompletionHandler:completionHandler];
+    } else {
+      completionHandler();
+    }
+    return;
+  }
   NSDictionary *remoteNotification = response.notification.request.content.userInfo;
   if (remoteNotification[@"gcm.message_id"]) {
     NSDictionary *notificationDict =

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -162,7 +162,6 @@ struct {
     _initialNotification = notificationDict;
   }
 
-
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
     [_originalDelegate userNotificationCenter:center
                didReceiveNotificationResponse:response

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -153,16 +153,15 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
-  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]) {
-    NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-    if (remoteNotification[@"gcm.message_id"]) {
-      NSDictionary *notificationDict =
-          [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
-      [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
-                                                 body:notificationDict];
-      _initialNotification = notificationDict;
-    }
+  NSDictionary *remoteNotification = response.notification.request.content.userInfo;
+  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier] && remoteNotification[@"gcm.message_id"]) {
+    NSDictionary *notificationDict =
+        [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
+    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
+                                               body:notificationDict];
+    _initialNotification = notificationDict;
   }
+
 
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
     [_originalDelegate userNotificationCenter:center

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -151,6 +151,16 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
+  if (![[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]){
+    if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
+      [_originalDelegate userNotificationCenter:center
+                 didReceiveNotificationResponse:response
+                          withCompletionHandler:completionHandler];
+    } else {
+      completionHandler();
+    }
+    return;
+  }
   NSDictionary *remoteNotification = response.notification.request.content.userInfo;
   if (remoteNotification[@"gcm.message_id"]) {
     NSDictionary *notificationDict =

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -152,7 +152,8 @@ struct {
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
   NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier] && remoteNotification[@"gcm.message_id"]) {
+  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier] &&
+      remoteNotification[@"gcm.message_id"]) {
     NSDictionary *notificationDict =
         [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
     [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
@@ -160,10 +161,13 @@ struct {
     _initialNotification = notificationDict;
   }
 
-  if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
-    [_originalDelegate userNotificationCenter:center
-               didReceiveNotificationResponse:response
-                        withCompletionHandler:completionHandler];
+  // _originalDelegate is weak — capture strong local before nil-check + message
+  // (same race as willPresent; otherwise completionHandler may never run).
+  id<UNUserNotificationCenterDelegate> strongOriginalDelegate = _originalDelegate;
+  if (strongOriginalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
+    [strongOriginalDelegate userNotificationCenter:center
+                    didReceiveNotificationResponse:response
+                             withCompletionHandler:completionHandler];
   } else {
     completionHandler();
   }
@@ -171,8 +175,9 @@ struct {
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     openSettingsForNotification:(nullable UNNotification *)notification {
-  if (_originalDelegate != nil && originalDelegateRespondsTo.openSettingsForNotification) {
-    [_originalDelegate userNotificationCenter:center openSettingsForNotification:notification];
+  id<UNUserNotificationCenterDelegate> strongOriginalDelegate = _originalDelegate;
+  if (strongOriginalDelegate != nil && originalDelegateRespondsTo.openSettingsForNotification) {
+    [strongOriginalDelegate userNotificationCenter:center openSettingsForNotification:notification];
   } else {
     NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
     [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_settings_for_notification_opened"

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -151,23 +151,15 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
-  if (![[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]){
-    if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
-      [_originalDelegate userNotificationCenter:center
-                 didReceiveNotificationResponse:response
-                          withCompletionHandler:completionHandler];
-    } else {
-      completionHandler();
+  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]) {
+    NSDictionary *remoteNotification = response.notification.request.content.userInfo;
+    if (remoteNotification[@"gcm.message_id"]) {
+      NSDictionary *notificationDict =
+          [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
+      [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
+                                                 body:notificationDict];
+      _initialNotification = notificationDict;
     }
-    return;
-  }
-  NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-  if (remoteNotification[@"gcm.message_id"]) {
-    NSDictionary *notificationDict =
-        [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
-    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
-                                               body:notificationDict];
-    _initialNotification = notificationDict;
   }
 
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -160,7 +160,6 @@ struct {
     _initialNotification = notificationDict;
   }
 
-
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
     [_originalDelegate userNotificationCenter:center
                didReceiveNotificationResponse:response

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -151,16 +151,15 @@ struct {
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center
     didReceiveNotificationResponse:(UNNotificationResponse *)response
              withCompletionHandler:(void (^)(void))completionHandler {
-  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier]) {
-    NSDictionary *remoteNotification = response.notification.request.content.userInfo;
-    if (remoteNotification[@"gcm.message_id"]) {
-      NSDictionary *notificationDict =
-          [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
-      [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
-                                                 body:notificationDict];
-      _initialNotification = notificationDict;
-    }
+  NSDictionary *remoteNotification = response.notification.request.content.userInfo;
+  if ([[response actionIdentifier] isEqualToString:UNNotificationDefaultActionIdentifier] && remoteNotification[@"gcm.message_id"]) {
+    NSDictionary *notificationDict =
+        [RNFBMessagingSerializer remoteMessageUserInfoToDict:remoteNotification];
+    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_notification_opened"
+                                               body:notificationDict];
+    _initialNotification = notificationDict;
   }
+
 
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
     [_originalDelegate userNotificationCenter:center


### PR DESCRIPTION
### Description 

🔥 Fix: emit messaging_notification_opened only for default notification action on iOS.

## Summary

Ensure `messaging_notification_opened` is emitted only when the default notification action is triggered on iOS.

Previously the event could be emitted for all `UNNotificationResponse` actions, including custom notification actions.

This change restricts the event emission to `UNNotificationDefaultActionIdentifier`, ensuring `onNotificationOpenedApp` is invoked only when the user taps the notification body.

---

## Why

When notifications include custom actions (e.g. **Reply**, **Mark as Read**), selecting those actions previously triggered `messaging_notification_opened`.

This caused `onNotificationOpenedApp` to fire and often resulted in unintended navigation or redirection in apps that rely on the default notification tap behavior for routing.

By emitting the event only for `UNNotificationDefaultActionIdentifier`, custom actions no longer trigger `onNotificationOpenedApp`, aligning the behavior with expected iOS notification interaction patterns.

---

### Related issues

N/A

---

### Release Summary

Fix iOS behavior where `messaging_notification_opened` could be emitted for custom notification actions. The event is now emitted only for the default notification tap.

---

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

### Test Plan

1. Send a push notification via Firebase Cloud Messaging with custom actions (e.g. Reply).
2. Tap the notification body → `onNotificationOpenedApp` is triggered.
3. Tap a custom action → `onNotificationOpenedApp` is **not triggered**.
4. Verified behavior on a physical iOS device.

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
