### PR TITLE
chore(repo): add Gemini Code Assist config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,14 @@
+have_fun: false
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: LOW
+  max_review_comments: -1
+  pull_request_opened:
+    help: true
+    summary: true
+    code_review: true
+    include_drafts: true
+ignore_patterns:
+  - "**/node_modules/**"

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,12 @@
+# React Native Firebase Gemini Review Guide
+
+If an `AGENTS.md` file exists at the repository root, follow that guidance first.
+
+If no root `AGENTS.md` file exists, use the guidance below.
+
+## Testing expectations
+
+- Suggest tests when behavior changes or regression risk increases.
+- Prefer focused tests near the changed package rather than broad new coverage.
+- Avoid asking for redundant tests when existing coverage already appears sufficient.
+

--- a/packages/app/lib/modular.ts
+++ b/packages/app/lib/modular.ts
@@ -116,6 +116,14 @@ export function getApp(name?: string): ReactNativeFirebase.FirebaseApp {
 }
 
 /**
+ * Retrieves the default Firebase app instance.
+ * @returns The default Firebase app instance.
+ */
+export function getDefaultApp(): ReactNativeFirebase.FirebaseApp {
+  return getApp();
+}
+
+/**
  * Sets the log level across all Firebase SDKs.
  * @param logLevel - The log level to set ('debug', 'verbose', 'info', 'warn', 'error', 'silent').
  * @returns void

--- a/packages/app/lib/modular.ts
+++ b/packages/app/lib/modular.ts
@@ -116,14 +116,6 @@ export function getApp(name?: string): ReactNativeFirebase.FirebaseApp {
 }
 
 /**
- * Retrieves the default Firebase app instance.
- * @returns The default Firebase app instance.
- */
-export function getDefaultApp(): ReactNativeFirebase.FirebaseApp {
-  return getApp();
-}
-
-/**
  * Sets the log level across all Firebase SDKs.
  * @param logLevel - The log level to set ('debug', 'verbose', 'info', 'warn', 'error', 'silent').
  * @returns void


### PR DESCRIPTION
## Summary
- add a repository-level `.gemini/config.yaml` to enable Gemini Code Assist behavior in this repo
- enable PR-opened help, summary, and code review so the integration is easy to verify on this PR
- keep the initial configuration minimal and non-invasive for a first integration test

## Test plan
- [ ] Confirm Gemini Code Assist posts on this draft PR
- [ ] Verify the PR receives the configured help message and summary
- [ ] Verify code review runs against the branch changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds repo tooling configuration plus a small additive helper that delegates to existing `getApp()` behavior.
> 
> **Overview**
> Adds a `.gemini/config.yaml` and `.gemini/styleguide.md` to enable and tune Gemini Code Assist behavior (PR-opened help/summary/review, low severity threshold, and ignore patterns).
> 
> Extends the modular app API by introducing `getDefaultApp()` in `packages/app/lib/modular.ts` as a convenience wrapper around `getApp()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9012106206f2da6194e8cb95323a5dadef4ec46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->