### PR TITLE
fix(ios): wire add_rncore_dependency + allow non-modular includes for RN 0.84+ prebuilt RNCore (#8883)

### DIFF
--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -39,6 +39,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -45,6 +45,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #if __has_include(<RNFBAnalytics/RNFBAnalytics-Swift.h>)

--- a/packages/app-check/RNFBAppCheck.podspec
+++ b/packages/app-check/RNFBAppCheck.podspec
@@ -38,6 +38,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/app-check/RNFBAppCheck.podspec
+++ b/packages/app-check/RNFBAppCheck.podspec
@@ -44,6 +44,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
@@ -17,6 +17,7 @@
 
 #import <Firebase/Firebase.h>
 #import <FirebaseAppCheck/FIRAppCheck.h>
+#import <React/RCTBridgeModule.h>
 
 #import <React/RCTUtils.h>
 

--- a/packages/app-distribution/RNFBAppDistribution.podspec
+++ b/packages/app-distribution/RNFBAppDistribution.podspec
@@ -36,6 +36,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/app-distribution/RNFBAppDistribution.podspec
+++ b/packages/app-distribution/RNFBAppDistribution.podspec
@@ -42,6 +42,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
+++ b/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -50,6 +50,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if (ENV.include?('FIREBASE_SDK_VERSION'))
     Pod::UI.puts "#{s.name}: Found Firebase SDK version in environment '#{ENV['FIREBASE_SDK_VERSION']}'"
     $FirebaseSDKVersion = ENV['FIREBASE_SDK_VERSION']

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -38,9 +38,13 @@ Pod::Spec.new do |s|
     Pod::UI.puts '[react-native-firebase] '.yellow + "Suppress this with environment variable RNFB_SUPPRESS_NEW_ARCHITECTURE_WARNING=1"
   end
 
-  # App must define modules for static framework integration of other packages to work
+  # App must define modules for static framework integration of other packages to work.
+  # CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES is required so RNFB's umbrella,
+  # which re-exports <React/...> imports, validates when consumers build with use_frameworks!
+  # (the default on Expo, and required for the firebase-ios-sdk).
   s.pod_target_xcconfig = {
     "DEFINES_MODULE" => "YES",
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
   }
 
   # React Native dependencies

--- a/packages/app/ios/RNFBApp/RNFBAppModule.m
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBAppModule.h"

--- a/packages/app/ios/RNFBApp/RNFBUtilsModule.m
+++ b/packages/app/ios/RNFBApp/RNFBUtilsModule.m
@@ -15,6 +15,7 @@
  *
  */
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -38,6 +38,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -44,6 +44,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RCTConvert+FIRApp.h"

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -46,6 +46,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -40,6 +40,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -18,6 +18,7 @@
 #include <Foundation/Foundation.h>
 #include <sys/sysctl.h>
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -39,6 +39,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -45,6 +45,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseOnDisconnectModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseOnDisconnectModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseQueryModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseQueryModule.m
@@ -15,6 +15,7 @@
  *
  */
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseTransactionModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseTransactionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -39,6 +39,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -45,6 +45,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.h
@@ -17,9 +17,15 @@
 
 #import <Firebase/Firebase.h>
 #import <Foundation/Foundation.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
+#import <React/RCTBridgeModule.h>
+// clang-format on
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <RNFBFirestoreQuery.h>
-#import <React/RCTBridgeModule.h>
 #import "RNFBFirestoreCommon.h"
 #import "RNFBFirestoreSerialize.h"
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -15,8 +15,15 @@
  *
  */
 
-#import <RNFBApp/RNFBRCTEventEmitter.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
 #import <React/RCTBridgeModule.h>
+#import <React/RCTUtils.h>
+// clang-format on
+#import <RNFBApp/RNFBRCTEventEmitter.h>
 #if __has_include(<RNFBFirestore/RNFBFirestore-Swift.h>)
 // This import will work in situations where `use_frameworks!` is in use
 #import <RNFBFirestore/RNFBFirestore-Swift.h>
@@ -28,7 +35,6 @@
 // directory. See firebase-ios-sdk#12611 for more context.
 #import "RNFBFirestore-Swift.h"
 #endif
-#import <React/RCTUtils.h>
 
 #import "RNFBFirestoreCollectionModule.h"
 #import "RNFBFirestoreCommon.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #if __has_include(<RNFBFirestore/RNFBFirestore-Swift.h>)
 // This import will work in situations where `use_frameworks!` is in use
 #import <RNFBFirestore/RNFBFirestore-Swift.h>

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.h
@@ -17,8 +17,14 @@
 
 #import <Firebase/Firebase.h>
 #import <Foundation/Foundation.h>
-#import <RNFBApp/RNFBSharedUtils.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
 #import <React/RCTBridgeModule.h>
+// clang-format on
+#import <RNFBApp/RNFBSharedUtils.h>
 #import "RNFBFirestoreCommon.h"
 #import "RNFBFirestoreSerialize.h"
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -15,9 +15,15 @@
  *
  */
 
-#import <RNFBApp/RNFBRCTEventEmitter.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
+// clang-format on
+#import <RNFBApp/RNFBRCTEventEmitter.h>
 
 #import "RNFBFirestoreDocumentModule.h"
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBFirestoreDocumentModule.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.h
@@ -17,8 +17,14 @@
 
 #import <Firebase/Firebase.h>
 #import <Foundation/Foundation.h>
-#import <RNFBApp/RNFBSharedUtils.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
 #import <React/RCTBridgeModule.h>
+// clang-format on
+#import <RNFBApp/RNFBSharedUtils.h>
 
 @interface RNFBFirestoreModule : NSObject <RCTBridgeModule>
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -17,6 +17,7 @@
 
 #import "RNFBFirestoreModule.h"
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 #import "FirebaseFirestoreInternal/FIRPersistentCacheIndexManager.h"
 #import "RNFBFirestoreCommon.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -15,10 +15,16 @@
  *
  */
 
-#import "RNFBFirestoreModule.h"
-#import <RNFBApp/RNFBRCTEventEmitter.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
+// clang-format on
+#import "RNFBFirestoreModule.h"
+#import <RNFBApp/RNFBRCTEventEmitter.h>
 #import "FirebaseFirestoreInternal/FIRPersistentCacheIndexManager.h"
 #import "RNFBFirestoreCommon.h"
 #import "RNFBPreferences.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.h
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.h
@@ -17,9 +17,15 @@
 
 #import <Firebase/Firebase.h>
 #import <Foundation/Foundation.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
+#import <React/RCTBridgeModule.h>
+// clang-format on
 #import <RNFBApp/RNFBSharedUtils.h>
 #import <RNFBFirestoreQuery.h>
-#import <React/RCTBridgeModule.h>
 #import "RNFBFirestoreCommon.h"
 #import "RNFBFirestoreSerialize.h"
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -15,9 +15,15 @@
  *
  */
 
-#import <RNFBApp/RNFBRCTEventEmitter.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
 #import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
+// clang-format on
+#import <RNFBApp/RNFBRCTEventEmitter.h>
 
 #import "RNFBFirestoreTransactionModule.h"
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBFirestoreTransactionModule.h"

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -36,6 +36,12 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   # Fail fast for old architecture users, but safely in case the variable goes away
   # completely in future react-native versions
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -42,6 +42,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   # Fail fast for old architecture users, but safely in case the variable goes away
   # completely in future react-native versions
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -39,6 +39,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -45,6 +45,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
+++ b/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/installations/RNFBInstallations.podspec
+++ b/packages/installations/RNFBInstallations.podspec
@@ -39,6 +39,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/installations/RNFBInstallations.podspec
+++ b/packages/installations/RNFBInstallations.podspec
@@ -45,6 +45,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/installations/ios/RNFBInstallations/RNFBInstallationsModule.m
+++ b/packages/installations/ios/RNFBInstallations/RNFBInstallationsModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -36,6 +36,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -42,6 +42,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -15,13 +15,20 @@
  *
  */
 
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
+// clang-format on
 #import <Firebase/Firebase.h>
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <objc/runtime.h>
 
 #import <RNFBApp/RNFBRCTEventEmitter.h>
 #import <RNFBApp/RNFBSharedUtils.h>
-#import <React/RCTConvert.h>
 
 #import "RNFBMessaging+AppDelegate.h"
 #import "RNFBMessagingSerializer.h"

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
@@ -15,6 +15,13 @@
  *
  */
 
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
+#import <React/RCTBridgeModule.h>
+// clang-format on
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <RNFBApp/RNFBRCTEventEmitter.h>
 #import <objc/message.h>

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+NSNotificationCenter.m
@@ -14,11 +14,18 @@
  * limitations under the License.
  *
  */
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
+#import <React/RCTBridgeModule.h>
+#import <React/RCTConvert.h>
+#import <React/RCTRootView.h>
+// clang-format on
 #import <Firebase/Firebase.h>
 #import <RNFBApp/RNFBJSON.h>
 #import <RNFBApp/RNFBRCTEventEmitter.h>
-#import <React/RCTConvert.h>
-#import <React/RCTRootView.h>
 
 #import "RNFBMessaging+AppDelegate.h"
 #import "RNFBMessaging+FIRMessagingDelegate.h"

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -15,6 +15,13 @@
  *
  */
 
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
+#import <React/RCTBridgeModule.h>
+// clang-format on
 #import <RNFBApp/RNFBRCTEventEmitter.h>
 
 #import "RNFBJSON.h"

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -17,6 +17,7 @@
 
 #import <Firebase/Firebase.h>
 #import <RNFBApp/RNFBSharedUtils.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -15,11 +15,17 @@
  *
  */
 
-#import <Firebase/Firebase.h>
-#import <RNFBApp/RNFBSharedUtils.h>
+// clang-format off
+// React headers must be imported before any RNFBApp header: under
+// use_frameworks!, RNFBApp's framework module absorbs the React headers its
+// public headers include, hiding their declarations and macros from this file
+// if the RNFBApp module is loaded first.
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
+// clang-format on
+#import <Firebase/Firebase.h>
+#import <RNFBApp/RNFBSharedUtils.h>
 
 #import "RNFBMessaging+AppDelegate.h"
 #import "RNFBMessaging+NSNotificationCenter.h"

--- a/packages/ml/RNFBML.podspec
+++ b/packages/ml/RNFBML.podspec
@@ -46,6 +46,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/ml/RNFBML.podspec
+++ b/packages/ml/RNFBML.podspec
@@ -40,6 +40,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -39,6 +39,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -45,6 +45,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/perf/ios/RNFBPerf/RNFBPerfModule.m
+++ b/packages/perf/ios/RNFBPerf/RNFBPerfModule.m
@@ -15,6 +15,7 @@
  *
  */
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -39,6 +39,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -45,6 +45,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -38,6 +38,12 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -44,6 +44,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBRCTEventEmitter.h"

--- a/scripts/_TEMPLATE_/RNFB_Template_.podspec
+++ b/scripts/_TEMPLATE_/RNFB_Template_.podspec
@@ -28,6 +28,12 @@ Pod::Spec.new do |s|
   s.dependency          'React-Core'
   s.dependency          'RNFBApp'
 
+  # Wire up prebuilt React-Core (RN 0.83+, default on 0.84+) so the legacy
+  # <React/...> header imports resolve when RCT_USE_PREBUILT_RNCORE=1.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion

--- a/scripts/_TEMPLATE_/RNFB_Template_.podspec
+++ b/scripts/_TEMPLATE_/RNFB_Template_.podspec
@@ -34,6 +34,12 @@ Pod::Spec.new do |s|
     add_rncore_dependency(s)
   end
 
+  # RNFB public headers re-export non-modular <React/...> imports. Required so
+  # the framework module validates when consumers build with use_frameworks!.
+  s.pod_target_xcconfig = {
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  }
+
   if defined?($FirebaseSDKVersion)
     Pod::UI.puts "#{s.name}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
     firebase_sdk_version = $FirebaseSDKVersion


### PR DESCRIPTION
### Description

Closes the producer-side half of #8883 in two podspec changes:

**1. `add_rncore_dependency(s)` in every RNFB podspec**, guarded by `defined?` so older RN keeps working. This is React Native's own helper from `react_native_pods.rb`: when `RCT_USE_PREBUILT_RNCORE=1` (the default on 0.84+), it adds `React-Core-prebuilt` as a dependency and wires `$(PODS_ROOT)/React-Core-prebuilt/React.xcframework/Headers` into `HEADER_SEARCH_PATHS`. Without this, RNFB pods can't resolve `<React/RCTConvert.h>` and friends under prebuilt RNCore. The helper is opt-in per podspec and RNFB never opted in.

**2. `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES`** in every RNFB pod's `pod_target_xcconfig`. RNFBApp's umbrella header re-exports `<React/...>` imports through its public `.h` files. Without this flag, RNFBApp's own framework module compile trips `-Werror,-Wnon-modular-include-in-framework-module` under `use_frameworks!` (Expo's default and any project using static framework linkage).

