### PR TITLE
chore: fix issue labeler and restrict workflow token permissions

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -19,6 +19,10 @@ on:
       - '.spellcheck.dict.txt'
       - '**/*.md'
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/issue-labels.yaml
+++ b/.github/workflows/issue-labels.yaml
@@ -4,48 +4,61 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  issues: write
+
 jobs:
   label-op-response:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if the comment is from the OP
+      - name: Check if the comment is from the issue author
         id: check-op
-        run: |
-          OP=${{ github.event.issue.user.login }}
-          COMMENTER=${{ github.event.comment.user.login }}
-
-          if [ "$OP" = "$COMMENTER" ]; then
-            echo "op_comment=true" >> $GITHUB_ENV
-          else
-            echo "op_comment=false" >> $GITHUB_ENV
-          fi
-
-      - name: Add 'Needs Attention' label if OP responded and it was open
-        if: env.op_comment == 'true' && github.event.issue.state == 'open'
-        # https://github.com/actions-ecosystem/action-add-labels/releases
-        uses: actions-ecosystem/action-add-labels@bd52874380e3909a1ac983768df6976535ece7d8 # v1.1.0
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
-          labels: 'Needs Attention'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          script: |
+            const isOpComment =
+              context.payload.comment.user.login ===
+              context.payload.issue.user.login;
+            core.setOutput('op_comment', isOpComment ? 'true' : 'false');
 
-      - name: Remove 'blocked customer-response' label if OP responded and it was open
-        if: env.op_comment == 'true' && github.event.issue.state == 'open'
-        # https://github.com/actions-ecosystem/action-remove-labels/releases
-        uses: actions-ecosystem/action-remove-labels@f5dccab59b9ed79c1a5ddd2ab6d8771449b0250f # v1.3.0
+      - name: Update labels when the issue author responded on an open item
+        if: steps.check-op.outputs.op_comment == 'true' && github.event.issue.state == 'open'
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
-          labels: 'blocked: customer-response'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          script: |
+            const issueNumber = context.payload.issue.number;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: ['Needs Attention'],
+            });
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                name: 'blocked: customer-response',
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
 
-      - name: Add comment if OP responded but issue was closed
-        if: env.op_comment == 'true' && github.event.issue.state == 'closed'
-        # https://github.com/actions-ecosystem/action-create-comment/releases
-        uses: actions-ecosystem/action-create-comment@5b43c092bf96ebc715dbbe5682ecf3b771223855 # v1.0.0
+      - name: Comment when the issue author responded on a closed item
+        if: steps.check-op.outputs.op_comment == 'true' && github.event.issue.state == 'closed'
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
-          body: |
-            In order to prioritize work in this repository, closed issues and pull requests do not regularly receive attention.
-
-            If the underlying issue or pull request still requires attention, opening a new issue with a reproduction
-            after testing with current versions, or reposting the pull request as a new PR may be the most effective way forward.
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: [
+                'In order to prioritize work in this repository, closed issues and pull requests do not regularly receive attention.',
+                '',
+                'If the underlying issue or pull request still requires attention, opening a new issue with a reproduction',
+                'after testing with current versions, or reposting the pull request as a new PR may be the most effective way forward.',
+              ].join('\n'),
+            });

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,10 @@ on:
       - main
       - release-v*
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/rnfb-js-sdk-comparison.yml
+++ b/.github/workflows/rnfb-js-sdk-comparison.yml
@@ -20,6 +20,10 @@ on:
       - '.spellcheck.dict.txt'
       - '**/*.md'
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,12 +5,10 @@ on:
   schedule:
     - cron: 35 * * * *
 permissions:
-  contents: read
+  issues: write
+  pull-requests: write
 jobs:
   stale:
-    permissions:
-      issues: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/stale/releases
@@ -20,7 +18,9 @@ jobs:
           stale-issue-message: |
             Hello 👋, to help manage issues we automatically close stale issues.
 
-            This issue has been automatically marked as stale because it has not had activity for quite some time.Has this issue been fixed, or does it still require attention?
+            This issue has been automatically marked as stale because it has not had activity for quite some time.
+
+            Has this issue been fixed, or does it still require attention?
 
             > This issue will be closed in 15 days if no further activity occurs.
 

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -27,6 +27,10 @@ on:
       - '.spellcheck.dict.txt'
       - '**/*.md'
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -27,6 +27,10 @@ on:
       - '.spellcheck.dict.txt'
       - '**/*.md'
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -27,6 +27,10 @@ on:
       - '.spellcheck.dict.txt'
       - '**/*.md'
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -19,6 +19,10 @@ on:
       - '.spellcheck.dict.txt'
       - '**/*.md'
 
+permissions:
+  contents: read
+  actions: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Two CI hygiene problems on `main`:

1. **Issue labeler broken** — `issue-labels.yaml` pinned `actions-ecosystem/action-add-labels` to a non-existent SHA (typo in commit `8e53fa6b3`), so every run failed at action download since 2026-06-18. The `actions-ecosystem` actions are also unmaintained.
2. **Over-broad default token** — Most workflows inherited the org default `GITHUB_TOKEN` scope instead of declaring minimal permissions.

**Decisions:** Replace the three ecosystem actions with `github-script` and the default token (`issues: write` only); drop the admin `GH_TOKEN` dependency for this workflow. Add explicit minimal permissions per workflow (`contents: read` + `actions: write` where cache/artifacts are used). Fix a stale-bot message typo while touching `stale.yml`.

**Remediation:** Audited all failed labeler runs; only one had a missed action (closed-item comment on #8914), already posted manually.

## Test plan

- [ ] CI green on this PR
- [ ] Observe labeler behavior on real issue/PR comments over the next few days (OP reply on open → `Needs Attention` / remove `blocked: customer-response`; OP reply on closed → standard bot comment)
