### PR TITLE
chore: skill with validation commands for TS/JS development

### DIFF
--- a/.agents/skills/ts-js-validation/SKILL.md
+++ b/.agents/skills/ts-js-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ts-js-validation
-description: Validate TypeScript and JavaScript changes in React Native Firebase by formatting package JS/TS sources and running the root prepare, TypeScript compile, consumer TypeScript compile, and Jest test scripts. Use when a developer updates TS/JS code and wants the standard RNFB validation pass before handing off or committing.
+description: Validate TypeScript and JavaScript changes in React Native Firebase by running the root prepare, TypeScript compile, API reference, Jest, formatting, and compare-types scripts. Use when a developer updates TS/JS code and wants the standard RNFB validation pass before handing off or committing.
 metadata:
   owner_team: react-native-firebase
   maintainer: russell.wheatley
@@ -16,7 +16,7 @@ metadata:
 
 Use this skill to validate changes to TypeScript or JavaScript code in the React Native Firebase monorepo.
 
-It is for developer-facing validation after editing package JS/TS sources, type tests, Jest tests, or shared TypeScript configuration. It formats code and runs the standard root validation commands that catch generated package setup issues, TypeScript errors, consumer type regressions, and Jest failures.
+It is for developer-facing validation after editing package JS/TS sources, type tests, Jest tests, or shared TypeScript configuration. It runs the standard root validation commands that catch generated package setup issues, TypeScript errors, consumer type regressions, API reference regressions, Jest failures, formatting drift, and firebase-js-sdk type parity drift.
 
 ## Triggers
 
@@ -42,9 +42,9 @@ Do not use this skill for:
 
 Set one clear default path so the agent does not choose randomly between options.
 
-- Default tool or method: run the root Yarn scripts in this order from the repository root: `yarn lerna:prepare`, `yarn tsc:compile`, `yarn tsc:compile:consumer`, `yarn tests:jest`, and `yarn format:js`
+- Default tool or method: run the root Yarn scripts in this order from the repository root: `yarn lerna:prepare`, `yarn tsc:compile`, `yarn tsc:compile:consumer`, `yarn reference:api`, `yarn tests:jest`, `yarn format:js`, and `yarn compare:types`
 - Fallback when default fails: if a command fails, stop the sequence, inspect the failure, fix issues only when the user asked for fixes or the fix is clearly in the current change set, then rerun the failed command and any later commands
-- Why this default exists: `lerna:prepare`, both TypeScript compiles, and Jest cover the JS/TS surfaces most likely to regress in this monorepo, while `format:js` keeps package JS/TS sources normalized before handoff
+- Why this default exists: `lerna:prepare`, both TypeScript compiles, API reference generation, Jest, formatting, and compare-types cover the JS/TS surfaces most likely to regress in this monorepo
 
 ## Gotchas
 
@@ -52,7 +52,9 @@ Set one clear default path so the agent does not choose randomly between options
 - Run commands from the repository root so workspace resolution, root `tsconfig.json`, and Jest configuration are consistent.
 - `yarn lerna:prepare` may rebuild or refresh package artifacts needed before TypeScript or tests run.
 - `yarn tsc:compile` checks the repository TypeScript project, while `yarn tsc:compile:consumer` checks the consumer-facing TypeScript project. Run both.
+- `yarn reference:api` runs TypeDoc and should come after consumer TypeScript compilation.
 - `yarn tests:jest` is the root Jest entrypoint. If it fails, report the failing test file or suite and the first actionable error rather than dumping the full output.
+- `yarn compare:types` installs dependencies under `.github/scripts/compare-types` before running the type parity comparison. Keep it last.
 - If validation is slow, keep the command running rather than replacing it with a narrower command unless the user explicitly asks for targeted validation.
 
 ## Workflow
@@ -63,8 +65,10 @@ Set one clear default path so the agent does not choose randomly between options
    1. `yarn lerna:prepare`
    2. `yarn tsc:compile`
    3. `yarn tsc:compile:consumer`
