### PR TITLE
refactor(ml,app-distribution): align namespaced firebase export with other packages

### DIFF
--- a/packages/app-distribution/lib/namespaced.ts
+++ b/packages/app-distribution/lib/namespaced.ts
@@ -91,9 +91,13 @@ const appDistributionNamespace = createModuleNamespace({
 
 export default appDistributionNamespace;
 
-export const firebase = getFirebaseRoot() as unknown as ReactNativeFirebase.Module & {
-  appDistribution: typeof appDistributionNamespace;
-  app(name?: string): ReactNativeFirebase.FirebaseApp & {
-    appDistribution(): FirebaseAppDistributionTypes.Module;
-  };
-};
+// import appDistribution, { firebase } from '@react-native-firebase/app-distribution';
+// appDistribution().X(...);
+// firebase.appDistribution().X(...);
+export const firebase =
+  getFirebaseRoot() as unknown as ReactNativeFirebase.FirebaseNamespacedExport<
+    'appDistribution',
+    FirebaseAppDistributionTypes.Module,
+    FirebaseAppDistributionTypes.Statics,
+    false
+  >;

--- a/packages/ml/lib/namespaced.ts
+++ b/packages/ml/lib/namespaced.ts
@@ -62,7 +62,10 @@ export default defaultExport;
 // import ml, { firebase } from '@react-native-firebase/ml';
 // ml().X(...);
 // firebase.ml().X(...);
-export const firebase = getFirebaseRoot() as unknown as ReactNativeFirebase.Module & {
-  ml: typeof defaultExport;
-  app(name?: string): ReactNativeFirebase.FirebaseApp & { ml(): FirebaseMLTypes.Module };
-};
+export const firebase =
+  getFirebaseRoot() as unknown as ReactNativeFirebase.FirebaseNamespacedExport<
+    'ml',
+    FirebaseMLTypes.Module,
+    FirebaseMLTypes.Statics,
+    false
+  >;

--- a/packages/ml/lib/namespaced.ts
+++ b/packages/ml/lib/namespaced.ts
@@ -67,5 +67,5 @@ export const firebase =
     'ml',
     FirebaseMLTypes.Module,
     FirebaseMLTypes.Statics,
-    false
+    true
   >;


### PR DESCRIPTION

### Description

Use FirebaseNamespacedExport instead of the manual Module intersection type.

This was noticed as an inconsistency in these two packages during migration debt analysis

Small refactor to align them with what I believe is best practice

### Related issues

- #8584 

### Release Summary

Minor refactor, should have no effect.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

types tests still pass

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