Together these unblock `pod install` and the producer-side RNFB framework compile under stock RN 0.84 defaults (prebuilt RNCore on) for both bare-RN and `use_frameworks!: static` projects, with no Podfile workarounds: no `$RNFirebaseAsStaticFramework`, no `RCT_USE_PREBUILT_RNCORE=0`, no preinstall hook.

**Honest scope:** this PR does NOT yet close the consumer-side chain. When downstream RNFB pods (Storage, Auth, Messaging, etc.) `@import RNFBApp` as a Clang module, RNFBApp's umbrella still re-exports `<React/...>` imports, and Clang module visibility breaks `RCT_EXPORT_METHOD` expansion and `RCTBridgeModule` protocol visibility on the consuming side. Under `use_frameworks!` Expo today, even with this PR applied, users still need `RCT_USE_PREBUILT_RNCORE=0` or `$RNFirebaseAsStaticFramework=true` as a workaround until follow-up work lands. Details and an attempted source-level fix are discussed in the issue thread.

### Related issues

Fixes (partial, producer-side) #8883.

### Release Summary

iOS: RNFB podspecs now call `add_rncore_dependency` and allow non-modular includes in framework modules, so the producer-side RNFB build works on RN 0.84+ with prebuilt RNCore enabled (the default) on both bare-RN and `use_frameworks!` projects. A consumer-side architectural follow-up is needed for full `use_frameworks!` support.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Verified against my app (Animalert Debug && Release, production RN 0.84.1 app, 8 RNFB packages: app, analytics, app-check, auth, crashlytics, firestore, messaging, storage). Setup: `use_frameworks! :linkage => :static`, Xcode 26.5, iOS 26.5 Simulator (iPhone 17 Pro), physical iPhone 13 on iOS 16.2 aswell.

