### PR TITLE
feat(analytics): add support for googleAppMeasurementOnDeviceConversion in iOS Expo plugin

### DIFF
--- a/docs/analytics/usage/index.mdx
+++ b/docs/analytics/usage/index.mdx
@@ -169,7 +169,47 @@ During `pod install`, using that variable installs the `FirebaseAnalytics/Core` 
 or Firebase Analytics without needing the App Tracking Transparency handling (assuming no other parts
 of your app handle data in a way that requires ATT)
 
+If you use Expo, including EAS Build, add the Analytics config plugin to your `app.json` / `app.config.js` instead of editing the generated Podfile manually:
+
+```json
+[
+  "@react-native-firebase/analytics",
+  {
+    "ios": {
+      "withoutAdIdSupport": true
+    }
+  }
+]
+```
+
+This adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to the generated iOS `Podfile` during prebuild.
+
 Note that for obvious reasons, configuring Firebase Analytics for use without IDFA is incompatible with AdMob
+
+# Google Analytics on-device conversion measurement
+
+If you would like to enable Google Analytics on-device conversion measurement APIs on iOS, define the following variable in your Podfile:
+
+```ruby
+$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
+```
+
+During `pod install`, using that variable adds the `GoogleAdsOnDeviceConversion` Pod.
+
+If you use Expo, including EAS Build, add the Analytics config plugin to your `app.json` / `app.config.js` instead of editing the generated Podfile manually:
+
+```json
+[
+  "@react-native-firebase/analytics",
+  {
+    "ios": {
+      "googleAppMeasurementOnDeviceConversion": true
+    }
+  }
+]
+```
+
+This adds `$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true` to the generated iOS `Podfile` during prebuild.
 
 # Device Identification
 

--- a/docs/analytics/usage/index.mdx
+++ b/docs/analytics/usage/index.mdx
@@ -169,21 +169,6 @@ During `pod install`, using that variable installs the `FirebaseAnalytics/Core` 
 or Firebase Analytics without needing the App Tracking Transparency handling (assuming no other parts
 of your app handle data in a way that requires ATT)
 
-If you use Expo, including EAS Build, add the Analytics config plugin to your `app.json` / `app.config.js` instead of editing the generated Podfile manually:
-
-```json
-[
-  "@react-native-firebase/analytics",
-  {
-    "ios": {
-      "withoutAdIdSupport": true
-    }
-  }
-]
-```
-
-This adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to the generated iOS `Podfile` during prebuild.
-
 Note that for obvious reasons, configuring Firebase Analytics for use without IDFA is incompatible with AdMob
 
 # Google Analytics on-device conversion measurement

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -78,20 +78,21 @@ The following is an example `app.json` to enable the React Native Firebase modul
 
 > Listing a module in the Config Plugins (the `"plugins"` array in the JSON above) is only required for React Native Firebase modules that involve _native installation steps_ - e.g. modifying the Xcode project, `Podfile`, `build.gradle`, `AndroidManifest.xml` etc. React Native Firebase modules without native steps will work out of the box; no `"plugins"` entry is required. Not all modules have Expo Config Plugins provided yet. A React Native Firebase module has Config Plugin support if it contains an `app.plugin.js` file in its package directory (e.g.`node_modules/@react-native-firebase/app/app.plugin.js`).
 
-If you use `@react-native-firebase/analytics` with Expo, including EAS Build, and want to opt out of iOS Ad ID support, add the Analytics config plugin with the `withoutAdIdSupport` iOS option:
+If you use `@react-native-firebase/analytics` with Expo, including EAS Build, and want to configure iOS Analytics Podfile flags, add the Analytics config plugin with the relevant iOS options:
 
 ```json
 [
   "@react-native-firebase/analytics",
   {
     "ios": {
-      "withoutAdIdSupport": true
+      "withoutAdIdSupport": true,
+      "googleAppMeasurementOnDeviceConversion": true
     }
   }
 ]
 ```
 
-This adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to the generated iOS `Podfile` during prebuild.
+The `withoutAdIdSupport` option adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to opt out of iOS Ad ID support. The `googleAppMeasurementOnDeviceConversion` option adds `$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true` to include Google Analytics on-device conversion measurement support. You may omit either option if it is not needed.
 
 ### Local app compilation
 

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -40,7 +40,7 @@ yarn add @react-native-firebase/analytics
 
 ### Expo
 
