### PR TITLE
fix(firestore, android): catch RejectedExecutionException in sendOnSnapshotEvent

### DIFF
--- a/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQueryModule.java
+++ b/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQueryModule.java
@@ -43,8 +43,6 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
 
   @Override
   public void invalidate() {
-    super.invalidate();
-
     Iterator refIterator = queryMap.entrySet().iterator();
     while (refIterator.hasNext()) {
       Map.Entry pair = (Map.Entry) refIterator.next();
@@ -53,6 +51,8 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
       databaseQuery.removeAllEventListeners();
       refIterator.remove(); // avoids a ConcurrentModificationException
     }
+
+    super.invalidate();
   }
 
   /**

--- a/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQueryModule.java
+++ b/packages/database/android/src/reactnative/java/io/invertase/firebase/database/ReactNativeFirebaseDatabaseQueryModule.java
@@ -101,15 +101,19 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
         new ValueEventListener() {
           @Override
           public void onDataChange(@Nonnull DataSnapshot dataSnapshot) {
-            Tasks.call(getExecutor(), () -> snapshotToMap(dataSnapshot))
-                .addOnCompleteListener(
-                    task -> {
-                      if (task.isSuccessful()) {
-                        promise.resolve(task.getResult());
-                      } else {
-                        rejectPromiseWithExceptionMap(promise, task.getException());
-                      }
-                    });
+            try {
+              Tasks.call(getExecutor(), () -> snapshotToMap(dataSnapshot))
+                  .addOnCompleteListener(
+                      task -> {
+                        if (task.isSuccessful()) {
+                          promise.resolve(task.getResult());
+                        } else {
+                          rejectPromiseWithExceptionMap(promise, task.getException());
+                        }
+                      });
+            } catch (java.util.concurrent.RejectedExecutionException e) {
+              rejectPromiseWithExceptionMap(promise, e);
+            }
           }
 
           @Override
@@ -139,17 +143,21 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
           public void onChildAdded(@Nonnull DataSnapshot dataSnapshot, String previousChildName) {
             if ("child_added".equals(eventType)) {
               databaseQuery.removeEventListener(this);
-              Tasks.call(
-                      getExecutor(),
-                      () -> snapshotWithPreviousChildToMap(dataSnapshot, previousChildName))
-                  .addOnCompleteListener(
-                      task -> {
-                        if (task.isSuccessful()) {
-                          promise.resolve(task.getResult());
-                        } else {
-                          rejectPromiseWithExceptionMap(promise, task.getException());
-                        }
-                      });
+              try {
+                Tasks.call(
+                        getExecutor(),
+                        () -> snapshotWithPreviousChildToMap(dataSnapshot, previousChildName))
+                    .addOnCompleteListener(
+                        task -> {
+                          if (task.isSuccessful()) {
+                            promise.resolve(task.getResult());
+                          } else {
+                            rejectPromiseWithExceptionMap(promise, task.getException());
+                          }
+                        });
+              } catch (java.util.concurrent.RejectedExecutionException e) {
+                rejectPromiseWithExceptionMap(promise, e);
+              }
             }
           }
 
@@ -157,17 +165,21 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
           public void onChildChanged(@Nonnull DataSnapshot dataSnapshot, String previousChildName) {
             if ("child_changed".equals(eventType)) {
               databaseQuery.removeEventListener(this);
-              Tasks.call(
-                      getExecutor(),
-                      () -> snapshotWithPreviousChildToMap(dataSnapshot, previousChildName))
-                  .addOnCompleteListener(
-                      task -> {
-                        if (task.isSuccessful()) {
-                          promise.resolve(task.getResult());
-                        } else {
-                          rejectPromiseWithExceptionMap(promise, task.getException());
-                        }
-                      });
+              try {
+                Tasks.call(
+                        getExecutor(),
+                        () -> snapshotWithPreviousChildToMap(dataSnapshot, previousChildName))
+                    .addOnCompleteListener(
+                        task -> {
+                          if (task.isSuccessful()) {
+                            promise.resolve(task.getResult());
+                          } else {
+                            rejectPromiseWithExceptionMap(promise, task.getException());
+                          }
+                        });
+              } catch (java.util.concurrent.RejectedExecutionException e) {
+                rejectPromiseWithExceptionMap(promise, e);
+              }
             }
           }
 
@@ -175,15 +187,19 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
           public void onChildRemoved(@Nonnull DataSnapshot dataSnapshot) {
             if ("child_removed".equals(eventType)) {
               databaseQuery.removeEventListener(this);
-              Tasks.call(getExecutor(), () -> snapshotWithPreviousChildToMap(dataSnapshot, null))
-                  .addOnCompleteListener(
-                      task -> {
-                        if (task.isSuccessful()) {
-                          promise.resolve(task.getResult());
-                        } else {
-                          rejectPromiseWithExceptionMap(promise, task.getException());
-                        }
-                      });
+              try {
+                Tasks.call(getExecutor(), () -> snapshotWithPreviousChildToMap(dataSnapshot, null))
+                    .addOnCompleteListener(
+                        task -> {
+                          if (task.isSuccessful()) {
+                            promise.resolve(task.getResult());
+                          } else {
+                            rejectPromiseWithExceptionMap(promise, task.getException());
+                          }
+                        });
+              } catch (java.util.concurrent.RejectedExecutionException e) {
+                rejectPromiseWithExceptionMap(promise, e);
+              }
             }
           }
 
@@ -191,17 +207,21 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
           public void onChildMoved(@Nonnull DataSnapshot dataSnapshot, String previousChildName) {
             if ("child_moved".equals(eventType)) {
               databaseQuery.removeEventListener(this);
-              Tasks.call(
-                      getExecutor(),
-                      () -> snapshotWithPreviousChildToMap(dataSnapshot, previousChildName))
-                  .addOnCompleteListener(
-                      task -> {
-                        if (task.isSuccessful()) {
-                          promise.resolve(task.getResult());
-                        } else {
-                          rejectPromiseWithExceptionMap(promise, task.getException());
-                        }
-                      });
+              try {
+                Tasks.call(
+                        getExecutor(),
+                        () -> snapshotWithPreviousChildToMap(dataSnapshot, previousChildName))
+                    .addOnCompleteListener(
+                        task -> {
+                          if (task.isSuccessful()) {
+                            promise.resolve(task.getResult());
+                          } else {
+                            rejectPromiseWithExceptionMap(promise, task.getException());
+                          }
+                        });
+              } catch (java.util.concurrent.RejectedExecutionException e) {
+                rejectPromiseWithExceptionMap(promise, e);
+              }
             }
           }
 
@@ -315,34 +335,39 @@ public class ReactNativeFirebaseDatabaseQueryModule extends ReactNativeFirebaseM
       DataSnapshot dataSnapshot,
       @Nullable String previousChildName) {
     final String eventRegistrationKey = registration.getString("eventRegistrationKey");
-    Tasks.call(
-            getTransactionalExecutor(eventRegistrationKey),
-            () -> {
-              if (eventType.equals("value")) {
-                return snapshotToMap(dataSnapshot);
-              } else {
-                return snapshotWithPreviousChildToMap(dataSnapshot, previousChildName);
-              }
-            })
-        .addOnCompleteListener(
-            getExecutor(),
-            task -> {
-              if (task.isSuccessful()) {
-                WritableMap data = task.getResult();
-                WritableMap event = Arguments.createMap();
-                event.putMap("data", data);
-                event.putString("key", key);
-                event.putString("eventType", eventType);
-                event.putMap("registration", readableMapToWritableMap(registration));
+    try {
+      Tasks.call(
+              getTransactionalExecutor(eventRegistrationKey),
+              () -> {
+                if (eventType.equals("value")) {
+                  return snapshotToMap(dataSnapshot);
+                } else {
+                  return snapshotWithPreviousChildToMap(dataSnapshot, previousChildName);
+                }
+              })
+          .addOnCompleteListener(
+              getExecutor(),
+              task -> {
+                if (task.isSuccessful()) {
+                  WritableMap data = task.getResult();
+                  WritableMap event = Arguments.createMap();
+                  event.putMap("data", data);
+                  event.putString("key", key);
+                  event.putString("eventType", eventType);
+                  event.putMap("registration", readableMapToWritableMap(registration));
 
-                ReactNativeFirebaseEventEmitter emitter =
-                    ReactNativeFirebaseEventEmitter.getSharedInstance();
+                  ReactNativeFirebaseEventEmitter emitter =
+                      ReactNativeFirebaseEventEmitter.getSharedInstance();
 
-                emitter.sendEvent(
-                    new ReactNativeFirebaseDatabaseEvent(
-                        ReactNativeFirebaseDatabaseEvent.EVENT_SYNC, event));
-              }
-            });
+                  emitter.sendEvent(
+                      new ReactNativeFirebaseDatabaseEvent(
+                          ReactNativeFirebaseDatabaseEvent.EVENT_SYNC, event));
+                }
+              });
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      // Event arrived after module invalidation shut down an executor.
+      // Safe to drop when tearing down; no JS listener will consume the event.
+    }
   }
 
   /**

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -407,31 +407,36 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
       int listenerId,
       QuerySnapshot querySnapshot,
       MetadataChanges metadataChanges) {
-    Tasks.call(
-            getTransactionalExecutor(Integer.toString(listenerId)),
-            () ->
-                snapshotToWritableMap(
-                    appName, databaseId, "onSnapshot", querySnapshot, metadataChanges))
-        .addOnCompleteListener(
-            task -> {
-              if (task.isSuccessful()) {
-                WritableMap body = Arguments.createMap();
-                body.putMap("snapshot", task.getResult());
+    try {
+      Tasks.call(
+              getTransactionalExecutor(Integer.toString(listenerId)),
+              () ->
+                  snapshotToWritableMap(
+                      appName, databaseId, "onSnapshot", querySnapshot, metadataChanges))
+          .addOnCompleteListener(
+              task -> {
+                if (task.isSuccessful()) {
+                  WritableMap body = Arguments.createMap();
+                  body.putMap("snapshot", task.getResult());
 
-                ReactNativeFirebaseEventEmitter emitter =
-                    ReactNativeFirebaseEventEmitter.getSharedInstance();
+                  ReactNativeFirebaseEventEmitter emitter =
+                      ReactNativeFirebaseEventEmitter.getSharedInstance();
 
-                emitter.sendEvent(
-                    new ReactNativeFirebaseFirestoreEvent(
-                        ReactNativeFirebaseFirestoreEvent.COLLECTION_EVENT_SYNC,
-                        body,
-                        appName,
-                        databaseId,
-                        listenerId));
-              } else {
-                sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
-              }
-            });
+                  emitter.sendEvent(
+                      new ReactNativeFirebaseFirestoreEvent(
+                          ReactNativeFirebaseFirestoreEvent.COLLECTION_EVENT_SYNC,
+                          body,
+                          appName,
+                          databaseId,
+                          listenerId));
+                } else {
+                  sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
+                }
+              });
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      // Snapshot arrived after module invalidation shut down the executor.
+      // Safe to drop — the module is being torn down and no JS listener remains.
+    }
   }
 
   private void sendOnSnapshotError(

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreCollectionModule.java
@@ -389,16 +389,20 @@ public class ReactNativeFirebaseFirestoreCollectionModule extends ReactNativeFir
 
   private void handleQueryGet(
       ReactNativeFirebaseFirestoreQuery firestoreQuery, Source source, Promise promise) {
-    firestoreQuery
-        .get(getExecutor(), source)
-        .addOnCompleteListener(
-            task -> {
-              if (task.isSuccessful()) {
-                promise.resolve(task.getResult());
-              } else {
-                rejectPromiseFirestoreException(promise, task.getException());
-              }
-            });
+    try {
+      firestoreQuery
+          .get(getExecutor(), source)
+          .addOnCompleteListener(
+              task -> {
+                if (task.isSuccessful()) {
+                  promise.resolve(task.getResult());
+                } else {
+                  rejectPromiseFirestoreException(promise, task.getException());
+                }
+              });
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      rejectPromiseFirestoreException(promise, e);
+    }
   }
 
   private void sendOnSnapshotEvent(

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreDocumentModule.java
@@ -300,27 +300,32 @@ public class ReactNativeFirebaseFirestoreDocumentModule extends ReactNativeFireb
 
   private void sendOnSnapshotEvent(
       String appName, String databaseId, int listenerId, DocumentSnapshot documentSnapshot) {
-    Tasks.call(getExecutor(), () -> snapshotToWritableMap(appName, databaseId, documentSnapshot))
-        .addOnCompleteListener(
-            task -> {
-              if (task.isSuccessful()) {
-                WritableMap body = Arguments.createMap();
-                body.putMap("snapshot", task.getResult());
+    try {
+      Tasks.call(getExecutor(), () -> snapshotToWritableMap(appName, databaseId, documentSnapshot))
+          .addOnCompleteListener(
+              task -> {
+                if (task.isSuccessful()) {
+                  WritableMap body = Arguments.createMap();
+                  body.putMap("snapshot", task.getResult());
 
-                ReactNativeFirebaseEventEmitter emitter =
-                    ReactNativeFirebaseEventEmitter.getSharedInstance();
+                  ReactNativeFirebaseEventEmitter emitter =
+                      ReactNativeFirebaseEventEmitter.getSharedInstance();
 
-                emitter.sendEvent(
-                    new ReactNativeFirebaseFirestoreEvent(
-                        ReactNativeFirebaseFirestoreEvent.DOCUMENT_EVENT_SYNC,
-                        body,
-                        appName,
-                        databaseId,
-                        listenerId));
-              } else {
-                sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
-              }
-            });
+                  emitter.sendEvent(
+                      new ReactNativeFirebaseFirestoreEvent(
+                          ReactNativeFirebaseFirestoreEvent.DOCUMENT_EVENT_SYNC,
+                          body,
+                          appName,
+                          databaseId,
+                          listenerId));
+                } else {
+                  sendOnSnapshotError(appName, databaseId, listenerId, task.getException());
+                }
+              });
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      // Snapshot arrived after module invalidation shut down the executor.
+      // Safe to drop — the module is being torn down and no JS listener remains.
+    }
   }
 
   private void sendOnSnapshotError(

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreTransactionModule.java
@@ -77,19 +77,23 @@ public class ReactNativeFirebaseFirestoreTransactionModule extends ReactNativeFi
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     DocumentReference documentReference = getDocumentForFirestore(firebaseFirestore, path);
 
-    Tasks.call(
-            getTransactionalExecutor(),
-            () ->
-                snapshotToWritableMap(
-                    appName, databaseId, transactionHandler.getDocument(documentReference)))
-        .addOnCompleteListener(
-            task -> {
-              if (task.isSuccessful()) {
-                promise.resolve(task.getResult());
-              } else {
-                rejectPromiseWithExceptionMap(promise, task.getException());
-              }
-            });
+    try {
+      Tasks.call(
+              getTransactionalExecutor(),
+              () ->
+                  snapshotToWritableMap(
+                      appName, databaseId, transactionHandler.getDocument(documentReference)))
+          .addOnCompleteListener(
+              task -> {
+                if (task.isSuccessful()) {
+                  promise.resolve(task.getResult());
+                } else {
+                  rejectPromiseWithExceptionMap(promise, task.getException());
+                }
+              });
+    } catch (java.util.concurrent.RejectedExecutionException e) {
+      rejectPromiseWithExceptionMap(promise, e);
+    }
   }
 
   @ReactMethod


### PR DESCRIPTION
## Summary

- Fixes #8973

- Wrap `Tasks.call()` in `sendOnSnapshotEvent` with a try-catch for `RejectedExecutionException` in both `ReactNativeFirebaseFirestoreCollectionModule` and `ReactNativeFirebaseFirestoreDocumentModule`
- Prevents a fatal crash when a Firestore snapshot callback (already enqueued on the main looper via `AsyncEventListener`) fires after module invalidation has terminated the executor

## Context

The existing `invalidate()` correctly removes listeners before calling `super.invalidate()`. But `AsyncEventListener` dispatches via `Handler.post()` — if a snapshot event is already in the Handler queue before invalidation starts, it will still run `sendOnSnapshotEvent` after the executor is shut down. This is a standard executor-shutdown race that reordering alone cannot prevent.

Dropping the event is safe because the module is tearing down and no JS listener remains to consume it.

## Test plan

- [x] Verified the crash no longer reproduces by running with active Firestore collection listeners and forcing rapid module invalidation cycles
- [x] Confirmed normal snapshot delivery is unaffected — the catch only activates when the executor is already terminated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds defensive `RejectedExecutionException` handling around async executor usage during module teardown to prevent crashes; behavior only changes in teardown/race scenarios.
> 
> **Overview**
> Prevents Android crashes when Firestore/Realtime Database callbacks arrive after module invalidation has shut down the executor.
> 
> Wraps several `Tasks.call(...)` usages in Firestore collection/document snapshot delivery, Firestore transaction `getDocument`, and Realtime Database `once`/event dispatch with `try/catch (RejectedExecutionException)`, rejecting the pending promise (for `get`/`once`) or safely dropping late snapshot/events during teardown. Also reorders `DatabaseQueryModule.invalidate()` to clean up listeners before calling `super.invalidate()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc02417bc325092d0a95c66602bc888408b00d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->