### PR TITLE
[firestore][android] fix instance cache key for Firestore initialization

### DIFF
--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
@@ -50,7 +50,7 @@ public class UniversalFirebaseFirestoreCommon {
 
     setFirestoreSettings(instance, firestoreKey);
 
-    instanceCache.put(appName, new WeakReference<FirebaseFirestore>(instance));
+    instanceCache.put(firestoreKey, new WeakReference<FirebaseFirestore>(instance));
 
     return instance;
   }


### PR DESCRIPTION
## Summary
- fix the Android Firestore instance cache write to use `firestoreKey`
- avoid cache misses that can lead to repeated `setFirestoreSettings(...)` calls

## Details
`getFirestoreForApp()` reads from `instanceCache` using `appName + ":" + databaseId`, but was writing back using only `appName`.

That makes the cache internally inconsistent:
- lookup key: `firestoreKey`
- write key: `appName`

This change makes the cache write use the same key as the lookup.

Fixes #8981

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to cache key selection; main risk is altered instance reuse behavior for apps using multiple Firestore database IDs.
> 
> **Overview**
> Fixes an Android Firestore caching bug where `getFirestoreForApp()` stored instances in `instanceCache` under `appName` instead of the composite `firestoreKey` (`appName:databaseId`).
> 
> This aligns cache writes with cache reads, preventing cache misses and avoiding repeated `setFirestoreSettings(...)` application for the same app/database pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5ead25fc93661fc7d047ab8f574500cd4a9ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->