-   4. `yarn tests:jest`
-   5. `yarn format:js`
+   4. `yarn reference:api`
+   5. `yarn tests:jest`
+   6. `yarn format:js`
+   7. `yarn compare:types`
 4. If `yarn format:js` changes files, include those formatting changes in the validation context and inspect the relevant diff before continuing.
 5. If a command fails:
    - stop before running later commands
@@ -80,11 +84,13 @@ Use this loop before finalizing:
    1. `yarn lerna:prepare`
    2. `yarn tsc:compile`
    3. `yarn tsc:compile:consumer`
-   4. `yarn tests:jest`
-   5. `yarn format:js`
+   4. `yarn reference:api`
+   5. `yarn tests:jest`
+   6. `yarn format:js`
+   7. `yarn compare:types`
 2. If validation fails because of current TS/JS changes and fixing is in scope, fix the issue and rerun the failed command plus all later commands.
 3. If validation fails for unrelated or environment-specific reasons, stop and report the blocker with the command that failed and the shortest useful error summary.
-4. Only report success when all five commands complete successfully.
+4. Only report success when all seven commands complete successfully.
 
 ## Output format
 
@@ -101,8 +107,10 @@ Use this template:
 - `yarn lerna:prepare`: passed | failed | not run
 - `yarn tsc:compile`: passed | failed | not run
 - `yarn tsc:compile:consumer`: passed | failed | not run
+- `yarn reference:api`: passed | failed | not run
 - `yarn tests:jest`: passed | failed | not run
 - `yarn format:js`: passed | failed | changed files
+- `yarn compare:types`: passed | failed | not run
 
 ## Findings
 - failing suite, compiler error, or setup blocker if any
@@ -115,7 +123,7 @@ Use this template:
 
 - Keep responses factual and grounded in command output.
 - Do not skip any command in the default sequence unless the user explicitly narrows validation.
-- Do not claim validation passed if formatting changed files but later commands were not rerun.
+- Do not claim validation passed unless `compare:types` ran after any formatting changes.
 - Do not revert unrelated local changes.
 - Avoid broad refactors while fixing validation failures.
 
@@ -125,8 +133,10 @@ Use this template:
   - `lerna:prepare`
   - `tsc:compile`
   - `tsc:compile:consumer`
+  - `reference:api`
   - `tests:jest`
   - `format:js`
+  - `compare:types`
 
 Load files only when needed:
 

