### PR TITLE
fix(ios): import RCTBridgeModule.h directly in .m files using RCT_EXPORT_* macros

### DIFF
--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #if __has_include(<RNFBAnalytics/RNFBAnalytics-Swift.h>)

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.m
@@ -17,6 +17,7 @@
 
 #import <Firebase/Firebase.h>
 #import <FirebaseAppCheck/FIRAppCheck.h>
+#import <React/RCTBridgeModule.h>
 
 #import <React/RCTUtils.h>
 

--- a/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
+++ b/packages/app-distribution/ios/RNFBAppDistribution/RNFBAppDistributionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/app/ios/RNFBApp/RNFBAppModule.m
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBAppModule.h"

--- a/packages/app/ios/RNFBApp/RNFBUtilsModule.m
+++ b/packages/app/ios/RNFBApp/RNFBUtilsModule.m
@@ -15,6 +15,7 @@
  *
  */
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RCTConvert+FIRApp.h"

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.m
@@ -18,6 +18,7 @@
 #include <Foundation/Foundation.h>
 #include <sys/sysctl.h>
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseOnDisconnectModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseOnDisconnectModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseQueryModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseQueryModule.m
@@ -15,6 +15,7 @@
  *
  */
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseReferenceModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/database/ios/RNFBDatabase/RNFBDatabaseTransactionModule.m
+++ b/packages/database/ios/RNFBDatabase/RNFBDatabaseTransactionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBDatabaseCommon.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #if __has_include(<RNFBFirestore/RNFBFirestore-Swift.h>)
 // This import will work in situations where `use_frameworks!` is in use
 #import <RNFBFirestore/RNFBFirestore-Swift.h>

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreDocumentModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBFirestoreDocumentModule.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.m
@@ -17,6 +17,7 @@
 
 #import "RNFBFirestoreModule.h"
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 #import "FirebaseFirestoreInternal/FIRPersistentCacheIndexManager.h"
 #import "RNFBFirestoreCommon.h"

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreTransactionModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <RNFBApp/RNFBRCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBFirestoreTransactionModule.h"

--- a/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
+++ b/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/installations/ios/RNFBInstallations/RNFBInstallationsModule.m
+++ b/packages/installations/ios/RNFBInstallations/RNFBInstallationsModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBApp/RNFBSharedUtils.h"

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -17,6 +17,7 @@
 
 #import <Firebase/Firebase.h>
 #import <RNFBApp/RNFBSharedUtils.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/perf/ios/RNFBPerf/RNFBPerfModule.m
+++ b/packages/perf/ios/RNFBPerf/RNFBPerfModule.m
@@ -15,6 +15,7 @@
  *
  */
 
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTUtils.h>
 

--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.m
@@ -16,6 +16,7 @@
  */
 
 #import <Firebase/Firebase.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTUtils.h>
 
 #import "RNFBRCTEventEmitter.h"


### PR DESCRIPTION
### Description

22 RNFB `.m` files use `RCT_EXPORT_METHOD`, `RCT_EXPORT_MODULE`, or `RCT_REMAP_METHOD` but never directly `#import <React/RCTBridgeModule.h>`. They've been picking up the macros transitively through the package's own `.h` files. That chain is becoming unreliable under newer RN + `use_frameworks!` because Clang modules scope `#define`s and don't propagate them across boundaries.

This PR adds the explicit `#import <React/RCTBridgeModule.h>` at the top of each affected `.m`. One line per file, pure hygiene, no behavior change. Makes the macros reliably available regardless of how transitive includes resolve, now or in the future.

Related to #8988 (firestore-specific symptom) and complements #8883. Applied uniformly across all RNFB packages instead of just firestore. Happy to defer to a narrower scope if maintainers prefer.

### Related issues

Helps #8883 (consumer-side chain). Related to #8988.

### Release Summary

iOS: every RNFB `.m` file using `RCT_EXPORT_*` macros now directly imports `<React/RCTBridgeModule.h>`. Removes a brittle transitive-include dependency.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Verified on Animalert (RN 0.84.1, 8 RNFB packages). Setup: `use_frameworks! :linkage => :static`, `$RNFirebaseAsStaticFramework = true`, `ENV['RCT_USE_PREBUILT_RNCORE'] = '0'` (the documented workaround until #8883's consumer side closes). Xcode 26.5. Tested on iPhone 17 Pro iOS 26.5 simulator and iPhone 13 physical device.

Before: Debug fails at every RNFB module's `RCT_EXPORT_METHOD` with cascading parse errors.

After: clean Debug and Release builds of the full Animalert workspace, `.app` bundles produced for both configurations.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