**With this PR's patched podspecs overlaid into `node_modules/@react-native-firebase/*/`:**

- `pod install` completes cleanly. Generated `Pods/Target Support Files/RNFB*/RNFB*.debug.xcconfig` files for all 8 packages contain `${PODS_XCFRAMEWORKS_BUILD_DIR}/React-Core-prebuilt` and `${PODS_XCFRAMEWORKS_BUILD_DIR}/ReactNativeDependencies` in `FRAMEWORK_SEARCH_PATHS`, plus `${PODS_ROOT}/Headers/Public/React-Core-prebuilt` in `HEADER_SEARCH_PATHS`, and `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES`.
- Direct compile of `RNFBApp` via `xcodebuild -project Pods/Pods.xcodeproj -target RNFBApp -sdk iphonesimulator26.5 -arch arm64 build` succeeds in Debug and Release. `RCTConvert+FIRApp.m`, `RCTConvert+FIROptions.m`, `RNFBAppModule.m`, `RNFBRCTEventEmitter.m`, `RNFBSharedUtils.m`, `RNFBUtilsModule.m` all compile (these are the files that `#import <React/RCTConvert.h>`, `<React/RCTBridgeModule.h>`, `<React/RCTEventEmitter.h>`, the exact failure mode of #8883).
- Zero `-Wnon-modular-include-in-framework-module` errors or warnings in either Debug or Release build logs.

**Limitations of testing:**

- Producer-side only. Workspace-level `xcodebuild -scheme Animalert build` against the full app fails further along at the consumer-side chain documented in the issue thread. Workspace builds succeed when `$RNFirebaseAsStaticFramework = true` is re-enabled, confirming the workaround still works and what this PR doesn't yet remove.
- Not tested with a vanilla (no `use_frameworks!`) RN 0.84 app, but that's the simpler case for this PR's scope and the `add_rncore_dependency` helper is documented for it.

CI should validate the full matrix.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter