### PR TITLE
chore(messaging)!: deprecate permissions APIs, use react-native-permissions or expo-notifications

### DIFF
--- a/docs/messaging/ios-permissions.mdx
+++ b/docs/messaging/ios-permissions.mdx
@@ -5,6 +5,8 @@ next: /messaging/notifications
 previous: /messaging/usage/ios-setup
 ---
 
+> **Deprecated:** Notification permission APIs (`requestPermission`, `hasPermission`, `AuthorizationStatus`, and `IOSPermissions`) in `@react-native-firebase/messaging` are deprecated and will be removed in a future major release. Use [react-native-permissions](https://github.com/zoontek/react-native-permissions) or [expo-notifications](https://docs.expo.dev/versions/latest/sdk/notifications/) for notification permission requests on iOS and Android instead. See [issue #6283](https://github.com/invertase/react-native-firebase/issues/6283).
+
 ## Understanding permissions
 
 Before diving into requesting notification permissions from your users, it is important to understand how iOS handles permissions.

--- a/docs/messaging/usage/index.mdx
+++ b/docs/messaging/usage/index.mdx
@@ -88,6 +88,8 @@ The module also provides basic support for displaying local notifications, to le
 
 ## iOS - Requesting permissions
 
+> **Deprecated:** `requestPermission`, `hasPermission`, and `AuthorizationStatus` are deprecated. Use [react-native-permissions](https://github.com/zoontek/react-native-permissions) or [expo-notifications](https://docs.expo.dev/versions/latest/sdk/notifications/) instead. See [issue #6283](https://github.com/invertase/react-native-firebase/issues/6283).
+
 iOS prevents messages containing notification (or 'alert') payloads from being displayed unless you have received explicit permission from the user.
 
 > To learn more about local notifications, view the [Notifications](/messaging/notifications) documentation.
@@ -114,7 +116,9 @@ application. To learn more, view the advanced [iOS Permissions](/messaging/ios-p
 
 ## Android - Requesting permissions
 
-On Android API level 32 and below, you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For API level 33+ you will need to request the permission manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions`
+> **Deprecated:** `requestPermission` and `hasPermission` are deprecated no-ops on Android API level 32 and below. Use [react-native-permissions](https://github.com/zoontek/react-native-permissions) or [expo-notifications](https://docs.expo.dev/versions/latest/sdk/notifications/) for notification permission requests on API level 33+. See [issue #6283](https://github.com/invertase/react-native-firebase/issues/6283).
+
+On Android API level 32 and below, you do not need to request user permission. This method can still be called on Android devices; however, and will always resolve successfully. For API level 33+ you will need to request the permission manually using either the built-in react-native `PermissionsAndroid` APIs or a related module such as `react-native-permissions` or `expo-notifications`
 
 ```
   import {PermissionsAndroid} from 'react-native';

--- a/packages/messaging/lib/modular.ts
+++ b/packages/messaging/lib/modular.ts
@@ -120,6 +120,10 @@ export function onTokenRefresh(messaging: Messaging, listener: (token: string) =
  * @param messaging - Messaging instance.
  * @param iosPermissions - All the available permissions for iOS that can be requested.
  * @returns Promise that resolves with the authorization status.
+ * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+ * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+ * requests instead. These APIs will be removed in a future major release.
+ * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
  */
 export function requestPermission(
   messaging: Messaging,
@@ -257,6 +261,10 @@ export function setAPNSToken(messaging: Messaging, token: string, type?: string)
  * Returns a `AuthorizationStatus` as to whether the user has messaging permission for this app.
  * @param messaging - Messaging instance.
  * @returns Promise that resolves with the authorization status.
+ * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+ * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+ * requests instead. These APIs will be removed in a future major release.
+ * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
  */
 export function hasPermission(messaging: Messaging): Promise<AuthorizationStatus> {
   // @ts-ignore - MODULAR_DEPRECATION_ARG is used internally

--- a/packages/messaging/lib/namespaced.ts
+++ b/packages/messaging/lib/namespaced.ts
@@ -257,6 +257,10 @@ class FirebaseMessagingModule extends FirebaseModule implements Messaging {
 
   /**
    * @platform ios
+   * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+   * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+   * requests instead. These APIs will be removed in a future major release.
+   * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
    */
   requestPermission(permissions?: IOSPermissions): Promise<AuthorizationStatusType> {
     if (isAndroid) {
@@ -360,6 +364,12 @@ class FirebaseMessagingModule extends FirebaseModule implements Messaging {
     return this.native.setAPNSToken(token, type);
   }
 
+  /**
+   * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+   * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+   * requests instead. These APIs will be removed in a future major release.
+   * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
+   */
   hasPermission(): Promise<AuthorizationStatusType> {
     return this.native.hasPermission();
   }

--- a/packages/messaging/lib/statics.ts
+++ b/packages/messaging/lib/statics.ts
@@ -1,6 +1,13 @@
 // shared between namespaced and modular API
 
-// Export as objects for runtime use (matching the old statics.js pattern)
+/**
+ * Authorization status values returned by the deprecated permission APIs.
+ *
+ * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+ * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+ * requests instead. These APIs will be removed in a future major release.
+ * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
+ */
 export const AuthorizationStatus = {
   NOT_DETERMINED: -1,
   DENIED: 0,

--- a/packages/messaging/lib/types/messaging.ts
+++ b/packages/messaging/lib/types/messaging.ts
@@ -380,6 +380,11 @@ export type NotificationAndroidVisibility =
 /**
  * An interface representing all the available permissions that can be requested by your app via
  * the `requestPermission` API.
+ *
+ * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+ * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+ * requests instead. These APIs will be removed in a future major release.
+ * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
  */
 export interface IOSPermissions {
   /**
@@ -444,6 +449,11 @@ export interface IOSPermissions {
  *
  * Value is truthy if authorized, compare against an exact status (e.g. iOS PROVISIONAL) for a more
  * granular status.
+ *
+ * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+ * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+ * requests instead. These APIs will be removed in a future major release.
+ * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
  */
 export type AuthorizationStatus =
   | -1 // NOT_DETERMINED - The app user has not yet chosen whether to allow the application to create notifications. Usually this status is returned prior to the first call of `requestPermission`. @platform ios iOS
@@ -560,6 +570,11 @@ export interface Messaging extends ReactNativeFirebase.FirebaseModule {
    * be received or sent.
    *
    * > You can safely call this method on Android without platform checks. It's a no-op on Android and will promise resolve `AuthorizationStatus.AUTHORIZED`.
+   *
+   * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+   * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+   * requests instead. These APIs will be removed in a future major release.
+   * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
    */
   requestPermission(permissions?: IOSPermissions): Promise<AuthorizationStatus>;
 
@@ -618,6 +633,11 @@ export interface Messaging extends ReactNativeFirebase.FirebaseModule {
 
   /**
    * Returns a `AuthorizationStatus` as to whether the user has messaging permission for this app.
+   *
+   * @deprecated Use {@link https://github.com/zoontek/react-native-permissions react-native-permissions} or
+   * {@link https://docs.expo.dev/versions/latest/sdk/notifications/ expo-notifications} for notification permission
+   * requests instead. These APIs will be removed in a future major release.
+   * See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}.
    */
   hasPermission(): Promise<AuthorizationStatus>;
 
@@ -715,6 +735,7 @@ export interface Messaging extends ReactNativeFirebase.FirebaseModule {
 
 export interface Statics {
   SDK_VERSION: string;
+  /** @deprecated See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}. */
   AuthorizationStatus: typeof AuthorizationStatusConst;
   NotificationAndroidPriority: typeof NotificationAndroidPriorityConst;
   NotificationAndroidVisibility: typeof NotificationAndroidVisibilityConst;
@@ -765,7 +786,9 @@ export namespace FirebaseMessagingTypes {
   export type NotificationIOSCriticalSound = _NotificationIOSCriticalSound;
   export type NotificationAndroidPriority = _NotificationAndroidPriority;
   export type NotificationAndroidVisibility = _NotificationAndroidVisibility;
+  /** @deprecated See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}. */
   export type IOSPermissions = _IOSPermissions;
+  /** @deprecated See {@link https://github.com/invertase/react-native-firebase/issues/6283 #6283}. */
   export type AuthorizationStatus = _AuthorizationStatus;
   export type SendErrorEvent = _SendErrorEvent;
 }


### PR DESCRIPTION


### Description

Deprecate permissions-related APIs, they are not firebase-specific and other packages handle them much more completely (expo-notifications for Expo users, and react-native-permissions for CLI)

It is a documentation change and adding `@deprecation` to APIs.

### Related issues

- Fixes #6283

### Release Summary

This commit is marked as a breaking change since it introduces a deprecation - those can be done any time but I wanted it to show up brightly in the release notes

It will be batched with the next / coming shortly release off main which is breaking for other reasons

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] Yes
  - [ ] No



### Test Plan

yarn targets lint:spellcheck lint:markdown lint and reference:api all pass

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
