### PR TITLE
feat(auth): expose OAuth credential tokens in user credential result

### DIFF
--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -171,6 +171,50 @@ describe('Auth', function () {
       });
     });
 
+    describe('UserCredential', function () {
+      it('should include OAuth credential data returned by native auth result', function () {
+        const returnedCredential = {
+          providerId: 'oidc.test-provider',
+          accessToken: 'access-token',
+          idToken: 'id-token',
+          secret: null,
+        };
+        const nativeUserCredential = {
+          additionalUserInfo: {
+            isNewUser: false,
+            profile: null,
+            providerId: 'oidc.test-provider',
+            username: null,
+          },
+          credential: returnedCredential,
+          user: {
+            uid: 'test-user-id',
+            displayName: null,
+            email: 'test@example.com',
+            emailVerified: true,
+            isAnonymous: false,
+            metadata: {
+              lastSignInTime: '2023-01-01T00:00:00.000Z',
+              creationTime: '2023-01-01T00:00:00.000Z',
+            },
+            multiFactor: {
+              enrolledFactors: [],
+            },
+            phoneNumber: null,
+            tenantId: null,
+            photoURL: null,
+            providerData: [],
+            providerId: 'firebase',
+          },
+        };
+        // @ts-ignore test
+        const userCredential = auth()._setUserCredential(nativeUserCredential);
+
+        expect(userCredential.user.uid).toBe('test-user-id');
+        expect(userCredential.credential).toEqual(returnedCredential);
+      });
+    });
+
     describe('getMultiFactorResolver', function () {
       it('should return null if no resolver object is found', function () {
         const unknownError = NativeFirebaseError.fromEvent(

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -59,6 +59,7 @@ import com.google.firebase.auth.MultiFactorAssertion;
 import com.google.firebase.auth.MultiFactorInfo;
 import com.google.firebase.auth.MultiFactorResolver;
 import com.google.firebase.auth.MultiFactorSession;
+import com.google.firebase.auth.OAuthCredential;
 import com.google.firebase.auth.OAuthProvider;
 import com.google.firebase.auth.PhoneAuthCredential;
 import com.google.firebase.auth.PhoneAuthOptions;
@@ -2373,6 +2374,14 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
 
         authResultMap.putMap("additionalUserInfo", additionalUserInfoMap);
       }
+
+      WritableMap credentialMap = authCredentialToMap(authResult.getCredential());
+      if (credentialMap != null) {
+        authResultMap.putMap("credential", credentialMap);
+      } else {
+        authResultMap.putNull("credential");
+      }
+
       authResultMap.putMap("user", userMap);
 
       promise.resolve(authResultMap);
@@ -2380,6 +2389,37 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
     } else {
       promiseNoUser(promise, true);
     }
+  }
+
+  @Nullable
+  private WritableMap authCredentialToMap(@Nullable AuthCredential authCredential) {
+    if (!(authCredential instanceof OAuthCredential)) {
+      return null;
+    }
+
+    OAuthCredential oauthCredential = (OAuthCredential) authCredential;
+    WritableMap credentialMap = Arguments.createMap();
+    credentialMap.putString("providerId", oauthCredential.getProvider());
+
+    if (oauthCredential.getAccessToken() != null) {
+      credentialMap.putString("accessToken", oauthCredential.getAccessToken());
+    } else {
+      credentialMap.putNull("accessToken");
+    }
+
+    if (oauthCredential.getIdToken() != null) {
+      credentialMap.putString("idToken", oauthCredential.getIdToken());
+    } else {
+      credentialMap.putNull("idToken");
+    }
+
+    if (oauthCredential.getSecret() != null) {
+      credentialMap.putString("secret", oauthCredential.getSecret());
+    } else {
+      credentialMap.putNull("secret");
+    }
+
+    return credentialMap;
   }
 
   /**

--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
@@ -2399,25 +2399,10 @@ class ReactNativeFirebaseAuthModule extends ReactNativeFirebaseModule {
 
     OAuthCredential oauthCredential = (OAuthCredential) authCredential;
     WritableMap credentialMap = Arguments.createMap();
-    credentialMap.putString("providerId", oauthCredential.getProvider());
-
-    if (oauthCredential.getAccessToken() != null) {
-      credentialMap.putString("accessToken", oauthCredential.getAccessToken());
-    } else {
-      credentialMap.putNull("accessToken");
-    }
-
-    if (oauthCredential.getIdToken() != null) {
-      credentialMap.putString("idToken", oauthCredential.getIdToken());
-    } else {
-      credentialMap.putNull("idToken");
-    }
-
-    if (oauthCredential.getSecret() != null) {
-      credentialMap.putString("secret", oauthCredential.getSecret());
-    } else {
-      credentialMap.putNull("secret");
-    }
+    SharedUtils.mapPutValue("providerId", oauthCredential.getProvider(), credentialMap);
+    SharedUtils.mapPutValue("accessToken", oauthCredential.getAccessToken(), credentialMap);
+    SharedUtils.mapPutValue("idToken", oauthCredential.getIdToken(), credentialMap);
+    SharedUtils.mapPutValue("secret", oauthCredential.getSecret(), credentialMap);
 
     return credentialMap;
   }

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -1798,7 +1798,7 @@ RCT_EXPORT_METHOD(useEmulator
   FIROAuthCredential *oauthCredential = (FIROAuthCredential *)authCredential;
   NSMutableDictionary *credentialDict = [NSMutableDictionary dictionary];
 
-  [credentialDict setValue:oauthCredential.provider forKey:keyProviderId];
+  [credentialDict setValue:oauthCredential.provider ?: [NSNull null] forKey:keyProviderId];
   [credentialDict setValue:oauthCredential.accessToken ?: [NSNull null] forKey:keyAccessToken];
   [credentialDict setValue:oauthCredential.IDToken ?: [NSNull null] forKey:keyIdToken];
   [credentialDict setValue:oauthCredential.secret ?: [NSNull null] forKey:keySecret];

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -29,13 +29,17 @@ static NSString *const keyUid = @"uid";
 static NSString *const keyUser = @"user";
 static NSString *const keyEmail = @"email";
 static NSString *const keyAndroid = @"android";
+static NSString *const keyIdToken = @"idToken";
+static NSString *const keySecret = @"secret";
 static NSString *const keyProfile = @"profile";
 static NSString *const keyNewUser = @"isNewUser";
 static NSString *const keyUsername = @"username";
+static NSString *const keyCredential = @"credential";
 static NSString *const keyMultiFactor = @"multiFactor";
 static NSString *const keyPhotoUrl = @"photoURL";
 static NSString *const keyBundleId = @"bundleId";
 static NSString *const keyInstallApp = @"installApp";
+static NSString *const keyAccessToken = @"accessToken";
 static NSString *const keyProviderId = @"providerId";
 static NSString *const keyPhoneNumber = @"phoneNumber";
 static NSString *const keyDisplayName = @"displayName";
@@ -664,7 +668,8 @@ RCT_EXPORT_METHOD(signInWithProvider
 
                                                 [self promiseWithAuthResult:resolve
                                                                    rejecter:reject
-                                                                 authResult:authResult];
+                                                                 authResult:authResult
+                                                                 credential:credential];
                                               }];
                               }
                             }];
@@ -1304,7 +1309,8 @@ RCT_EXPORT_METHOD(linkWithProvider
 
                                                 [self promiseWithAuthResult:resolve
                                                                    rejecter:reject
-                                                                 authResult:authResult];
+                                                                 authResult:authResult
+                                                                 credential:credential];
                                               }];
                               }
                             }];
@@ -1433,7 +1439,8 @@ RCT_EXPORT_METHOD(reauthenticateWithProvider
 
                                                           [self promiseWithAuthResult:resolve
                                                                              rejecter:reject
-                                                                           authResult:authResult];
+                                                                           authResult:authResult
+                                                                           credential:credential];
                                                         }];
                               }
                             }];
@@ -1730,6 +1737,13 @@ RCT_EXPORT_METHOD(useEmulator
 - (void)promiseWithAuthResult:(RCTPromiseResolveBlock)resolve
                      rejecter:(RCTPromiseRejectBlock)reject
                    authResult:(FIRAuthDataResult *)authResult {
+  [self promiseWithAuthResult:resolve rejecter:reject authResult:authResult credential:nil];
+}
+
+- (void)promiseWithAuthResult:(RCTPromiseResolveBlock)resolve
+                     rejecter:(RCTPromiseRejectBlock)reject
+                   authResult:(FIRAuthDataResult *)authResult
+                   credential:(FIRAuthCredential *)credential {
   if (authResult && authResult.user) {
     NSMutableDictionary *authResultDict = [NSMutableDictionary dictionary];
 
@@ -1761,11 +1775,35 @@ RCT_EXPORT_METHOD(useEmulator
       [authResultDict setValue:[NSNull null] forKey:keyAdditionalUserInfo];
     }
 
+    FIRAuthCredential *resultCredential = authResult.credential ?: credential;
+    NSDictionary *credentialDict = [self oauthResultCredentialToDict:resultCredential];
+    if (credentialDict) {
+      [authResultDict setValue:credentialDict forKey:keyCredential];
+    } else {
+      [authResultDict setValue:[NSNull null] forKey:keyCredential];
+    }
+
     [authResultDict setValue:[self firebaseUserToDict:authResult.user] forKey:keyUser];
     resolve(authResultDict);
   } else {
     [self promiseNoUser:resolve rejecter:reject isError:YES];
   }
+}
+
+- (NSDictionary *)oauthResultCredentialToDict:(FIRAuthCredential *)authCredential {
+  if (![authCredential isKindOfClass:[FIROAuthCredential class]]) {
+    return nil;
+  }
+
+  FIROAuthCredential *oauthCredential = (FIROAuthCredential *)authCredential;
+  NSMutableDictionary *credentialDict = [NSMutableDictionary dictionary];
+
+  [credentialDict setValue:oauthCredential.provider forKey:keyProviderId];
+  [credentialDict setValue:oauthCredential.accessToken ?: [NSNull null] forKey:keyAccessToken];
+  [credentialDict setValue:oauthCredential.IDToken ?: [NSNull null] forKey:keyIdToken];
+  [credentialDict setValue:oauthCredential.secret ?: [NSNull null] forKey:keySecret];
+
+  return credentialDict;
 }
 
 - (NSArray<NSObject *> *)convertProviderData:(NSArray<id<FIRUserInfo>> *)providerData {

--- a/packages/auth/lib/index.d.ts
+++ b/packages/auth/lib/index.d.ts
@@ -92,6 +92,28 @@ export namespace FirebaseAuthTypes {
   }
 
   /**
+   * Represents the OAuth credential returned by a sign-in, link, or reauthentication operation.
+   */
+  export interface OAuthCredential {
+    /**
+     * The authentication provider ID for the credential. For example, 'facebook.com', or 'google.com'.
+     */
+    providerId: string;
+    /**
+     * The OAuth access token associated with the credential, if one was returned by the provider.
+     */
+    accessToken?: string | null;
+    /**
+     * The OAuth ID token associated with the credential, if one was returned by the provider.
+     */
+    idToken?: string | null;
+    /**
+     * The OAuth access token secret associated with the credential, if one was returned by the provider.
+     */
+    secret?: string | null;
+  }
+
+  /**
    * Interface that represents an auth provider. Implemented by other providers.
    */
   export interface AuthProvider {
@@ -507,13 +529,17 @@ export namespace FirebaseAuthTypes {
    * information that was returned from the identity provider. operationType could be 'signIn' for
    * a sign-in operation, 'link' for a linking operation and 'reauthenticate' for a re-authentication operation.
    *
-   * TODO @salakar; missing credential, operationType
+   * TODO @salakar; missing operationType
    */
   export interface UserCredential {
     /**
      * Any additional user information assigned to the user.
      */
     additionalUserInfo?: AdditionalUserInfo;
+    /**
+     * The OAuth credential returned by the identity provider, if one was returned.
+     */
+    credential?: OAuthCredential | null;
     /**
      * Returns the {@link User} interface of this credential.
      */

--- a/packages/auth/lib/index.js
+++ b/packages/auth/lib/index.js
@@ -202,6 +202,7 @@ class FirebaseAuthModule extends FirebaseModule {
     this.emitter.emit(this.eventNameForApp('onUserChanged'), this._user);
     return {
       additionalUserInfo: userCredential.additionalUserInfo,
+      credential: userCredential.credential ?? null,
       user,
     };
   }

--- a/packages/auth/lib/web/RNFBAuthModule.js
+++ b/packages/auth/lib/web/RNFBAuthModule.js
@@ -225,6 +225,8 @@ function multiFactorInfoToObject(multiFactorInfo) {
  */
 function authResultToObject(userCredential) {
   const additional = getAdditionalUserInfo(userCredential);
+  const credential = OAuthProvider.credentialFromResult(userCredential);
+
   return {
     user: userToObject(userCredential.user),
     additionalUserInfo: {
@@ -233,6 +235,14 @@ function authResultToObject(userCredential) {
       providerId: additional.providerId,
       username: additional.username,
     },
+    credential: credential
+      ? {
+          providerId: credential.providerId,
+          accessToken: credential.accessToken ?? null,
+          idToken: credential.idToken ?? null,
+          secret: credential.secret ?? null,
+        }
+      : null,
   };
 }
 

--- a/packages/auth/type-test.ts
+++ b/packages/auth/type-test.ts
@@ -202,6 +202,8 @@ const emailCredential = EmailAuthProvider.credential('test@example.com', 'passwo
 signInWithCredential(authInstance, emailCredential).then(
   (credential: FirebaseAuthTypes.UserCredential) => {
     console.log(credential.user.email);
+    console.log(credential.credential?.accessToken);
+    console.log(credential.credential?.idToken);
   },
 );
 


### PR DESCRIPTION

### Related issues

- Fixes #8316

### Release Summary

Include OAuth credential token data on Auth `UserCredential` results.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Ran:

```sh
yarn tests:jest packages/auth/__tests__/auth.test.ts
yarn tsc:compile
yarn tsc:compile:consumer
yarn lint:js
yarn lint:ios:check
yarn reference:api
yarn compare:types
git diff --check
```

Also checked Android formatting for the touched Java file:

```sh
JAVA_HOME=/opt/homebrew/opt/openjdk PATH=/opt/homebrew/opt/openjdk/bin:$PATH ./node_modules/.bin/google-java-format --set-exit-if-changed --dry-run packages/auth/android/src/main/java/io/invertase/firebase/auth/ReactNativeFirebaseAuthModule.java
```

No e2e test was added because this change is covered at the bridge serialization/type level and a full OIDC runtime test requires provider configuration.
```


