### PR TITLE
feat(analytics): add Expo config plugin for withoutAdIdSupport

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,21 @@ The following is an example `app.json` to enable the React Native Firebase modul
 
 > Listing a module in the Config Plugins (the `"plugins"` array in the JSON above) is only required for React Native Firebase modules that involve _native installation steps_ - e.g. modifying the Xcode project, `Podfile`, `build.gradle`, `AndroidManifest.xml` etc. React Native Firebase modules without native steps will work out of the box; no `"plugins"` entry is required. Not all modules have Expo Config Plugins provided yet. A React Native Firebase module has Config Plugin support if it contains an `app.plugin.js` file in its package directory (e.g.`node_modules/@react-native-firebase/app/app.plugin.js`).
 
+If you use `@react-native-firebase/analytics` with Expo, including EAS Build, and want to opt out of iOS Ad ID support, add the Analytics config plugin with the `withoutAdIdSupport` iOS option:
+
+```json
+[
+  "@react-native-firebase/analytics",
+  {
+    "ios": {
+      "withoutAdIdSupport": true
+    }
+  }
+]
+```
+
+This adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to the generated iOS `Podfile` during prebuild.
+
 ### Local app compilation
 
 If you are compiling your app locally, run [`npx expo prebuild --clean`](https://docs.expo.dev/workflow/prebuild/) to generate the native project directories. Then, follow the local app compilation steps described in [Local app development](https://docs.expo.dev/guides/local-app-development/) guide in Expo docs. If you prefer using a build service, refer to [EAS Build](https://docs.expo.dev/build/setup/).

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -38,6 +38,29 @@ Requires `@react-native-firebase/app` to be installed.
 yarn add @react-native-firebase/analytics
 ```
 
+### Expo
+
+If you use Expo, including EAS Build, and want to build iOS Analytics without Ad ID support, add the Analytics config plugin to your `app.json` / `app.config.js`:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@react-native-firebase/analytics",
+        {
+          "ios": {
+            "withoutAdIdSupport": true
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+This adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to the generated iOS `Podfile` during prebuild, which excludes `FirebaseAnalytics/IdentitySupport`.
+
 ## Documentation
 
 - [Quick Start](https://rnfirebase.io/analytics/usage)

--- a/packages/analytics/app.plugin.js
+++ b/packages/analytics/app.plugin.js
@@ -1,0 +1,1 @@
+module.exports = require('./plugin/build');

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -9,7 +9,7 @@
     "build": "genversion --esm --semi lib/version.ts",
     "build:clean": "rimraf android/build && rimraf ios/build",
     "build:plugin": "rimraf plugin/build && tsc --build plugin",
-    "lint:plugin": "eslint plugin/src/*",
+    "lint:plugin": "eslint \"plugin/src/**/*.{ts,js}\"",
     "compile": "bob build",
     "prepare": "yarn run build && yarn run build:plugin && yarn compile"
   },

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -8,8 +8,10 @@
   "scripts": {
     "build": "genversion --esm --semi lib/version.ts",
     "build:clean": "rimraf android/build && rimraf ios/build",
+    "build:plugin": "rimraf plugin/build && tsc --build plugin",
+    "lint:plugin": "eslint plugin/src/*",
     "compile": "bob build",
-    "prepare": "yarn run build && yarn compile"
+    "prepare": "yarn run build && yarn run build:plugin && yarn compile"
   },
   "repository": {
     "type": "git",
@@ -23,7 +25,8 @@
     "analytics"
   ],
   "peerDependencies": {
-    "@react-native-firebase/app": "24.0.0"
+    "@react-native-firebase/app": "24.0.0",
+    "expo": ">=47.0.0"
   },
   "publishConfig": {
     "access": "public",
@@ -33,7 +36,14 @@
     "superstruct": "^2.0.2"
   },
   "devDependencies": {
-    "react-native-builder-bob": "^0.40.17"
+    "expo": "^55.0.5",
+    "react-native-builder-bob": "^0.40.17",
+    "typescript": "^5.9.3"
+  },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
   },
   "exports": {
     ".": {
@@ -41,6 +51,7 @@
       "types": "./dist/typescript/lib/index.d.ts",
       "default": "./dist/module/index.js"
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "react-native-builder-bob": {

--- a/packages/analytics/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/analytics/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`Analytics Config Plugin iOS Tests adds the Podfile flag when withoutAdIdSupport is enabled 1`] = `
+"platform :ios, '15.0'
+
+prepare_react_native_project!
+# @generated begin @react-native-firebase/analytics-withoutAdIdSupport - expo prebuild (DO NOT MODIFY) sync-06c0e725ab83bc834a9294f76fea47cf14bb6ac3
+$RNFirebaseAnalyticsWithoutAdIdSupport = true
+# @generated end @react-native-firebase/analytics-withoutAdIdSupport
+
+target 'ReactNativeFirebaseDemo' do
+end
+"
+`;

--- a/packages/analytics/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/analytics/plugin/__tests__/iosPlugin.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { setAnalyticsPodfileWithoutAdIdSupport } from '../src/ios/podfile';
+
+const podfileFixture = `platform :ios, '15.0'
+
+prepare_react_native_project!
+
+target 'ReactNativeFirebaseDemo' do
+end
+`;
+
+describe('Analytics Config Plugin iOS Tests', function () {
+  it('adds the Podfile flag when withoutAdIdSupport is enabled', function () {
+    const result = setAnalyticsPodfileWithoutAdIdSupport(podfileFixture, true);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('is idempotent when the Podfile flag is already present', function () {
+    const onceModified = setAnalyticsPodfileWithoutAdIdSupport(podfileFixture, true);
+    const twiceModified = setAnalyticsPodfileWithoutAdIdSupport(onceModified, true);
+
+    expect(twiceModified).toEqual(onceModified);
+  });
+
+  it('removes the generated Podfile flag when withoutAdIdSupport is disabled', function () {
+    const onceModified = setAnalyticsPodfileWithoutAdIdSupport(podfileFixture, true);
+    const restored = setAnalyticsPodfileWithoutAdIdSupport(onceModified, false);
+
+    expect(restored).toEqual(podfileFixture);
+  });
+});

--- a/packages/analytics/plugin/src/index.ts
+++ b/packages/analytics/plugin/src/index.ts
@@ -13,5 +13,5 @@ const withRnFirebaseAnalytics: ConfigPlugin<PluginConfigType> = (config, props) 
   ]);
 };
 
-const pak = require('@react-native-firebase/analytics/package.json');
+const pak = require('../../package.json');
 export default createRunOncePlugin(withRnFirebaseAnalytics, pak.name, pak.version);

--- a/packages/analytics/plugin/src/index.ts
+++ b/packages/analytics/plugin/src/index.ts
@@ -1,0 +1,17 @@
+import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
+
+import { withIosWithoutAdIdSupport } from './ios';
+import { PluginConfigType } from './pluginConfig';
+
+/**
+ * A config plugin for configuring `@react-native-firebase/analytics`
+ */
+const withRnFirebaseAnalytics: ConfigPlugin<PluginConfigType> = (config, props) => {
+  return withPlugins(config, [
+    // iOS
+    [withIosWithoutAdIdSupport, props],
+  ]);
+};
+
+const pak = require('@react-native-firebase/analytics/package.json');
+export default createRunOncePlugin(withRnFirebaseAnalytics, pak.name, pak.version);

--- a/packages/analytics/plugin/src/ios/index.ts
+++ b/packages/analytics/plugin/src/ios/index.ts
@@ -1,0 +1,3 @@
+import { withIosWithoutAdIdSupport } from './podfile';
+
+export { withIosWithoutAdIdSupport };

--- a/packages/analytics/plugin/src/ios/podfile.ts
+++ b/packages/analytics/plugin/src/ios/podfile.ts
@@ -1,0 +1,44 @@
+import { ConfigPlugin, withPodfile } from '@expo/config-plugins';
+import {
+  mergeContents,
+  removeGeneratedContents,
+} from '@expo/config-plugins/build/utils/generateCode';
+
+import { PluginConfigType } from '../pluginConfig';
+
+const TAG = '@react-native-firebase/analytics-withoutAdIdSupport';
+const ANCHOR = /prepare_react_native_project!/;
+const FLAG = '$RNFirebaseAnalyticsWithoutAdIdSupport = true';
+
+export function setAnalyticsPodfileWithoutAdIdSupport(
+  src: string,
+  enabled: boolean = false,
+): string {
+  if (!enabled) {
+    return removeGeneratedContents(src, TAG) ?? src;
+  }
+
+  if (src.includes(FLAG)) {
+    return src;
+  }
+
+  return mergeContents({
+    src,
+    newSrc: FLAG,
+    tag: TAG,
+    anchor: ANCHOR,
+    offset: 1,
+    comment: '#',
+  }).contents;
+}
+
+export const withIosWithoutAdIdSupport: ConfigPlugin<PluginConfigType> = (config, props) => {
+  return withPodfile(config, config => {
+    config.modResults.contents = setAnalyticsPodfileWithoutAdIdSupport(
+      config.modResults.contents,
+      props.ios?.withoutAdIdSupport === true,
+    );
+
+    return config;
+  });
+};

--- a/packages/analytics/plugin/src/ios/podfile.ts
+++ b/packages/analytics/plugin/src/ios/podfile.ts
@@ -32,7 +32,7 @@ export const withIosWithoutAdIdSupport: ConfigPlugin<PluginConfigType> = (config
   return withPodfile(config, config => {
     config.modResults.contents = setAnalyticsPodfileWithoutAdIdSupport(
       config.modResults.contents,
-      props.ios?.withoutAdIdSupport === true,
+      props?.ios?.withoutAdIdSupport === true,
     );
 
     return config;

--- a/packages/analytics/plugin/src/ios/podfile.ts
+++ b/packages/analytics/plugin/src/ios/podfile.ts
@@ -18,10 +18,6 @@ export function setAnalyticsPodfileWithoutAdIdSupport(
     return removeGeneratedContents(src, TAG) ?? src;
   }
 
-  if (src.includes(FLAG)) {
-    return src;
-  }
-
   return mergeContents({
     src,
     newSrc: FLAG,

--- a/packages/analytics/plugin/src/pluginConfig.ts
+++ b/packages/analytics/plugin/src/pluginConfig.ts
@@ -1,0 +1,7 @@
+export interface PluginConfigType {
+  ios?: PluginConfigTypeIos;
+}
+
+export interface PluginConfigTypeIos {
+  withoutAdIdSupport?: boolean;
+}

--- a/packages/analytics/plugin/tsconfig.json
+++ b/packages/analytics/plugin/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node-lts/tsconfig",
+  "compilerOptions": {
+    "outDir": "build",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["./src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6134,10 +6134,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-native-firebase/analytics@workspace:packages/analytics"
   dependencies:
+    expo: "npm:^55.0.5"
     react-native-builder-bob: "npm:^0.40.17"
     superstruct: "npm:^2.0.2"
+    typescript: "npm:^5.9.3"
   peerDependencies:
     "@react-native-firebase/app": 24.0.0
+    expo: ">=47.0.0"
+  peerDependenciesMeta:
+    expo:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Description

This adds an Expo config plugin for `@react-native-firebase/analytics` so Expo and EAS users can declaratively opt out of iOS Ad ID support.

Today the native CocoaPods integration already supports `$RNFirebaseAnalyticsWithoutAdIdSupport = true`, but Expo users do not have a package-level config plugin for Analytics that can write that Podfile variable during prebuild.

This PR adds that missing Expo surface by:

- adding `@react-native-firebase/analytics/app.plugin.js`
- adding an Analytics Expo plugin with `ios.withoutAdIdSupport`
- updating the generated iOS `Podfile` when `withoutAdIdSupport` is enabled
- documenting the Expo / EAS usage in the Analytics README and Expo installation docs
- adding Jest coverage for add, idempotency, and removal behavior

### Related issues

- Related to discussion #6180

### Release Summary

- feat(analytics): add Expo config plugin support for `ios.withoutAdIdSupport`

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- `./node_modules/.bin/tsc --build packages/analytics/plugin`
- `./node_modules/.bin/eslint packages/analytics/plugin/src packages/analytics/plugin/__tests__`
- `yarn tests:jest packages/analytics/plugin/__tests__/iosPlugin.test.ts`

:fire:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Expo config plugin that mutates the generated iOS `Podfile` for Analytics; risk is mainly around iOS prebuild/pods generation for Expo/EAS users if the merge/remove logic or anchor matching behaves unexpectedly.
> 
> **Overview**
> Enables Expo/EAS users of `@react-native-firebase/analytics` to declaratively disable iOS Ad ID support via a new config plugin option `ios.withoutAdIdSupport`.
> 
> Adds an `app.plugin.js` entrypoint and a TypeScript Expo config plugin that injects (and can remove, idempotently) `$RNFirebaseAnalyticsWithoutAdIdSupport = true` into the generated iOS `Podfile` during prebuild. Documentation is updated to show the new Expo configuration, and Jest coverage is added for the Podfile patching behavior.
> 
> Updates `@react-native-firebase/analytics` packaging to build/export the plugin (`prepare` runs `build:plugin`), and adds optional `expo` peer dependency plus related dev deps/lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc81073d002447c915f1dea27aea004194ba9f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->