-If you use Expo, including EAS Build, and want to build iOS Analytics without Ad ID support, add the Analytics config plugin to your `app.json` / `app.config.js`:
+If you use Expo, including EAS Build, and want to configure iOS Analytics Podfile flags, add the Analytics config plugin to your `app.json` / `app.config.js`:
 
 ```json
 {
@@ -50,7 +50,8 @@ If you use Expo, including EAS Build, and want to build iOS Analytics without Ad
         "@react-native-firebase/analytics",
         {
           "ios": {
-            "withoutAdIdSupport": true
+            "withoutAdIdSupport": true,
+            "googleAppMeasurementOnDeviceConversion": true
           }
         }
       ]
@@ -59,7 +60,7 @@ If you use Expo, including EAS Build, and want to build iOS Analytics without Ad
 }
 ```
 
-This adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to the generated iOS `Podfile` during prebuild, which excludes `FirebaseAnalytics/IdentitySupport`.
+The `withoutAdIdSupport` option adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` during prebuild, which excludes `FirebaseAnalytics/IdentitySupport`. The `googleAppMeasurementOnDeviceConversion` option adds `$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true`, which includes Google Analytics on-device conversion measurement support. You may omit either option if it is not needed.
 
 ## Documentation
 

--- a/packages/analytics/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/analytics/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Analytics Config Plugin iOS Tests adds both iOS Podfile flags when both analytics options are enabled 1`] = `
+"platform :ios, '15.0'
+
+prepare_react_native_project!
+# @generated begin @react-native-firebase/analytics-googleAppMeasurementOnDeviceConversion - expo prebuild (DO NOT MODIFY) sync-6d1952a1f7b9ccb2d313cbd66659db4cdeae591f
+$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
+# @generated end @react-native-firebase/analytics-googleAppMeasurementOnDeviceConversion
+# @generated begin @react-native-firebase/analytics-withoutAdIdSupport - expo prebuild (DO NOT MODIFY) sync-06c0e725ab83bc834a9294f76fea47cf14bb6ac3
+$RNFirebaseAnalyticsWithoutAdIdSupport = true
+# @generated end @react-native-firebase/analytics-withoutAdIdSupport
+
+target 'ReactNativeFirebaseDemo' do
+end
+"
+`;
+
 exports[`Analytics Config Plugin iOS Tests adds the Podfile flag when googleAppMeasurementOnDeviceConversion is enabled 1`] = `
 "platform :ios, '15.0'
 

--- a/packages/analytics/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
+++ b/packages/analytics/plugin/__tests__/__snapshots__/iosPlugin.test.ts.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`Analytics Config Plugin iOS Tests adds the Podfile flag when googleAppMeasurementOnDeviceConversion is enabled 1`] = `
+"platform :ios, '15.0'
+
+prepare_react_native_project!
+# @generated begin @react-native-firebase/analytics-googleAppMeasurementOnDeviceConversion - expo prebuild (DO NOT MODIFY) sync-6d1952a1f7b9ccb2d313cbd66659db4cdeae591f
+$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true
+# @generated end @react-native-firebase/analytics-googleAppMeasurementOnDeviceConversion
+
+target 'ReactNativeFirebaseDemo' do
+end
+"
+`;
+
 exports[`Analytics Config Plugin iOS Tests adds the Podfile flag when withoutAdIdSupport is enabled 1`] = `
 "platform :ios, '15.0'
 

--- a/packages/analytics/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/analytics/plugin/__tests__/iosPlugin.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { setAnalyticsPodfileWithoutAdIdSupport, setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion } from '../src/ios/podfile';
+import {
+  setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion,
+  setAnalyticsPodfileWithoutAdIdSupport,
+} from '../src/ios/podfile';
 
 const podfileFixture = `platform :ios, '15.0'
 
@@ -36,16 +39,35 @@ describe('Analytics Config Plugin iOS Tests', function () {
   });
 
   it('is idempotent when the ODM Podfile flag is already present', function () {
-    const onceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(podfileFixture, true);
-    const twiceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(onceModified, true);
+    const onceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
+      podfileFixture,
+      true,
+    );
+    const twiceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
+      onceModified,
+      true,
+    );
 
     expect(twiceModified).toEqual(onceModified);
   });
 
   it('removes the generated Podfile flag when googleAppMeasurementOnDeviceConversion is disabled', function () {
-    const onceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(podfileFixture, true);
+    const onceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
+      podfileFixture,
+      true,
+    );
     const restored = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(onceModified, false);
 
     expect(restored).toEqual(podfileFixture);
+  });
+
+  it('adds both iOS Podfile flags when both analytics options are enabled', function () {
+    const withWithoutAdIdSupport = setAnalyticsPodfileWithoutAdIdSupport(podfileFixture, true);
+    const result = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
+      withWithoutAdIdSupport,
+      true,
+    );
+
+    expect(result).toMatchSnapshot();
   });
 });

--- a/packages/analytics/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/analytics/plugin/__tests__/iosPlugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { setAnalyticsPodfileWithoutAdIdSupport } from '../src/ios/podfile';
+import { setAnalyticsPodfileWithoutAdIdSupport, setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion } from '../src/ios/podfile';
 
 const podfileFixture = `platform :ios, '15.0'
 
