### PR TITLE
docs: favicon for reference site, new custom subdomain for reference site

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -23,7 +23,7 @@
     {
       "id": "reference",
       "title": "Reference API",
-      "href": "https://invertase.github.io/react-native-firebase/modules.html"
+      "href": "https://reference.rnfirebase.io/modules.html"
     }
   ],
   "sidebar": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:all": "yarn lint && yarn lint:markdown && yarn lint:spellcheck && yarn tsc:compile",
     "test:full": "bash ./scripts/run-full-tests.sh",
     "reference:api": "typedoc",
-    "reference:api:gh-pages": "typedoc --out apidocs-out --hostedBaseUrl https://invertase.github.io/react-native-firebase/ --useHostedBaseUrlForAbsoluteLinks",
+    "reference:api:gh-pages": "typedoc --out apidocs-out --hostedBaseUrl https://reference.rnfirebase.io/ --useHostedBaseUrlForAbsoluteLinks",
     "tests:ai:mocks": "yarn ts-node ./scripts/fetch_ai_mock_responses.ts && yarn ts-node ./packages/ai/__tests__/test-utils/convert-mocks.ts",
     "tests:jest": "jest",
     "tests:jest-watch": "jest --watch",

--- a/typedoc.json
+++ b/typedoc.json
@@ -38,6 +38,7 @@
   "hideGenerator": true,
   "cleanOutputDir": true,
   "titleLink": "https://github.com/invertase/react-native-firebase",
+  "favicon": "https://static.invertase.io/assets/react-native-firebase-favicon.png",
   "navigationLinks": {
     "GitHub": "https://github.com/invertase/react-native-firebase",
     "npm": "https://www.npmjs.com/search?q=scope%3Areact-native-firebase"


### PR DESCRIPTION
### Description

Take advantage of the new https://reference.rnfirebase.io subdomain, and prettify the typedoc just a tiny bit with a favicon

### Related issues

None filed, but it is a follow-on for all the documentation work PRs and issues...

### Release Summary

No software release, but a publish of the typedoc will be required after this for it to take effect

--> https://github.com/invertase/react-native-firebase/actions/workflows/deploy-api-reference.yml

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

- Check favicon after Github Pages deploy (it did work locally after `yarn reference:api`)
- Check "reference" tab link on docs.pages after merge to main (it does look correct when looking at the branch preview: https://docs.page/invertase/react-native-firebase~docs-tweaks)

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
