### PR TITLE
fix(expo): VS code extension not picking up expo support via metadata in package.json

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -75,5 +75,8 @@
   "eslintIgnore": [
     "node_modules/",
     "dist/"
-  ]
+  ],
+  "expo": {
+    "plugin": "./app.plugin.js"
+  }
 }

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -73,5 +73,8 @@
   "eslintIgnore": [
     "node_modules/",
     "dist/"
-  ]
+  ],
+  "expo": {
+    "plugin": "./app.plugin.js"
+  }
 }

--- a/packages/app-distribution/package.json
+++ b/packages/app-distribution/package.json
@@ -71,5 +71,8 @@
   "eslintIgnore": [
     "node_modules/",
     "dist/"
-  ]
+  ],
+  "expo": {
+    "plugin": "./app.plugin.js"
+  }
 }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -144,5 +144,8 @@
   "eslintIgnore": [
     "node_modules/",
     "dist/"
-  ]
+  ],
+  "expo": {
+    "plugin": "./app.plugin.js"
+  }
 }

--- a/packages/app/plugin/__tests__/packageManifest.test.ts
+++ b/packages/app/plugin/__tests__/packageManifest.test.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+
+const pluginPackages = [
+  'analytics',
+  'app',
+  'app-check',
+  'app-distribution',
+  'auth',
+  'crashlytics',
+  'messaging',
+  'perf',
+] as const;
+
+const repoRoot = path.resolve(__dirname, '../../../../');
+
+interface ExpoPluginPackageJson {
+  expo?: {
+    plugin?: string;
+  };
+  exports?: Record<string, string>;
+}
+
+function readPackageJson(pkg: (typeof pluginPackages)[number]): ExpoPluginPackageJson {
+  const packageJsonPath = path.resolve(repoRoot, 'packages', pkg, 'package.json');
+
+  try {
+    return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as ExpoPluginPackageJson;
+  } catch (error) {
+    throw new Error(`Failed to read ${pkg}/package.json: ${String(error)}`);
+  }
+}
+
+describe('Expo config plugin package manifests', function () {
+  it.each(pluginPackages)('%s declares app.plugin.js for Expo tooling', function (pkg) {
+    const packageJsonPath = path.resolve(repoRoot, 'packages', pkg, 'package.json');
+    const pluginEntryPath = path.resolve(repoRoot, 'packages', pkg, 'app.plugin.js');
+
+    expect(fs.existsSync(packageJsonPath)).toBe(true);
+    expect(fs.existsSync(pluginEntryPath)).toBe(true);
+
+    const manifest = readPackageJson(pkg);
+
+    expect(manifest.expo).toMatchObject({
+      plugin: './app.plugin.js',
+    });
+
+    // Older JS packages do not declare an exports map yet, but any package that does
+    // must keep the config plugin subpath available for Expo's resolver.
+    if (manifest.exports) {
+      expect(manifest.exports['./app.plugin.js']).toBe('./app.plugin.js');
+    }
+  });
+});

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,5 +42,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "expo": {
+    "plugin": "./app.plugin.js"
   }
 }

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -76,5 +76,8 @@
         }
       ]
     ]
+  },
+  "expo": {
+    "plugin": "./app.plugin.js"
   }
 }

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -72,5 +72,8 @@
   "eslintIgnore": [
     "node_modules/",
     "dist/"
-  ]
+  ],
+  "expo": {
+    "plugin": "./app.plugin.js"
+  }
 }

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -43,5 +43,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
+  },
+  "expo": {
+    "plugin": "./app.plugin.js"
   }
 }


### PR DESCRIPTION
### Description

Expo config plugin tooling could warn that RNFB packages were not valid config plugins when referenced by package name alone, even though `app.plugin.js` was present and direct references to that file worked. This change makes the plugin entry explicit by adding Expo plugin metadata to every RNFB package that ships `app.plugin.js`, and adds a regression test to keep that manifest contract in place.

possibly closes https://github.com/invertase/react-native-firebase/issues/8976

Await user feedback.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
