### PR TITLE
docs(repo): update code of conduct links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-- [Code of Conduct](https://github.com/invertase/meta/blob/master/CODE_OF_CONDUCT.md)
+- [Code of Conduct](https://github.com/invertase/.github/blob/main/CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Looking for the Version 5 documentation? [View legacy documentation](https://v5.
 - [PRs](https://github.com/invertase/react-native-firebase/pulls)
 - [Documentation](https://rnfirebase.io)
 - [Community](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md)
-- [Code of Conduct](https://github.com/invertase/meta/blob/main/CODE_OF_CONDUCT.md)
+- [Code of Conduct](https://github.com/invertase/.github/blob/main/CODE_OF_CONDUCT.md)
 
 ## License
 


### PR DESCRIPTION
## Summary
- update the repository code of conduct link to point at the shared `invertase/.github` location
- update the README code of conduct link to the same shared canonical location
- remove the stale dependency on the old `invertase/meta` path

## Test plan
- [ ] Docs-only change