### PR TITLE
fix(analytics): coerce JS string or double params to native integral values as needed

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -1390,7 +1390,7 @@ describe('Analytics', function () {
           () =>
             analytics.logLevelEnd({
               level: 12,
-              success: 'true',
+              success: true,
             }),
           'logLevelEnd',
         );
@@ -1401,7 +1401,7 @@ describe('Analytics', function () {
           () =>
             logLevelEnd(analytics, {
               level: 12,
-              success: 'true',
+              success: true,
             }),
           'logLevelEnd',
         );

--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -211,6 +211,10 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
               double number = itemBundle.getDouble(FirebaseAnalytics.Param.QUANTITY);
               itemBundle.putInt(FirebaseAnalytics.Param.QUANTITY, (int) number);
             }
+            if (itemBundle.containsKey(FirebaseAnalytics.Param.INDEX)) {
+              double number = itemBundle.getDouble(FirebaseAnalytics.Param.INDEX);
+              itemBundle.putLong(FirebaseAnalytics.Param.INDEX, (long) number);
+            }
             validBundles.add(itemBundle);
           }
         }

--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -26,6 +26,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.google.firebase.analytics.FirebaseAnalytics;
 import io.invertase.firebase.common.ReactNativeFirebaseModule;
 import java.util.ArrayList;
+import java.util.Locale;
 import javax.annotation.Nullable;
 
 public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModule {
@@ -233,6 +234,7 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
     }
 
     coerceLongNumericParams(bundle);
+    coerceSuccessParamToLong(bundle);
 
     if (bundle.containsKey(FirebaseAnalytics.Param.EXTEND_SESSION)) {
       double number = bundle.getDouble(FirebaseAnalytics.Param.EXTEND_SESSION);
@@ -248,5 +250,23 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
         bundle.putLong(key, (long) number);
       }
     }
+  }
+
+  private static void coerceSuccessParamToLong(Bundle bundle) {
+    if (!bundle.containsKey(FirebaseAnalytics.Param.SUCCESS)) {
+      return;
+    }
+    Object value = bundle.get(FirebaseAnalytics.Param.SUCCESS);
+    bundle.remove(FirebaseAnalytics.Param.SUCCESS);
+    long asLong = 0L;
+    if (value instanceof Boolean) {
+      asLong = (Boolean) value ? 1L : 0L;
+    } else if (value instanceof Number) {
+      asLong = ((Number) value).longValue() != 0L ? 1L : 0L;
+    } else if (value instanceof String) {
+      String s = ((String) value).trim().toLowerCase(Locale.ROOT);
+      asLong = ("1".equals(s) || "true".equals(s) || "yes".equals(s)) ? 1L : 0L;
+    }
+    bundle.putLong(FirebaseAnalytics.Param.SUCCESS, asLong);
   }
 }

--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/ReactNativeFirebaseAnalyticsModule.java
@@ -30,6 +30,22 @@ import javax.annotation.Nullable;
 
 public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModule {
   private static final String SERVICE_NAME = "Analytics";
+
+  /**
+   * GA4 parameters that must be sent as long values. React Native's bridge stores JS numbers as
+   * doubles in {@link Bundle}; Firebase Analytics expects integral types for these keys.
+   */
+  private static final String[] LONG_NUMERIC_PARAM_KEYS =
+      new String[] {
+        FirebaseAnalytics.Param.QUANTITY,
+        FirebaseAnalytics.Param.INDEX,
+        FirebaseAnalytics.Param.LEVEL,
+        FirebaseAnalytics.Param.NUMBER_OF_NIGHTS,
+        FirebaseAnalytics.Param.NUMBER_OF_PASSENGERS,
+        FirebaseAnalytics.Param.NUMBER_OF_ROOMS,
+        FirebaseAnalytics.Param.SCORE,
+      };
+
   private final UniversalFirebaseAnalyticsModule module;
 
   ReactNativeFirebaseAnalyticsModule(ReactApplicationContext reactContext) {
@@ -207,14 +223,7 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
         for (Object item : itemsArray) {
           if (item instanceof Bundle) {
             Bundle itemBundle = (Bundle) item;
-            if (itemBundle.containsKey(FirebaseAnalytics.Param.QUANTITY)) {
-              double number = itemBundle.getDouble(FirebaseAnalytics.Param.QUANTITY);
-              itemBundle.putInt(FirebaseAnalytics.Param.QUANTITY, (int) number);
-            }
-            if (itemBundle.containsKey(FirebaseAnalytics.Param.INDEX)) {
-              double number = itemBundle.getDouble(FirebaseAnalytics.Param.INDEX);
-              itemBundle.putLong(FirebaseAnalytics.Param.INDEX, (long) number);
-            }
+            coerceLongNumericParams(itemBundle);
             validBundles.add(itemBundle);
           }
         }
@@ -223,10 +232,21 @@ public class ReactNativeFirebaseAnalyticsModule extends ReactNativeFirebaseModul
       }
     }
 