@@ -26,6 +26,25 @@ describe('Analytics Config Plugin iOS Tests', function () {
   it('removes the generated Podfile flag when withoutAdIdSupport is disabled', function () {
     const onceModified = setAnalyticsPodfileWithoutAdIdSupport(podfileFixture, true);
     const restored = setAnalyticsPodfileWithoutAdIdSupport(onceModified, false);
+
+    expect(restored).toEqual(podfileFixture);
+  });
+
+  it('adds the Podfile flag when googleAppMeasurementOnDeviceConversion is enabled', function () {
+    const result = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(podfileFixture, true);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('is idempotent when the ODM Podfile flag is already present', function () {
+    const onceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(podfileFixture, true);
+    const twiceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(onceModified, true);
+
+    expect(twiceModified).toEqual(onceModified);
+  });
+
+  it('removes the generated Podfile flag when googleAppMeasurementOnDeviceConversion is disabled', function () {
+    const onceModified = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(podfileFixture, true);
+    const restored = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(onceModified, false);
 
     expect(restored).toEqual(podfileFixture);
   });

--- a/packages/analytics/plugin/src/index.ts
+++ b/packages/analytics/plugin/src/index.ts
@@ -1,6 +1,6 @@
 import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
 
-import { withIosWithoutAdIdSupport } from './ios';
+import { withIosWithoutAdIdSupport, withIosGoogleAppMeasurementOnDeviceConversion } from './ios';
 import { PluginConfigType } from './pluginConfig';
 
 /**
@@ -10,6 +10,7 @@ const withRnFirebaseAnalytics: ConfigPlugin<PluginConfigType> = (config, props) 
   return withPlugins(config, [
     // iOS
     [withIosWithoutAdIdSupport, props],
+    [withIosGoogleAppMeasurementOnDeviceConversion, props],
   ]);
 };
 

--- a/packages/analytics/plugin/src/ios/index.ts
+++ b/packages/analytics/plugin/src/ios/index.ts
@@ -1,3 +1,3 @@
-import { withIosWithoutAdIdSupport } from './podfile';
+import { withIosWithoutAdIdSupport, withIosGoogleAppMeasurementOnDeviceConversion } from './podfile';
 
-export { withIosWithoutAdIdSupport };
+export { withIosWithoutAdIdSupport, withIosGoogleAppMeasurementOnDeviceConversion };

--- a/packages/analytics/plugin/src/ios/podfile.ts
+++ b/packages/analytics/plugin/src/ios/podfile.ts
@@ -9,6 +9,8 @@ import { PluginConfigType } from '../pluginConfig';
 const TAG = '@react-native-firebase/analytics-withoutAdIdSupport';
 const ANCHOR = /prepare_react_native_project!/;
 const FLAG = '$RNFirebaseAnalyticsWithoutAdIdSupport = true';
+const TAG_ODM = '@react-native-firebase/analytics-googleAppMeasurementOnDeviceConversion';
+const FLAG_ODM = '$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true';
 
 export function setAnalyticsPodfileWithoutAdIdSupport(
   src: string,
@@ -27,6 +29,35 @@ export function setAnalyticsPodfileWithoutAdIdSupport(
     comment: '#',
   }).contents;
 }
+
+export function setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
+  src: string,
+  enabled: boolean = false,
+): string {
+  if (!enabled) {
+    return removeGeneratedContents(src, TAG_ODM) ?? src;
+  }
+
+  return mergeContents({
+    src,
+    newSrc: FLAG_ODM,
+    tag: TAG_ODM,
+    anchor: ANCHOR,
+    offset: 1,
+    comment: '#',
+  }).contents;
+}
+
+export const withIosGoogleAppMeasurementOnDeviceConversion: ConfigPlugin<PluginConfigType> = (config, props) => {
+  return withPodfile(config, config => {
+    config.modResults.contents = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
+      config.modResults.contents,
+      props?.ios?.googleAppMeasurementOnDeviceConversion === true,
+    );
+
+    return config;
+  });
+};
 
 export const withIosWithoutAdIdSupport: ConfigPlugin<PluginConfigType> = (config, props) => {
   return withPodfile(config, config => {

--- a/packages/analytics/plugin/src/ios/podfile.ts
+++ b/packages/analytics/plugin/src/ios/podfile.ts
@@ -12,43 +12,44 @@ const FLAG = '$RNFirebaseAnalyticsWithoutAdIdSupport = true';
 const TAG_ODM = '@react-native-firebase/analytics-googleAppMeasurementOnDeviceConversion';
 const FLAG_ODM = '$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true';
 
-export function setAnalyticsPodfileWithoutAdIdSupport(
+function setAnalyticsPodfileFlag(
   src: string,
+  tag: string,
+  flag: string,
   enabled: boolean = false,
 ): string {
   if (!enabled) {
-    return removeGeneratedContents(src, TAG) ?? src;
+    return removeGeneratedContents(src, tag) ?? src;
   }
 
   return mergeContents({
     src,
-    newSrc: FLAG,
-    tag: TAG,
+    newSrc: flag,
+    tag,
     anchor: ANCHOR,
     offset: 1,
     comment: '#',
   }).contents;
+}
+
+export function setAnalyticsPodfileWithoutAdIdSupport(
+  src: string,
+  enabled: boolean = false,
+): string {
+  return setAnalyticsPodfileFlag(src, TAG, FLAG, enabled);
 }
 
 export function setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
   src: string,
   enabled: boolean = false,
 ): string {
-  if (!enabled) {
-    return removeGeneratedContents(src, TAG_ODM) ?? src;
-  }
-
-  return mergeContents({
-    src,
-    newSrc: FLAG_ODM,
-    tag: TAG_ODM,
-    anchor: ANCHOR,
-    offset: 1,
-    comment: '#',
-  }).contents;
+  return setAnalyticsPodfileFlag(src, TAG_ODM, FLAG_ODM, enabled);
 }
 
-export const withIosGoogleAppMeasurementOnDeviceConversion: ConfigPlugin<PluginConfigType> = (config, props) => {
+export const withIosGoogleAppMeasurementOnDeviceConversion: ConfigPlugin<PluginConfigType> = (
+  config,
+  props,
+) => {
   return withPodfile(config, config => {
     config.modResults.contents = setAnalyticsPodfileGoogleAppMeasurementOnDeviceConversion(
       config.modResults.contents,

--- a/packages/analytics/plugin/src/pluginConfig.ts
+++ b/packages/analytics/plugin/src/pluginConfig.ts
@@ -4,4 +4,8 @@ export interface PluginConfigType {
 
 export interface PluginConfigTypeIos {
   withoutAdIdSupport?: boolean;
+  /**
+   * @platform ios iOS
+   */
+  googleAppMeasurementOnDeviceConversion?: boolean;
 }


### PR DESCRIPTION
### Description

This PR adds support for the `googleAppMeasurementOnDeviceConversion` configuration option in the iOS Expo plugin for `@react-native-firebase/analytics`.

Enabling this option adds `$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true` to the project's Podfile, allowing users to enable Google Analytics on-device conversion measurement in their Expo projects.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->
None.

### Release Summary

feat(analytics): add support for googleAppMeasurementOnDeviceConversion in iOS Expo plugin

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Added 3 new Jest tests in `packages/analytics/plugin/__tests__/iosPlugin.test.ts` to verify:
1. The Podfile flag is added correctly when the option is enabled.
2. The modification is idempotent.
3. The flag is removed when the option is disabled.

---

:fire:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional iOS Podfile flag injection/removal path using the existing generated-code mechanism, plus unit tests; limited to build-time configuration changes.
> 
> **Overview**
> Adds a new iOS plugin option, `ios.googleAppMeasurementOnDeviceConversion`, that conditionally injects (and can remove) a generated Podfile snippet setting `$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true`.
> 
> Wires this new config plugin into the main analytics Expo plugin pipeline and extends Jest coverage/snapshots to verify insertion, idempotency, and removal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4554075754e18eeae69d4271a6e8f657864661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->