--- a/.agents/skills/ts-js-validation/SKILL.md
+++ b/.agents/skills/ts-js-validation/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: ts-js-validation
+description: Validate TypeScript and JavaScript changes in React Native Firebase by formatting package JS/TS sources and running the root prepare, TypeScript compile, consumer TypeScript compile, and Jest test scripts. Use when a developer updates TS/JS code and wants the standard RNFB validation pass before handing off or committing.
+metadata:
+  owner_team: react-native-firebase
+  maintainer: russell.wheatley
+  status: draft
+  tags: typescript,javascript,testing,validation,formatting,react-native-firebase
+  last_reviewed: "2026-05-08"
+  version: "0.1.0"
+---
+
+# React Native Firebase TS/JS Validation
+
+## Scope
+
+Use this skill to validate changes to TypeScript or JavaScript code in the React Native Firebase monorepo.
+
+It is for developer-facing validation after editing package JS/TS sources, type tests, Jest tests, or shared TypeScript configuration. It formats code and runs the standard root validation commands that catch generated package setup issues, TypeScript errors, consumer type regressions, and Jest failures.
+
+## Triggers
+
+Use this skill when the user asks for:
+
+- testing TS or JS changes
+- validating TypeScript or JavaScript edits before commit or handoff
+- running the standard JS validation pass for RNFB
+- checking whether package JS/TS changes compile and pass Jest
+- formatting package JS/TS code and then running validation
+
+## Out-of-scope boundaries
+
+Do not use this skill for:
+
+- Android Java/Kotlin formatting or build validation
+- iOS Objective-C, Objective-C++, C++, Swift, or pod validation
+- documentation-only changes that do not affect JS/TS behavior
+- release validation that requires the full platform, emulator, Detox, or packaging matrix
+- migrating a package from JavaScript to TypeScript; use the TypeScript refactor or migration skills instead
+
+## Defaults
+
+Set one clear default path so the agent does not choose randomly between options.
+
+- Default tool or method: run the root Yarn scripts in this order from the repository root: `yarn format:js`, `yarn lerna:prepare`, `yarn tsc:compile`, `yarn tsc:compile:consumer`, and `yarn tests:jest`
+- Fallback when default fails: if a command fails, stop the sequence, inspect the failure, fix issues only when the user asked for fixes or the fix is clearly in the current change set, then rerun the failed command and any later commands
+- Why this default exists: formatting first avoids reporting stale style noise, while `lerna:prepare`, both TypeScript compiles, and Jest cover the JS/TS surfaces most likely to regress in this monorepo
+
+## Gotchas
+
+- `yarn format:js` writes changes across `packages/**/*.{js,ts,tsx}`. Check the diff after formatting and do not revert user changes.
+- Run commands from the repository root so workspace resolution, root `tsconfig.json`, and Jest configuration are consistent.
+- `yarn lerna:prepare` may rebuild or refresh package artifacts needed before TypeScript or tests run.
+- `yarn tsc:compile` checks the repository TypeScript project, while `yarn tsc:compile:consumer` checks the consumer-facing TypeScript project. Run both.
+- `yarn tests:jest` is the root Jest entrypoint. If it fails, report the failing test file or suite and the first actionable error rather than dumping the full output.
+- If validation is slow, keep the command running rather than replacing it with a narrower command unless the user explicitly asks for targeted validation.
+
+## Workflow
+
+1. Confirm the task is TS/JS validation and note any specific changed package or test files the user mentioned.
+2. Check whether the worktree has unrelated dirty files before formatting if the current task includes code edits or commit preparation.
+3. Run the validation sequence from the repository root:
+   1. `yarn format:js`
+   2. `yarn lerna:prepare`
+   3. `yarn tsc:compile`
+   4. `yarn tsc:compile:consumer`
+   5. `yarn tests:jest`
+4. If `yarn format:js` changes files, include those formatting changes in the validation context and inspect the relevant diff before continuing.
+5. If a command fails:
+   - stop before running later commands
+   - identify whether the failure belongs to the current TS/JS changes, pre-existing repo state, or missing local setup
+   - fix current-change failures when authorized, then rerun the failed command and continue the remaining sequence
+6. Return a concise result with the commands run, pass/fail status, and any remaining blockers.
+
+## Validation loop
+
+Use this loop before finalizing:
+
+1. Run the root validation sequence:
+   - `yarn format:js`
+   - `yarn lerna:prepare`
+   - `yarn tsc:compile`
+   - `yarn tsc:compile:consumer`
+   - `yarn tests:jest`
+2. If validation fails because of current TS/JS changes and fixing is in scope, fix the issue and rerun the failed command plus all later commands.
+3. If validation fails for unrelated or environment-specific reasons, stop and report the blocker with the command that failed and the shortest useful error summary.
+4. Only report success when all five commands complete successfully after formatting.
+
+## Output format
+
+Use this template:
+
+```markdown
+# TS/JS Validation
+
+## Summary
+- passed | failed | blocked
+- one-sentence validation verdict
+
+## Commands
+- `yarn format:js`: passed | failed | changed files
+- `yarn lerna:prepare`: passed | failed | not run
+- `yarn tsc:compile`: passed | failed | not run
+- `yarn tsc:compile:consumer`: passed | failed | not run
+- `yarn tests:jest`: passed | failed | not run
+
+## Findings
+- failing suite, compiler error, or setup blocker if any
+
+## Next actions
+1. next required action, only if validation did not fully pass
+```
+
+## Constraints
+
+- Keep responses factual and grounded in command output.
+- Do not skip any command in the default sequence unless the user explicitly narrows validation.
+- Do not claim validation passed if formatting changed files but later commands were not rerun.
+- Do not revert unrelated local changes.
+- Avoid broad refactors while fixing validation failures.
+
+## Additional resources
+
+- See the root `package.json` scripts:
+  - `lerna:prepare`
+  - `tsc:compile`
+  - `tsc:compile:consumer`
+  - `tests:jest`
+  - `format:js`
+
+Load files only when needed:
+
+- Read `package.json` if command names or script definitions need to be confirmed.
+- Read affected package `package.json`, `type-test.ts`, or nearby `__tests__/` files only when a failure needs package-specific diagnosis.

