### PR TITLE
feat(ai): expose recent firebase-js-sdk APIs in react-native-firebase

### DIFF
--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -164,11 +164,6 @@ const config: PackageConfig = {
       reason:
         'RN Firebase does not currently expose `maxSequentialFunctionCalls`, so its request options are limited to timeout and base URL.',
     },
-    {
-      name: 'UsageMetadata',
-      reason:
-        'RN Firebase usage metadata does not currently surface tool-use and cache token accounting fields that are present in the JS SDK declaration.',
-    },
   ],
 };
 

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -102,11 +102,6 @@ const config: PackageConfig = {
         'Chrome Prompt API prompt options type used by browser-only on-device language model integration.',
     },
     {
-      name: 'AnyOfSchema',
-      reason:
-        'RN Firebase schema-builder does not currently expose the `anyOf` helper class, so union-schema composition is not part of the public RN AI API.',
-    },
-    {
       name: 'LiveServerGoingAwayNotice',
       reason:
         'RN Firebase live sessions do not currently surface the server `goingAwayNotice` message type in the public API.',
@@ -251,26 +246,6 @@ const config: PackageConfig = {
         'RN Firebase does not currently expose `maxSequentalFunctionCalls`, so its request options are limited to timeout and base URL.',
     },
     {
-      name: 'Schema',
-      reason:
-        'RN Firebase schema-builder requires an explicit `type` and does not expose the JS SDK `anyOf` helper, so the public schema shape differs.',
-    },
-    {
-      name: 'SchemaInterface',
-      reason:
-        'RN Firebase schema interfaces require an explicit `type`, whereas the JS SDK declaration leaves `type` optional in the base interface.',
-    },
-    {
-      name: 'SchemaRequest',
-      reason:
-        'RN Firebase request-shaped schemas require an explicit `type`, whereas the JS SDK declaration leaves `type` optional.',
-    },
-    {
-      name: 'SchemaShared',
-      reason:
-        'RN Firebase shared schema typing omits the JS SDK `anyOf` property because `AnyOfSchema` is not currently part of the public RN API.',
-    },
-    {
       name: 'TemplateGenerativeModel',
       reason:
         'RN Firebase template generative model methods do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
@@ -279,11 +254,6 @@ const config: PackageConfig = {
       name: 'TemplateImagenModel',
       reason:
         'RN Firebase template Imagen model methods do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
-    },
-    {
-      name: 'TypedSchema',
-      reason:
-        'RN Firebase typed schema unions do not currently include `AnyOfSchema`, so the exported union is smaller than the JS SDK version.',
     },
     {
       name: 'UsageMetadata',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -151,11 +151,6 @@ const config: PackageConfig = {
       reason:
         'Template tool unions are part of firebase-js-sdk template tooling that RN Firebase does not currently expose.',
     },
-    {
-      name: 'ThinkingLevel',
-      reason:
-        'RN Firebase supports thinking budgets but does not currently expose the JS SDK `ThinkingLevel` preset constants/type.',
-    },
   ],
   extraInRN: [
     {
@@ -284,11 +279,6 @@ const config: PackageConfig = {
       name: 'TemplateImagenModel',
       reason:
         'RN Firebase template Imagen model methods do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
-    },
-    {
-      name: 'ThinkingConfig',
-      reason:
-        'RN Firebase thinking config supports `thinkingBudget` and `includeThoughts`, but does not currently expose the JS SDK `thinkingLevel` preset field.',
     },
     {
       name: 'TypedSchema',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -101,31 +101,6 @@ const config: PackageConfig = {
       reason:
         'Chrome Prompt API prompt options type used by browser-only on-device language model integration.',
     },
-    {
-      name: 'StartTemplateChatParams',
-      reason:
-        'Template chat startup parameters are part of the firebase-js-sdk template chat API, which RN Firebase does not currently expose.',
-    },
-    {
-      name: 'TemplateChatSession',
-      reason:
-        'Template chat sessions are not currently part of the RN Firebase public AI API.',
-    },
-    {
-      name: 'TemplateFunctionDeclaration',
-      reason:
-        'Template function declaration helpers are part of firebase-js-sdk template tooling that RN Firebase does not currently expose.',
-    },
-    {
-      name: 'TemplateFunctionDeclarationsTool',
-      reason:
-        'Template function declaration tools are part of firebase-js-sdk template tooling that RN Firebase does not currently expose.',
-    },
-    {
-      name: 'TemplateTool',
-      reason:
-        'Template tool unions are part of firebase-js-sdk template tooling that RN Firebase does not currently expose.',
-    },
   ],
   extraInRN: [
     {
@@ -194,11 +169,6 @@ const config: PackageConfig = {
       name: 'RequestOptions',
       reason:
         'RN Firebase does not currently expose `maxSequentialFunctionCalls`, so its request options are limited to timeout and base URL.',
-    },
-    {
-      name: 'TemplateGenerativeModel',
-      reason:
-        'RN Firebase template generative models do not currently expose `startChat`, so template chat sessions remain absent.',
     },
     {
       name: 'UsageMetadata',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -102,11 +102,6 @@ const config: PackageConfig = {
         'Chrome Prompt API prompt options type used by browser-only on-device language model integration.',
     },
     {
-      name: 'SingleRequestOptions',
-      reason:
-        'RN Firebase does not currently expose per-call request overrides such as `AbortSignal`; requests are configured via model-level `RequestOptions` only.',
-    },
-    {
       name: 'ChatSessionBase',
       reason:
         'Base class used by the firebase-js-sdk template chat implementation. RN Firebase exposes its concrete chat session surface instead.',
@@ -193,7 +188,7 @@ const config: PackageConfig = {
     {
       name: 'ChatSession',
       reason:
-        'RN Firebase chat sessions do not currently accept per-call `SingleRequestOptions`, so `sendMessage` and `sendMessageStream` expose fewer parameters.',
+        'RN Firebase chat sessions expose `getHistory()` directly on the concrete class while the firebase-js-sdk inherits it from `ChatSessionBase`.',
     },
     {
       name: 'FunctionDeclaration',
@@ -211,29 +206,14 @@ const config: PackageConfig = {
         'RN Firebase does not currently expose the JS SDK `responseJsonSchema` generation config field.',
     },
     {
-      name: 'GenerativeModel',
-      reason:
-        'RN Firebase generative model methods do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
-    },
-    {
-      name: 'ImagenModel',
-      reason:
-        'RN Firebase Imagen model requests do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
-    },
-    {
       name: 'RequestOptions',
       reason:
-        'RN Firebase does not currently expose `maxSequentalFunctionCalls`, so its request options are limited to timeout and base URL.',
+        'RN Firebase does not currently expose `maxSequentialFunctionCalls`, so its request options are limited to timeout and base URL.',
     },
     {
       name: 'TemplateGenerativeModel',
       reason:
-        'RN Firebase template generative model methods do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
-    },
-    {
-      name: 'TemplateImagenModel',
-      reason:
-        'RN Firebase template Imagen model methods do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
+        'RN Firebase template generative models do not currently expose `startChat`, so template chat sessions remain absent.',
     },
     {
       name: 'UsageMetadata',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -102,11 +102,6 @@ const config: PackageConfig = {
         'Chrome Prompt API prompt options type used by browser-only on-device language model integration.',
     },
     {
-      name: 'ObjectSchemaRequest',
-      reason:
-        'RN Firebase exposes `ObjectSchemaInterface` for schema helper typing, but does not separately export the raw request-shape `ObjectSchemaRequest` type.',
-    },
-    {
       name: 'SingleRequestOptions',
       reason:
         'RN Firebase does not currently expose per-call request overrides such as `AbortSignal`; requests are configured via model-level `RequestOptions` only.',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -154,16 +154,6 @@ const config: PackageConfig = {
       reason:
         'Both packages expose the same URL retrieval status constants, but the generated declaration text differs (`string`-valued object in JS SDK vs readonly literal constants in RN).',
     },
-    {
-      name: 'FunctionDeclaration',
-      reason:
-        'RN Firebase function declarations accept `ObjectSchemaInterface` only and do not expose the JS SDK `functionReference` auto-calling hook.',
-    },
-    {
-      name: 'RequestOptions',
-      reason:
-        'RN Firebase does not currently expose `maxSequentialFunctionCalls`, so its request options are limited to timeout and base URL.',
-    },
   ],
 };
 

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -186,11 +186,6 @@ const config: PackageConfig = {
         'RN Firebase function declarations accept `ObjectSchemaInterface` only and do not expose the JS SDK `functionReference` auto-calling hook.',
     },
     {
-      name: 'FunctionResponse',
-      reason:
-        'RN Firebase function responses omit the optional `parts` field from the JS SDK declaration and only expose the structured response payload.',
-    },
-    {
       name: 'GenerationConfig',
       reason:
         'RN Firebase does not currently expose the JS SDK `responseJsonSchema` generation config field.',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -102,11 +102,6 @@ const config: PackageConfig = {
         'Chrome Prompt API prompt options type used by browser-only on-device language model integration.',
     },
     {
-      name: 'LiveServerGoingAwayNotice',
-      reason:
-        'RN Firebase live sessions do not currently surface the server `goingAwayNotice` message type in the public API.',
-    },
-    {
       name: 'ObjectSchemaRequest',
       reason:
         'RN Firebase exposes `ObjectSchemaInterface` for schema helper typing, but does not separately export the raw request-shape `ObjectSchemaRequest` type.',
@@ -229,16 +224,6 @@ const config: PackageConfig = {
       name: 'ImagenModel',
       reason:
         'RN Firebase Imagen model requests do not currently accept per-call `SingleRequestOptions`, so request overrides are limited to model-level `RequestOptions`.',
-    },
-    {
-      name: 'LiveResponseType',
-      reason:
-        'RN Firebase live response typing omits `GOING_AWAY_NOTICE` because `LiveServerGoingAwayNotice` is not currently surfaced in the public API.',
-    },
-    {
-      name: 'LiveSession',
-      reason:
-        'RN Firebase live sessions do not currently expose `LiveServerGoingAwayNotice` from `receive()`, so the response union is smaller than the JS SDK.',
     },
     {
       name: 'RequestOptions',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -102,11 +102,6 @@ const config: PackageConfig = {
         'Chrome Prompt API prompt options type used by browser-only on-device language model integration.',
     },
     {
-      name: 'ChatSessionBase',
-      reason:
-        'Base class used by the firebase-js-sdk template chat implementation. RN Firebase exposes its concrete chat session surface instead.',
-    },
-    {
       name: 'StartTemplateChatParams',
       reason:
         'Template chat startup parameters are part of the firebase-js-sdk template chat API, which RN Firebase does not currently expose.',
@@ -184,11 +179,6 @@ const config: PackageConfig = {
       name: 'URLRetrievalStatus',
       reason:
         'Both packages expose the same URL retrieval status constants, but the generated declaration text differs (`string`-valued object in JS SDK vs readonly literal constants in RN).',
-    },
-    {
-      name: 'ChatSession',
-      reason:
-        'RN Firebase chat sessions expose `getHistory()` directly on the concrete class while the firebase-js-sdk inherits it from `ChatSessionBase`.',
     },
     {
       name: 'FunctionDeclaration',

--- a/.github/scripts/compare-types/configs/ai.ts
+++ b/.github/scripts/compare-types/configs/ai.ts
@@ -68,8 +68,7 @@ const config: PackageConfig = {
     },
     {
       name: 'LanguageModelExpected',
-      reason:
-        'Chrome Prompt API type tied to browser-only on-device language model integration.',
+      reason: 'Chrome Prompt API type tied to browser-only on-device language model integration.',
     },
     {
       name: 'LanguageModelMessage',
@@ -159,11 +158,6 @@ const config: PackageConfig = {
       name: 'FunctionDeclaration',
       reason:
         'RN Firebase function declarations accept `ObjectSchemaInterface` only and do not expose the JS SDK `functionReference` auto-calling hook.',
-    },
-    {
-      name: 'GenerationConfig',
-      reason:
-        'RN Firebase does not currently expose the JS SDK `responseJsonSchema` generation config field.',
     },
     {
       name: 'RequestOptions',

--- a/packages/ai/__tests__/chat-session.test.ts
+++ b/packages/ai/__tests__/chat-session.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it, afterEach, jest } from '@jest/globals';
 
 import * as generateContentMethods from '../lib/methods/generate-content';
-import { GenerateContentStreamResult } from '../lib/types';
+import { EnhancedGenerateContentResponse, GenerateContentStreamResult } from '../lib/types';
 import { ChatSession } from '../lib/methods/chat-session';
 import { ApiSettings } from '../lib/types/internal';
 import { RequestOptions } from '../lib/types/requests';
@@ -34,6 +34,15 @@ const fakeApiSettings: ApiSettings = {
 const requestOptions: RequestOptions = {
   timeout: 1000,
 };
+
+function streamResult(response: EnhancedGenerateContentResponse): GenerateContentStreamResult {
+  return {
+    stream: (async function* () {
+      yield response;
+    })(),
+    response: Promise.resolve(response),
+  };
+}
 
 describe('ChatSession', () => {
   afterEach(() => {
@@ -127,6 +136,102 @@ describe('ChatSession', () => {
           signal: controller.signal,
         },
       );
+    });
+
+    it('automatically calls functionReference from stream function calls', async () => {
+      const getWeather = jest.fn<(args: object) => object>().mockReturnValue({ temperature: 72 });
+      const functionCallResponse = {
+        candidates: [
+          {
+            index: 0,
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'getWeather',
+                    args: { city: 'London' },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        functionCalls: () => [{ name: 'getWeather', args: { city: 'London' } }],
+      } as EnhancedGenerateContentResponse;
+      const finalResponse = {
+        candidates: [
+          {
+            index: 0,
+            content: {
+              role: 'model',
+              parts: [{ text: 'It is 72 degrees.' }],
+            },
+          },
+        ],
+        functionCalls: () => undefined,
+      } as EnhancedGenerateContentResponse;
+      const generateContentStreamStub = jest
+        .spyOn(generateContentMethods, 'generateContentStream')
+        .mockResolvedValueOnce(streamResult(functionCallResponse))
+        .mockResolvedValueOnce(streamResult(finalResponse));
+      const chatSession = new ChatSession(
+        fakeApiSettings,
+        'a-model',
+        {
+          tools: [
+            {
+              functionDeclarations: [
+                {
+                  name: 'getWeather',
+                  description: 'Gets weather for a city.',
+                  functionReference: getWeather,
+                },
+              ],
+            },
+          ],
+        },
+        requestOptions,
+      );
+
+      const result = await chatSession.sendMessageStream('weather in London');
+      await result.response;
+      const history = await chatSession.getHistory();
+
+      expect(getWeather).toHaveBeenCalledWith({ city: 'London' });
+      expect(generateContentStreamStub).toHaveBeenCalledTimes(2);
+      expect(history).toEqual([
+        {
+          role: 'user',
+          parts: [{ text: 'weather in London' }],
+        },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'getWeather',
+                args: { city: 'London' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'function',
+          parts: [
+            {
+              functionResponse: {
+                name: 'getWeather',
+                response: { temperature: 72 },
+              },
+            },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [{ text: 'It is 72 degrees.' }],
+        },
+      ]);
     });
 
     it('downstream sendPromise errors should log but not throw', async () => {

--- a/packages/ai/__tests__/chat-session.test.ts
+++ b/packages/ai/__tests__/chat-session.test.ts
@@ -57,6 +57,29 @@ describe('ChatSession', () => {
         requestOptions,
       );
     });
+
+    it('merges per-call request options over session request options', async () => {
+      const controller = new AbortController();
+      const generateContentStub = jest
+        .spyOn(generateContentMethods, 'generateContent')
+        .mockResolvedValue({ response: { candidates: [] } } as any);
+      const chatSession = new ChatSession(fakeApiSettings, 'a-model', {}, requestOptions);
+
+      await chatSession.sendMessage('hello', {
+        timeout: 2000,
+        signal: controller.signal,
+      });
+
+      expect(generateContentStub).toHaveBeenCalledWith(
+        fakeApiSettings,
+        'a-model',
+        expect.anything(),
+        {
+          timeout: 2000,
+          signal: controller.signal,
+        },
+      );
+    });
   });
 
   describe('sendMessageStream()', () => {
@@ -79,6 +102,31 @@ describe('ChatSession', () => {
       jest.runAllTimers();
       expect(consoleStub).not.toHaveBeenCalled();
       jest.useRealTimers();
+    });
+
+    it('merges per-call request options over session request options', async () => {
+      const controller = new AbortController();
+      const generateContentStreamStub = jest
+        .spyOn(generateContentMethods, 'generateContentStream')
+        .mockResolvedValue({
+          response: Promise.resolve({ candidates: [] }),
+        } as unknown as GenerateContentStreamResult);
+      const chatSession = new ChatSession(fakeApiSettings, 'a-model', {}, requestOptions);
+
+      await chatSession.sendMessageStream('hello', {
+        timeout: 2000,
+        signal: controller.signal,
+      });
+
+      expect(generateContentStreamStub).toHaveBeenCalledWith(
+        fakeApiSettings,
+        'a-model',
+        expect.anything(),
+        {
+          timeout: 2000,
+          signal: controller.signal,
+        },
+      );
     });
 
     it('downstream sendPromise errors should log but not throw', async () => {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -69,6 +69,7 @@ import {
   ModalityTokenCount,
   ModelParams,
   ObjectSchemaInterface,
+  ObjectSchemaRequest,
   PromptFeedback,
   RequestOptions,
   RetrievedContextAttribution,
@@ -359,6 +360,31 @@ describe('AI', function () {
     it('`ObjectSchemaInterface` type is properly exposed to end user', function () {
       const _typeCheck: ObjectSchemaInterface = {} as ObjectSchemaInterface;
       expect(typeof _typeCheck).toBeDefined();
+    });
+
+    it('`ObjectSchemaRequest` type is properly exposed to end user', function () {
+      const _typeCheck: ObjectSchemaRequest = {
+        type: 'object',
+        properties: {},
+      };
+      expect(typeof _typeCheck).toBe('object');
+    });
+
+    it('`FunctionDeclaration.parameters` accepts ObjectSchemaRequest', function () {
+      const _typeCheck: FunctionDeclaration = {
+        name: 'getWeather',
+        description: 'Gets weather for a city.',
+        parameters: {
+          type: 'object',
+          properties: {
+            city: {
+              type: SchemaType.STRING,
+            },
+          },
+          required: ['city'],
+        },
+      };
+      expect(typeof _typeCheck).toBe('object');
     });
 
     it('`PromptFeedback` type is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   // Runtime values (classes, functions, constants)
+  AnyOfSchema,
   BackendType,
   POSSIBLE_ROLES,
   AIError,
@@ -116,6 +117,10 @@ describe('AI', function () {
 
     it('`POSSIBLE_ROLES` constant is properly exposed to end user', function () {
       expect(POSSIBLE_ROLES).toBeDefined();
+    });
+
+    it('`AnyOfSchema` class is properly exposed to end user', function () {
+      expect(AnyOfSchema).toBeDefined();
     });
 
     it('`ThinkingLevel` constant is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -28,6 +28,8 @@ import {
   getGenerativeModel,
   ChatSession,
   ChatSessionBase,
+  TemplateChatSession,
+  TemplateGenerativeModel,
   GoogleAIBackend,
   VertexAIBackend,
   // Types that exist - imported for type checking
@@ -84,6 +86,10 @@ import {
   Segment,
   SingleRequestOptions,
   StartChatParams,
+  StartTemplateChatParams,
+  TemplateFunctionDeclaration,
+  TemplateFunctionDeclarationsTool,
+  TemplateTool,
   TextPart,
   ThinkingConfig,
   ThinkingLevel,
@@ -162,6 +168,14 @@ describe('AI', function () {
 
     it('`ChatSessionBase` class is properly exposed to end user', function () {
       expect(ChatSessionBase).toBeDefined();
+    });
+
+    it('`TemplateChatSession` class is properly exposed to end user', function () {
+      expect(TemplateChatSession).toBeDefined();
+    });
+
+    it('`TemplateGenerativeModel` class is properly exposed to end user', function () {
+      expect(TemplateGenerativeModel).toBeDefined();
     });
 
     it('`GoogleAIBackend` class is properly exposed to end user', function () {
@@ -470,6 +484,44 @@ describe('AI', function () {
     it('`StartChatParams` type is properly exposed to end user', function () {
       const _typeCheck: StartChatParams = {} as StartChatParams;
       expect(typeof _typeCheck).toBeDefined();
+    });
+
+    it('`StartTemplateChatParams` type is properly exposed to end user', function () {
+      const _typeCheck: StartTemplateChatParams = {
+        templateId: 'my-template',
+        templateVariables: { city: 'London' },
+      };
+      expect(typeof _typeCheck).toBe('object');
+    });
+
+    it('`TemplateFunctionDeclaration` type is properly exposed to end user', function () {
+      const _typeCheck: TemplateFunctionDeclaration = {
+        name: 'getWeather',
+        parameters: {
+          type: 'object',
+          properties: {
+            city: {
+              type: SchemaType.STRING,
+            },
+          },
+        },
+        functionReference: () => ({ temperature: 72 }),
+      };
+      expect(typeof _typeCheck).toBe('object');
+    });
+
+    it('`TemplateFunctionDeclarationsTool` type is properly exposed to end user', function () {
+      const _typeCheck: TemplateFunctionDeclarationsTool = {
+        functionDeclarations: [{ name: 'getWeather' }],
+      };
+      expect(typeof _typeCheck).toBe('object');
+    });
+
+    it('`TemplateTool` type is properly exposed to end user', function () {
+      const _typeCheck: TemplateTool = {
+        functionDeclarations: [{ name: 'getWeather' }],
+      };
+      expect(typeof _typeCheck).toBe('object');
     });
 
     it('`TextPart` type is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -352,8 +352,16 @@ describe('AI', function () {
     });
 
     it('`GenerationConfig` type is properly exposed to end user', function () {
-      const _typeCheck: GenerationConfig = {} as GenerationConfig;
-      expect(typeof _typeCheck).toBeDefined();
+      const _typeCheck: GenerationConfig = {
+        responseMimeType: 'application/json',
+        responseJsonSchema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'string' },
+          },
+        },
+      };
+      expect(typeof _typeCheck).toBe('object');
     });
 
     it('`GenerativeContentBlob` type is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -563,8 +563,16 @@ describe('AI', function () {
     });
 
     it('`UsageMetadata` type is properly exposed to end user', function () {
-      const _typeCheck: UsageMetadata = {} as UsageMetadata;
-      expect(typeof _typeCheck).toBeDefined();
+      const _typeCheck: UsageMetadata = {
+        promptTokenCount: 5,
+        candidatesTokenCount: 7,
+        totalTokenCount: 12,
+        toolUsePromptTokenCount: 3,
+        toolUsePromptTokensDetails: [{ modality: Modality.TEXT, tokenCount: 3 }],
+        cachedContentTokenCount: 2,
+        cacheTokensDetails: [{ modality: Modality.TEXT, tokenCount: 2 }],
+      };
+      expect(typeof _typeCheck).toBe('object');
     });
 
     it('`VideoMetadata` type is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -80,6 +80,8 @@ import {
   Segment,
   StartChatParams,
   TextPart,
+  ThinkingConfig,
+  ThinkingLevel,
   ToolConfig,
   URLContext,
   URLContextMetadata,
@@ -114,6 +116,14 @@ describe('AI', function () {
 
     it('`POSSIBLE_ROLES` constant is properly exposed to end user', function () {
       expect(POSSIBLE_ROLES).toBeDefined();
+    });
+
+    it('`ThinkingLevel` constant is properly exposed to end user', function () {
+      expect(ThinkingLevel).toBeDefined();
+      expect(ThinkingLevel.MINIMAL).toBe('MINIMAL');
+      expect(ThinkingLevel.LOW).toBe('LOW');
+      expect(ThinkingLevel.MEDIUM).toBe('MEDIUM');
+      expect(ThinkingLevel.HIGH).toBe('HIGH');
     });
 
     it('`AIError` class is properly exposed to end user', function () {
@@ -167,6 +177,11 @@ describe('AI', function () {
     it('`Tool` type is properly exposed to end user', function () {
       const _typeCheck: Tool = {} as Tool;
       expect(typeof _typeCheck).toBeDefined();
+    });
+
+    it('`ThinkingConfig` type is properly exposed to end user', function () {
+      const _typeCheck: ThinkingConfig = { thinkingLevel: ThinkingLevel.LOW };
+      expect(typeof _typeCheck).toBe('object');
     });
 
     it('`TypedSchema` type is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -81,6 +81,7 @@ import {
   SchemaShared,
   SearchEntrypoint,
   Segment,
+  SingleRequestOptions,
   StartChatParams,
   TextPart,
   ThinkingConfig,
@@ -395,6 +396,16 @@ describe('AI', function () {
     it('`RequestOptions` type is properly exposed to end user', function () {
       const _typeCheck: RequestOptions = {} as RequestOptions;
       expect(typeof _typeCheck).toBeDefined();
+    });
+
+    it('`SingleRequestOptions` type is properly exposed to end user', function () {
+      const controller = new AbortController();
+      const _typeCheck: SingleRequestOptions = {
+        timeout: 1000,
+        baseUrl: 'https://example.com',
+        signal: controller.signal,
+      };
+      expect(typeof _typeCheck).toBe('object');
     });
 
     it('`RetrievedContextAttribution` type is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -298,6 +298,15 @@ describe('AI', function () {
       expect(typeof _typeCheck).toBeDefined();
     });
 
+    it('`FunctionResponse.parts` type is properly exposed to end user', function () {
+      const _typeCheck: FunctionResponse = {
+        name: 'getWeather',
+        response: { temperature: 72 },
+        parts: [{ text: 'Weather lookup complete.' }],
+      };
+      expect(typeof _typeCheck).toBe('object');
+    });
+
     it('`FunctionResponsePart` type is properly exposed to end user', function () {
       const _typeCheck: FunctionResponsePart = {} as FunctionResponsePart;
       expect(typeof _typeCheck).toBeDefined();

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -65,6 +65,7 @@ import {
   GroundingAttribution,
   GroundingMetadata,
   InlineDataPart,
+  LiveServerGoingAwayNotice,
   ModalityTokenCount,
   ModelParams,
   ObjectSchemaInterface,
@@ -102,6 +103,7 @@ import {
   HarmCategory,
   HarmProbability,
   HarmSeverity,
+  LiveResponseType,
   Modality,
   SchemaType,
 } from '../lib';
@@ -526,6 +528,18 @@ describe('AI', function () {
       expect(URLRetrievalStatus.URL_RETRIEVAL_STATUS_UNSPECIFIED).toBe(
         'URL_RETRIEVAL_STATUS_UNSPECIFIED',
       );
+    });
+
+    it('`LiveResponseType.GOING_AWAY_NOTICE` constant is properly exposed to end user', function () {
+      expect(LiveResponseType.GOING_AWAY_NOTICE).toBe('goingAwayNotice');
+    });
+
+    it('`LiveServerGoingAwayNotice` type is properly exposed to end user', function () {
+      const _typeCheck: LiveServerGoingAwayNotice = {
+        type: 'goingAwayNotice',
+        timeLeft: 10,
+      };
+      expect(typeof _typeCheck).toBe('object');
     });
   });
 });

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -27,6 +27,7 @@ import {
   getAI,
   getGenerativeModel,
   ChatSession,
+  ChatSessionBase,
   GoogleAIBackend,
   VertexAIBackend,
   // Types that exist - imported for type checking
@@ -157,6 +158,10 @@ describe('AI', function () {
 
     it('`ChatSession` class is properly exposed to end user', function () {
       expect(ChatSession).toBeDefined();
+    });
+
+    it('`ChatSessionBase` class is properly exposed to end user', function () {
+      expect(ChatSessionBase).toBeDefined();
     });
 
     it('`GoogleAIBackend` class is properly exposed to end user', function () {

--- a/packages/ai/__tests__/exported-types.test.ts
+++ b/packages/ai/__tests__/exported-types.test.ts
@@ -73,6 +73,7 @@ import {
   ModelParams,
   ObjectSchemaInterface,
   ObjectSchemaRequest,
+  ObjectSchema,
   PromptFeedback,
   RequestOptions,
   RetrievedContextAttribution,
@@ -82,6 +83,7 @@ import {
   SchemaParams,
   SchemaRequest,
   SchemaShared,
+  Schema,
   SearchEntrypoint,
   Segment,
   SingleRequestOptions,
@@ -424,14 +426,33 @@ describe('AI', function () {
       expect(typeof _typeCheck).toBe('object');
     });
 
+    it('`FunctionDeclaration` accepts ObjectSchema and functionReference', function () {
+      const parameters: ObjectSchema = Schema.object({
+        properties: {
+          city: Schema.string(),
+        },
+      });
+      const _typeCheck: FunctionDeclaration = {
+        name: 'getWeather',
+        description: 'Gets weather for a city.',
+        parameters,
+        functionReference: () => ({ temperature: 72 }),
+      };
+      expect(typeof _typeCheck).toBe('object');
+    });
+
     it('`PromptFeedback` type is properly exposed to end user', function () {
       const _typeCheck: PromptFeedback = {} as PromptFeedback;
       expect(typeof _typeCheck).toBeDefined();
     });
 
     it('`RequestOptions` type is properly exposed to end user', function () {
-      const _typeCheck: RequestOptions = {} as RequestOptions;
-      expect(typeof _typeCheck).toBeDefined();
+      const _typeCheck: RequestOptions = {
+        timeout: 1000,
+        baseUrl: 'https://example.com',
+        maxSequentialFunctionCalls: 3,
+      };
+      expect(typeof _typeCheck).toBe('object');
     });
 
     it('`SingleRequestOptions` type is properly exposed to end user', function () {

--- a/packages/ai/__tests__/generate-content.test.ts
+++ b/packages/ai/__tests__/generate-content.test.ts
@@ -167,10 +167,19 @@ describe('generateContent()', () => {
     const mockResponse = getMockResponse(
       BackendName.VertexAI,
       'unary-success-basic-response-long-usage-metadata.json',
-    );
-    const makeRequestStub = jest
-      .spyOn(request, 'makeRequest')
-      .mockResolvedValue(mockResponse as Response);
+    ) as Response;
+    const mockResponseJson = await mockResponse.json();
+    mockResponseJson.usageMetadata = {
+      ...mockResponseJson.usageMetadata,
+      toolUsePromptTokenCount: 3,
+      toolUsePromptTokensDetails: [{ modality: 'TEXT', tokenCount: 3 }],
+      cachedContentTokenCount: 5,
+      cacheTokensDetails: [{ modality: 'TEXT', tokenCount: 5 }],
+    };
+    const makeRequestStub = jest.spyOn(request, 'makeRequest').mockResolvedValue({
+      ...mockResponse,
+      json: () => Promise.resolve(mockResponseJson),
+    } as Response);
     const result = await generateContent(fakeApiSettings, 'model', fakeRequestParams);
     expect(result.response.usageMetadata?.totalTokenCount).toEqual(1913);
     expect(result.response.usageMetadata?.candidatesTokenCount).toEqual(76);
@@ -178,6 +187,12 @@ describe('generateContent()', () => {
     expect(result.response.usageMetadata?.promptTokensDetails?.[0]?.tokenCount).toEqual(1806);
     expect(result.response.usageMetadata?.candidatesTokensDetails?.[0]?.modality).toEqual('TEXT');
     expect(result.response.usageMetadata?.candidatesTokensDetails?.[0]?.tokenCount).toEqual(76);
+    expect(result.response.usageMetadata).toMatchObject({
+      toolUsePromptTokenCount: 3,
+      toolUsePromptTokensDetails: [{ modality: 'TEXT', tokenCount: 3 }],
+      cachedContentTokenCount: 5,
+      cacheTokensDetails: [{ modality: 'TEXT', tokenCount: 5 }],
+    });
     expect(makeRequestStub).toHaveBeenCalledWith(
       expect.objectContaining({
         model: 'model',

--- a/packages/ai/__tests__/generate-content.test.ts
+++ b/packages/ai/__tests__/generate-content.test.ts
@@ -127,6 +127,42 @@ describe('generateContent()', () => {
     );
   });
 
+  it('passes FunctionResponse.parts through in request bodies', async () => {
+    const mockResponse = getMockResponse(
+      BackendName.VertexAI,
+      'unary-success-basic-reply-short.json',
+    );
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValue(mockResponse as Response);
+    const params: GenerateContentRequest = {
+      contents: [
+        {
+          role: 'function',
+          parts: [
+            {
+              functionResponse: {
+                name: 'getWeather',
+                response: { temperature: 72 },
+                parts: [{ text: 'Weather lookup complete.' }],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    await generateContent(fakeApiSettings, 'model', params);
+
+    expect(makeRequestStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'model',
+        task: Task.GENERATE_CONTENT,
+      }),
+      expect.stringContaining('"parts":[{"text":"Weather lookup complete."}]'),
+    );
+  });
+
   it('long response with token details', async () => {
     const mockResponse = getMockResponse(
       BackendName.VertexAI,

--- a/packages/ai/__tests__/generative-model.test.ts
+++ b/packages/ai/__tests__/generative-model.test.ts
@@ -573,6 +573,100 @@ describe('GenerativeModel', () => {
     makeRequestStub.mockRestore();
   });
 
+  it('automatically calls functionReference from chat.sendMessage function calls', async () => {
+    const getWeather = jest.fn<(args: object) => object>().mockReturnValue({ temperature: 72 });
+    const genModel = new GenerativeModel(fakeAI, {
+      model: 'my-model',
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: 'getWeather',
+              description: 'Gets weather for a city.',
+              functionReference: getWeather,
+            },
+          ],
+        },
+      ],
+    });
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValueOnce(
+        responseFromJson({
+          candidates: [
+            {
+              index: 0,
+              content: {
+                role: 'model',
+                parts: [
+                  {
+                    functionCall: {
+                      name: 'getWeather',
+                      args: { city: 'London' },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        responseFromJson({
+          candidates: [
+            {
+              index: 0,
+              content: {
+                role: 'model',
+                parts: [{ text: 'It is 72 degrees.' }],
+              },
+            },
+          ],
+        }),
+      );
+    const chat = genModel.startChat();
+
+    const result = await chat.sendMessage('weather in London');
+    const history = await chat.getHistory();
+
+    expect(result.response.text()).toBe('It is 72 degrees.');
+    expect(getWeather).toHaveBeenCalledWith({ city: 'London' });
+    expect(makeRequestStub).toHaveBeenCalledTimes(2);
+    expect(history).toEqual([
+      {
+        role: 'user',
+        parts: [{ text: 'weather in London' }],
+      },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'getWeather',
+              args: { city: 'London' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'function',
+        parts: [
+          {
+            functionResponse: {
+              name: 'getWeather',
+              response: { temperature: 72 },
+            },
+          },
+        ],
+      },
+      {
+        role: 'model',
+        parts: [{ text: 'It is 72 degrees.' }],
+      },
+    ]);
+    makeRequestStub.mockRestore();
+  });
+
   it('passes CodeExecutionTool through to chat.sendMessage', async function () {
     const genModel = new GenerativeModel(fakeAI, {
       model: 'my-model',

--- a/packages/ai/__tests__/generative-model.test.ts
+++ b/packages/ai/__tests__/generative-model.test.ts
@@ -124,6 +124,44 @@ describe('GenerativeModel', () => {
     makeRequestStub.mockRestore();
   });
 
+  it('merges per-call request options over model request options for generateContent', async () => {
+    const controller = new AbortController();
+    const genModel = new GenerativeModel(
+      fakeAI,
+      {
+        model: 'my-model',
+      },
+      {
+        timeout: 1000,
+        baseUrl: 'https://model.example.com',
+      },
+    );
+    const mockResponse = getMockResponse(
+      BackendName.VertexAI,
+      'unary-success-basic-reply-short.json',
+    );
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValue(mockResponse as Response);
+
+    await genModel.generateContent('hello', {
+      timeout: 2000,
+      signal: controller.signal,
+    });
+
+    expect(makeRequestStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestOptions: {
+          timeout: 2000,
+          baseUrl: 'https://model.example.com',
+          signal: controller.signal,
+        },
+      }),
+      expect.any(String),
+    );
+    makeRequestStub.mockRestore();
+  });
+
   it('passes thinkingLevel through to generateContent', async () => {
     const genModel = new GenerativeModel(fakeAI, {
       model: 'my-model',
@@ -172,6 +210,42 @@ describe('GenerativeModel', () => {
       'Cannot set both thinkingBudget and thinkingLevel in a config.',
     );
     expect(makeRequestStub).not.toHaveBeenCalled();
+    makeRequestStub.mockRestore();
+  });
+
+  it('merges per-call request options over model request options for countTokens', async () => {
+    const controller = new AbortController();
+    const genModel = new GenerativeModel(
+      fakeAI,
+      {
+        model: 'my-model',
+      },
+      {
+        timeout: 1000,
+        baseUrl: 'https://model.example.com',
+      },
+    );
+    const makeRequestStub = jest.spyOn(request, 'makeRequest').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ totalTokens: 1 }),
+    } as Response);
+
+    await genModel.countTokens('hello', {
+      timeout: 2000,
+      signal: controller.signal,
+    });
+
+    expect(makeRequestStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: request.Task.COUNT_TOKENS,
+        requestOptions: {
+          timeout: 2000,
+          baseUrl: 'https://model.example.com',
+          signal: controller.signal,
+        },
+      }),
+      expect.any(String),
+    );
     makeRequestStub.mockRestore();
   });
 
@@ -433,7 +507,7 @@ describe('GenerativeModel', () => {
         task: request.Task.COUNT_TOKENS,
         apiSettings: expect.anything(),
         stream: false,
-        requestOptions: undefined,
+        requestOptions: {},
       }),
       expect.stringContaining('hello'),
     );

--- a/packages/ai/__tests__/generative-model.test.ts
+++ b/packages/ai/__tests__/generative-model.test.ts
@@ -21,6 +21,7 @@ import { AI, FunctionCallingMode, ThinkingLevel } from '../lib/public-types';
 import * as request from '../lib/requests/request';
 import { BackendName, getMockResponse } from './test-utils/mock-response';
 import { VertexAIBackend } from '../lib/backend';
+import { GenerateContentResponse } from '../lib';
 
 const fakeAI: AI = {
   app: {
@@ -35,6 +36,10 @@ const fakeAI: AI = {
   backend: new VertexAIBackend('us-central1'),
   location: 'us-central1',
 };
+
+function responseFromJson(json: GenerateContentResponse): Response {
+  return { json: async () => json } as Response;
+}
 
 describe('GenerativeModel', () => {
   it('passes CodeExecutionTool and URLContextTool with other tools through to generateContent', async function () {
@@ -359,6 +364,151 @@ describe('GenerativeModel', () => {
       }),
       expect.stringMatching(new RegExp(`be formal|otherfunc|${FunctionCallingMode.AUTO}`)),
     );
+    makeRequestStub.mockRestore();
+  });
+
+  it('automatically calls functionReference from generateContent function calls', async () => {
+    const getWeather = jest.fn<(args: object) => object>().mockReturnValue({ temperature: 72 });
+    const genModel = new GenerativeModel(fakeAI, {
+      model: 'my-model',
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: 'getWeather',
+              description: 'Gets weather for a city.',
+              functionReference: getWeather,
+            },
+          ],
+        },
+      ],
+    });
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValueOnce(
+        responseFromJson({
+          candidates: [
+            {
+              index: 0,
+              content: {
+                role: 'model',
+                parts: [
+                  {
+                    functionCall: {
+                      id: 'call-1',
+                      name: 'getWeather',
+                      args: { city: 'London' },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        responseFromJson({
+          candidates: [
+            {
+              index: 0,
+              content: {
+                role: 'model',
+                parts: [{ text: 'It is 72 degrees.' }],
+              },
+            },
+          ],
+        }),
+      );
+
+    const result = await genModel.generateContent('weather in London');
+
+    expect(result.response.text()).toBe('It is 72 degrees.');
+    expect(getWeather).toHaveBeenCalledWith({ city: 'London' });
+    expect(makeRequestStub).toHaveBeenCalledTimes(2);
+    const followUpBody = JSON.parse(makeRequestStub.mock.calls[1]![1] as string);
+    expect(followUpBody.contents).toEqual([
+      {
+        role: 'user',
+        parts: [{ text: 'weather in London' }],
+      },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              id: 'call-1',
+              name: 'getWeather',
+              args: { city: 'London' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'function',
+        parts: [
+          {
+            functionResponse: {
+              id: 'call-1',
+              name: 'getWeather',
+              response: { temperature: 72 },
+            },
+          },
+        ],
+      },
+    ]);
+    makeRequestStub.mockRestore();
+  });
+
+  it('returns the latest response when maxSequentialFunctionCalls is reached', async () => {
+    const getWeather = jest.fn<(args: object) => object>().mockReturnValue({ temperature: 72 });
+    const genModel = new GenerativeModel(
+      fakeAI,
+      {
+        model: 'my-model',
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: 'getWeather',
+                description: 'Gets weather for a city.',
+                functionReference: getWeather,
+              },
+            ],
+          },
+        ],
+      },
+      { maxSequentialFunctionCalls: 1 },
+    );
+    const functionCallResponse: GenerateContentResponse = {
+      candidates: [
+        {
+          index: 0,
+          content: {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  name: 'getWeather',
+                  args: { city: 'London' },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValueOnce(responseFromJson(functionCallResponse))
+      .mockResolvedValueOnce(responseFromJson(functionCallResponse));
+
+    const result = await genModel.generateContent('weather in London');
+
+    expect(result.response.functionCalls()).toEqual([
+      { name: 'getWeather', args: { city: 'London' } },
+    ]);
+    expect(getWeather).toHaveBeenCalledTimes(1);
+    expect(makeRequestStub).toHaveBeenCalledTimes(2);
     makeRequestStub.mockRestore();
   });
 

--- a/packages/ai/__tests__/generative-model.test.ts
+++ b/packages/ai/__tests__/generative-model.test.ts
@@ -17,7 +17,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { type ReactNativeFirebase } from '@react-native-firebase/app';
 import { GenerativeModel } from '../lib/models/generative-model';
-import { AI, FunctionCallingMode } from '../lib/public-types';
+import { AI, FunctionCallingMode, ThinkingLevel } from '../lib/public-types';
 import * as request from '../lib/requests/request';
 import { BackendName, getMockResponse } from './test-utils/mock-response';
 import { VertexAIBackend } from '../lib/backend';
@@ -121,6 +121,57 @@ describe('GenerativeModel', () => {
       }),
       expect.stringMatching(new RegExp(`myfunc|be friendly|${FunctionCallingMode.NONE}`)),
     );
+    makeRequestStub.mockRestore();
+  });
+
+  it('passes thinkingLevel through to generateContent', async () => {
+    const genModel = new GenerativeModel(fakeAI, {
+      model: 'my-model',
+      generationConfig: {
+        thinkingConfig: {
+          thinkingLevel: ThinkingLevel.LOW,
+        },
+      },
+    });
+    const mockResponse = getMockResponse(
+      BackendName.VertexAI,
+      'unary-success-basic-reply-short.json',
+    );
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValue(mockResponse as Response);
+
+    await genModel.generateContent('hello');
+
+    expect(makeRequestStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'publishers/google/models/my-model',
+        task: request.Task.GENERATE_CONTENT,
+        apiSettings: expect.anything(),
+        stream: false,
+        requestOptions: {},
+      }),
+      expect.stringContaining(`"thinkingLevel":"${ThinkingLevel.LOW}"`),
+    );
+    makeRequestStub.mockRestore();
+  });
+
+  it('throws when thinkingBudget and thinkingLevel are both set', async () => {
+    const genModel = new GenerativeModel(fakeAI, {
+      model: 'my-model',
+      generationConfig: {
+        thinkingConfig: {
+          thinkingBudget: 100,
+          thinkingLevel: ThinkingLevel.HIGH,
+        },
+      },
+    });
+    const makeRequestStub = jest.spyOn(request, 'makeRequest');
+
+    await expect(genModel.generateContent('hello')).rejects.toThrow(
+      'Cannot set both thinkingBudget and thinkingLevel in a config.',
+    );
+    expect(makeRequestStub).not.toHaveBeenCalled();
     makeRequestStub.mockRestore();
   });
 

--- a/packages/ai/__tests__/generative-model.test.ts
+++ b/packages/ai/__tests__/generative-model.test.ts
@@ -194,6 +194,43 @@ describe('GenerativeModel', () => {
     makeRequestStub.mockRestore();
   });
 
+  it('passes responseJsonSchema through to generateContent', async () => {
+    const genModel = new GenerativeModel(fakeAI, {
+      model: 'my-model',
+      generationConfig: {
+        responseMimeType: 'application/json',
+        responseJsonSchema: {
+          type: 'object',
+          properties: {
+            answer: { type: 'string' },
+          },
+          required: ['answer'],
+        },
+      },
+    });
+    const mockResponse = getMockResponse(
+      BackendName.VertexAI,
+      'unary-success-basic-reply-short.json',
+    );
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValue(mockResponse as Response);
+
+    await genModel.generateContent('hello');
+
+    expect(makeRequestStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'publishers/google/models/my-model',
+        task: request.Task.GENERATE_CONTENT,
+        apiSettings: expect.anything(),
+        stream: false,
+        requestOptions: {},
+      }),
+      expect.stringContaining('"responseJsonSchema":{"type":"object"'),
+    );
+    makeRequestStub.mockRestore();
+  });
+
   it('throws when thinkingBudget and thinkingLevel are both set', async () => {
     const genModel = new GenerativeModel(fakeAI, {
       model: 'my-model',

--- a/packages/ai/__tests__/googleai-mappers.test.ts
+++ b/packages/ai/__tests__/googleai-mappers.test.ts
@@ -37,6 +37,7 @@ import {
   HarmCategory,
   HarmProbability,
   HarmSeverity,
+  Modality,
   PromptFeedback,
   SafetyRating,
   URLRetrievalStatus,
@@ -168,7 +169,11 @@ describe('Google AI Mappers', () => {
         usageMetadata: {
           promptTokenCount: 5,
           candidatesTokenCount: 0,
+          toolUsePromptTokenCount: 3,
           totalTokenCount: 5,
+          toolUsePromptTokensDetails: [{ modality: Modality.TEXT, tokenCount: 3 }],
+          cachedContentTokenCount: 2,
+          cacheTokensDetails: [{ modality: Modality.TEXT, tokenCount: 2 }],
         },
       };
       const mappedResponse = mapGenerateContentResponse(googleAIResponse);

--- a/packages/ai/__tests__/imagen-model.test.ts
+++ b/packages/ai/__tests__/imagen-model.test.ts
@@ -141,6 +141,43 @@ describe('ImagenModel', () => {
     );
   });
 
+  it('generateImages merges per-call request options over model request options', async () => {
+    const controller = new AbortController();
+    const mockResponse = getMockResponse(
+      BackendName.VertexAI,
+      'unary-success-generate-images-base64.json',
+    );
+    const makeRequestStub = jest
+      .spyOn(request, 'makeRequest')
+      .mockResolvedValue(mockResponse as Response);
+    const imagenModel = new ImagenModel(
+      fakeAI,
+      {
+        model: 'my-model',
+      },
+      {
+        timeout: 1000,
+        baseUrl: 'https://model.example.com',
+      },
+    );
+
+    await imagenModel.generateImages('A toy boat.', {
+      timeout: 2000,
+      signal: controller.signal,
+    });
+
+    expect(makeRequestStub).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestOptions: {
+          timeout: 2000,
+          baseUrl: 'https://model.example.com',
+          signal: controller.signal,
+        },
+      }),
+      expect.any(String),
+    );
+  });
+
   it('throws if prompt blocked', async () => {
     const mockResponse = getMockResponse(
       BackendName.VertexAI,

--- a/packages/ai/__tests__/live-session.test.ts
+++ b/packages/ai/__tests__/live-session.test.ts
@@ -20,6 +20,7 @@ import {
   FunctionResponse,
   LiveResponseType,
   LiveServerContent,
+  LiveServerGoingAwayNotice,
   LiveServerToolCall,
   LiveServerToolCallCancellation,
 } from '../lib/types';
@@ -233,13 +234,16 @@ describe('LiveSession', function () {
         toolCallCancellation: { functionIds: ['123'] },
       });
       mockHandler.simulateServerMessage({
+        goAway: { timeLeft: '10.500s' },
+      });
+      mockHandler.simulateServerMessage({
         serverContent: { turnComplete: true },
       });
       await new Promise<void>(r => setTimeout(() => r(), 10)); // Wait for the listener to process messages
       mockHandler.endStream();
 
       const responses = await receivePromise;
-      expect(responses).toHaveLength(4);
+      expect(responses).toHaveLength(5);
       expect(responses[0]).toEqual({
         type: LiveResponseType.SERVER_CONTENT,
         modelTurn: { parts: [{ text: 'response 1' }] },
@@ -252,6 +256,34 @@ describe('LiveSession', function () {
         type: LiveResponseType.TOOL_CALL_CANCELLATION,
         functionIds: ['123'],
       } as LiveServerToolCallCancellation);
+      expect(responses[3]).toEqual({
+        type: LiveResponseType.GOING_AWAY_NOTICE,
+        timeLeft: 10.5,
+      } as LiveServerGoingAwayNotice);
+    });
+
+    it('should default malformed goAway timeLeft values to zero', async function () {
+      const receivePromise = (async () => {
+        const responses = [];
+        for await (const response of session.receive()) {
+          responses.push(response);
+        }
+        return responses;
+      })();
+
+      mockHandler.simulateServerMessage({
+        goAway: { timeLeft: 'invalid' },
+      });
+      await new Promise<void>(r => setTimeout(() => r(), 10)); // Wait for the listener to process messages
+      mockHandler.endStream();
+
+      const responses = await receivePromise;
+      expect(responses).toEqual([
+        {
+          type: LiveResponseType.GOING_AWAY_NOTICE,
+          timeLeft: 0,
+        },
+      ]);
     });
 
     it('should log a warning and skip messages that are not objects', async function () {

--- a/packages/ai/__tests__/request.test.ts
+++ b/packages/ai/__tests__/request.test.ts
@@ -31,6 +31,15 @@ const fakeApiSettings: ApiSettings = {
   backend: new VertexAIBackend(),
 };
 
+function createAbortErrorForTest(reason?: unknown): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException(reason == null ? 'Aborted' : String(reason), 'AbortError');
+  }
+  const error = new Error(reason == null ? 'Aborted' : String(reason));
+  error.name = 'AbortError';
+  return error;
+}
+
 describe('request methods', () => {
   afterEach(() => {
     jest.restoreAllMocks(); // Use Jest's restoreAllMocks
@@ -244,6 +253,62 @@ describe('request methods', () => {
   });
 
   describe('makeRequest', () => {
+    it('throws an AbortError without fetching if the external signal is already aborted', async () => {
+      const fetchMock = jest.spyOn(globalThis, 'fetch');
+      const controller = new AbortController();
+      (controller.abort as (reason?: unknown) => void)('user cancelled');
+
+      await expect(
+        makeRequest(
+          {
+            model: 'models/model-name',
+            task: Task.GENERATE_CONTENT,
+            apiSettings: fakeApiSettings,
+            stream: false,
+            requestOptions: {
+              signal: controller.signal,
+            },
+          },
+          '',
+        ),
+      ).rejects.toMatchObject({
+        name: 'AbortError',
+        message: 'user cancelled',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('aborts the fetch signal when the external signal aborts', async () => {
+      const controller = new AbortController();
+      const fetchMock = jest.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
+        return new Promise((_resolve, reject) => {
+          (init?.signal as AbortSignal).addEventListener('abort', () => {
+            reject(createAbortErrorForTest());
+          });
+          (controller.abort as (reason?: unknown) => void)('cancelled during fetch');
+        });
+      });
+
+      await expect(
+        makeRequest(
+          {
+            model: 'models/model-name',
+            task: Task.GENERATE_CONTENT,
+            apiSettings: fakeApiSettings,
+            stream: false,
+            requestOptions: {
+              signal: controller.signal,
+            },
+          },
+          '',
+        ),
+      ).rejects.toMatchObject({
+        name: 'AbortError',
+        message: expect.any(String),
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
     it('no error', async () => {
       const fetchMock = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,

--- a/packages/ai/__tests__/schema-builder.test.ts
+++ b/packages/ai/__tests__/schema-builder.test.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from '@jest/globals';
-import { Schema } from '../lib/requests/schema-builder';
+import { AnyOfSchema, Schema } from '../lib/requests/schema-builder';
 import { AIErrorCode } from '../lib/types';
 
 describe('Schema builder', () => {
@@ -127,6 +127,80 @@ describe('Schema builder', () => {
       },
       required: ['someInput'],
     });
+  });
+
+  it('builds an anyOf schema', () => {
+    const schema = Schema.anyOf({
+      description: 'string or object',
+      anyOf: [
+        Schema.string(),
+        Schema.object({
+          properties: {
+            count: Schema.integer(),
+          },
+        }),
+      ],
+    });
+
+    expect(schema).toBeInstanceOf(AnyOfSchema);
+    expect(schema.toJSON()).toEqual({
+      type: undefined,
+      description: 'string or object',
+      anyOf: [
+        {
+          type: 'string',
+          nullable: false,
+        },
+        {
+          type: 'object',
+          nullable: false,
+          properties: {
+            count: {
+              type: 'integer',
+              nullable: false,
+            },
+          },
+          required: ['count'],
+        },
+      ],
+      nullable: false,
+    });
+  });
+
+  it('serializes anyOf schemas nested inside object schemas', () => {
+    const schema = Schema.object({
+      properties: {
+        value: Schema.anyOf({
+          anyOf: [Schema.string(), Schema.number()],
+        }),
+      },
+    });
+
+    expect(schema.toJSON()).toEqual({
+      type: 'object',
+      nullable: false,
+      properties: {
+        value: {
+          type: undefined,
+          anyOf: [
+            {
+              type: 'string',
+              nullable: false,
+            },
+            {
+              type: 'number',
+              nullable: false,
+            },
+          ],
+          nullable: false,
+        },
+      },
+      required: ['value'],
+    });
+  });
+
+  it('throws if anyOf is empty', () => {
+    expect(() => Schema.anyOf({ anyOf: [] })).toThrow(AIErrorCode.INVALID_SCHEMA);
   });
 
   it('builds layered schema - partially filled out', () => {

--- a/packages/ai/__tests__/template-generative-model.test.ts
+++ b/packages/ai/__tests__/template-generative-model.test.ts
@@ -144,4 +144,94 @@ describe('TemplateGenerativeModel', function () {
       );
     });
   });
+
+  describe('startChat', function () {
+    it('should create a template chat session with the configured request options', function () {
+      const model = new TemplateGenerativeModel(fakeAI, { timeout: 5000 });
+      const chat = model.startChat({
+        templateId: TEMPLATE_ID,
+        templateVariables: TEMPLATE_VARS,
+      });
+
+      expect(chat.params).toEqual({
+        templateId: TEMPLATE_ID,
+        templateVariables: TEMPLATE_VARS,
+      });
+      expect(chat.requestOptions).toEqual({ timeout: 5000 });
+    });
+
+    it('should call templateGenerateContent with template chat parameters', async function () {
+      const templateGenerateContentSpy = jest
+        .spyOn(generateContentMethods, 'templateGenerateContent')
+        .mockResolvedValue({
+          response: {
+            candidates: [{ content: { parts: [{ text: 'hello back' }] } }],
+          },
+        } as any);
+      const model = new TemplateGenerativeModel(fakeAI, {
+        timeout: 5000,
+        baseUrl: 'https://model.example.com',
+      });
+      const chat = model.startChat({
+        templateId: TEMPLATE_ID,
+        templateVariables: TEMPLATE_VARS,
+      });
+      const controller = new AbortController();
+
+      await chat.sendMessage('hello', {
+        timeout: 2000,
+        signal: controller.signal,
+      });
+
+      expect(templateGenerateContentSpy).toHaveBeenCalledWith(
+        model._apiSettings,
+        TEMPLATE_ID,
+        expect.objectContaining({
+          inputs: TEMPLATE_VARS,
+          contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        }),
+        {
+          timeout: 2000,
+          baseUrl: 'https://model.example.com',
+          signal: controller.signal,
+        },
+      );
+      await expect(chat.getHistory()).resolves.toEqual([
+        { role: 'user', parts: [{ text: 'hello' }] },
+        { role: 'model', parts: [{ text: 'hello back' }] },
+      ]);
+    });
+
+    it('should call templateGenerateContentStream with template chat parameters', async function () {
+      const templateGenerateContentStreamSpy = jest
+        .spyOn(generateContentMethods, 'templateGenerateContentStream')
+        .mockResolvedValue({
+          response: Promise.resolve({
+            candidates: [{ content: { parts: [{ text: 'stream back' }] } }],
+          }),
+        } as any);
+      const model = new TemplateGenerativeModel(fakeAI, { timeout: 5000 });
+      const chat = model.startChat({
+        templateId: TEMPLATE_ID,
+        templateVariables: TEMPLATE_VARS,
+      });
+
+      const result = await chat.sendMessageStream('hello');
+      await result.response;
+
+      expect(templateGenerateContentStreamSpy).toHaveBeenCalledWith(
+        model._apiSettings,
+        TEMPLATE_ID,
+        expect.objectContaining({
+          inputs: TEMPLATE_VARS,
+          contents: [{ role: 'user', parts: [{ text: 'hello' }] }],
+        }),
+        { timeout: 5000 },
+      );
+      await expect(chat.getHistory()).resolves.toEqual([
+        { role: 'user', parts: [{ text: 'hello' }] },
+        { role: 'model', parts: [{ text: 'stream back' }] },
+      ]);
+    });
+  });
 });

--- a/packages/ai/__tests__/template-generative-model.test.ts
+++ b/packages/ai/__tests__/template-generative-model.test.ts
@@ -21,6 +21,7 @@ import { AI } from '../lib/public-types';
 import { VertexAIBackend } from '../lib/backend';
 import { TemplateGenerativeModel } from '../lib/models/template-generative-model';
 import * as generateContentMethods from '../lib/methods/generate-content';
+import { EnhancedGenerateContentResponse, GenerateContentStreamResult } from '../lib/types';
 
 const fakeAI: AI = {
   app: {
@@ -38,6 +39,15 @@ const fakeAI: AI = {
 
 const TEMPLATE_ID = 'my-template';
 const TEMPLATE_VARS = { a: 1, b: '2' };
+
+function streamResult(response: EnhancedGenerateContentResponse): GenerateContentStreamResult {
+  return {
+    stream: (async function* () {
+      yield response;
+    })(),
+    response: Promise.resolve(response),
+  };
+}
 
 describe('TemplateGenerativeModel', function () {
   afterEach(function () {
@@ -202,6 +212,134 @@ describe('TemplateGenerativeModel', function () {
       ]);
     });
 
+    it('automatically calls functionReference from template chat function calls', async function () {
+      const getWeather = jest.fn<(args: object) => object>().mockReturnValue({ temperature: 72 });
+      const functionCallResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'getWeather',
+                    args: { city: 'London' },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        functionCalls: () => [{ name: 'getWeather', args: { city: 'London' } }],
+      } as EnhancedGenerateContentResponse;
+      const finalResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'It is 72 degrees.' }],
+            },
+          },
+        ],
+        text: () => 'It is 72 degrees.',
+        functionCalls: () => undefined,
+      } as EnhancedGenerateContentResponse;
+      const templateGenerateContentSpy = jest
+        .spyOn(generateContentMethods, 'templateGenerateContent')
+        .mockResolvedValueOnce({ response: functionCallResponse })
+        .mockResolvedValueOnce({ response: finalResponse });
+      const model = new TemplateGenerativeModel(fakeAI, { timeout: 5000 });
+      const chat = model.startChat({
+        templateId: TEMPLATE_ID,
+        templateVariables: TEMPLATE_VARS,
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: 'getWeather',
+                functionReference: getWeather,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await chat.sendMessage('weather in London');
+      const history = await chat.getHistory();
+
+      expect(result.response.text()).toBe('It is 72 degrees.');
+      expect(getWeather).toHaveBeenCalledWith({ city: 'London' });
+      expect(templateGenerateContentSpy).toHaveBeenCalledTimes(2);
+      expect(templateGenerateContentSpy).toHaveBeenLastCalledWith(
+        model._apiSettings,
+        TEMPLATE_ID,
+        expect.objectContaining({
+          inputs: TEMPLATE_VARS,
+          contents: [
+            {
+              role: 'user',
+              parts: [{ text: 'weather in London' }],
+            },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'getWeather',
+                    args: { city: 'London' },
+                  },
+                },
+              ],
+            },
+            {
+              role: 'function',
+              parts: [
+                {
+                  functionResponse: {
+                    name: 'getWeather',
+                    response: { temperature: 72 },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        { timeout: 5000 },
+      );
+      expect(history).toEqual([
+        {
+          role: 'user',
+          parts: [{ text: 'weather in London' }],
+        },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'getWeather',
+                args: { city: 'London' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'function',
+          parts: [
+            {
+              functionResponse: {
+                name: 'getWeather',
+                response: { temperature: 72 },
+              },
+            },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [{ text: 'It is 72 degrees.' }],
+        },
+      ]);
+    });
+
     it('should call templateGenerateContentStream with template chat parameters', async function () {
       const templateGenerateContentStreamSpy = jest
         .spyOn(generateContentMethods, 'templateGenerateContentStream')
@@ -231,6 +369,134 @@ describe('TemplateGenerativeModel', function () {
       await expect(chat.getHistory()).resolves.toEqual([
         { role: 'user', parts: [{ text: 'hello' }] },
         { role: 'model', parts: [{ text: 'stream back' }] },
+      ]);
+    });
+
+    it('automatically calls functionReference from streaming template chat function calls', async function () {
+      const getWeather = jest.fn<(args: object) => object>().mockReturnValue({ temperature: 72 });
+      const functionCallResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'getWeather',
+                    args: { city: 'London' },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        functionCalls: () => [{ name: 'getWeather', args: { city: 'London' } }],
+      } as EnhancedGenerateContentResponse;
+      const finalResponse = {
+        candidates: [
+          {
+            content: {
+              role: 'model',
+              parts: [{ text: 'It is 72 degrees.' }],
+            },
+          },
+        ],
+        text: () => 'It is 72 degrees.',
+        functionCalls: () => undefined,
+      } as EnhancedGenerateContentResponse;
+      const templateGenerateContentStreamSpy = jest
+        .spyOn(generateContentMethods, 'templateGenerateContentStream')
+        .mockResolvedValueOnce(streamResult(functionCallResponse))
+        .mockResolvedValueOnce(streamResult(finalResponse));
+      const model = new TemplateGenerativeModel(fakeAI, { timeout: 5000 });
+      const chat = model.startChat({
+        templateId: TEMPLATE_ID,
+        templateVariables: TEMPLATE_VARS,
+        tools: [
+          {
+            functionDeclarations: [
+              {
+                name: 'getWeather',
+                functionReference: getWeather,
+              },
+            ],
+          },
+        ],
+      });
+
+      const result = await chat.sendMessageStream('weather in London');
+      await result.response;
+      const history = await chat.getHistory();
+
+      expect(getWeather).toHaveBeenCalledWith({ city: 'London' });
+      expect(templateGenerateContentStreamSpy).toHaveBeenCalledTimes(2);
+      expect(templateGenerateContentStreamSpy).toHaveBeenLastCalledWith(
+        model._apiSettings,
+        TEMPLATE_ID,
+        expect.objectContaining({
+          inputs: TEMPLATE_VARS,
+          contents: [
+            {
+              role: 'user',
+              parts: [{ text: 'weather in London' }],
+            },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    name: 'getWeather',
+                    args: { city: 'London' },
+                  },
+                },
+              ],
+            },
+            {
+              role: 'function',
+              parts: [
+                {
+                  functionResponse: {
+                    name: 'getWeather',
+                    response: { temperature: 72 },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        { timeout: 5000 },
+      );
+      expect(history).toEqual([
+        {
+          role: 'user',
+          parts: [{ text: 'weather in London' }],
+        },
+        {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'getWeather',
+                args: { city: 'London' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'function',
+          parts: [
+            {
+              functionResponse: {
+                name: 'getWeather',
+                response: { temperature: 72 },
+              },
+            },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [{ text: 'It is 72 degrees.' }],
+        },
       ]);
     });
   });

--- a/packages/ai/__tests__/template-generative-model.test.ts
+++ b/packages/ai/__tests__/template-generative-model.test.ts
@@ -70,6 +70,33 @@ describe('TemplateGenerativeModel', function () {
         { timeout: 5000 },
       );
     });
+
+    it('should merge per-call request options over model request options', async function () {
+      const controller = new AbortController();
+      const templateGenerateContentSpy = jest
+        .spyOn(generateContentMethods, 'templateGenerateContent')
+        .mockResolvedValue({} as any);
+      const model = new TemplateGenerativeModel(fakeAI, {
+        timeout: 5000,
+        baseUrl: 'https://model.example.com',
+      });
+
+      await model.generateContent(TEMPLATE_ID, TEMPLATE_VARS, {
+        timeout: 2000,
+        signal: controller.signal,
+      });
+
+      expect(templateGenerateContentSpy).toHaveBeenCalledWith(
+        model._apiSettings,
+        TEMPLATE_ID,
+        { inputs: TEMPLATE_VARS },
+        {
+          timeout: 2000,
+          baseUrl: 'https://model.example.com',
+          signal: controller.signal,
+        },
+      );
+    });
   });
 
   describe('generateContentStream', function () {
@@ -87,6 +114,33 @@ describe('TemplateGenerativeModel', function () {
         TEMPLATE_ID,
         { inputs: TEMPLATE_VARS },
         { timeout: 5000 },
+      );
+    });
+
+    it('should merge per-call request options over model request options', async function () {
+      const controller = new AbortController();
+      const templateGenerateContentStreamSpy = jest
+        .spyOn(generateContentMethods, 'templateGenerateContentStream')
+        .mockResolvedValue({} as any);
+      const model = new TemplateGenerativeModel(fakeAI, {
+        timeout: 5000,
+        baseUrl: 'https://model.example.com',
+      });
+
+      await model.generateContentStream(TEMPLATE_ID, TEMPLATE_VARS, {
+        timeout: 2000,
+        signal: controller.signal,
+      });
+
+      expect(templateGenerateContentStreamSpy).toHaveBeenCalledWith(
+        model._apiSettings,
+        TEMPLATE_ID,
+        { inputs: TEMPLATE_VARS },
+        {
+          timeout: 2000,
+          baseUrl: 'https://model.example.com',
+          signal: controller.signal,
+        },
       );
     });
   });

--- a/packages/ai/__tests__/template-imagen-model.test.ts
+++ b/packages/ai/__tests__/template-imagen-model.test.ts
@@ -86,6 +86,46 @@ describe('TemplateImagenModel', function () {
       );
     });
 
+    it('should merge per-call request options over model request options', async function () {
+      const controller = new AbortController();
+      const makeRequestSpy = jest.spyOn(request, 'makeRequest').mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            predictions: [
+              {
+                bytesBase64Encoded:
+                  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+                mimeType: 'image/png',
+              },
+            ],
+          }),
+      } as Response);
+      const model = new TemplateImagenModel(fakeAI, {
+        timeout: 5000,
+        baseUrl: 'https://model.example.com',
+      });
+
+      await model.generateImages(TEMPLATE_ID, TEMPLATE_VARS, {
+        timeout: 2000,
+        signal: controller.signal,
+      });
+
+      expect(makeRequestSpy).toHaveBeenCalledWith(
+        {
+          task: ServerPromptTemplateTask.TEMPLATE_PREDICT,
+          templateId: TEMPLATE_ID,
+          apiSettings: model._apiSettings,
+          stream: false,
+          requestOptions: {
+            timeout: 2000,
+            baseUrl: 'https://model.example.com',
+            signal: controller.signal,
+          },
+        },
+        JSON.stringify({ inputs: TEMPLATE_VARS }),
+      );
+    });
+
     it('should return the result of handlePredictResponse', async function () {
       const mockPrediction = {
         bytesBase64Encoded:

--- a/packages/ai/lib/index.ts
+++ b/packages/ai/lib/index.ts
@@ -32,7 +32,7 @@ import {
 import { WebSocketHandlerImpl } from './websocket';
 
 export * from './public-types';
-export { ChatSession } from './methods/chat-session';
+export { ChatSession, ChatSessionBase } from './methods/chat-session';
 export { LiveSession } from './methods/live-session';
 export * from './requests/schema-builder';
 export { ImagenImageFormat } from './requests/imagen-image-format';

--- a/packages/ai/lib/index.ts
+++ b/packages/ai/lib/index.ts
@@ -32,7 +32,7 @@ import {
 import { WebSocketHandlerImpl } from './websocket';
 
 export * from './public-types';
-export { ChatSession, ChatSessionBase } from './methods/chat-session';
+export { ChatSession, ChatSessionBase, TemplateChatSession } from './methods/chat-session';
 export { LiveSession } from './methods/live-session';
 export * from './requests/schema-builder';
 export { ImagenImageFormat } from './requests/imagen-image-format';

--- a/packages/ai/lib/methods/automatic-function-calling.ts
+++ b/packages/ai/lib/methods/automatic-function-calling.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Content,
+  FunctionCall,
+  FunctionDeclaration,
+  FunctionResponse,
+  GenerateContentRequest,
+  GenerateContentResult,
+  SingleRequestOptions,
+  Tool,
+} from '../types';
+import { ApiSettings } from '../types/internal';
+import { generateContent } from './generate-content';
+
+const DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS = 10;
+
+export interface AutomaticFunctionCallingResult {
+  result: GenerateContentResult;
+  addedContents: Content[];
+}
+
+export async function generateContentWithAutomaticFunctionCalling(
+  apiSettings: ApiSettings,
+  model: string,
+  params: GenerateContentRequest,
+  result: GenerateContentResult,
+  requestOptions?: SingleRequestOptions,
+): Promise<AutomaticFunctionCallingResult> {
+  let remainingFunctionCalls =
+    requestOptions?.maxSequentialFunctionCalls ?? DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS;
+  let currentParams = params;
+  let currentResult = result;
+  const addedContents: Content[] = [];
+
+  while (remainingFunctionCalls > 0) {
+    const functionCalls = currentResult.response.functionCalls?.();
+    if (!functionCalls?.length) {
+      return { result: currentResult, addedContents };
+    }
+
+    const functionResponses = await callFunctionReferences(currentParams.tools, functionCalls);
+    if (!functionResponses) {
+      return { result: currentResult, addedContents };
+    }
+
+    const responseContent = getModelResponseContent(currentResult);
+    if (!responseContent) {
+      return { result: currentResult, addedContents };
+    }
+
+    remainingFunctionCalls -= 1;
+    const functionResponseContent: Content = {
+      role: 'function',
+      parts: functionResponses.map(functionResponse => ({ functionResponse })),
+    };
+    addedContents.push(responseContent, functionResponseContent);
+    currentParams = {
+      ...currentParams,
+      contents: [...currentParams.contents, responseContent, functionResponseContent],
+    };
+    currentResult = await generateContent(apiSettings, model, currentParams, requestOptions);
+  }
+
+  return { result: currentResult, addedContents };
+}
+
+function getModelResponseContent(result: GenerateContentResult): Content | undefined {
+  const responseContent = result.response.candidates?.[0]?.content;
+  if (!responseContent) {
+    return undefined;
+  }
+  return {
+    parts: responseContent.parts || [],
+    role: responseContent.role || 'model',
+  };
+}
+
+async function callFunctionReferences(
+  tools: Tool[] | undefined,
+  functionCalls: FunctionCall[],
+): Promise<FunctionResponse[] | undefined> {
+  const declarations = getFunctionDeclarationsWithReferences(tools);
+  if (!declarations.length) {
+    return undefined;
+  }
+
+  const functionResponses: FunctionResponse[] = [];
+  for (const functionCall of functionCalls) {
+    const declaration = declarations.find(candidate => candidate.name === functionCall.name);
+    if (!declaration?.functionReference) {
+      return undefined;
+    }
+
+    const response = (await declaration.functionReference(functionCall.args)) as object;
+    functionResponses.push({
+      id: functionCall.id,
+      name: functionCall.name,
+      response,
+    });
+  }
+  return functionResponses;
+}
+
+function getFunctionDeclarationsWithReferences(tools: Tool[] | undefined): FunctionDeclaration[] {
+  return (
+    tools?.flatMap(tool =>
+      'functionDeclarations' in tool
+        ? (tool.functionDeclarations?.filter(declaration => declaration.functionReference) ?? [])
+        : [],
+    ) ?? []
+  );
+}

--- a/packages/ai/lib/methods/automatic-function-calling.ts
+++ b/packages/ai/lib/methods/automatic-function-calling.ts
@@ -22,16 +22,23 @@ import {
   FunctionResponse,
   GenerateContentRequest,
   GenerateContentResult,
+  GenerateContentStreamResult,
+  EnhancedGenerateContentResponse,
   SingleRequestOptions,
   Tool,
 } from '../types';
 import { ApiSettings } from '../types/internal';
-import { generateContent } from './generate-content';
+import { generateContent, generateContentStream } from './generate-content';
 
 const DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS = 10;
 
 export interface AutomaticFunctionCallingResult {
   result: GenerateContentResult;
+  addedContents: Content[];
+}
+
+export interface AutomaticFunctionCallingStreamResult {
+  result: GenerateContentStreamResult;
   addedContents: Content[];
 }
 
@@ -80,8 +87,61 @@ export async function generateContentWithAutomaticFunctionCalling(
   return { result: currentResult, addedContents };
 }
 
-function getModelResponseContent(result: GenerateContentResult): Content | undefined {
-  const responseContent = result.response.candidates?.[0]?.content;
+export async function generateContentStreamWithAutomaticFunctionCalling(
+  apiSettings: ApiSettings,
+  model: string,
+  params: GenerateContentRequest,
+  result: GenerateContentStreamResult,
+  requestOptions?: SingleRequestOptions,
+): Promise<AutomaticFunctionCallingStreamResult> {
+  if (!getFunctionDeclarationsWithReferences(params.tools).length) {
+    return { result, addedContents: [] };
+  }
+
+  let remainingFunctionCalls =
+    requestOptions?.maxSequentialFunctionCalls ?? DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS;
+  let currentParams = params;
+  let currentResult = result;
+  const addedContents: Content[] = [];
+
+  while (remainingFunctionCalls > 0) {
+    const response = await currentResult.response;
+    const functionCalls = response.functionCalls?.();
+    if (!functionCalls?.length) {
+      return { result: currentResult, addedContents };
+    }
+
+    const functionResponses = await callFunctionReferences(currentParams.tools, functionCalls);
+    if (!functionResponses) {
+      return { result: currentResult, addedContents };
+    }
+
+    const responseContent = getModelResponseContent(response);
+    if (!responseContent) {
+      return { result: currentResult, addedContents };
+    }
+
+    remainingFunctionCalls -= 1;
+    const functionResponseContent: Content = {
+      role: 'function',
+      parts: functionResponses.map(functionResponse => ({ functionResponse })),
+    };
+    addedContents.push(responseContent, functionResponseContent);
+    currentParams = {
+      ...currentParams,
+      contents: [...currentParams.contents, responseContent, functionResponseContent],
+    };
+    currentResult = await generateContentStream(apiSettings, model, currentParams, requestOptions);
+  }
+
+  return { result: currentResult, addedContents };
+}
+
+function getModelResponseContent(
+  responseOrResult: GenerateContentResult | EnhancedGenerateContentResponse,
+): Content | undefined {
+  const response = 'response' in responseOrResult ? responseOrResult.response : responseOrResult;
+  const responseContent = response.candidates?.[0]?.content;
   if (!responseContent) {
     return undefined;
   }

--- a/packages/ai/lib/methods/automatic-function-calling.ts
+++ b/packages/ai/lib/methods/automatic-function-calling.ts
@@ -25,10 +25,17 @@ import {
   GenerateContentStreamResult,
   EnhancedGenerateContentResponse,
   SingleRequestOptions,
+  TemplateFunctionDeclaration,
+  TemplateTool,
   Tool,
 } from '../types';
 import { ApiSettings } from '../types/internal';
-import { generateContent, generateContentStream } from './generate-content';
+import {
+  generateContent,
+  generateContentStream,
+  templateGenerateContent,
+  templateGenerateContentStream,
+} from './generate-content';
 
 const DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS = 10;
 
@@ -40,6 +47,12 @@ export interface AutomaticFunctionCallingResult {
 export interface AutomaticFunctionCallingStreamResult {
   result: GenerateContentStreamResult;
   addedContents: Content[];
+}
+
+export interface TemplateAutomaticFunctionCallingRequest {
+  contents: Content[];
+  tools?: TemplateTool[];
+  [key: string]: unknown;
 }
 
 export async function generateContentWithAutomaticFunctionCalling(
@@ -82,6 +95,56 @@ export async function generateContentWithAutomaticFunctionCalling(
       contents: [...currentParams.contents, responseContent, functionResponseContent],
     };
     currentResult = await generateContent(apiSettings, model, currentParams, requestOptions);
+  }
+
+  return { result: currentResult, addedContents };
+}
+
+export async function templateGenerateContentWithAutomaticFunctionCalling(
+  apiSettings: ApiSettings,
+  templateId: string,
+  params: TemplateAutomaticFunctionCallingRequest,
+  result: GenerateContentResult,
+  requestOptions?: SingleRequestOptions,
+): Promise<AutomaticFunctionCallingResult> {
+  let remainingFunctionCalls =
+    requestOptions?.maxSequentialFunctionCalls ?? DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS;
+  let currentParams = params;
+  let currentResult = result;
+  const addedContents: Content[] = [];
+
+  while (remainingFunctionCalls > 0) {
+    const functionCalls = currentResult.response.functionCalls?.();
+    if (!functionCalls?.length) {
+      return { result: currentResult, addedContents };
+    }
+
+    const functionResponses = await callFunctionReferences(currentParams.tools, functionCalls);
+    if (!functionResponses) {
+      return { result: currentResult, addedContents };
+    }
+
+    const responseContent = getModelResponseContent(currentResult);
+    if (!responseContent) {
+      return { result: currentResult, addedContents };
+    }
+
+    remainingFunctionCalls -= 1;
+    const functionResponseContent: Content = {
+      role: 'function',
+      parts: functionResponses.map(functionResponse => ({ functionResponse })),
+    };
+    addedContents.push(responseContent, functionResponseContent);
+    currentParams = {
+      ...currentParams,
+      contents: [...currentParams.contents, responseContent, functionResponseContent],
+    };
+    currentResult = await templateGenerateContent(
+      apiSettings,
+      templateId,
+      currentParams,
+      requestOptions,
+    );
   }
 
   return { result: currentResult, addedContents };
@@ -137,6 +200,61 @@ export async function generateContentStreamWithAutomaticFunctionCalling(
   return { result: currentResult, addedContents };
 }
 
+export async function templateGenerateContentStreamWithAutomaticFunctionCalling(
+  apiSettings: ApiSettings,
+  templateId: string,
+  params: TemplateAutomaticFunctionCallingRequest,
+  result: GenerateContentStreamResult,
+  requestOptions?: SingleRequestOptions,
+): Promise<AutomaticFunctionCallingStreamResult> {
+  if (!getFunctionDeclarationsWithReferences(params.tools).length) {
+    return { result, addedContents: [] };
+  }
+
+  let remainingFunctionCalls =
+    requestOptions?.maxSequentialFunctionCalls ?? DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS;
+  let currentParams = params;
+  let currentResult = result;
+  const addedContents: Content[] = [];
+
+  while (remainingFunctionCalls > 0) {
+    const response = await currentResult.response;
+    const functionCalls = response.functionCalls?.();
+    if (!functionCalls?.length) {
+      return { result: currentResult, addedContents };
+    }
+
+    const functionResponses = await callFunctionReferences(currentParams.tools, functionCalls);
+    if (!functionResponses) {
+      return { result: currentResult, addedContents };
+    }
+
+    const responseContent = getModelResponseContent(response);
+    if (!responseContent) {
+      return { result: currentResult, addedContents };
+    }
+
+    remainingFunctionCalls -= 1;
+    const functionResponseContent: Content = {
+      role: 'function',
+      parts: functionResponses.map(functionResponse => ({ functionResponse })),
+    };
+    addedContents.push(responseContent, functionResponseContent);
+    currentParams = {
+      ...currentParams,
+      contents: [...currentParams.contents, responseContent, functionResponseContent],
+    };
+    currentResult = await templateGenerateContentStream(
+      apiSettings,
+      templateId,
+      currentParams,
+      requestOptions,
+    );
+  }
+
+  return { result: currentResult, addedContents };
+}
+
 function getModelResponseContent(
   responseOrResult: GenerateContentResult | EnhancedGenerateContentResponse,
 ): Content | undefined {
@@ -152,7 +270,7 @@ function getModelResponseContent(
 }
 
 async function callFunctionReferences(
-  tools: Tool[] | undefined,
+  tools: Tool[] | TemplateTool[] | undefined,
   functionCalls: FunctionCall[],
 ): Promise<FunctionResponse[] | undefined> {
   const declarations = getFunctionDeclarationsWithReferences(tools);
@@ -177,7 +295,9 @@ async function callFunctionReferences(
   return functionResponses;
 }
 
-function getFunctionDeclarationsWithReferences(tools: Tool[] | undefined): FunctionDeclaration[] {
+function getFunctionDeclarationsWithReferences(
+  tools: Tool[] | TemplateTool[] | undefined,
+): Array<FunctionDeclaration | TemplateFunctionDeclaration> {
   return (
     tools?.flatMap(tool =>
       'functionDeclarations' in tool

--- a/packages/ai/lib/methods/chat-session.ts
+++ b/packages/ai/lib/methods/chat-session.ts
@@ -45,18 +45,11 @@ const SILENT_ERROR = 'SILENT_ERROR';
  *
  * @public
  */
-export class ChatSession {
-  private _apiSettings: ApiSettings;
-  private _history: Content[] = [];
-  private _sendPromise: Promise<void> = Promise.resolve();
+export class ChatSessionBase<ParamsType extends { history?: Content[] } = StartChatParams> {
+  protected _history: Content[] = [];
+  protected _sendPromise: Promise<void> = Promise.resolve();
 
-  constructor(
-    apiSettings: ApiSettings,
-    public model: string,
-    public params?: StartChatParams,
-    public requestOptions?: RequestOptions,
-  ) {
-    this._apiSettings = apiSettings;
+  constructor(public params?: ParamsType, public requestOptions?: RequestOptions) {
     if (params?.history) {
       validateChatHistory(params.history);
       this._history = params.history;
@@ -71,6 +64,26 @@ export class ChatSession {
   async getHistory(): Promise<Content[]> {
     await this._sendPromise;
     return this._history;
+  }
+}
+
+/**
+ * ChatSession class that enables sending chat messages and stores
+ * history of sent and received messages so far.
+ *
+ * @public
+ */
+export class ChatSession extends ChatSessionBase<StartChatParams> {
+  private _apiSettings: ApiSettings;
+
+  constructor(
+    apiSettings: ApiSettings,
+    public model: string,
+    public params?: StartChatParams,
+    public requestOptions?: RequestOptions,
+  ) {
+    super(params, requestOptions);
+    this._apiSettings = apiSettings;
   }
 
   /**

--- a/packages/ai/lib/methods/chat-session.ts
+++ b/packages/ai/lib/methods/chat-session.ts
@@ -24,12 +24,18 @@ import {
   RequestOptions,
   SingleRequestOptions,
   StartChatParams,
+  StartTemplateChatParams,
   EnhancedGenerateContentResponse,
 } from '../types';
 import { formatNewContent } from '../requests/request-helpers';
 import { formatBlockErrorMessage } from '../requests/response-helpers';
 import { validateChatHistory } from './chat-session-helpers';
-import { generateContent, generateContentStream } from './generate-content';
+import {
+  generateContent,
+  generateContentStream,
+  templateGenerateContent,
+  templateGenerateContentStream,
+} from './generate-content';
 import { ApiSettings } from '../types/internal';
 import { logger } from '../logger';
 import { mergeRequestOptions } from '../requests/request-options';
@@ -49,7 +55,10 @@ export class ChatSessionBase<ParamsType extends { history?: Content[] } = StartC
   protected _history: Content[] = [];
   protected _sendPromise: Promise<void> = Promise.resolve();
 
-  constructor(public params?: ParamsType, public requestOptions?: RequestOptions) {
+  constructor(
+    public params?: ParamsType,
+    public requestOptions?: RequestOptions,
+  ) {
     if (params?.history) {
       validateChatHistory(params.history);
       this._history = params.history;
@@ -202,5 +211,142 @@ export class ChatSession extends ChatSessionBase<StartChatParams> {
         }
       });
     return streamPromise;
+  }
+}
+
+/**
+ * ChatSession class for server-side templates that enables sending chat
+ * messages and stores history of sent and received messages so far.
+ *
+ * @beta
+ */
+export class TemplateChatSession extends ChatSessionBase<StartTemplateChatParams> {
+  private _apiSettings: ApiSettings;
+
+  constructor(
+    apiSettings: ApiSettings,
+    public params: StartTemplateChatParams,
+    public requestOptions?: RequestOptions,
+  ) {
+    super(params, requestOptions);
+    this._apiSettings = apiSettings;
+  }
+
+  /**
+   * Sends a chat message and receives a non-streaming
+   * {@link GenerateContentResult}
+   */
+  async sendMessage(
+    request: string | Array<string | Part>,
+    singleRequestOptions?: SingleRequestOptions,
+  ): Promise<GenerateContentResult> {
+    await this._sendPromise;
+    const newContent = formatNewContent(request);
+    const templateParams = this._buildTemplateChatRequest(newContent);
+    let finalResult = {} as GenerateContentResult;
+    // Add onto the chain.
+    this._sendPromise = this._sendPromise
+      .then(() =>
+        templateGenerateContent(
+          this._apiSettings,
+          this.params.templateId,
+          templateParams,
+          mergeRequestOptions(this.requestOptions, singleRequestOptions),
+        ),
+      )
+      .then((result: GenerateContentResult) => {
+        if (result.response.candidates && result.response.candidates.length > 0) {
+          this._history.push(newContent);
+          const responseContent: Content = {
+            parts: result.response.candidates?.[0]?.content.parts || [],
+            // Response seems to come back without a role set.
+            role: result.response.candidates?.[0]?.content.role || 'model',
+          };
+          this._history.push(responseContent);
+        } else {
+          const blockErrorMessage = formatBlockErrorMessage(result.response);
+          if (blockErrorMessage) {
+            logger.warn(
+              `sendMessage() was unsuccessful. ${blockErrorMessage}. Inspect response object for details.`,
+            );
+          }
+        }
+        finalResult = result;
+      });
+    await this._sendPromise;
+    return finalResult;
+  }
+
+  /**
+   * Sends a chat message and receives the response as a
+   * {@link GenerateContentStreamResult} containing an iterable stream
+   * and a response promise.
+   */
+  async sendMessageStream(
+    request: string | Array<string | Part>,
+    singleRequestOptions?: SingleRequestOptions,
+  ): Promise<GenerateContentStreamResult> {
+    await this._sendPromise;
+    const newContent = formatNewContent(request);
+    const templateParams = this._buildTemplateChatRequest(newContent);
+    const streamPromise = templateGenerateContentStream(
+      this._apiSettings,
+      this.params.templateId,
+      templateParams,
+      mergeRequestOptions(this.requestOptions, singleRequestOptions),
+    );
+
+    // Add onto the chain.
+    this._sendPromise = this._sendPromise
+      .then(() => streamPromise)
+      // This must be handled to avoid unhandled rejection, but jump
+      // to the final catch block with a label to not log this error.
+      .catch(_ignored => {
+        throw new Error(SILENT_ERROR);
+      })
+      .then(streamResult => streamResult.response)
+      .then((response: EnhancedGenerateContentResponse) => {
+        if (response.candidates && response.candidates.length > 0) {
+          this._history.push(newContent);
+          const responseContent = { ...response.candidates[0]?.content };
+          // Response seems to come back without a role set.
+          if (!responseContent.role) {
+            responseContent.role = 'model';
+          }
+          this._history.push(responseContent as Content);
+        } else {
+          const blockErrorMessage = formatBlockErrorMessage(response);
+          if (blockErrorMessage) {
+            logger.warn(
+              `sendMessageStream() was unsuccessful. ${blockErrorMessage}. Inspect response object for details.`,
+            );
+          }
+        }
+      })
+      .catch(e => {
+        // Errors in streamPromise are already catchable by the user as
+        // streamPromise is returned.
+        // Avoid duplicating the error message in logs.
+        if (e.message !== SILENT_ERROR) {
+          // Users do not have access to _sendPromise to catch errors
+          // downstream from streamPromise, so they should not throw.
+          logger.error(e);
+        }
+      });
+    return streamPromise;
+  }
+
+  private _buildTemplateChatRequest(newContent: Content): object {
+    return {
+      ...(this.params.templateVariables !== undefined
+        ? { inputs: this.params.templateVariables }
+        : {}),
+      safetySettings: this.params.safetySettings,
+      generationConfig: this.params.generationConfig,
+      tools: this.params.tools,
+      toolConfig: this.params.toolConfig,
+      systemInstruction: this.params.systemInstruction,
+      contents: [...this._history, newContent],
+    };
   }
 }

--- a/packages/ai/lib/methods/chat-session.ts
+++ b/packages/ai/lib/methods/chat-session.ts
@@ -25,7 +25,6 @@ import {
   SingleRequestOptions,
   StartChatParams,
   StartTemplateChatParams,
-  EnhancedGenerateContentResponse,
 } from '../types';
 import { formatNewContent } from '../requests/request-helpers';
 import { formatBlockErrorMessage } from '../requests/response-helpers';
@@ -39,6 +38,9 @@ import {
 import {
   generateContentStreamWithAutomaticFunctionCalling,
   generateContentWithAutomaticFunctionCalling,
+  TemplateAutomaticFunctionCallingRequest,
+  templateGenerateContentStreamWithAutomaticFunctionCalling,
+  templateGenerateContentWithAutomaticFunctionCalling,
 } from './automatic-function-calling';
 import { ApiSettings } from '../types/internal';
 import { logger } from '../logger';
@@ -271,17 +273,26 @@ export class TemplateChatSession extends ChatSessionBase<StartTemplateChatParams
     let finalResult = {} as GenerateContentResult;
     // Add onto the chain.
     this._sendPromise = this._sendPromise
-      .then(() =>
-        templateGenerateContent(
+      .then(async () => {
+        const requestOptions = mergeRequestOptions(this.requestOptions, singleRequestOptions);
+        const result = await templateGenerateContent(
           this._apiSettings,
           this.params.templateId,
           templateParams,
-          mergeRequestOptions(this.requestOptions, singleRequestOptions),
-        ),
-      )
-      .then((result: GenerateContentResult) => {
+          requestOptions,
+        );
+        return templateGenerateContentWithAutomaticFunctionCalling(
+          this._apiSettings,
+          this.params.templateId,
+          templateParams,
+          result,
+          requestOptions,
+        );
+      })
+      .then(({ result, addedContents }) => {
         if (result.response.candidates && result.response.candidates.length > 0) {
           this._history.push(newContent);
+          this._history.push(...addedContents);
           const responseContent: Content = {
             parts: result.response.candidates?.[0]?.content.parts || [],
             // Response seems to come back without a role set.
@@ -314,11 +325,20 @@ export class TemplateChatSession extends ChatSessionBase<StartTemplateChatParams
     await this._sendPromise;
     const newContent = formatNewContent(request);
     const templateParams = this._buildTemplateChatRequest(newContent);
+    const requestOptions = mergeRequestOptions(this.requestOptions, singleRequestOptions);
     const streamPromise = templateGenerateContentStream(
       this._apiSettings,
       this.params.templateId,
       templateParams,
-      mergeRequestOptions(this.requestOptions, singleRequestOptions),
+      requestOptions,
+    ).then(result =>
+      templateGenerateContentStreamWithAutomaticFunctionCalling(
+        this._apiSettings,
+        this.params.templateId,
+        templateParams,
+        result,
+        requestOptions,
+      ),
     );
 
     // Add onto the chain.
@@ -329,10 +349,13 @@ export class TemplateChatSession extends ChatSessionBase<StartTemplateChatParams
       .catch(_ignored => {
         throw new Error(SILENT_ERROR);
       })
-      .then(streamResult => streamResult.response)
-      .then((response: EnhancedGenerateContentResponse) => {
+      .then(({ result, addedContents }) =>
+        result.response.then(response => ({ response, addedContents })),
+      )
+      .then(({ response, addedContents }) => {
         if (response.candidates && response.candidates.length > 0) {
           this._history.push(newContent);
+          this._history.push(...addedContents);
           const responseContent = { ...response.candidates[0]?.content };
           // Response seems to come back without a role set.
           if (!responseContent.role) {
@@ -358,10 +381,10 @@ export class TemplateChatSession extends ChatSessionBase<StartTemplateChatParams
           logger.error(e);
         }
       });
-    return streamPromise;
+    return (await streamPromise).result;
   }
 
-  private _buildTemplateChatRequest(newContent: Content): object {
+  private _buildTemplateChatRequest(newContent: Content): TemplateAutomaticFunctionCallingRequest {
     return {
       ...(this.params.templateVariables !== undefined
         ? { inputs: this.params.templateVariables }

--- a/packages/ai/lib/methods/chat-session.ts
+++ b/packages/ai/lib/methods/chat-session.ts
@@ -36,7 +36,10 @@ import {
   templateGenerateContent,
   templateGenerateContentStream,
 } from './generate-content';
-import { generateContentWithAutomaticFunctionCalling } from './automatic-function-calling';
+import {
+  generateContentStreamWithAutomaticFunctionCalling,
+  generateContentWithAutomaticFunctionCalling,
+} from './automatic-function-calling';
 import { ApiSettings } from '../types/internal';
 import { logger } from '../logger';
 import { mergeRequestOptions } from '../requests/request-options';
@@ -176,11 +179,20 @@ export class ChatSession extends ChatSessionBase<StartChatParams> {
       systemInstruction: this.params?.systemInstruction,
       contents: [...this._history, newContent],
     };
+    const requestOptions = mergeRequestOptions(this.requestOptions, singleRequestOptions);
     const streamPromise = generateContentStream(
       this._apiSettings,
       this.model,
       generateContentRequest,
-      mergeRequestOptions(this.requestOptions, singleRequestOptions),
+      requestOptions,
+    ).then(result =>
+      generateContentStreamWithAutomaticFunctionCalling(
+        this._apiSettings,
+        this.model,
+        generateContentRequest,
+        result,
+        requestOptions,
+      ),
     );
 
     // Add onto the chain.
@@ -191,10 +203,13 @@ export class ChatSession extends ChatSessionBase<StartChatParams> {
       .catch(_ignored => {
         throw new Error(SILENT_ERROR);
       })
-      .then(streamResult => streamResult.response)
-      .then((response: EnhancedGenerateContentResponse) => {
+      .then(({ result, addedContents }) =>
+        result.response.then(response => ({ response, addedContents })),
+      )
+      .then(({ response, addedContents }) => {
         if (response.candidates && response.candidates.length > 0) {
           this._history.push(newContent);
+          this._history.push(...addedContents);
           const responseContent = { ...response.candidates[0]?.content };
           // Response seems to come back without a role set.
           if (!responseContent.role) {
@@ -220,7 +235,7 @@ export class ChatSession extends ChatSessionBase<StartChatParams> {
           logger.error(e);
         }
       });
-    return streamPromise;
+    return (await streamPromise).result;
   }
 }
 

--- a/packages/ai/lib/methods/chat-session.ts
+++ b/packages/ai/lib/methods/chat-session.ts
@@ -36,6 +36,7 @@ import {
   templateGenerateContent,
   templateGenerateContentStream,
 } from './generate-content';
+import { generateContentWithAutomaticFunctionCalling } from './automatic-function-calling';
 import { ApiSettings } from '../types/internal';
 import { logger } from '../logger';
 import { mergeRequestOptions } from '../requests/request-options';
@@ -116,17 +117,26 @@ export class ChatSession extends ChatSessionBase<StartChatParams> {
     let finalResult = {} as GenerateContentResult;
     // Add onto the chain.
     this._sendPromise = this._sendPromise
-      .then(() =>
-        generateContent(
+      .then(async () => {
+        const requestOptions = mergeRequestOptions(this.requestOptions, singleRequestOptions);
+        const result = await generateContent(
           this._apiSettings,
           this.model,
           generateContentRequest,
-          mergeRequestOptions(this.requestOptions, singleRequestOptions),
-        ),
-      )
-      .then((result: GenerateContentResult) => {
+          requestOptions,
+        );
+        return generateContentWithAutomaticFunctionCalling(
+          this._apiSettings,
+          this.model,
+          generateContentRequest,
+          result,
+          requestOptions,
+        );
+      })
+      .then(({ result, addedContents }) => {
         if (result.response.candidates && result.response.candidates.length > 0) {
           this._history.push(newContent);
+          this._history.push(...addedContents);
           const responseContent: Content = {
             parts: result.response.candidates?.[0]?.content.parts || [],
             // Response seems to come back without a role set.

--- a/packages/ai/lib/methods/chat-session.ts
+++ b/packages/ai/lib/methods/chat-session.ts
@@ -22,6 +22,7 @@ import {
   GenerateContentStreamResult,
   Part,
   RequestOptions,
+  SingleRequestOptions,
   StartChatParams,
   EnhancedGenerateContentResponse,
 } from '../types';
@@ -31,6 +32,7 @@ import { validateChatHistory } from './chat-session-helpers';
 import { generateContent, generateContentStream } from './generate-content';
 import { ApiSettings } from '../types/internal';
 import { logger } from '../logger';
+import { mergeRequestOptions } from '../requests/request-options';
 
 /**
  * Do not log a message for this error.
@@ -75,7 +77,10 @@ export class ChatSession {
    * Sends a chat message and receives a non-streaming
    * {@link GenerateContentResult}
    */
-  async sendMessage(request: string | Array<string | Part>): Promise<GenerateContentResult> {
+  async sendMessage(
+    request: string | Array<string | Part>,
+    singleRequestOptions?: SingleRequestOptions,
+  ): Promise<GenerateContentResult> {
     await this._sendPromise;
     const newContent = formatNewContent(request);
     const generateContentRequest: GenerateContentRequest = {
@@ -90,7 +95,12 @@ export class ChatSession {
     // Add onto the chain.
     this._sendPromise = this._sendPromise
       .then(() =>
-        generateContent(this._apiSettings, this.model, generateContentRequest, this.requestOptions),
+        generateContent(
+          this._apiSettings,
+          this.model,
+          generateContentRequest,
+          mergeRequestOptions(this.requestOptions, singleRequestOptions),
+        ),
       )
       .then((result: GenerateContentResult) => {
         if (result.response.candidates && result.response.candidates.length > 0) {
@@ -122,6 +132,7 @@ export class ChatSession {
    */
   async sendMessageStream(
     request: string | Array<string | Part>,
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentStreamResult> {
     await this._sendPromise;
     const newContent = formatNewContent(request);
@@ -137,7 +148,7 @@ export class ChatSession {
       this._apiSettings,
       this.model,
       generateContentRequest,
-      this.requestOptions,
+      mergeRequestOptions(this.requestOptions, singleRequestOptions),
     );
 
     // Add onto the chain.

--- a/packages/ai/lib/methods/count-tokens.ts
+++ b/packages/ai/lib/methods/count-tokens.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { CountTokensRequest, CountTokensResponse, RequestOptions } from '../types';
+import { CountTokensRequest, CountTokensResponse, SingleRequestOptions } from '../types';
 import { Task, makeRequest } from '../requests/request';
 import { ApiSettings } from '../types/internal';
 import { BackendType } from '../public-types';
@@ -27,14 +27,14 @@ import * as GoogleAIMapper from '../googleai-mappers';
  * @param apiSettings The {@link ApiSettings} to use for the request.
  * @param model The model to use for the request.
  * @param params The {@link CountTokensRequest} to send.
- * @param requestOptions The {@link RequestOptions} to use for the request.
+ * @param requestOptions The {@link SingleRequestOptions} to use for the request.
  * @returns The {@link CountTokensResponse} from the request.
  */
 export async function countTokens(
   apiSettings: ApiSettings,
   model: string,
   params: CountTokensRequest,
-  requestOptions?: RequestOptions,
+  requestOptions?: SingleRequestOptions,
 ): Promise<CountTokensResponse> {
   let body: string = '';
   switch (apiSettings.backend.backendType) {

--- a/packages/ai/lib/methods/generate-content.ts
+++ b/packages/ai/lib/methods/generate-content.ts
@@ -22,7 +22,7 @@ import {
   GenerateContentResult,
   GenerateContentStreamResult,
   GenerationConfig,
-  RequestOptions,
+  SingleRequestOptions,
 } from '../types';
 import { Task, makeRequest, ServerPromptTemplateTask } from '../requests/request';
 import { createEnhancedContentResponse } from '../requests/response-helpers';
@@ -55,14 +55,14 @@ function validateGenerationConfig(generationConfig?: GenerationConfig): void {
  * @param apiSettings The {@link ApiSettings} to use for the request.
  * @param model The model to use for the request.
  * @param params The {@link GenerateContentRequest} to send.
- * @param requestOptions The {@link RequestOptions} to use for the request.
+ * @param requestOptions The {@link SingleRequestOptions} to use for the request.
  * @returns The {@link GenerateContentStreamResult} from the request.
  */
 export async function generateContentStream(
   apiSettings: ApiSettings,
   model: string,
   params: GenerateContentRequest,
-  requestOptions?: RequestOptions,
+  requestOptions?: SingleRequestOptions,
 ): Promise<GenerateContentStreamResult> {
   validateGenerationConfig(params.generationConfig);
   if (apiSettings.backend.backendType === BackendType.GOOGLE_AI) {
@@ -87,7 +87,7 @@ export async function generateContentStream(
  * @param apiSettings The {@link ApiSettings} to use for the request.
  * @param model The model to use for the request.
  * @param params The {@link GenerateContentRequest} to send.
- * @param requestOptions The {@link RequestOptions} to use for the request.
+ * @param requestOptions The {@link SingleRequestOptions} to use for the request.
  * @returns The {@link GenerateContentResult} from the request.
  */
 
@@ -95,7 +95,7 @@ export async function generateContent(
   apiSettings: ApiSettings,
   model: string,
   params: GenerateContentRequest,
-  requestOptions?: RequestOptions,
+  requestOptions?: SingleRequestOptions,
 ): Promise<GenerateContentResult> {
   validateGenerationConfig(params.generationConfig);
   if (apiSettings.backend.backendType === BackendType.GOOGLE_AI) {
@@ -143,7 +143,7 @@ async function processGenerateContentResponse(
  * @param apiSettings The {@link ApiSettings} to use for the request.
  * @param templateId The ID of the server-side template to execute.
  * @param templateParams The parameters to populate the template with.
- * @param requestOptions The {@link RequestOptions} to use for the request.
+ * @param requestOptions The {@link SingleRequestOptions} to use for the request.
  * @returns The {@link GenerateContentResult} from the request.
  *
  * @beta
@@ -152,7 +152,7 @@ export async function templateGenerateContent(
   apiSettings: ApiSettings,
   templateId: string,
   templateParams: object,
-  requestOptions?: RequestOptions,
+  requestOptions?: SingleRequestOptions,
 ): Promise<GenerateContentResult> {
   const response = await makeRequest(
     {
@@ -177,7 +177,7 @@ export async function templateGenerateContent(
  * @param apiSettings The {@link ApiSettings} to use for the request.
  * @param templateId The ID of the server-side template to execute.
  * @param templateParams The parameters to populate the template with.
- * @param requestOptions The {@link RequestOptions} to use for the request.
+ * @param requestOptions The {@link SingleRequestOptions} to use for the request.
  * @returns The {@link GenerateContentStreamResult} from the request.
  *
  * @beta
@@ -186,7 +186,7 @@ export async function templateGenerateContentStream(
   apiSettings: ApiSettings,
   templateId: string,
   templateParams: object,
-  requestOptions?: RequestOptions,
+  requestOptions?: SingleRequestOptions,
 ): Promise<GenerateContentStreamResult> {
   const response = await makeRequest(
     {

--- a/packages/ai/lib/methods/generate-content.ts
+++ b/packages/ai/lib/methods/generate-content.ts
@@ -16,10 +16,12 @@
  */
 
 import {
+  AIErrorCode,
   GenerateContentRequest,
   GenerateContentResponse,
   GenerateContentResult,
   GenerateContentStreamResult,
+  GenerationConfig,
   RequestOptions,
 } from '../types';
 import { Task, makeRequest, ServerPromptTemplateTask } from '../requests/request';
@@ -28,6 +30,24 @@ import { processStream } from '../requests/stream-reader';
 import { ApiSettings } from '../types/internal';
 import { BackendType } from '../public-types';
 import * as GoogleAIMapper from '../googleai-mappers';
+import { AIError } from '../errors';
+
+/**
+ * Client-side validation of common `GenerationConfig` pitfalls, in order
+ * to save the developer a wasted request.
+ */
+function validateGenerationConfig(generationConfig?: GenerationConfig): void {
+  if (
+    // != allows for null and undefined. 0 is considered "set" by the model.
+    generationConfig?.thinkingConfig?.thinkingBudget != null &&
+    generationConfig.thinkingConfig?.thinkingLevel != null
+  ) {
+    throw new AIError(
+      AIErrorCode.UNSUPPORTED,
+      'Cannot set both thinkingBudget and thinkingLevel in a config.',
+    );
+  }
+}
 
 /**
  * Generates a content stream from a request body.
@@ -44,6 +64,7 @@ export async function generateContentStream(
   params: GenerateContentRequest,
   requestOptions?: RequestOptions,
 ): Promise<GenerateContentStreamResult> {
+  validateGenerationConfig(params.generationConfig);
   if (apiSettings.backend.backendType === BackendType.GOOGLE_AI) {
     params = GoogleAIMapper.mapGenerateContentRequest(params);
   }
@@ -76,6 +97,7 @@ export async function generateContent(
   params: GenerateContentRequest,
   requestOptions?: RequestOptions,
 ): Promise<GenerateContentResult> {
+  validateGenerationConfig(params.generationConfig);
   if (apiSettings.backend.backendType === BackendType.GOOGLE_AI) {
     params = GoogleAIMapper.mapGenerateContentRequest(params);
   }

--- a/packages/ai/lib/methods/live-session.ts
+++ b/packages/ai/lib/methods/live-session.ts
@@ -21,6 +21,7 @@ import {
   GenerativeContentBlob,
   LiveResponseType,
   LiveServerContent,
+  LiveServerGoingAwayNotice,
   LiveServerToolCall,
   LiveServerToolCallCancellation,
   Part,
@@ -223,7 +224,10 @@ export class LiveSession {
    * @beta
    */
   async *receive(): AsyncGenerator<
-    LiveServerContent | LiveServerToolCall | LiveServerToolCallCancellation
+    | LiveServerContent
+    | LiveServerToolCall
+    | LiveServerToolCallCancellation
+    | LiveServerGoingAwayNotice
   > {
     if (this.isClosed) {
       throw new AIError(
@@ -252,6 +256,12 @@ export class LiveSession {
               }
             ).toolCallCancellation,
           } as LiveServerToolCallCancellation;
+        } else if ('goAway' in message) {
+          const notice = (message as { goAway: { timeLeft?: string } }).goAway;
+          yield {
+            type: LiveResponseType.GOING_AWAY_NOTICE,
+            timeLeft: parseDuration(notice.timeLeft),
+          } as LiveServerGoingAwayNotice;
         } else {
           logger.warn(
             `Received an unknown message type from the server: ${JSON.stringify(message)}`,
@@ -341,4 +351,15 @@ export class LiveSession {
       }
     }
   }
+}
+
+/**
+ * Parses a duration string (e.g. "3.000000001s") into a number of seconds.
+ */
+function parseDuration(duration?: string): number {
+  if (!duration || !duration.endsWith('s')) {
+    return 0;
+  }
+  const val = Number(duration.slice(0, -1));
+  return Number.isNaN(val) ? 0 : val;
 }

--- a/packages/ai/lib/models/generative-model.ts
+++ b/packages/ai/lib/models/generative-model.ts
@@ -20,9 +20,6 @@ import {
   Content,
   CountTokensRequest,
   CountTokensResponse,
-  FunctionCall,
-  FunctionDeclaration,
-  FunctionResponse,
   GenerateContentRequest,
   GenerateContentResult,
   GenerateContentStreamResult,
@@ -42,8 +39,7 @@ import { formatGenerateContentInput, formatSystemInstruction } from '../requests
 import { mergeRequestOptions } from '../requests/request-options';
 import { AIModel } from './ai-model';
 import { AI } from '../public-types';
-
-const DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS = 10;
+import { generateContentWithAutomaticFunctionCalling } from '../methods/automatic-function-calling';
 
 /**
  * Class for generative model APIs.
@@ -86,7 +82,15 @@ export class GenerativeModel extends AIModel {
     };
     const requestOptions = mergeRequestOptions(this.requestOptions, singleRequestOptions);
     const result = await generateContent(this._apiSettings, this.model, params, requestOptions);
-    return this._generateContentWithAutomaticFunctionCalling(params, result, requestOptions);
+    return (
+      await generateContentWithAutomaticFunctionCalling(
+        this._apiSettings,
+        this.model,
+        params,
+        result,
+        requestOptions,
+      )
+    ).result;
   }
 
   /**
@@ -153,94 +157,6 @@ export class GenerativeModel extends AIModel {
       this.model,
       formattedParams,
       mergeRequestOptions(this.requestOptions, singleRequestOptions),
-    );
-  }
-
-  private async _generateContentWithAutomaticFunctionCalling(
-    params: GenerateContentRequest,
-    result: GenerateContentResult,
-    requestOptions?: SingleRequestOptions,
-  ): Promise<GenerateContentResult> {
-    let remainingFunctionCalls =
-      requestOptions?.maxSequentialFunctionCalls ?? DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS;
-    let currentParams = params;
-    let currentResult = result;
-
-    while (remainingFunctionCalls > 0) {
-      const functionCalls = currentResult.response.functionCalls?.();
-      if (!functionCalls?.length) {
-        return currentResult;
-      }
-
-      const functionResponses = await this._callFunctionReferences(
-        currentParams.tools,
-        functionCalls,
-      );
-      if (!functionResponses) {
-        return currentResult;
-      }
-
-      const responseContent = currentResult.response.candidates?.[0]?.content;
-      if (!responseContent) {
-        return currentResult;
-      }
-
-      remainingFunctionCalls -= 1;
-      currentParams = {
-        ...currentParams,
-        contents: [
-          ...currentParams.contents,
-          responseContent,
-          {
-            role: 'function',
-            parts: functionResponses.map(functionResponse => ({ functionResponse })),
-          },
-        ],
-      };
-      currentResult = await generateContent(
-        this._apiSettings,
-        this.model,
-        currentParams,
-        requestOptions,
-      );
-    }
-
-    return currentResult;
-  }
-
-  private async _callFunctionReferences(
-    tools: Tool[] | undefined,
-    functionCalls: FunctionCall[],
-  ): Promise<FunctionResponse[] | undefined> {
-    const declarations = this._getFunctionDeclarationsWithReferences(tools);
-    if (!declarations.length) {
-      return undefined;
-    }
-
-    const functionResponses: FunctionResponse[] = [];
-    for (const functionCall of functionCalls) {
-      const declaration = declarations.find(candidate => candidate.name === functionCall.name);
-      if (!declaration?.functionReference) {
-        return undefined;
-      }
-
-      const response = (await declaration.functionReference(functionCall.args)) as object;
-      functionResponses.push({
-        id: functionCall.id,
-        name: functionCall.name,
-        response,
-      });
-    }
-    return functionResponses;
-  }
-
-  private _getFunctionDeclarationsWithReferences(tools: Tool[] | undefined): FunctionDeclaration[] {
-    return (
-      tools?.flatMap(tool =>
-        'functionDeclarations' in tool
-          ? (tool.functionDeclarations?.filter(declaration => declaration.functionReference) ?? [])
-          : [],
-      ) ?? []
     );
   }
 }

--- a/packages/ai/lib/models/generative-model.ts
+++ b/packages/ai/lib/models/generative-model.ts
@@ -28,6 +28,7 @@ import {
   Part,
   RequestOptions,
   SafetySetting,
+  SingleRequestOptions,
   StartChatParams,
   Tool,
   ToolConfig,
@@ -35,6 +36,7 @@ import {
 import { ChatSession } from '../methods/chat-session';
 import { countTokens } from '../methods/count-tokens';
 import { formatGenerateContentInput, formatSystemInstruction } from '../requests/request-helpers';
+import { mergeRequestOptions } from '../requests/request-options';
 import { AIModel } from './ai-model';
 import { AI } from '../public-types';
 
@@ -66,6 +68,7 @@ export class GenerativeModel extends AIModel {
    */
   async generateContent(
     request: GenerateContentRequest | string | Array<string | Part>,
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentResult> {
     const formattedParams = formatGenerateContentInput(request);
     return generateContent(
@@ -79,7 +82,7 @@ export class GenerativeModel extends AIModel {
         systemInstruction: this.systemInstruction,
         ...formattedParams,
       },
-      this.requestOptions,
+      mergeRequestOptions(this.requestOptions, singleRequestOptions),
     );
   }
 
@@ -91,6 +94,7 @@ export class GenerativeModel extends AIModel {
    */
   async generateContentStream(
     request: GenerateContentRequest | string | Array<string | Part>,
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentStreamResult> {
     const formattedParams = formatGenerateContentInput(request);
     return generateContentStream(
@@ -104,7 +108,7 @@ export class GenerativeModel extends AIModel {
         systemInstruction: this.systemInstruction,
         ...formattedParams,
       },
-      this.requestOptions,
+      mergeRequestOptions(this.requestOptions, singleRequestOptions),
     );
   }
 
@@ -138,8 +142,14 @@ export class GenerativeModel extends AIModel {
    */
   async countTokens(
     request: CountTokensRequest | string | Array<string | Part>,
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<CountTokensResponse> {
     const formattedParams = formatGenerateContentInput(request);
-    return countTokens(this._apiSettings, this.model, formattedParams);
+    return countTokens(
+      this._apiSettings,
+      this.model,
+      formattedParams,
+      mergeRequestOptions(this.requestOptions, singleRequestOptions),
+    );
   }
 }

--- a/packages/ai/lib/models/generative-model.ts
+++ b/packages/ai/lib/models/generative-model.ts
@@ -20,6 +20,9 @@ import {
   Content,
   CountTokensRequest,
   CountTokensResponse,
+  FunctionCall,
+  FunctionDeclaration,
+  FunctionResponse,
   GenerateContentRequest,
   GenerateContentResult,
   GenerateContentStreamResult,
@@ -39,6 +42,8 @@ import { formatGenerateContentInput, formatSystemInstruction } from '../requests
 import { mergeRequestOptions } from '../requests/request-options';
 import { AIModel } from './ai-model';
 import { AI } from '../public-types';
+
+const DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS = 10;
 
 /**
  * Class for generative model APIs.
@@ -71,19 +76,17 @@ export class GenerativeModel extends AIModel {
     singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentResult> {
     const formattedParams = formatGenerateContentInput(request);
-    return generateContent(
-      this._apiSettings,
-      this.model,
-      {
-        generationConfig: this.generationConfig,
-        safetySettings: this.safetySettings,
-        tools: this.tools,
-        toolConfig: this.toolConfig,
-        systemInstruction: this.systemInstruction,
-        ...formattedParams,
-      },
-      mergeRequestOptions(this.requestOptions, singleRequestOptions),
-    );
+    const params: GenerateContentRequest = {
+      generationConfig: this.generationConfig,
+      safetySettings: this.safetySettings,
+      tools: this.tools,
+      toolConfig: this.toolConfig,
+      systemInstruction: this.systemInstruction,
+      ...formattedParams,
+    };
+    const requestOptions = mergeRequestOptions(this.requestOptions, singleRequestOptions);
+    const result = await generateContent(this._apiSettings, this.model, params, requestOptions);
+    return this._generateContentWithAutomaticFunctionCalling(params, result, requestOptions);
   }
 
   /**
@@ -150,6 +153,94 @@ export class GenerativeModel extends AIModel {
       this.model,
       formattedParams,
       mergeRequestOptions(this.requestOptions, singleRequestOptions),
+    );
+  }
+
+  private async _generateContentWithAutomaticFunctionCalling(
+    params: GenerateContentRequest,
+    result: GenerateContentResult,
+    requestOptions?: SingleRequestOptions,
+  ): Promise<GenerateContentResult> {
+    let remainingFunctionCalls =
+      requestOptions?.maxSequentialFunctionCalls ?? DEFAULT_MAX_SEQUENTIAL_FUNCTION_CALLS;
+    let currentParams = params;
+    let currentResult = result;
+
+    while (remainingFunctionCalls > 0) {
+      const functionCalls = currentResult.response.functionCalls?.();
+      if (!functionCalls?.length) {
+        return currentResult;
+      }
+
+      const functionResponses = await this._callFunctionReferences(
+        currentParams.tools,
+        functionCalls,
+      );
+      if (!functionResponses) {
+        return currentResult;
+      }
+
+      const responseContent = currentResult.response.candidates?.[0]?.content;
+      if (!responseContent) {
+        return currentResult;
+      }
+
+      remainingFunctionCalls -= 1;
+      currentParams = {
+        ...currentParams,
+        contents: [
+          ...currentParams.contents,
+          responseContent,
+          {
+            role: 'function',
+            parts: functionResponses.map(functionResponse => ({ functionResponse })),
+          },
+        ],
+      };
+      currentResult = await generateContent(
+        this._apiSettings,
+        this.model,
+        currentParams,
+        requestOptions,
+      );
+    }
+
+    return currentResult;
+  }
+
+  private async _callFunctionReferences(
+    tools: Tool[] | undefined,
+    functionCalls: FunctionCall[],
+  ): Promise<FunctionResponse[] | undefined> {
+    const declarations = this._getFunctionDeclarationsWithReferences(tools);
+    if (!declarations.length) {
+      return undefined;
+    }
+
+    const functionResponses: FunctionResponse[] = [];
+    for (const functionCall of functionCalls) {
+      const declaration = declarations.find(candidate => candidate.name === functionCall.name);
+      if (!declaration?.functionReference) {
+        return undefined;
+      }
+
+      const response = (await declaration.functionReference(functionCall.args)) as object;
+      functionResponses.push({
+        id: functionCall.id,
+        name: functionCall.name,
+        response,
+      });
+    }
+    return functionResponses;
+  }
+
+  private _getFunctionDeclarationsWithReferences(tools: Tool[] | undefined): FunctionDeclaration[] {
+    return (
+      tools?.flatMap(tool =>
+        'functionDeclarations' in tool
+          ? (tool.functionDeclarations?.filter(declaration => declaration.functionReference) ?? [])
+          : [],
+      ) ?? []
     );
   }
 }

--- a/packages/ai/lib/models/imagen-model.ts
+++ b/packages/ai/lib/models/imagen-model.ts
@@ -24,11 +24,13 @@ import {
   ImagenGenerationConfig,
   ImagenInlineImage,
   RequestOptions,
+  SingleRequestOptions,
   ImagenModelParams,
   ImagenGenerationResponse,
   ImagenSafetySettings,
 } from '../types';
 import { AIModel } from './ai-model';
+import { mergeRequestOptions } from '../requests/request-options';
 
 /**
  * Class for Imagen model APIs.
@@ -101,7 +103,10 @@ export class ImagenModel extends AIModel {
    *
    * @beta
    */
-  async generateImages(prompt: string): Promise<ImagenGenerationResponse<ImagenInlineImage>> {
+  async generateImages(
+    prompt: string,
+    singleRequestOptions?: SingleRequestOptions,
+  ): Promise<ImagenGenerationResponse<ImagenInlineImage>> {
     const body = createPredictRequestBody(prompt, {
       ...this.generationConfig,
       ...this.safetySettings,
@@ -112,7 +117,7 @@ export class ImagenModel extends AIModel {
         task: Task.PREDICT,
         apiSettings: this._apiSettings,
         stream: false,
-        requestOptions: this.requestOptions,
+        requestOptions: mergeRequestOptions(this.requestOptions, singleRequestOptions),
       },
       JSON.stringify(body),
     );
@@ -141,6 +146,7 @@ export class ImagenModel extends AIModel {
   async generateImagesGCS(
     prompt: string,
     gcsURI: string,
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<ImagenGenerationResponse<ImagenGCSImage>> {
     const body = createPredictRequestBody(prompt, {
       gcsURI,
@@ -153,7 +159,7 @@ export class ImagenModel extends AIModel {
         task: Task.PREDICT,
         apiSettings: this._apiSettings,
         stream: false,
-        requestOptions: this.requestOptions,
+        requestOptions: mergeRequestOptions(this.requestOptions, singleRequestOptions),
       },
       JSON.stringify(body),
     );

--- a/packages/ai/lib/models/template-generative-model.ts
+++ b/packages/ai/lib/models/template-generative-model.ts
@@ -19,9 +19,10 @@ import {
   templateGenerateContent,
   templateGenerateContentStream,
 } from '../methods/generate-content';
-import { GenerateContentResult, RequestOptions } from '../types';
+import { GenerateContentResult, RequestOptions, SingleRequestOptions } from '../types';
 import { AI, GenerateContentStreamResult } from '../public-types';
 import { ApiSettings } from '../types/internal';
+import { mergeRequestOptions } from '../requests/request-options';
 import { initApiSettings } from './utils';
 
 /**
@@ -63,12 +64,13 @@ export class TemplateGenerativeModel {
   async generateContent(
     templateId: string,
     templateVariables: object, // anything!
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentResult> {
     return templateGenerateContent(
       this._apiSettings,
       templateId,
       { inputs: templateVariables },
-      this.requestOptions,
+      mergeRequestOptions(this.requestOptions, singleRequestOptions),
     );
   }
 
@@ -87,12 +89,13 @@ export class TemplateGenerativeModel {
   async generateContentStream(
     templateId: string,
     templateVariables: object,
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentStreamResult> {
     return templateGenerateContentStream(
       this._apiSettings,
       templateId,
       { inputs: templateVariables },
-      this.requestOptions,
+      mergeRequestOptions(this.requestOptions, singleRequestOptions),
     );
   }
 }

--- a/packages/ai/lib/models/template-generative-model.ts
+++ b/packages/ai/lib/models/template-generative-model.ts
@@ -19,11 +19,17 @@ import {
   templateGenerateContent,
   templateGenerateContentStream,
 } from '../methods/generate-content';
-import { GenerateContentResult, RequestOptions, SingleRequestOptions } from '../types';
+import {
+  GenerateContentResult,
+  RequestOptions,
+  SingleRequestOptions,
+  StartTemplateChatParams,
+} from '../types';
 import { AI, GenerateContentStreamResult } from '../public-types';
 import { ApiSettings } from '../types/internal';
 import { mergeRequestOptions } from '../requests/request-options';
 import { initApiSettings } from './utils';
+import { TemplateChatSession } from '../methods/chat-session';
 
 /**
  * {@link GenerativeModel} APIs that execute on a server-side template.
@@ -63,7 +69,7 @@ export class TemplateGenerativeModel {
    */
   async generateContent(
     templateId: string,
-    templateVariables: object, // anything!
+    templateVariables: Record<string, unknown>,
     singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentResult> {
     return templateGenerateContent(
@@ -88,7 +94,7 @@ export class TemplateGenerativeModel {
    */
   async generateContentStream(
     templateId: string,
-    templateVariables: object,
+    templateVariables: Record<string, unknown>,
     singleRequestOptions?: SingleRequestOptions,
   ): Promise<GenerateContentStreamResult> {
     return templateGenerateContentStream(
@@ -97,5 +103,18 @@ export class TemplateGenerativeModel {
       { inputs: templateVariables },
       mergeRequestOptions(this.requestOptions, singleRequestOptions),
     );
+  }
+
+  /**
+   * Starts a {@link TemplateChatSession} that will use this template to
+   * respond to messages.
+   *
+   * @param params - Configurations for the chat, including the template
+   * ID and input variables.
+   *
+   * @beta
+   */
+  startChat(params: StartTemplateChatParams): TemplateChatSession {
+    return new TemplateChatSession(this._apiSettings, params, this.requestOptions);
   }
 }

--- a/packages/ai/lib/models/template-imagen-model.ts
+++ b/packages/ai/lib/models/template-imagen-model.ts
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-import { RequestOptions } from '../types';
+import { RequestOptions, SingleRequestOptions } from '../types';
 import { AI, ImagenGenerationResponse, ImagenInlineImage } from '../public-types';
 import { ApiSettings } from '../types/internal';
 import { makeRequest, ServerPromptTemplateTask } from '../requests/request';
+import { mergeRequestOptions } from '../requests/request-options';
 import { handlePredictResponse } from '../requests/response-helpers';
 import { initApiSettings } from './utils';
 
@@ -61,6 +62,7 @@ export class TemplateImagenModel {
   async generateImages(
     templateId: string,
     templateVariables: object,
+    singleRequestOptions?: SingleRequestOptions,
   ): Promise<ImagenGenerationResponse<ImagenInlineImage>> {
     const response = await makeRequest(
       {
@@ -68,7 +70,7 @@ export class TemplateImagenModel {
         templateId,
         apiSettings: this._apiSettings,
         stream: false,
-        requestOptions: this.requestOptions,
+        requestOptions: mergeRequestOptions(this.requestOptions, singleRequestOptions),
       },
       JSON.stringify({ inputs: templateVariables }),
     );

--- a/packages/ai/lib/requests/request-options.ts
+++ b/packages/ai/lib/requests/request-options.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RequestOptions, SingleRequestOptions } from '../types';
+
+export function mergeRequestOptions(
+  requestOptions?: RequestOptions,
+  singleRequestOptions?: SingleRequestOptions,
+): SingleRequestOptions | undefined {
+  if (!requestOptions && !singleRequestOptions) {
+    return undefined;
+  }
+  return {
+    ...requestOptions,
+    ...singleRequestOptions,
+  };
+}

--- a/packages/ai/lib/requests/request.ts
+++ b/packages/ai/lib/requests/request.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { Platform } from 'react-native';
-import { AIErrorCode, ErrorDetails, RequestOptions } from '../types';
+import { AIErrorCode, ErrorDetails, SingleRequestOptions } from '../types';
 import { AIError } from '../errors';
 import { ApiSettings } from '../types/internal';
 import {
@@ -48,7 +48,7 @@ export class RequestUrl {
     public task: Task,
     public apiSettings: ApiSettings,
     public stream: boolean,
-    public requestOptions?: RequestOptions,
+    public requestOptions?: SingleRequestOptions,
   ) {}
   toString(): string {
     // @ts-ignore
@@ -112,13 +112,29 @@ export class RequestUrl {
   }
 }
 
+function createAbortError(reason?: unknown): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException(
+      reason == null ? 'Aborted' : String(reason),
+      'AbortError',
+    ) as unknown as Error;
+  }
+  const error = new Error(reason == null ? 'Aborted' : String(reason));
+  error.name = 'AbortError';
+  return error;
+}
+
+function getAbortSignalReason(signal?: AbortSignal): unknown {
+  return (signal as AbortSignal & { reason?: unknown } | undefined)?.reason;
+}
+
 export class TemplateRequestUrl {
   constructor(
     public templateId: string,
     public task: ServerPromptTemplateTask,
     public apiSettings: ApiSettings,
     public stream: boolean,
-    public requestOptions?: RequestOptions,
+    public requestOptions?: SingleRequestOptions,
   ) {}
 
   toString(): string {
@@ -227,7 +243,7 @@ export async function constructRequest(
   apiSettings: ApiSettings,
   stream: boolean,
   body: string,
-  requestOptions?: RequestOptions,
+  requestOptions?: SingleRequestOptions,
 ): Promise<{ url: string; fetchOptions: RequestInit }> {
   const url = new RequestUrl(model, task, apiSettings, stream, requestOptions);
   return {
@@ -246,7 +262,7 @@ export async function constructTemplateRequest(
   apiSettings: ApiSettings,
   stream: boolean,
   body: string,
-  requestOptions?: RequestOptions,
+  requestOptions?: SingleRequestOptions,
 ): Promise<{ url: string; fetchOptions: RequestInit }> {
   const url = new TemplateRequestUrl(templateId, task, apiSettings, stream, requestOptions);
   return {
@@ -266,7 +282,7 @@ export async function makeRequest(
     task: Task;
     apiSettings: ApiSettings;
     stream: boolean;
-    requestOptions?: RequestOptions;
+    requestOptions?: SingleRequestOptions;
   },
   body: string,
 ): Promise<Response>;
@@ -277,7 +293,7 @@ export async function makeRequest(
     task: ServerPromptTemplateTask;
     apiSettings: ApiSettings;
     stream: boolean;
-    requestOptions?: RequestOptions;
+    requestOptions?: SingleRequestOptions;
   },
   body: string,
 ): Promise<Response>;
@@ -289,14 +305,14 @@ export async function makeRequest(
         task: Task;
         apiSettings: ApiSettings;
         stream: boolean;
-        requestOptions?: RequestOptions;
+        requestOptions?: SingleRequestOptions;
       }
     | {
         templateId: string;
         task: ServerPromptTemplateTask;
         apiSettings: ApiSettings;
         stream: boolean;
-        requestOptions?: RequestOptions;
+        requestOptions?: SingleRequestOptions;
       },
   body: string,
 ): Promise<Response> {
@@ -320,6 +336,17 @@ export async function makeRequest(
 
   let response;
   let fetchTimeoutId: string | number | NodeJS.Timeout | undefined;
+  const externalSignal = params.requestOptions?.signal;
+  let externalAbortReason: unknown;
+  if (externalSignal?.aborted) {
+    throw createAbortError(getAbortSignalReason(externalSignal));
+  }
+  const abortController = new AbortController();
+  const abortFromExternalSignal = (): void => {
+    externalAbortReason = getAbortSignalReason(externalSignal);
+    abortController.abort();
+  };
+  externalSignal?.addEventListener('abort', abortFromExternalSignal, { once: true });
   try {
     const request = isTemplateRequest
       ? await constructTemplateRequest(
@@ -343,7 +370,6 @@ export async function makeRequest(
       params.requestOptions?.timeout != null && params.requestOptions.timeout >= 0
         ? params.requestOptions.timeout
         : DEFAULT_FETCH_TIMEOUT_MS;
-    const abortController = new AbortController();
     fetchTimeoutId = setTimeout(() => abortController.abort(), timeoutMillis);
     request.fetchOptions.signal = abortController.signal;
     const fetchOptions = params.stream
@@ -406,6 +432,9 @@ export async function makeRequest(
     }
   } catch (e) {
     let err = e as Error;
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw createAbortError(externalAbortReason);
+    }
     if (
       (e as AIError).code !== AIErrorCode.FETCH_ERROR &&
       (e as AIError).code !== AIErrorCode.API_NOT_ENABLED &&
@@ -420,6 +449,7 @@ export async function makeRequest(
     if (fetchTimeoutId) {
       clearTimeout(fetchTimeoutId);
     }
+    externalSignal?.removeEventListener('abort', abortFromExternalSignal);
   }
   return response;
 }

--- a/packages/ai/lib/requests/schema-builder.ts
+++ b/packages/ai/lib/requests/schema-builder.ts
@@ -34,10 +34,11 @@ import {
  */
 export abstract class Schema implements SchemaInterface {
   /**
-   * Optional. The type of the property. {@link
-   * SchemaType}.
+   * Optional. The type of the property.
+   * This can only be undefined when using `anyOf` schemas, which do not have an
+   * explicit type in the {@link https://swagger.io/docs/specification/v3_0/data-models/data-types/#any-type | OpenAPI specification}.
    */
-  type: SchemaType;
+  type?: SchemaType;
   /** Optional. The format of the property.
    * Supported formats:<br/>
    * <ul>
@@ -69,7 +70,6 @@ export abstract class Schema implements SchemaInterface {
     for (const paramKey in schemaParams) {
       this[paramKey] = schemaParams[paramKey];
     }
-    // Ensure these are explicitly set to avoid TS errors.
     this.type = schemaParams.type;
     this.nullable = schemaParams.hasOwnProperty('nullable') ? !!schemaParams.nullable : false;
   }
@@ -80,7 +80,7 @@ export abstract class Schema implements SchemaInterface {
    * @internal
    */
   toJSON(): SchemaRequest {
-    const obj: { type: SchemaType; [key: string]: unknown } = {
+    const obj: { type?: SchemaType; [key: string]: unknown } = {
       type: this.type,
     };
     for (const prop in this) {
@@ -127,6 +127,10 @@ export abstract class Schema implements SchemaInterface {
   static boolean(booleanParams?: SchemaParams): BooleanSchema {
     return new BooleanSchema(booleanParams);
   }
+
+  static anyOf(anyOfParams: SchemaParams & { anyOf: TypedSchema[] }): AnyOfSchema {
+    return new AnyOfSchema(anyOfParams);
+  }
 }
 
 /**
@@ -139,7 +143,8 @@ export type TypedSchema =
   | StringSchema
   | BooleanSchema
   | ObjectSchema
-  | ArraySchema;
+  | ArraySchema
+  | AnyOfSchema;
 
 /**
  * Schema class for "integer" types.
@@ -283,5 +288,36 @@ export class ObjectSchema extends Schema {
     }
     delete (obj as ObjectSchemaInterface).optionalProperties;
     return obj as SchemaRequest;
+  }
+}
+
+/**
+ * Schema class representing a value that can conform to any of the provided sub-schemas. This is
+ * useful when a field can accept multiple distinct types or structures.
+ * @public
+ */
+export class AnyOfSchema extends Schema {
+  anyOf: TypedSchema[];
+
+  constructor(schemaParams: SchemaParams & { anyOf: TypedSchema[] }) {
+    if (schemaParams.anyOf.length === 0) {
+      throw new AIError(AIErrorCode.INVALID_SCHEMA, "The 'anyOf' array must not be empty.");
+    }
+    super({
+      ...schemaParams,
+      type: undefined, // anyOf schemas do not have an explicit type
+    });
+    this.anyOf = schemaParams.anyOf;
+  }
+
+  /**
+   * @internal
+   */
+  toJSON(): SchemaRequest {
+    const obj = super.toJSON();
+    if (this.anyOf && Array.isArray(this.anyOf)) {
+      obj.anyOf = this.anyOf.map(s => s.toJSON());
+    }
+    return obj;
   }
 }

--- a/packages/ai/lib/types/content.ts
+++ b/packages/ai/lib/types/content.ts
@@ -192,6 +192,7 @@ export interface FunctionResponse {
   id?: string;
   name: string;
   response: object;
+  parts?: Part[];
 }
 
 /**

--- a/packages/ai/lib/types/enums.ts
+++ b/packages/ai/lib/types/enums.ts
@@ -340,3 +340,26 @@ export const Language = {
  * @beta
  */
 export type Language = (typeof Language)[keyof typeof Language];
+
+/**
+ * A preset that controls the model's "thinking" process. Use
+ * `ThinkingLevel.LOW` for faster responses on less complex tasks, and
+ * `ThinkingLevel.HIGH` for better reasoning on more complex tasks.
+ *
+ * @public
+ */
+export const ThinkingLevel = {
+  MINIMAL: 'MINIMAL',
+  LOW: 'LOW',
+  MEDIUM: 'MEDIUM',
+  HIGH: 'HIGH',
+};
+
+/**
+ * A preset that controls the model's "thinking" process. Use
+ * `ThinkingLevel.LOW` for faster responses on less complex tasks, and
+ * `ThinkingLevel.HIGH` for better reasoning on more complex tasks.
+ *
+ * @public
+ */
+export type ThinkingLevel = (typeof ThinkingLevel)[keyof typeof ThinkingLevel];

--- a/packages/ai/lib/types/requests.ts
+++ b/packages/ai/lib/types/requests.ts
@@ -25,7 +25,7 @@ import {
   ResponseModality,
   ThinkingLevel,
 } from './enums';
-import { ObjectSchemaInterface, SchemaRequest } from './schema';
+import { ObjectSchemaInterface, ObjectSchemaRequest, SchemaRequest } from './schema';
 
 /**
  * Base parameters for a number of methods.
@@ -279,7 +279,7 @@ export interface FunctionDeclaration {
    * format. Reflects the Open API 3.03 Parameter Object. Parameter names are
    * case-sensitive. For a function with no parameters, this can be left unset.
    */
-  parameters?: ObjectSchemaInterface;
+  parameters?: ObjectSchemaInterface | ObjectSchemaRequest;
 }
 
 /**

--- a/packages/ai/lib/types/requests.ts
+++ b/packages/ai/lib/types/requests.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { TypedSchema } from '../requests/schema-builder';
+import { ObjectSchema, TypedSchema } from '../requests/schema-builder';
 import { Content, Part } from './content';
 import {
   FunctionCallingMode,
@@ -213,6 +213,22 @@ export interface StartChatParams extends BaseParams {
 }
 
 /**
+ * Params for {@link TemplateGenerativeModel.startChat}.
+ * @beta
+ */
+export interface StartTemplateChatParams extends Omit<StartChatParams, 'tools'> {
+  /**
+   * The ID of the server-side template to execute.
+   */
+  templateId: string;
+  /**
+   * A key-value map of variables to populate the template with.
+   */
+  templateVariables?: Record<string, unknown>;
+  tools?: TemplateTool[];
+}
+
+/**
  * Params for calling {@link GenerativeModel.countTokens}
  * @public
  */
@@ -384,6 +400,53 @@ export interface FunctionDeclarationsTool {
    */
   functionDeclarations?: FunctionDeclaration[];
 }
+
+/**
+ * Structured representation of a template function declaration.
+ * @beta
+ */
+export interface TemplateFunctionDeclaration {
+  /**
+   * The name of the function to call. Must start with a letter or an
+   * underscore. Must be a-z, A-Z, 0-9, or contain underscores and dashes, with
+   * a max length of 64.
+   */
+  name: string;
+  /**
+   * Description is intentionally unsupported for template function declarations.
+   */
+  description?: never;
+  /**
+   * Optional. Describes the parameters to this function in JSON Schema Object
+   * format.
+   */
+  parameters?: ObjectSchema | ObjectSchemaRequest;
+  /**
+   * Reference to an actual function to call. Specifying this will cause the
+   * function to be called automatically when requested by the model.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- Matches firebase-js-sdk public API.
+  functionReference?: Function;
+}
+
+/**
+ * A piece of code that enables the system to interact with external systems.
+ * @beta
+ */
+export interface TemplateFunctionDeclarationsTool {
+  /**
+   * Optional. One or more function declarations
+   * to be passed to the server-side template execution.
+   */
+  functionDeclarations?: TemplateFunctionDeclaration[];
+}
+
+/**
+ * Defines a tool that a {@link TemplateGenerativeModel} can call
+ * to access external knowledge.
+ * @beta
+ */
+export type TemplateTool = TemplateFunctionDeclarationsTool;
 
 /**
  * Tool config. This config is shared for all tools provided in the request.

--- a/packages/ai/lib/types/requests.ts
+++ b/packages/ai/lib/types/requests.ts
@@ -23,6 +23,7 @@ import {
   HarmBlockThreshold,
   HarmCategory,
   ResponseModality,
+  ThinkingLevel,
 } from './enums';
 import { ObjectSchemaInterface, SchemaRequest } from './schema';
 
@@ -404,10 +405,25 @@ export interface ThinkingConfig {
    * If you don't specify a budget, the model will determine the appropriate amount
    * of thinking based on the complexity of the prompt.
    *
+   * The model will also error if `thinkingLevel` and `thinkingBudget` are
+   * both set.
+   *
    * An error will be thrown if you set a thinking budget for a model that does not support this
    * feature or if the specified budget is not within the model's supported range.
    */
   thinkingBudget?: number;
+
+  /**
+   * If not specified, Gemini will use the model's default dynamic thinking level.
+   *
+   * @remarks
+   * Note: The model will error if `thinkingLevel` and `thinkingBudget` are
+   * both set.
+   *
+   * Important: Gemini 2.5 series models do not support thinking levels; use
+   * `thinkingBudget` to set a thinking budget instead.
+   */
+  thinkingLevel?: ThinkingLevel;
 
   /**
    * Whether to include "thought summaries" in the model's response.

--- a/packages/ai/lib/types/requests.ts
+++ b/packages/ai/lib/types/requests.ts
@@ -25,7 +25,7 @@ import {
   ResponseModality,
   ThinkingLevel,
 } from './enums';
-import { ObjectSchemaInterface, ObjectSchemaRequest, SchemaRequest } from './schema';
+import { ObjectSchemaRequest, SchemaRequest } from './schema';
 
 /**
  * Base parameters for a number of methods.
@@ -271,6 +271,15 @@ export interface RequestOptions {
    * Base url for endpoint. Defaults to https://firebasevertexai.googleapis.com
    */
   baseUrl?: string;
+  /**
+   * Limits amount of sequential function calls the SDK can make during automatic
+   * function calling, in order to prevent infinite loops. If not specified,
+   * this value defaults to 10.
+   *
+   * When it reaches this limit, it will return the last response received
+   * from the model, whether it is a text response or further function calls.
+   */
+  maxSequentialFunctionCalls?: number;
 }
 
 /**
@@ -320,7 +329,13 @@ export interface FunctionDeclaration {
    * format. Reflects the Open API 3.03 Parameter Object. Parameter names are
    * case-sensitive. For a function with no parameters, this can be left unset.
    */
-  parameters?: ObjectSchemaInterface | ObjectSchemaRequest;
+  parameters?: ObjectSchema | ObjectSchemaRequest;
+  /**
+   * Reference to an actual function to call. Specifying this will cause the
+   * function to be called automatically when requested by the model.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type -- Matches firebase-js-sdk public API.
+  functionReference?: Function;
 }
 
 /**

--- a/packages/ai/lib/types/requests.ts
+++ b/packages/ai/lib/types/requests.ts
@@ -248,6 +248,21 @@ export interface RequestOptions {
 }
 
 /**
+ * Options that can be provided per-request.
+ *
+ * Options specified here will override any default {@link RequestOptions}
+ * configured on a model.
+ *
+ * @public
+ */
+export interface SingleRequestOptions extends RequestOptions {
+  /**
+   * An `AbortSignal` instance that allows cancelling ongoing requests.
+   */
+  signal?: AbortSignal;
+}
+
+/**
  * Defines a tool that model can call to access external knowledge.
  * @public
  */

--- a/packages/ai/lib/types/requests.ts
+++ b/packages/ai/lib/types/requests.ts
@@ -117,6 +117,16 @@ export interface GenerationConfig {
    */
   responseSchema?: TypedSchema | SchemaRequest;
   /**
+   * Output schema of the generated response. This is an alternative to
+   * `responseSchema` that accepts [JSON Schema](https://json-schema.org/).
+   *
+   * If set, `responseSchema` must be omitted, but `responseMimeType`
+   * is required and must be set to `application/json`.
+   */
+  responseJsonSchema?: {
+    [key: string]: unknown;
+  };
+  /**
    * Generation modalities to be returned in generation responses.
    *
    * @remarks

--- a/packages/ai/lib/types/responses.ts
+++ b/packages/ai/lib/types/responses.ts
@@ -592,6 +592,19 @@ export interface LiveServerToolCallCancellation {
 }
 
 /**
+ * Notification that the server will not be able to service the client soon.
+ *
+ * @beta
+ */
+export interface LiveServerGoingAwayNotice {
+  type: 'goingAwayNotice';
+  /**
+   * The remaining time (in seconds) before the connection will be terminated.
+   */
+  timeLeft: number;
+}
+
+/**
  * The types of responses that can be returned by {@link LiveSession.receive}.
  *
  * @beta
@@ -600,6 +613,7 @@ export const LiveResponseType = {
   SERVER_CONTENT: 'serverContent',
   TOOL_CALL: 'toolCall',
   TOOL_CALL_CANCELLATION: 'toolCallCancellation',
+  GOING_AWAY_NOTICE: 'goingAwayNotice',
 };
 
 /**

--- a/packages/ai/lib/types/responses.ts
+++ b/packages/ai/lib/types/responses.ts
@@ -117,8 +117,28 @@ export interface UsageMetadata {
    */
   thoughtsTokenCount?: number;
   totalTokenCount: number;
+  /**
+   * The number of tokens used by tools.
+   */
+  toolUsePromptTokenCount?: number;
   promptTokensDetails?: ModalityTokenCount[];
   candidatesTokensDetails?: ModalityTokenCount[];
+  /**
+   * A list of tokens used by tools, broken down by modality.
+   */
+  toolUsePromptTokensDetails?: ModalityTokenCount[];
+  /**
+   * The number of tokens in the prompt that were served from the cache.
+   * If implicit caching is not active or no content was cached,
+   * this will be 0.
+   */
+  cachedContentTokenCount?: number;
+  /**
+   * Detailed breakdown of the cached tokens by modality (for example, text or
+   * image). This list provides granular insight into which parts of
+   * the content were cached.
+   */
+  cacheTokensDetails?: ModalityTokenCount[];
 }
 
 /**

--- a/packages/ai/lib/types/schema.ts
+++ b/packages/ai/lib/types/schema.ts
@@ -108,6 +108,23 @@ export interface SchemaRequest extends SchemaShared<SchemaRequest> {
 }
 
 /**
+ * Interface for JSON parameters in a schema of {@link SchemaType.OBJECT}
+ * when not using the `Schema.object()` helper.
+ * @public
+ */
+export interface ObjectSchemaRequest extends Omit<SchemaRequest, 'type'> {
+  type: 'object';
+  /**
+   * This is not a property accepted in the final request to the backend, but is
+   * a client-side convenience property that is only usable by constructing
+   * a schema through the `Schema.object()` helper method. Populating this
+   * property will cause response errors if the object is not wrapped with
+   * `Schema.object()`.
+   */
+  optionalProperties?: never;
+}
+
+/**
  * Interface for {@link Schema} class.
  * @public
  */

--- a/packages/ai/lib/types/schema.ts
+++ b/packages/ai/lib/types/schema.ts
@@ -42,6 +42,12 @@ export enum SchemaType {
  * @public
  */
 export interface SchemaShared<T> {
+  /**
+   * An array of {@link Schema}. The generated data must be valid against any of the schemas
+   * listed in this array. This allows specifying multiple possible structures or types for a
+   * single field.
+   */
+  anyOf?: T[];
   /** Optional. The format of the property.
    * When using the Gemini Developer API ({@link GoogleAIBackend}), this must be either `'enum'` or
    * `'date-time'`, otherwise requests will fail.
@@ -93,10 +99,10 @@ export interface SchemaParams extends SchemaShared<SchemaInterface> {}
  */
 export interface SchemaRequest extends SchemaShared<SchemaRequest> {
   /**
-   * The type of the property. {@link
-   * SchemaType}.
+   * The type of the property. this can only be undefined when using `anyOf` schemas,
+   * which do not have an explicit type in the {@link https://swagger.io/docs/specification/v3_0/data-models/data-types/#any-type | OpenAPI specification }.
    */
-  type: SchemaType;
+  type?: SchemaType;
   /** Optional. Array of required property. */
   required?: string[];
 }
@@ -107,10 +113,10 @@ export interface SchemaRequest extends SchemaShared<SchemaRequest> {
  */
 export interface SchemaInterface extends SchemaShared<SchemaInterface> {
   /**
-   * The type of the property. {@link
-   * SchemaType}.
+   * The type of the property. this can only be undefined when using `anyof` schemas,
+   * which do not have an explicit type in the {@link https://swagger.io/docs/specification/v3_0/data-models/data-types/#any-type | OpenAPI Specification}.
    */
-  type: SchemaType;
+  type?: SchemaType;
 }
 
 /**


### PR DESCRIPTION
### Description

This is a "converge towards API parity" PR for the AI package - there have been quite a few API elements added upstream in firebase-js-sdk and this PR should close the gap down a fair bit

### Related issues

None logged

### Release Summary

A series of feature conventional commits, a semver minor should issue

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

Mostly compare:types and tests:jest analysis, periodic local runs of tests:macos:test but CI will also confirm

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
