### PR TITLE
fix(perf): add null check in case trace, screenTraces & httpMetric SparseArrays are cleared during module teardown

### DIFF
--- a/packages/perf/android/src/main/java/io/invertase/firebase/perf/UniversalFirebasePerfModule.java
+++ b/packages/perf/android/src/main/java/io/invertase/firebase/perf/UniversalFirebasePerfModule.java
@@ -83,6 +83,10 @@ public class UniversalFirebasePerfModule extends UniversalFirebaseModule {
     return Tasks.call(
         () -> {
           Trace trace = traces.get(id);
+          // Traces can be cleared during module teardown before JS stops them.
+          if (trace == null) {
+            return null;
+          }
 
           Set<String> metricKeys = metrics.keySet();
           Set<String> attributeKeys = attributes.keySet();
@@ -119,6 +123,10 @@ public class UniversalFirebasePerfModule extends UniversalFirebaseModule {
     return Tasks.call(
         () -> {
           ScreenTrace trace = screenTraces.get(id);
+          // Screen traces can be cleared during module teardown before JS stops them.
+          if (trace == null) {
+            return null;
+          }
           trace.sendScreenTrace();
           screenTraces.remove(id);
 
@@ -140,6 +148,10 @@ public class UniversalFirebasePerfModule extends UniversalFirebaseModule {
     return Tasks.call(
         () -> {
           HttpMetric httpMetric = httpMetrics.get(id);
+          // HTTP metrics can be cleared during module teardown before JS stops them.
+          if (httpMetric == null) {
+            return null;
+          }
 
           if (httpMetricConfig.containsKey("httpResponseCode")) {
             httpMetric.setHttpResponseCode((int) httpMetricConfig.getDouble("httpResponseCode"));


### PR DESCRIPTION


### Description
- Possible that SparseArrays are cleared during module teardown. See here: https://github.com/invertase/react-native-firebase/blob/main/packages/perf/android/src/main/java/io/invertase/firebase/perf/UniversalFirebasePerfModule.java#L45-L50

fixes https://github.com/invertase/react-native-firebase/issues/8938

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