+    coerceLongNumericParams(bundle);
+
     if (bundle.containsKey(FirebaseAnalytics.Param.EXTEND_SESSION)) {
       double number = bundle.getDouble(FirebaseAnalytics.Param.EXTEND_SESSION);
       bundle.putLong(FirebaseAnalytics.Param.EXTEND_SESSION, (long) number);
     }
     return bundle;
+  }
+
+  private static void coerceLongNumericParams(Bundle bundle) {
+    for (String key : LONG_NUMERIC_PARAM_KEYS) {
+      if (bundle.containsKey(key)) {
+        double number = bundle.getDouble(key);
+        bundle.putLong(key, (long) number);
+      }
+    }
   }
 }

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -264,7 +264,7 @@ describe('analytics()', function () {
       it('calls logLevelEnd', async function () {
         await firebase.analytics().logLevelEnd({
           level: 123,
-          success: 'yes',
+          success: true,
         });
       });
     });
@@ -753,7 +753,7 @@ describe('analytics()', function () {
           const { getAnalytics, logLevelEnd } = analyticsModular;
           await logLevelEnd(getAnalytics(), {
             level: 123,
-            success: 'yes',
+            success: true,
           });
         });
       });

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -292,6 +292,7 @@ RCT_EXPORT_METHOD(setConsent
     newParams[kFIRParameterItems] = [newItems copy];
   }
   [self rnfb_coerceLongNumericParametersInMutableDictionary:newParams];
+  [self rnfb_coerceSuccessParameterInMutableDictionary:newParams];
   NSNumber *extendSession = [newParams valueForKey:kFIRParameterExtendSession];
   if ([extendSession isEqualToNumber:@1]) {
     newParams[kFIRParameterExtendSession] = @YES;
@@ -306,6 +307,24 @@ RCT_EXPORT_METHOD(setConsent
       dict[key] = @([value integerValue]);
     }
   }
+}
+
+- (void)rnfb_coerceSuccessParameterInMutableDictionary:(NSMutableDictionary *)dict {
+  id value = dict[kFIRParameterSuccess];
+  if (value == nil || value == [NSNull null]) {
+    return;
+  }
+  int success = 0;
+  if ([value isKindOfClass:[NSString class]]) {
+    NSString *lower = [(NSString *)value lowercaseString];
+    if ([lower isEqualToString:@"true"] || [lower isEqualToString:@"yes"] ||
+        [lower isEqualToString:@"1"]) {
+      success = 1;
+    }
+  } else {
+    success = [value boolValue] ? 1 : 0;
+  }
+  dict[kFIRParameterSuccess] = @(success);
 }
 
 /// Converts null values received over the bridge from NSNull to nil

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -32,6 +32,24 @@
 #import <RNFBApp/RNFBSharedUtils.h>
 #import "RNFBAnalyticsModule.h"
 
+/** GA4 parameters that must be sent as integer NSNumber values (not doubles from JS). */
+static NSArray<NSString *> *RNFBAnalyticsLongNumericParameterKeys(void) {
+  static NSArray<NSString *> *keys;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    keys = @[
+      kFIRParameterQuantity,
+      kFIRParameterIndex,
+      kFIRParameterLevel,
+      kFIRParameterNumberOfNights,
+      kFIRParameterNumberOfPassengers,
+      kFIRParameterNumberOfRooms,
+      kFIRParameterScore,
+    ];
+  });
+  return keys;
+}
+
 @implementation RNFBAnalyticsModule
 #pragma mark -
 #pragma mark Module Setup
@@ -268,21 +286,26 @@ RCT_EXPORT_METHOD(setConsent
     [(NSArray *)newParams[kFIRParameterItems]
         enumerateObjectsUsingBlock:^(id _Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
           NSMutableDictionary *item = [obj mutableCopy];
-          if (item[kFIRParameterQuantity]) {
-            item[kFIRParameterQuantity] = @([item[kFIRParameterQuantity] integerValue]);
-          }
-          if (item[kFIRParameterIndex]) {
-            item[kFIRParameterIndex] = @([item[kFIRParameterIndex] integerValue]);
-          }
+          [self rnfb_coerceLongNumericParametersInMutableDictionary:item];
           [newItems addObject:[item copy]];
         }];
     newParams[kFIRParameterItems] = [newItems copy];
   }
+  [self rnfb_coerceLongNumericParametersInMutableDictionary:newParams];
   NSNumber *extendSession = [newParams valueForKey:kFIRParameterExtendSession];
   if ([extendSession isEqualToNumber:@1]) {
     newParams[kFIRParameterExtendSession] = @YES;
   }
   return [newParams copy];