--- a/.agents/skills/ts-js-validation/SKILL.md
+++ b/.agents/skills/ts-js-validation/SKILL.md
@@ -42,9 +42,9 @@ Do not use this skill for:
 
 Set one clear default path so the agent does not choose randomly between options.
 
-- Default tool or method: run the root Yarn scripts in this order from the repository root: `yarn format:js`, `yarn lerna:prepare`, `yarn tsc:compile`, `yarn tsc:compile:consumer`, and `yarn tests:jest`
+- Default tool or method: run the root Yarn scripts in this order from the repository root: `yarn lerna:prepare`, `yarn tsc:compile`, `yarn tsc:compile:consumer`, `yarn tests:jest`, and `yarn format:js`
 - Fallback when default fails: if a command fails, stop the sequence, inspect the failure, fix issues only when the user asked for fixes or the fix is clearly in the current change set, then rerun the failed command and any later commands
-- Why this default exists: formatting first avoids reporting stale style noise, while `lerna:prepare`, both TypeScript compiles, and Jest cover the JS/TS surfaces most likely to regress in this monorepo
+- Why this default exists: `lerna:prepare`, both TypeScript compiles, and Jest cover the JS/TS surfaces most likely to regress in this monorepo, while `format:js` keeps package JS/TS sources normalized before handoff
 
 ## Gotchas
 
@@ -58,13 +58,13 @@ Set one clear default path so the agent does not choose randomly between options
 ## Workflow
 
 1. Confirm the task is TS/JS validation and note any specific changed package or test files the user mentioned.
-2. Check whether the worktree has unrelated dirty files before formatting if the current task includes code edits or commit preparation.
+2. Check whether the worktree has unrelated dirty files if the current task includes code edits or commit preparation.
 3. Run the validation sequence from the repository root:
-   1. `yarn format:js`
-   2. `yarn lerna:prepare`
-   3. `yarn tsc:compile`
-   4. `yarn tsc:compile:consumer`
-   5. `yarn tests:jest`
+   1. `yarn lerna:prepare`
+   2. `yarn tsc:compile`
+   3. `yarn tsc:compile:consumer`
+   4. `yarn tests:jest`
+   5. `yarn format:js`
 4. If `yarn format:js` changes files, include those formatting changes in the validation context and inspect the relevant diff before continuing.
 5. If a command fails:
    - stop before running later commands
@@ -77,14 +77,14 @@ Set one clear default path so the agent does not choose randomly between options
 Use this loop before finalizing:
 
 1. Run the root validation sequence:
-   - `yarn format:js`
-   - `yarn lerna:prepare`
-   - `yarn tsc:compile`
-   - `yarn tsc:compile:consumer`
-   - `yarn tests:jest`
+   1. `yarn lerna:prepare`
+   2. `yarn tsc:compile`
+   3. `yarn tsc:compile:consumer`
+   4. `yarn tests:jest`
+   5. `yarn format:js`
 2. If validation fails because of current TS/JS changes and fixing is in scope, fix the issue and rerun the failed command plus all later commands.
 3. If validation fails for unrelated or environment-specific reasons, stop and report the blocker with the command that failed and the shortest useful error summary.
-4. Only report success when all five commands complete successfully after formatting.
+4. Only report success when all five commands complete successfully.
 
 ## Output format
 
@@ -98,11 +98,11 @@ Use this template:
 - one-sentence validation verdict
 
 ## Commands
-- `yarn format:js`: passed | failed | changed files
 - `yarn lerna:prepare`: passed | failed | not run
 - `yarn tsc:compile`: passed | failed | not run
 - `yarn tsc:compile:consumer`: passed | failed | not run
 - `yarn tests:jest`: passed | failed | not run