+}
+
+- (void)rnfb_coerceLongNumericParametersInMutableDictionary:(NSMutableDictionary *)dict {
+  for (NSString *key in RNFBAnalyticsLongNumericParameterKeys()) {
+    id value = dict[key];
+    if (value != nil && value != [NSNull null]) {
+      dict[key] = @([value integerValue]);
+    }
+  }
 }
 
 /// Converts null values received over the bridge from NSNull to nil

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -271,6 +271,9 @@ RCT_EXPORT_METHOD(setConsent
           if (item[kFIRParameterQuantity]) {
             item[kFIRParameterQuantity] = @([item[kFIRParameterQuantity] integerValue]);
           }
+          if (item[kFIRParameterIndex]) {
+            item[kFIRParameterIndex] = @([item[kFIRParameterIndex] integerValue]);
+          }
           [newItems addObject:[item copy]];
         }];
     newParams[kFIRParameterItems] = [newItems copy];

--- a/packages/analytics/lib/structs.ts
+++ b/packages/analytics/lib/structs.ts
@@ -36,6 +36,7 @@ const Item = type({
   item_variant: optional(string()),
   quantity: optional(number()),
   price: optional(number()),
+  index: optional(number()),
 });
 
 export const ScreenView = type({

--- a/packages/analytics/lib/structs.ts
+++ b/packages/analytics/lib/structs.ts
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-import { object, string, number, array, optional, define, type } from 'superstruct';
+import { object, string, number, boolean, array, optional, define, type } from 'superstruct';
 
 const ShortDate = define(
   'ShortDate',
@@ -105,7 +105,7 @@ export const JoinGroup = object({
 
 export const LevelEnd = object({
   level: number(),
-  success: optional(string()),
+  success: optional(boolean()),
 });
 
 export const LevelStart = object({

--- a/packages/analytics/lib/types/analytics.ts
+++ b/packages/analytics/lib/types/analytics.ts
@@ -282,7 +282,7 @@ export interface LevelEndEventParameters {
   /**
    * The result of an operation.
    */
-  success?: string;
+  success?: boolean;
 }
 
 export interface LevelStartEventParameters {

--- a/packages/analytics/type-test.ts
+++ b/packages/analytics/type-test.ts
@@ -189,7 +189,7 @@ const earnVirtualCurrencyParams: EarnVirtualCurrencyEventParameters = {
 };
 const generateLeadParams: GenerateLeadEventParameters = { value: 123, currency: 'USD' };
 const joinGroupParams: JoinGroupEventParameters = { group_id: 'group1' };
-const levelEndParams: LevelEndEventParameters = { level: 1, success: 'true' };
+const levelEndParams: LevelEndEventParameters = { level: 1, success: true };
 const levelStartParams: LevelStartEventParameters = { level: 1 };
 const levelUpParams: LevelUpEventParameters = { level: 5, character: 'character1' };
 const loginParams: LoginEventParameters = { method: 'email' };


### PR DESCRIPTION
### Description

The React Native bridge converts all JS numbers to `double`, but the native Firebase SDK expects `FirebaseAnalytics.Param.INDEX` (which maps to `item_list_index`) as an integer/long. When a `double` is forwarded, Firebase does not recognise it as the standard ecommerce parameter — `item_list_index` ends up as `(not set)` in GA4 / BigQuery, breaking attribution of clicks/views to list positions.

The library already handles this exact problem for `Param.QUANTITY` in both native modules. This PR mirrors that conversion for `Param.INDEX`:

- **Android** (`ReactNativeFirebaseAnalyticsModule.java`): `putLong(FirebaseAnalytics.Param.INDEX, (long) number)`
- **iOS** (`RNFBAnalyticsModule.m`): `item[kFIRParameterIndex] = @([item[kFIRParameterIndex] integerValue])`

No JS / TS changes — the public API already accepts `index: number`, only the native coercion was missing.

### Related issues

None filed upstream; happy to open one if preferred.

### Release Summary

Fix `item_list_index` showing as `(not set)` in GA4 / BigQuery when `index` is provided on `items[]`.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

No tests added — the existing `QUANTITY` conversion (the precedent this PR follows) is also not covered by jest/e2e tests, since the coercion happens in the native modules below the JS bridge and there is no native test infra in the analytics package. Happy to add coverage if maintainers point me at the right place.

### Test Plan

Verified in production via \`patch-package\` against \`@react-native-firebase/analytics@22.3.0\` in a live e-commerce app:

- **Before:** \`item_list_index\` arrives as \`(not set)\` in GA4 / BigQuery despite \`index\` being set on every item.
- **After:** \`item_list_index\` is populated with the correct integer position for \`view_item_list\`, \`select_item\`, and related ecommerce events.

:fire:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native Android/iOS analytics parameter marshaling and tightens JS/TS validation for `success`, which could affect apps relying on previously accepted string values. Changes are localized to analytics event parameter conversion but can impact GA4/BigQuery reporting if incorrect.
> 
> **Overview**
> Fixes GA4 parameter typing issues by coercing specific numeric event params (e.g., `items[].index` and other GA4 long-only keys) from React Native bridge `double` values into native integral types on both Android and iOS, including within `items` arrays.
> 
> Also normalizes `LevelEnd.success` to be a boolean in JS/TS validation/types (and updates tests accordingly) while converting the native `success` value into the expected integer/long representation for the Firebase SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 005267186cb6499ba9fc2c7423141e8199e28dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