+- `yarn format:js`: passed | failed | changed files
 
 ## Findings
 - failing suite, compiler error, or setup blocker if any

--- a/.agents/skills/ts-js-validation/SKILL.md
+++ b/.agents/skills/ts-js-validation/SKILL.md
@@ -42,9 +42,21 @@ Do not use this skill for:
 
 Set one clear default path so the agent does not choose randomly between options.
 
-- Default tool or method: run the root Yarn scripts in this order from the repository root: `yarn lerna:prepare`, `yarn tsc:compile`, `yarn tsc:compile:consumer`, `yarn reference:api`, `yarn tests:jest`, `yarn format:js`, and `yarn compare:types`
+- Default tool or method: run the canonical command sequence below from the repository root
 - Fallback when default fails: if a command fails, stop the sequence, inspect the failure, fix issues only when the user asked for fixes or the fix is clearly in the current change set, then rerun the failed command and any later commands
 - Why this default exists: `lerna:prepare`, both TypeScript compiles, API reference generation, Jest, formatting, and compare-types cover the JS/TS surfaces most likely to regress in this monorepo
+
+## Command sequence
+
+Run these root `package.json` scripts in order:
+
+1. `yarn lerna:prepare`
+2. `yarn tsc:compile`
+3. `yarn tsc:compile:consumer`
+4. `yarn reference:api`
+5. `yarn tests:jest`
+6. `yarn format:js`
+7. `yarn compare:types`
 
 ## Gotchas
 
@@ -61,14 +73,7 @@ Set one clear default path so the agent does not choose randomly between options
 
 1. Confirm the task is TS/JS validation and note any specific changed package or test files the user mentioned.
 2. Check whether the worktree has unrelated dirty files if the current task includes code edits or commit preparation.
-3. Run the validation sequence from the repository root:
-   1. `yarn lerna:prepare`
-   2. `yarn tsc:compile`
-   3. `yarn tsc:compile:consumer`
-   4. `yarn reference:api`
-   5. `yarn tests:jest`
-   6. `yarn format:js`
-   7. `yarn compare:types`
+3. Run the command sequence from the repository root.
 4. If `yarn format:js` changes files, include those formatting changes in the validation context and inspect the relevant diff before continuing.
 5. If a command fails:
    - stop before running later commands
@@ -80,17 +85,10 @@ Set one clear default path so the agent does not choose randomly between options
 
 Use this loop before finalizing:
 
-1. Run the root validation sequence:
-   1. `yarn lerna:prepare`
-   2. `yarn tsc:compile`
-   3. `yarn tsc:compile:consumer`
-   4. `yarn reference:api`
-   5. `yarn tests:jest`
-   6. `yarn format:js`
-   7. `yarn compare:types`
+1. Run the command sequence.
 2. If validation fails because of current TS/JS changes and fixing is in scope, fix the issue and rerun the failed command plus all later commands.
 3. If validation fails for unrelated or environment-specific reasons, stop and report the blocker with the command that failed and the shortest useful error summary.
-4. Only report success when all seven commands complete successfully.
+4. Only report success when every command in the sequence completes successfully.
 
 ## Output format
 
@@ -128,15 +126,6 @@ Use this template:
 - Avoid broad refactors while fixing validation failures.
 
 ## Additional resources
-
-- See the root `package.json` scripts:
-  - `lerna:prepare`
-  - `tsc:compile`
-  - `tsc:compile:consumer`
-  - `reference:api`
-  - `tests:jest`
-  - `format:js`
-  - `compare:types`
 
 Load files only when needed:
 


### PR DESCRIPTION
### Description

- Adds a ts-js-validation skill for validating RNFB TypeScript and JavaScript changes.
- Runs the standard root workflow: lerna:prepare, both TypeScript compile checks, Jest, then JS/TS formatting.
- Documents failure handling, rerun expectations, and concise reporting for validation results.
- Keeps the workflow scoped to JS/TS changes, excluding native/platform and full release validation.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
