### PR TITLE
test: fix native coverage upload (again), and fail codecov if native upload fails

### DIFF
--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -273,9 +273,20 @@ jobs:
             yarn tests:android:post-e2e-coverage
 
       # https://github.com/codecov/codecov-action/releases
-      - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+      - name: Upload Codecov e2e TS (Android)
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         continue-on-error: true
         with:
+          files: coverage/lcov.info
+          flags: e2e-ts-android
+          verbose: true
+
+      - name: Upload Codecov Android native
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        continue-on-error: true
+        with:
+          files: tests/android/app/build/reports/jacoco/jacocoAndroidTestReport/jacocoAndroidTestReport.xml
+          flags: android-native
           verbose: true
 
       - name: Upload Emulator Log

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -420,10 +420,22 @@ jobs:
           path: .github/workflows/scripts/*.log
 
       # https://github.com/codecov/codecov-action/releases
-      - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+      - name: Upload Codecov e2e TS (iOS)
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         if: contains(matrix.buildmode, 'debug')
         continue-on-error: true
         with:
+          files: coverage/lcov.info
+          flags: e2e-ts-ios
+          verbose: true
+
+      - name: Upload Codecov iOS native
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        if: contains(matrix.buildmode, 'debug')
+        continue-on-error: true
+        with:
+          files: coverage/ios-native/lcov.info
+          flags: ios-native
           verbose: true
 
       - name: Yarn Cache Save

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -281,6 +281,8 @@ jobs:
       - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         continue-on-error: true
         with:
+          files: coverage/lcov.info
+          flags: e2e-ts-macos
           verbose: true
 
       - name: Stop Screen Recording and System Logging

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -65,6 +65,8 @@ jobs:
       # https://github.com/codecov/codecov-action/releases
       - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
+          files: coverage/lcov.info
+          flags: jest
           verbose: true
       # https://github.com/actions/cache/releases
       - uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch
+++ b/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch
@@ -102,6 +102,31 @@ index d6db5d5d7a4173eae88d97bf06eaeaf8b38c3b94..a85ebdf5a30607459be68463b3238b6f
      }
  
      override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
+diff --git a/src/devices/common/drivers/android/exec/ADB.js b/src/devices/common/drivers/android/exec/ADB.js
+index 3954219065ca5ac7c3ea81cb801b37ae5b5ff2d1..a10727b16240a91ad382d08284b6c8cfe5dbf8e2 100644
+--- a/src/devices/common/drivers/android/exec/ADB.js
++++ b/src/devices/common/drivers/android/exec/ADB.js
+@@ -380,7 +380,19 @@ class ADB {
+   }
+ 
+   async reverseRemove(deviceId, port) {
+-    return this.adbCmd(deviceId, `reverse --remove tcp:${port}`);
++    try {
++      return await this.adbCmd(deviceId, `reverse --remove tcp:${port}`);
++    } catch (error) {
++      const details = `${error.stderr || ''} ${error.message || ''}`;
++      if (/listener .* not found/i.test(details)) {
++        log.warn(
++          { deviceId, port },
++          'Ignoring missing adb reverse listener during Detox teardown',
++        );
++        return;
++      }
++      throw error;
++    }
+   }
+ 
+   async emuKill(deviceId) {
 diff --git a/src/server/handlers/AnonymousConnectionHandler.js b/src/server/handlers/AnonymousConnectionHandler.js
 index 10743c87d17de135317e1bac3e65159b9872412f..abbb302307fbd5eabbbff875983f284a4bb9e738 100644
 --- a/src/server/handlers/AnonymousConnectionHandler.js
@@ -146,28 +171,28 @@ index 10743c87d17de135317e1bac3e65159b9872412f..abbb302307fbd5eabbbff875983f284a
    }
  }
  
-diff --git a/src/devices/common/drivers/android/exec/ADB.js b/src/devices/common/drivers/android/exec/ADB.js
-index 1111111111111111111111111111111111111111..2222222222222222222222222222222222222222 100644
---- a/src/devices/common/drivers/android/exec/ADB.js
-+++ b/src/devices/common/drivers/android/exec/ADB.js
-@@ -379,7 +379,19 @@ class ADB {
-   }
+diff --git a/src/utils/ExclusiveLockfile.js b/src/utils/ExclusiveLockfile.js
+index da29ae99c8b90877f15715cdeb692ed8a2b47569..f53f49bca03b3acca4c4d8b05d087a8c1b601815 100644
+--- a/src/utils/ExclusiveLockfile.js
++++ b/src/utils/ExclusiveLockfile.js
+@@ -6,6 +6,9 @@ const DetoxRuntimeError = require('../errors/DetoxRuntimeError');
  
-   async reverseRemove(deviceId, port) {
--    return this.adbCmd(deviceId, `reverse --remove tcp:${port}`);
-+    try {
-+      return await this.adbCmd(deviceId, `reverse --remove tcp:${port}`);
-+    } catch (error) {
-+      const details = `${error.stderr || ''} ${error.message || ''}`;
-+      if (/listener .* not found/i.test(details)) {
-+        log.warn(
-+          { deviceId, port },
-+          'Ignoring missing adb reverse listener during Detox teardown',
-+        );
-+        return;
-+      }
-+      throw error;
-+    }
-   }
+ const retry = require('./retry');
  
-   async emuKill(deviceId) {
++// proper-lockfile default stale is 10s; CI runners under load can miss lock heartbeats → ECOMPROMISED.
++const DEVICE_REGISTRY_LOCK_STALE_MS = 20000;
++
+ const DEFAULT_OPTIONS = {
+   retry: { retries: 10000, interval: 5 },
+   read: { encoding: 'utf8' },
+@@ -107,7 +110,9 @@ class ExclusiveLockfile {
+     this._ensureFileExists();
+ 
+     await retry(this._options.retry, () => {
+-      const operationResult = plockfile.lockSync(this._lockFilePath);
++      const operationResult = plockfile.lockSync(this._lockFilePath, {
++        stale: DEVICE_REGISTRY_LOCK_STALE_MS,
++      });
+ 
+       this._isLocked = true;
+       this._invalidate();

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,27 @@ coverage:
     changes: no
 
 comment:
-  layout: 'header, diff'
+  layout: 'header, diff, flags'
   behavior: default
   require_changes: false
   after_n_builds: 3
+
+# Native upload gates. Flag names must match codecov-action `flags:` in CI workflows
+# (see okf-bundle/testing/coverage-design.md).
+flag_management:
+  individual_flags:
+    - name: ios-native
+      carryforward: false
+      statuses:
+        - type: project
+          target: 1%
+          threshold: 0%
+          informational: false
+
+    - name: android-native
+      carryforward: false
+      statuses:
+        - type: project
+          target: 1%
+          threshold: 0%
+          informational: false

--- a/okf-bundle/ci-workflows/android.md
+++ b/okf-bundle/ci-workflows/android.md
@@ -6,7 +6,7 @@
 2. `yarn tests:android:post-e2e-coverage` — poll/pull `coverage.ec`, Jacoco report (best-effort, never fails the job)
 3. Codecov upload — `continue-on-error: true`
 
-Native Android coverage is **not** pulled inside `tests/e2e/firebase.test.js`. Pulling mid-Detox ran before `DetoxTest.dumpCoverageData()` and routinely missed the file.
+Native Android coverage is **not** pulled inside `tests/e2e/firebase.test.js`. The Jet `after` hook in `tests/app.js` calls `RNFBTestingCoverage.flush()` in the **app process** to write `coverage.ec` before Detox SIGINTs instrumentation. Post-e2e pull runs after Detox exits.
 
 ## CI failure: Jet 1006 → adb `reverse --remove` mid-run
 
@@ -40,7 +40,7 @@ When the Jet/app WebSocket drops (1006), Detox can treat the session as dead and
 
 | Symptom | Likely cause |
 |---------|----------------|
-| `[native-coverage] Android native coverage pull failed` | Detox exited before instrumentation wrote `coverage.ec`; post-e2e poll may still recover it |
+| `[native-coverage] Android native coverage file not found after N attempts` | App-process flush did not run or failed; check Jet log for `[native-coverage] flushing android coverage` |
 | Empty Jacoco XML (~235 bytes) | No `.ec` pulled — check post-e2e logs |
 | `adb reverse --remove` in Detox logs | Expected on 1006; should be warn-only after Detox patch |
 | Detox red, tests green in log | Pre-patch: teardown adb error; re-run or check patch applied |

--- a/okf-bundle/ci-workflows/android.md
+++ b/okf-bundle/ci-workflows/android.md
@@ -32,7 +32,13 @@ Observed on [run 27803881448](https://github.com/invertase/react-native-firebase
 
 When the Jet/app WebSocket drops (1006), Detox can treat the session as dead and tear down instrumentation **while Jet is still in its 15s reconnect grace**. That triggers `reverseRemove` before the orchestration retry's `terminateApp()`. If the listener was never established or was already removed, adb exits non-zero.
 
-**Mitigation (patched):** `.yarn/patches/detox-npm-20.51.0-*.patch` makes `ADB.reverseRemove` ignore `listener 'tcp:…' not found` during teardown.
+**Mitigation (patched):** `.yarn/patches/detox-npm-20.51.0-*.patch`:
+
+- `ADB.reverseRemove` — ignore `listener 'tcp:…' not found` during teardown (below)
+- Android idling resources — force idle (network/timers/Fabric)
+- `ExclusiveLockfile.js` — 2× lock stale for `ECOMPROMISED` flake ([detox-patches.md](detox-patches.md))
+
+Full inventory: [detox-patches.md](detox-patches.md).
 
 **Orchestration retry:** `firebase.test.js` still retries on `RETRYABLE_DISCONNECT`; attempt 2 can pass all tests even when attempt 1's teardown logged adb noise.
 

--- a/okf-bundle/ci-workflows/android.md
+++ b/okf-bundle/ci-workflows/android.md
@@ -4,7 +4,7 @@
 
 1. `yarn tests:android:test-cover --headless` — Detox + Jet (pass/fail gate)
 2. `yarn tests:android:post-e2e-coverage` — poll/pull `coverage.ec`, Jacoco report (best-effort, never fails the job)
-3. Codecov upload — `continue-on-error: true`
+3. **Codecov upload** — two flagged uploads (`e2e-ts-android`, `android-native`); `continue-on-error: true` on the action steps. **`codecov/project/android-native`** fails if the native flag upload is missing (see [coverage design](../testing/coverage-design.md#native-upload-gates)).
 
 Native Android coverage is **not** pulled inside `tests/e2e/firebase.test.js`. The Jet `after` hook in `tests/app.js` calls `RNFBTestingCoverage.flush()` in the **app process** to write `coverage.ec` before Detox SIGINTs instrumentation. Post-e2e pull runs after Detox exits.
 
@@ -50,3 +50,4 @@ Full inventory: [detox-patches.md](detox-patches.md).
 | Empty Jacoco XML (~235 bytes) | No `.ec` pulled — check post-e2e logs |
 | `adb reverse --remove` in Detox logs | Expected on 1006; should be warn-only after Detox patch |
 | Detox red, tests green in log | Pre-patch: teardown adb error; re-run or check patch applied |
+| `codecov/project/android-native` fail | Jacoco XML not uploaded — check post-e2e logs and Codecov Uploads tab for `android-native` flag |

--- a/okf-bundle/ci-workflows/detox-patches.md
+++ b/okf-bundle/ci-workflows/detox-patches.md
@@ -1,0 +1,103 @@
+# Detox yarn patches
+
+E2E runs on **Detox 20.51.0** (`tests/package.json`), applied via Yarn Berry patch:
+
+`.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch`
+
+Patches are maintained in-repo (including by agents). Prefer **editing the patch file directly** or the headless workflow below — `yarn patch-commit` can prompt for overwrite confirmation, which fails in non-interactive shells.
+
+## Inventory
+
+| Change | File(s) | Platforms | Problem |
+|--------|---------|-----------|---------|
+| Disable network idling | `NetworkIdlingResource.kt` | Android | OkHttp never idle in RN Firebase tests → Detox sync timeout |
+| Disable timers idling | `TimersIdlingResource.kt` | Android | RN timer queue never drains → infinite idle wait |
+| Disable Fabric UI idling | `FabricUIManagerIdlingResources.kt` | Android | Stuck mount items on API 36+ / edge-to-edge → false busy |
+| Buffer early `ready` | `AnonymousConnectionHandler.js` | iOS | App sends `ready` before Detox login → `launchApp` stuck |
+| Ignore missing adb reverse on teardown | `ADB.js` | Android | Jet WS 1006 triggers mid-run `reverse --remove` → adb exit 1 |
+| **2× device-registry lock stale** | `ExclusiveLockfile.js` | iOS, macOS, Android | `proper-lockfile` `ECOMPROMISED` before tests start |
+
+Related non-Detox patches: `jet`, `mocha-remote-client`, `mocha-remote-server` (coverage over WebSocket) — see [coverage design](../testing/coverage-design.md).
+
+## Device registry lock (`ECOMPROMISED`)
+
+### Symptom
+
+Detox Test step fails **before any test output**, often ~30–60s after `yarn tests:ios:test:release` starts:
+
+```
+Error: Unable to update lock within the stale threshold
+  at .../proper-lockfile/lib/lockfile.js:109
+  code: 'ECOMPROMISED'
+```
+
+Build, pre-boot, and app install usually succeed. Codecov and coverage steps are skipped because Jest never starts.
+
+### Cause
+
+Detox serializes access to `~/Library/Detox/device.registry.json` (the **device allocation ledger**: which simulators/emulators are busy, session IDs, PIDs). It uses `proper-lockfile`, which refreshes the lock file mtime on a timer (default **stale = 10s**). If the runner is under load — simulator logging, Firestore emulator, `yeetd`, Xcode build cache — a heartbeat can miss that window and Detox throws `ECOMPROMISED`.
+
+This is a known Detox / CI flake ([Detox #4210](https://github.com/wix/Detox/issues/4210)). Community reports ~1-in-25 on busy macOS CI.
+
+### Mitigation (this repo)
+
+**Patch** `ExclusiveLockfile.js` to pass `{ stale: 20000 }` (2× default) into `plockfile.lockSync` when locking the device registry.
+
+We **do not** run `detox reset-lock-file` in CI. That command wipes `device.registry.json` — useful for local recovery, but it destroys Detox's ledger state and can mask concurrent-session bugs. Extending the stale window preserves the ledger while tolerating slow heartbeats.
+
+Other prerequisites already in place:
+
+- `maxWorkers: 1` in `tests/e2e/jest.config.js` (multi-worker lock contention is a common trigger)
+- Pre-boot simulator before Detox (orthogonal; fixes boot/migration, not lock heartbeats)
+
+### Diagnosing
+
+| Pattern | Meaning |
+|---------|---------|
+| Failure in first minute, no Jest/Detox test lines | Startup lock failure (this issue) |
+| `proper-lockfile` + `ECOMPROMISED` in Detox step log | Confirms lock heartbeat, not test logic |
+| Release fails, debug passes (or vice versa) | Timing/load flake; same root cause |
+| Orphan `node` in job cleanup | Stuck Detox/Jest from lock abort |
+
+```bash
+rg 'ECOMPROMISED|proper-lockfile|Unable to update lock' detox-step.log
+```
+
+### When to bump further
+
+If `ECOMPROMISED` persists after 20s, consider 30s in the patch (MetaMask used 20s on Bitrise). Re-evaluate when migrating off Detox to Appium.
+
+## Updating a Detox patch (headless)
+
+**Do not** `rsync` the whole `node_modules/detox` tree into a patch folder — that pulls in frameworks and multi‑MB artifacts.
+
+1. Edit the patched file under `tests/node_modules/detox/...` (after `yarn install`), **or** append a correct unified-diff hunk to `.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch`.
+2. Regenerate the patch file without prompts:
+
+```bash
+PATCH_DIR=$(yarn patch detox@npm:20.51.0 2>&1 | sed -n 's/.*folder: //p')
+SRC=tests/node_modules/detox
+
+# Copy ONLY the files this patch touches (see inventory table above)
+/bin/cp -f "$SRC/src/utils/ExclusiveLockfile.js" "$PATCH_DIR/src/utils/ExclusiveLockfile.js"
+/bin/cp -f "$SRC/src/server/handlers/AnonymousConnectionHandler.js" "$PATCH_DIR/src/server/handlers/AnonymousConnectionHandler.js"
+/bin/cp -f "$SRC/src/devices/common/drivers/android/exec/ADB.js" "$PATCH_DIR/src/devices/common/drivers/android/exec/ADB.js"
+/bin/cp -f "$SRC/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/NetworkIdlingResource.kt" \
+  "$PATCH_DIR/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/network/NetworkIdlingResource.kt"
+/bin/cp -f "$SRC/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt" \
+  "$PATCH_DIR/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/timers/TimersIdlingResource.kt"
+/bin/cp -f "$SRC/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/uimodule/fabric/FabricUIManagerIdlingResources.kt" \
+  "$PATCH_DIR/android/detox/src/full/java/com/wix/detox/reactnative/idlingresources/uimodule/fabric/FabricUIManagerIdlingResources.kt"
+
+yarn patch-commit -s "$PATCH_DIR"   # non-interactive when using /bin/cp -f, not plain cp
+```
+
+3. `yarn install` from repo root and confirm the change in `tests/node_modules/detox/...`.
+4. Update this doc and platform pages (`ios.md`, `android.md`) if behaviour or file list changes.
+
+**Detox version bump:** change `tests/package.json`, run `yarn`, re-apply all hunks (or redo the headless flow from a fresh `yarn patch`), run iOS + Android E2E.
+
+## Platform docs
+
+- [iOS](ios.md) — simulator boot, early-ready, Jet WS, lock flake sentinels
+- [Android](android.md) — idling resources, adb reverse teardown

--- a/okf-bundle/ci-workflows/index.md
+++ b/okf-bundle/ci-workflows/index.md
@@ -14,4 +14,4 @@ Knowledge for GitHub Actions workflows in this repository: how jobs are structur
 
 ## Related
 
-* [Testing / coverage design](../testing/coverage-design.md) — e2e coverage collection that runs inside the iOS workflow
+* [Testing / coverage design](../testing/coverage-design.md) — e2e coverage collection, Codecov flags, and upload gates

--- a/okf-bundle/ci-workflows/index.md
+++ b/okf-bundle/ci-workflows/index.md
@@ -5,8 +5,12 @@ Knowledge for GitHub Actions workflows in this repository: how jobs are structur
 ## Platforms
 
 * [iOS](ios.md) — simulator boot reliability, logging, and troubleshooting
-* [Android](android.md) — TBD
+* [Android](android.md) — idling resources, adb teardown, native coverage pull
 * [Other](other.md) — macOS Detox (non-iOS), Windows, and shared workflow concerns — TBD
+
+## Shared E2E dependencies
+
+* [Detox yarn patches](detox-patches.md) — inventory, `ECOMPROMISED` lock flake, headless patch update workflow
 
 ## Related
 

--- a/okf-bundle/ci-workflows/ios.md
+++ b/okf-bundle/ci-workflows/ios.md
@@ -85,6 +85,10 @@ A long gap with only `com.apple.datamigrator` activity and no `com.invertase.tes
 
 Device type is defined in `tests/.detoxrc.js` (`devices.simulator.device.type`). The boot script and Detox both use this name. CI does not hard-code a UDID.
 
+### Codecov (debug matrix only)
+
+After Detox, the debug leg runs `yarn tests:ios:test:process-coverage` then two flagged Codecov uploads (`e2e-ts-ios`, `ios-native`). **`codecov/project/ios-native`** blocks if the native flag upload is missing. Release legs skip coverage. Details: [coverage design](../testing/coverage-design.md#codecov-uploads-ci).
+
 ### E2E test app orchestration (Detox + Jet)
 
 After pre-boot succeeds, failures often move **inside** the test app process (`com.invertase.testing`, binary `testing`). Simulator boot and app install are fine; Detox `launchApp` stalls while the app stays alive. Several overlapping issues show up in CI logs.
@@ -205,7 +209,8 @@ rg 'testing\[' simulator.log | rg -i 'FIRApp|RNFB|RCTBridge|configure'
 | Pattern | Meaning |
 |---------|---------|
 | `ready action too early` in Detox step only | Early-ready race (patch should fix; check patch applied in `yarn install`) |
-| `ECOMPROMISED` / `Unable to update lock within the stale threshold` | Device registry lock heartbeat missed — see [detox-patches.md](detox-patches.md); check `ExclusiveLockfile.js` patch |
+| `ECOMPROMISED` / `Unable to update lock within the stale threshold` | Device registry lock heartbeat missed — see [detox-patches.md](detox-patches.md) |
+| `codecov/project/ios-native` fail | Native lcov not uploaded — check process-coverage step and Codecov Uploads tab for `ios-native` flag |
 | `waitForActive` without `waitForActiveDone` | Scene/active hang (issue 4) **or** Metro/JS load failure (issue 5) — check `[rnfb-lifecycle]` probes |
 | `probe+30s` / `probe+60s` with `UIApplication.state=inactive` or scene `unattached` | App never became foreground-active (issue 4); compare with SpringBoard `foreground-interactive` lines |
 | `probe+30s` / `probe+60s` with `active` / `foregroundActive` but no `waitForActiveDone` | Metro/JS bundle failure despite active UIKit (issue 5); check `RCTJavaScriptDidFailToLoad` and `packager-status-fetch` |

--- a/okf-bundle/ci-workflows/ios.md
+++ b/okf-bundle/ci-workflows/ios.md
@@ -100,9 +100,24 @@ ws-server The app has dispatched "ready" action too early.
 
 **Cause** — iOS `DetoxManager` sends proactive `ready` on `webSocketDidConnect` before the anonymous server handles `login`. Detox 20.x logs and drops that `ready`, leaving `device.launchApp()` stuck in `waitUntilReady`.
 
-**Mitigation** — `.yarn/patches/detox-npm-20.51.0-*.patch` buffers early `ready` and replays it after app `login` (`AnonymousConnectionHandler.js`).
+**Mitigation** — `.yarn/patches/detox-npm-20.51.0-*.patch` buffers early `ready` and replays it after app `login` (`AnonymousConnectionHandler.js`). Full patch list: [detox-patches.md](detox-patches.md).
 
-#### 2. Main-thread delay before WebSocket handshake
+#### 2. Device registry lock (`ECOMPROMISED`)
+
+**Detox step symptom** — failure before any test output, often within the first minute of `Detox Test Debug` / `Detox Test Release`:
+
+```
+Error: Unable to update lock within the stale threshold
+  code: 'ECOMPROMISED'
+```
+
+**Cause** — Detox locks `~/Library/Detox/device.registry.json` (device busy/available ledger) via `proper-lockfile`. Default stale window is 10s; under CI load (simulator logging, Firestore emulator, `yeetd`) lock heartbeats can miss it ([Detox #4210](https://github.com/wix/Detox/issues/4210)).
+
+**Mitigation** — same Detox patch doubles stale to 20s in `ExclusiveLockfile.js`. We do **not** use `detox reset-lock-file` in CI (wipes the ledger). See [detox-patches.md](detox-patches.md#device-registry-lock-ecompromised).
+
+**Sentinel** — `proper-lockfile` + `ECOMPROMISED` in the Detox step log; build and Pre-Boot steps green.
+
+#### 3. Main-thread delay before WebSocket handshake
 
 **Symptom** — Long gap (~30–60s) between `device com.invertase.testing launched` (Detox step log) and the first `Connection 1: ready` / `handshake successful` lines in `simulator.log`. Firebase configure, RN bridge startup, and LLVM coverage instrumentation run on the main thread and can defer Detox’s `URLSessionWebSocketDelegate` callbacks.
 
@@ -116,17 +131,17 @@ ws-server The app has dispatched "ready" action too early.
 | `detoxEnableSynchronization: 'NO'` at launch | `tests/e2e/firebase.test.js` |
 | `detoxURLBlacklistRegex: '.*'` | `tests/e2e/firebase.test.js` (existing) |
 
-#### 3. `waitForActive` / scene never foreground-active
+#### 4. `waitForActive` / scene never foreground-active
 
 **Symptom** — Detox reaches `isReady` and `waitForActive` but never logs `waitForActiveDone`. App process stays alive for the rest of the step timeout (~30+ min). In `simulator.log`, SpringBoard requests `foreground-interactive` while the app scene stays `UISceneActivationStateUnattached` and UIKit deactivation reasons (e.g. `3104`) never clear.
 
 **Instrumentation** — `tests/ios/testing/AppDelegate.mm` logs `[rnfb-lifecycle]` at launch, on UIApplication/UIScene lifecycle notifications, and at **+30s / +60s** one-shot probes if the app never becomes active. Confirms whether the stall is Detox-side or the app never reaching `UIApplicationStateActive` / `foregroundActive`.
 
-**Distinguish from issue 4** — If `[rnfb-lifecycle]` probes show `UIApplication.state=active` / `foregroundActive` but Detox still hangs on `waitForActive`, the cause is likely Metro/JS bundle load failure (issue 4), not scene activation.
+**Distinguish from issue 5** — If `[rnfb-lifecycle]` probes show `UIApplication.state=active` / `foregroundActive` but Detox still hangs on `waitForActive`, the cause is likely Metro/JS bundle load failure (issue 5), not scene activation.
 
-#### 4. Metro unresponsive at launch → `waitForActive` hang (active app)
+#### 5. Metro unresponsive at launch → `waitForActive` hang (active app)
 
-**Symptom** — Same Detox-side pattern as issue 3 (`waitForActive` without `waitForActiveDone`, multi-minute hang in `device.launchApp()`), but **`[rnfb-lifecycle]` shows the app is already active**. Often seen on debug CI only; release on the same run passes (embedded bundle, no live Metro).
+**Symptom** — Same Detox-side pattern as issue 4 (`waitForActive` without `waitForActiveDone`, multi-minute hang in `device.launchApp()`), but **`[rnfb-lifecycle]` shows the app is already active**. Often seen on debug CI only; release on the same run passes (embedded bundle, no live Metro).
 
 **Cause chain** (observed on run [27727525262](https://github.com/invertase/react-native-firebase/actions/runs/27727525262)):
 
@@ -169,7 +184,7 @@ rg 'testing\[' simulator.log | rg -i 'waitForActive|waitForActiveDone|com\.wix\.
 # App lifecycle confirmation (AppDelegate instrumentation)
 rg '\[rnfb-lifecycle\]' simulator.log
 
-# Metro / JS bundle load failure (issue 4)
+# Metro / JS bundle load failure (issue 5)
 rg '\[rnfb-lifecycle\].*RCTJavaScriptDidFailToLoad|packager-probe|packager-status-fetch' simulator.log
 rg 'No script URL provided|com\.facebook\.react\.log' simulator.log
 rg 'testing\[' simulator.log | rg '8081/status|index\.bundle'
@@ -190,15 +205,16 @@ rg 'testing\[' simulator.log | rg -i 'FIRApp|RNFB|RCTBridge|configure'
 | Pattern | Meaning |
 |---------|---------|
 | `ready action too early` in Detox step only | Early-ready race (patch should fix; check patch applied in `yarn install`) |
-| `waitForActive` without `waitForActiveDone` | Scene/active hang (issue 3) **or** Metro/JS load failure (issue 4) — check `[rnfb-lifecycle]` probes |
-| `probe+30s` / `probe+60s` with `UIApplication.state=inactive` or scene `unattached` | App never became foreground-active (issue 3); compare with SpringBoard `foreground-interactive` lines |
-| `probe+30s` / `probe+60s` with `active` / `foregroundActive` but no `waitForActiveDone` | Metro/JS bundle failure despite active UIKit (issue 4); check `RCTJavaScriptDidFailToLoad` and `packager-status-fetch` |
+| `ECOMPROMISED` / `Unable to update lock within the stale threshold` | Device registry lock heartbeat missed — see [detox-patches.md](detox-patches.md); check `ExclusiveLockfile.js` patch |
+| `waitForActive` without `waitForActiveDone` | Scene/active hang (issue 4) **or** Metro/JS load failure (issue 5) — check `[rnfb-lifecycle]` probes |
+| `probe+30s` / `probe+60s` with `UIApplication.state=inactive` or scene `unattached` | App never became foreground-active (issue 4); compare with SpringBoard `foreground-interactive` lines |
+| `probe+30s` / `probe+60s` with `active` / `foregroundActive` but no `waitForActiveDone` | Metro/JS bundle failure despite active UIKit (issue 5); check `RCTJavaScriptDidFailToLoad` and `packager-status-fetch` |
 | `packager-status-fetch ... error domain=NSURLErrorDomain code=-1001` | Metro TCP reachable but HTTP timed out from simulator |
 | `No script URL provided` in `com.facebook.react.log` | RN never got bundle URL; only `/status` attempts, no `index.bundle` |
 | `handshake successful` 30–60s after `simctl launch` | Main-thread startup delay; not a boot failure |
 | Only `com.apple.datamigrator` activity, no `testing[` | Pre-boot / migration issue — use Actions `[boot-status]` log, not Detox orchestration |
 
-**Example healthy sequence** (abbreviated): `didFinishLaunching+after` → `UIApplicationDidBecomeActiveNotification` / scene `foregroundActive` → Detox `loginSuccess` → `isReady` → `waitForActiveDone`. A gap between SpringBoard foreground request and `[rnfb-lifecycle]` `active` is the smoking gun for issue 3. For issue 4, lifecycle probes show `active` but you will see `RCTJavaScriptDidFailToLoad` and/or `No script URL provided` before Detox stalls on `waitForActive`.
+**Example healthy sequence** (abbreviated): `didFinishLaunching+after` → `UIApplicationDidBecomeActiveNotification` / scene `foregroundActive` → Detox `loginSuccess` → `isReady` → `waitForActiveDone`. A gap between SpringBoard foreground request and `[rnfb-lifecycle]` `active` is the smoking gun for issue 4. For issue 5, lifecycle probes show `active` but you will see `RCTJavaScriptDidFailToLoad` and/or `No script URL provided` before Detox stalls on `waitForActive`.
 
 For Metro-side post-mortem, also download `metro-*_log` and check whether Metro logged bundle requests or stalled around the launch timestamp:
 
@@ -210,13 +226,14 @@ rg -i 'BUNDLE|index\.bundle|8081|error|ECONN|transform' metro.log
 
 | Change | Location |
 |--------|----------|
-| Buffer early `ready`, replay after app `login` | `.yarn/patches/detox-npm-20.51.0-*.patch` |
+| Buffer early `ready`, replay after app `login` | `.yarn/patches/detox-npm-20.51.0-*.patch` → `AnonymousConnectionHandler.js` |
+| 2× device-registry lock stale (20s) | `.yarn/patches/detox-npm-20.51.0-*.patch` → `ExclusiveLockfile.js` |
 | Jet + Metro wait, bounded `launchApp` with retry, Detox launch args | `tests/e2e/firebase.test.js` |
 | Lifecycle + JS load / packager probe logging; bundle URL `127.0.0.1` | `tests/ios/testing/AppDelegate.mm` |
 | Pre-boot + `bootstatus` before install | `boot-simulator.sh` (orthogonal; fixes boot/migration only) |
 | Metro stdout/stderr artifact | `.github/workflows/tests_e2e_ios.yml` |
 
-#### 5. Jet WebSocket disconnect (1006 / 1001)
+#### 6. Jet WebSocket disconnect (1006 / 1001)
 
 **Symptom** (Detox Test Debug step, often debug build only):
 

--- a/okf-bundle/testing/coverage-design.md
+++ b/okf-bundle/testing/coverage-design.md
@@ -33,17 +33,18 @@ flowchart LR
     N --> T2[coverage/lcov.info]
   end
   subgraph android_native [E2e Android native]
-    D1[Detox e2e] --> EC[coverage.ec in app]
+    D1[Detox e2e] --> FLA[RNFBTestingCoverage.flush]
+    FLA --> EC[coverage.ec in app filesDir]
     EC --> P1[pull-native-coverage.js]
     P1 --> J1R[jacocoAndroidTestReport]
     J1R --> AX[jacoco XML]
   end
   subgraph ios_native [E2e iOS native]
-    D2[Detox e2e] --> FL[RNFBTestingCoverage.flush]
-    FL --> PR[coverage.profraw in Documents]
+    D2[Detox e2e] --> FLI[RNFBTestingCoverage.flush]
+    FLI --> PR[coverage.profraw in Documents]
     PR --> P2[pull-native-coverage.js]
     P2 --> LLVM[process-ios-native-coverage.js]
-    LLVM --> I2[coverage/ios-native.lcov.info]
+    LLVM --> I2[coverage/ios-native/lcov.info]
   end
   J2 --> C[Codecov]
   T2 --> C
@@ -108,13 +109,17 @@ After a Detox/macOS e2e run, expect log lines like `[jet-coverage] WS received N
 ## Pipeline
 
 1. Gradle enables `testCoverageEnabled` on RNFB Android library modules (`tests/android/build.gradle`).
-2. Detox e2e runs; the instrumented app writes `coverage.ec` when instrumentation finishes (`DetoxTest.dumpCoverageData()` after `Detox.runTests()` returns).
+2. Detox e2e runs Jet tests in the instrumented app. After all Mocha tests complete, the Jet `after` hook in `tests/app.js` calls `NativeModules.RNFBTestingCoverage.flush()` (`RNFBTestingCoverageModule` in the **app** process). This writes `coverage.ec` to the app `filesDir` **before** Detox SIGINTs the instrumentation process.
 3. **After Detox exits**, `yarn tests:android:post-e2e-coverage` (CI) or `yarn tests:android:pull-native-coverage` polls for `coverage.ec`, pulls it to `tests/android/app/build/output/coverage/emulator_coverage.ec`, then runs `jacocoAndroidTestReport`. A missing file logs a warning and does **not** fail the Detox test or the CI job (`continue-on-error` on Codecov upload).
 4. Jacoco XML is produced at:
 
    `tests/android/app/build/reports/jacoco/jacocoAndroidTestReport/jacocoAndroidTestReport.xml`
 
 CI runs step 3 inside the emulator job immediately after `yarn tests:android:test-cover`.
+
+## Why flush runs in the app process
+
+Detox sends **SIGINT** to the instrumentation process as soon as the Jet session ends. A Jacoco dump placed after `Detox.runTests()` in `DetoxTest.java` never runs. The app-process native module mirrors the iOS LLVM flush pattern: JS test completion → native module → file on disk → post-e2e pull.
 
 ## Jacoco configuration notes
 
@@ -141,7 +146,7 @@ CI runs step 3 inside the emulator job immediately after `yarn tests:android:tes
    - merges `.profraw` from `tests/ios/build/output/coverage/` (Detox) and optionally `Build/ProfileData/` (`xcodebuild test` only — not used by Detox today)
    - exports lcov with `xcrun llvm-cov export -format=lcov` against the main app binary (statically linked RNFB code), writing to a temp file (large reports exceed Node stdout buffer limits)
    - streams and rewrites `SF:` paths to repo-relative `packages/**` paths
-   - writes **`coverage/ios-native.lcov.info`**
+   - writes **`coverage/ios-native/lcov.info`**
    - **deletes the processed `.profraw` files** so a missing file on the next run is a clear signal that e2e did not produce fresh native coverage
 
 ## Objective-C and Swift
@@ -156,20 +161,20 @@ The Podfile `post_install` coverage flags are temporary. When native dependencie
 
 # Codecov uploads (CI)
 
-CI uses [codecov-action](https://github.com/codecov/codecov-action) v6 with `verbose: true`. It discovers coverage files under the repo, including:
+CI uses [codecov-action](https://github.com/codecov/codecov-action) v7 with `verbose: true`. It auto-discovers coverage files under the repo, including:
 
 | Workflow | Artifacts |
 |----------|-----------|
 | `tests_jest.yml` | `coverage/lcov.info`, `coverage-final.json`, `clover.xml` |
 | `tests_e2e_android.yml` | `coverage/lcov.info` + Jacoco XML |
 | `tests_e2e_other.yml` | `coverage/lcov.info` (macOS TS) |
-| `tests_e2e_ios.yml` (debug) | `coverage/lcov.info` + `coverage/ios-native.lcov.info` |
+| `tests_e2e_ios.yml` (debug) | `coverage/lcov.info` + `coverage/ios-native/lcov.info` |
 
 The iOS workflow runs `yarn tests:ios:test:process-coverage` after Detox (`if: always()`, `continue-on-error: true` for now). The process step exits 1 when profraw is missing.
 
 ## File naming
 
-The repo standard for JavaScript lcov is `coverage/lcov.info`. iOS native uses **`coverage/ios-native.lcov.info`**. Codecov detects **lcov format by file content**, not only by the exact name `lcov.info`.
+The repo standard for JavaScript lcov is **`coverage/lcov.info`**. iOS native lcov is **`coverage/ios-native/lcov.info`** — the basename `lcov.info` is required for codecov-action auto-discovery (files like `ios-native.lcov.info` are not matched). Android native coverage is **Jacoco XML**, not lcov; codecov discovers `jacoco*.xml` once the report is generated.
 
 Check the Codecov commit **Uploads** tab for **Processed** vs **Unusable** per upload — that is the authoritative signal, not small project percentage deltas.
 
@@ -192,24 +197,25 @@ yarn tests:android:post-e2e-coverage
 .codecov-venv/bin/codecovcli upload-process \
   -t "$CODECOV_TOKEN" -r invertase/react-native-firebase \
   --git-service github -C "$(git rev-parse HEAD)" -B "$(git branch --show-current)" \
-  -f coverage/ios-native.lcov.info -n local-ios-native --disable-search
+  -f coverage/ios-native/lcov.info -n local-ios-native --disable-search
 ```
 
 Metro must be running (`yarn tests:packager:jet`) for Detox e2e.
 
 # Critical invariants
 
-These must all be true for native iOS coverage to work. If any break, the e2e test should fail (not silently upload stale data).
+These must all be true for native coverage to work. If any break, the e2e test should fail (not silently upload stale data).
 
 | Invariant | Where enforced |
 |-----------|----------------|
-| App built with LLVM profile flags | `Podfile` `post_install` (run `pod install`) |
-| Profile path set at launch | `AppDelegate` → `RNFBTestingConfigureCoverageProfilePath()` |
-| JS module name matches native export | `RCT_EXPORT_MODULE(RNFBTestingCoverage)` + `NativeModules.RNFBTestingCoverage` in `tests/app.js` |
-| Flush runs after Mocha tests | Jet `after` hook in `tests/app.js` |
-| Profraw pulled before Detox teardown | `pull-native-coverage.js` on Jet `close` in `firebase.test.js` (iOS only) |
+| App built with LLVM profile flags (iOS) | `Podfile` `post_install` (run `pod install`) |
+| Profile path set at launch (iOS) | `AppDelegate` → `RNFBTestingConfigureCoverageProfilePath()` |
+| App built with Jacoco instrumentation (Android) | `testCoverageEnabled` in `tests/android/build.gradle` |
+| JS module name matches native export | `RNFBTestingCoverage` on iOS + Android; `NativeModules.RNFBTestingCoverage` in `tests/app.js` |
+| Native flush runs after Mocha tests | Jet `after` hook in `tests/app.js` (iOS + Android) |
+| Profraw pulled before Detox teardown (iOS) | `pull-native-coverage.js` on Jet `close` in `firebase.test.js` |
 | Android `coverage.ec` pulled after Detox | `yarn tests:android:post-e2e-coverage` in CI / local post-e2e step |
-| Fresh profraw processed after e2e | `process-ios-native-coverage.js` (deletes profraw after export) |
+| Fresh profraw processed after e2e (iOS) | `process-ios-native-coverage.js` (deletes profraw after export) |
 
 # Troubleshooting
 
@@ -219,10 +225,13 @@ These must all be true for native iOS coverage to work. If any break, the e2e te
 | No profraw after e2e; test still passes (old behaviour) | Pull in `afterAll` after `detox.cleanup()`, or wrong module name | Pull on Jet `close`; verify `RNFBTestingCoverage` export name |
 | Stale profraw uploaded | Re-processed old file without re-running e2e | Process step deletes profraw after export; missing file + exit 1 on next process |
 | `process-ios-native-coverage` succeeds but no `packages/` hits | Wrong binary / not instrumented | Rebuild with `yarn tests:ios:build`; check Podfile flags |
-| Empty Jacoco XML (~235 bytes) | AGP 8 class path, missing `src/reactnative/java`, or no `coverage.ec` pulled | See `jacocoAndroidTestReport`; check `[native-coverage] Android native coverage pull failed` warning |
+| Empty Jacoco XML (~235 bytes) | AGP 8 class path, missing `src/reactnative/java`, or no `coverage.ec` pulled | See `jacocoAndroidTestReport`; check post-e2e poll logs |
+| Android `coverage.ec` missing after passing e2e | Detox SIGINT before instrumentation `@Test` tail; flush not called from app | Verify `[native-coverage] flushing android coverage` in Jet log; check `RNFBTestingCoverageModule` registered in `MainApplication` |
+| Jet `after` hook logs coverage not enabled | Non-instrumented build (local release or no Jacoco/LLVM flags) | Expected on `tests:android:test` without debug Jacoco; use debug e2e builds for native coverage; hook catches errors so tests still pass |
 | iOS link: `swiftCompatibility56` undefined | Profile link flags applied to all Pods | Restrict `OTHER_LDFLAGS` profile flags to app target; RNFB pods compile-only |
 | No `[jet-coverage] WS received` lines | Patches not applied | `yarn install` from repo root; check `.yarn/patches/` |
 | NYC summary missing / empty `lcov.info` | Jet not run from `tests/` cwd | Detox spawns `yarn jet` inside `tests/`; macOS uses `cd tests && npx jet` |
+| Codecov missing iOS native files | Output not named `lcov.info` | Use `coverage/ios-native/lcov.info` (not `coverage/ios-native.lcov.info`) |
 | Codecov upload **Unusable** | Wrong `SF:` paths | Confirm path rewrite in `process-ios-native-coverage.js`; check Uploads tab message |
 
 # Future cleanups (non-blocking)

--- a/okf-bundle/testing/coverage-design.md
+++ b/okf-bundle/testing/coverage-design.md
@@ -161,22 +161,48 @@ The Podfile `post_install` coverage flags are temporary. When native dependencie
 
 # Codecov uploads (CI)
 
-CI uses [codecov-action](https://github.com/codecov/codecov-action) v7 with `verbose: true`. It auto-discovers coverage files under the repo, including:
+CI uses [codecov-action](https://github.com/codecov/codecov-action) v7 with explicit `files` and `flags` per upload (no auto-discovery for gated artifacts). Workflow steps use `continue-on-error: true` so a Codecov API hiccup does not fail the test job; **blocking gates** are the Codecov GitHub status checks configured in `codecov.yml`.
 
-| Workflow | Artifacts |
-|----------|-----------|
-| `tests_jest.yml` | `coverage/lcov.info`, `coverage-final.json`, `clover.xml` |
-| `tests_e2e_android.yml` | `coverage/lcov.info` + Jacoco XML |
-| `tests_e2e_other.yml` | `coverage/lcov.info` (macOS TS) |
-| `tests_e2e_ios.yml` (debug) | `coverage/lcov.info` + `coverage/ios-native/lcov.info` |
+## Flag inventory
 
-The iOS workflow runs `yarn tests:ios:test:process-coverage` after Detox (`if: always()`, `continue-on-error: true` for now). The process step exits 1 when profraw is missing.
+Flag names are defined in **`codecov.yml`** (`flag_management`) and must match **`flags:`** in the workflow step. Do not rename in one place without the other.
+
+| Flag | Workflow | File uploaded | Blocks PR? |
+|------|----------|---------------|------------|
+| `jest` | `tests_jest.yml` | `coverage/lcov.info` | No |
+| `e2e-ts-ios` | `tests_e2e_ios.yml` (debug only) | `coverage/lcov.info` | No |
+| `ios-native` | `tests_e2e_ios.yml` (debug only) | `coverage/ios-native/lcov.info` | **Yes** — `codecov/project/ios-native` |
+| `e2e-ts-android` | `tests_e2e_android.yml` | `coverage/lcov.info` | No |
+| `android-native` | `tests_e2e_android.yml` | `tests/android/app/build/reports/jacoco/jacocoAndroidTestReport/jacocoAndroidTestReport.xml` | **Yes** — `codecov/project/android-native` |
+| `e2e-ts-macos` | `tests_e2e_other.yml` | `coverage/lcov.info` | No |
+
+iOS **release** matrix legs do not upload coverage. macOS e2e has TS coverage only (no native gate).
+
+## Native upload gates
+
+Blocking flags use `carryforward: false` and `target: 1%` in `codecov.yml`:
+
+- **Upload present** with any reasonable native coverage → flag status **passes** (well above 1%).
+- **Upload missing** (file not produced, step skipped, or upload failed) → flag has **0%** → status **fails**.
+
+This gates **upload presence**, not native coverage percentage regressions. Overall `codecov/project` remains `informational: true`.
+
+PR comments include a **flags** table (`comment.layout: …, flags`).
+
+## Per-workflow artifacts
+
+| Workflow | Steps before Codecov |
+|----------|---------------------|
+| `tests_jest.yml` | `yarn tests:jest-coverage` |
+| `tests_e2e_ios.yml` (debug) | Detox → `yarn tests:ios:test:process-coverage` (`continue-on-error: true` on process step for now) |
+| `tests_e2e_android.yml` | Detox → `yarn tests:android:post-e2e-coverage` (soft-fail poll/pull in script) |
+| `tests_e2e_other.yml` | macOS Jet e2e |
 
 ## File naming
 
-The repo standard for JavaScript lcov is **`coverage/lcov.info`**. iOS native lcov is **`coverage/ios-native/lcov.info`** — the basename `lcov.info` is required for codecov-action auto-discovery (files like `ios-native.lcov.info` are not matched). Android native coverage is **Jacoco XML**, not lcov; codecov discovers `jacoco*.xml` once the report is generated.
+JavaScript lcov: **`coverage/lcov.info`**. iOS native lcov: **`coverage/ios-native/lcov.info`** (basename `lcov.info` required). Android native: **Jacoco XML** at the path in the table above after `jacocoAndroidTestReport`.
 
-Check the Codecov commit **Uploads** tab for **Processed** vs **Unusable** per upload — that is the authoritative signal, not small project percentage deltas.
+Check the Codecov commit **Uploads** tab: each flag should appear as **Processed**. **Unusable** means wrong format or paths — fix before relying on the gate.
 
 # Local iteration
 
@@ -231,8 +257,9 @@ These must all be true for native coverage to work. If any break, the e2e test s
 | iOS link: `swiftCompatibility56` undefined | Profile link flags applied to all Pods | Restrict `OTHER_LDFLAGS` profile flags to app target; RNFB pods compile-only |
 | No `[jet-coverage] WS received` lines | Patches not applied | `yarn install` from repo root; check `.yarn/patches/` |
 | NYC summary missing / empty `lcov.info` | Jet not run from `tests/` cwd | Detox spawns `yarn jet` inside `tests/`; macOS uses `cd tests && npx jet` |
-| Codecov missing iOS native files | Output not named `lcov.info` | Use `coverage/ios-native/lcov.info` (not `coverage/ios-native.lcov.info`) |
+| Codecov missing iOS native files | Output not named `lcov.info` or wrong path | Use `coverage/ios-native/lcov.info`; confirm `ios-native` flag upload in iOS debug workflow |
 | Codecov upload **Unusable** | Wrong `SF:` paths | Confirm path rewrite in `process-ios-native-coverage.js`; check Uploads tab message |
+| `codecov/project/ios-native` or `android-native` **fail** | Native flag upload missing (`carryforward: false` → 0%) | Check Uploads tab for that flag; iOS: process-coverage step + `coverage/ios-native/lcov.info`; Android: post-e2e Jacoco XML path |
 
 # Future cleanups (non-blocking)
 

--- a/okf-bundle/testing/index.md
+++ b/okf-bundle/testing/index.md
@@ -1,3 +1,3 @@
 # Testing
 
-* [Coverage design](coverage-design.md) - how unit and e2e coverage is collected, transformed, and uploaded
+* [Coverage design](coverage-design.md) — unit and e2e coverage collection, Codecov flags, and native upload gates

--- a/tests/android/app/src/androidTest/java/com/invertase/testing/DetoxTest.java
+++ b/tests/android/app/src/androidTest/java/com/invertase/testing/DetoxTest.java
@@ -1,14 +1,8 @@
 package com.invertase.testing;
 
-import java.io.File;
-import java.lang.reflect.Method;
-
-import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
-
-import com.google.firebase.appcheck.debug.testing.DebugAppCheckTestHelper;
 
 import com.wix.detox.Detox;
 import com.wix.detox.config.DetoxConfig;
@@ -29,33 +23,11 @@ public class DetoxTest {
 
   @Test
   public void runDetoxTests() {
-
     DetoxConfig detoxConfig = new DetoxConfig();
     detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
     detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
     detoxConfig.rnContextLoadTimeoutSec = 2400;
 
     Detox.runTests(mActivityRule, detoxConfig);
-    dumpCoverageData();
-  }
-
-  // If you send '-e coverage' as part of the instrumentation command line, it should dump coverage as the Instrumentation finishes.
-  // However, there is a long-standing UIAutomator bug that crashes the process during Instrumentation.finish, before dumping coverage.
-  // It is trivial to dump it ourselves though, using the same mechanism the AndroidJUnit4Runner woud use
-  // Code reference: https://android.googlesource.com/platform/frameworks/testing/+/refs/heads/master/support/src/android/support/test/internal/runner/listener/CoverageListener.java#68
-  // UIAutomator issue: https://github.com/android/testing-samples/issues/89
-  private void dumpCoverageData() {
-    String coverageFilePath = InstrumentationRegistry.getInstrumentation().getTargetContext().getFilesDir().getAbsolutePath() +
-                    File.separator + "coverage.ec";
-    File coverageFile = new File(coverageFilePath);
-    try {
-        Class<?> emmaRTClass = Class.forName("com.vladium.emma.rt.RT");
-        Method dumpCoverageMethod = emmaRTClass.getMethod("dumpCoverageData",
-                coverageFile.getClass(), boolean.class, boolean.class);
-        dumpCoverageMethod.invoke(null, coverageFile, false, false);
-        System.out.println("Dumped code coverage data to " + coverageFilePath);
-    } catch (Exception e) {
-      System.err.println("Unable to dump coverage report: " + e);
-    }
   }
 }

--- a/tests/android/app/src/main/java/com/invertase/testing/MainApplication.kt
+++ b/tests/android/app/src/main/java/com/invertase/testing/MainApplication.kt
@@ -21,8 +21,7 @@ class MainApplication : Application(), ReactApplication {
 
         override fun getPackages(): List<ReactPackage> =
             PackageList(this).packages.apply {
-              // Packages that cannot be autolinked yet can be added manually here, for example:
-              // add(MyReactNativePackage())
+              add(RNFBTestingCoveragePackage())
             }
 
         override fun getJSMainModuleName(): String = "index"

--- a/tests/android/app/src/main/java/com/invertase/testing/RNFBTestingCoverageModule.kt
+++ b/tests/android/app/src/main/java/com/invertase/testing/RNFBTestingCoverageModule.kt
@@ -1,0 +1,48 @@
+package com.invertase.testing
+
+import android.util.Log
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import java.io.File
+
+class RNFBTestingCoverageModule(reactContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactContext) {
+
+  override fun getName(): String = "RNFBTestingCoverage"
+
+  @ReactMethod
+  fun flush(promise: Promise) {
+    try {
+      val coverageFile = File(reactApplicationContext.filesDir, "coverage.ec")
+      val emmaRT = Class.forName("com.vladium.emma.rt.RT")
+      val dump =
+        emmaRT.getMethod(
+          "dumpCoverageData",
+          File::class.java,
+          Boolean::class.javaPrimitiveType,
+          Boolean::class.javaPrimitiveType,
+        )
+      dump.invoke(null, coverageFile, false, false)
+      Log.i(
+        TAG,
+        "[native-coverage] flushed Jacoco coverage to ${coverageFile.absolutePath}",
+      )
+      promise.resolve(coverageFile.absolutePath)
+    } catch (e: ClassNotFoundException) {
+      Log.w(
+        TAG,
+        "[native-coverage] Jacoco/Emma RT class not found; coverage is likely not enabled in this build",
+      )
+      promise.reject("coverage_not_enabled", "Jacoco/Emma RT class not found", e)
+    } catch (e: Exception) {
+      Log.e(TAG, "[native-coverage] flush failed", e)
+      promise.reject("coverage_flush_failed", "Failed to dump Jacoco coverage data", e)
+    }
+  }
+
+  companion object {
+    private const val TAG = "RNFBTestingCoverage"
+  }
+}

--- a/tests/android/app/src/main/java/com/invertase/testing/RNFBTestingCoveragePackage.kt
+++ b/tests/android/app/src/main/java/com/invertase/testing/RNFBTestingCoveragePackage.kt
@@ -1,0 +1,14 @@
+package com.invertase.testing
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class RNFBTestingCoveragePackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+    listOf(RNFBTestingCoverageModule(reactContext))
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+    emptyList()
+}

--- a/tests/app.js
+++ b/tests/app.js
@@ -249,17 +249,29 @@ function loadTests(_) {
     }
 
     after(async function flushNativeCoverageProfile() {
-      if (Platform.OS === 'ios') {
-        const { NativeModules } = require('react-native');
-        const coverageModule = NativeModules.RNFBTestingCoverage;
-        if (coverageModule?.flush) {
-          console.log('[ios-native-coverage] flushing LLVM profile from Jet after hook');
+      if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+        return;
+      }
+
+      const { NativeModules } = require('react-native');
+      const coverageModule = NativeModules.RNFBTestingCoverage;
+      if (coverageModule?.flush) {
+        console.log(`[native-coverage] flushing ${Platform.OS} coverage from Jet after hook`);
+        try {
           await coverageModule.flush();
-        } else {
-          console.warn(
-            '[ios-native-coverage] RNFBTestingCoverage native module not available; skipping flush',
-          );
+        } catch (error) {
+          if (error?.code === 'coverage_not_enabled') {
+            console.warn(
+              `[native-coverage] ${Platform.OS} coverage not enabled in this build; skipping flush`,
+            );
+          } else {
+            console.error(`[native-coverage] failed to flush ${Platform.OS} coverage:`, error);
+          }
         }
+      } else {
+        console.warn(
+          '[native-coverage] RNFBTestingCoverage native module not available; skipping flush',
+        );
       }
     });
   });

--- a/tests/scripts/process-ios-native-coverage.js
+++ b/tests/scripts/process-ios-native-coverage.js
@@ -17,7 +17,7 @@ function parseArgs(argv) {
     derivedData: path.join(testsDir, 'ios/build'),
     configuration: 'Debug',
     appName: 'testing',
-    output: path.join(repoRoot, 'coverage/ios-native.lcov.info'),
+    output: path.join(repoRoot, 'coverage/ios-native/lcov.info'),
   };
 
   for (let i = 0; i < argv.length; i += 1) {
@@ -42,7 +42,7 @@ Options:
   --derived-data <path>   Detox/Xcode derived data (default: tests/ios/build)
   --configuration <name>  Xcode configuration (default: Debug)
   --app-name <name>       App product name (default: testing)
-  --output <path>         lcov output path (default: coverage/ios-native.lcov.info)
+  --output <path>         lcov output path (default: coverage/ios-native/lcov.info)
 `);
       process.exit(0);
     }
@@ -182,7 +182,7 @@ async function main() {
 
   fs.mkdirSync(path.dirname(options.output), { recursive: true });
 
-  const profdataPath = path.join(path.dirname(options.output), 'ios-native.profdata');
+  const profdataPath = path.join(path.dirname(options.output), 'profdata');
   runOrThrow('xcrun', [
     'llvm-profdata',
     'merge',
@@ -192,7 +192,7 @@ async function main() {
     profdataPath,
   ]);
 
-  const rawLcovPath = path.join(path.dirname(options.output), 'ios-native.lcov.raw');
+  const rawLcovPath = path.join(path.dirname(options.output), 'lcov.raw');
   try {
     runToFileOrThrow('xcrun', [
       'llvm-cov',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11145,7 +11145,7 @@ __metadata:
 
 "detox@patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch":
   version: 20.51.0
-  resolution: "detox@patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch::version=20.51.0&hash=8d4fb1"
+  resolution: "detox@patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch::version=20.51.0&hash=1792b9"
   dependencies:
     "@wix-pilot/core": "npm:^3.4.2"
     "@wix-pilot/detox": "npm:^1.0.13"
@@ -11191,7 +11191,7 @@ __metadata:
       optional: true
   bin:
     detox: local-cli/cli.js
-  checksum: 10/135755651bb9d947f71d2834d29a883d88dc62830fe99882fea82c8621c15c10b347df10ce44bb18590dc82f643cfc065ef64bcce3c0b706a4aa6bd7287a0c23
+  checksum: 10/60809772b0b7667a4a4422158a0c74482a3fd5ae47f3467978b362cac7386c05731ff45818e9fddf881f76c51cc66ad13b493ab56a1b2e625b3ada99e4be3083
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

I am not concerned (yet) with native coverage not having high percentages, but I just finished overhauling native coverage in general, and now upload in specific, and I want a clear signal if native coverage generation -> dump -> process -> upload is failing

### Related issues

No issues but is a continuation of this PR:

- #9054

### Release Summary

two test comments === no release

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

If you go on codecov.io and see line coverage information in `packages/**/android` and `packages/**/ios` then this is working

If there is a pull request where there is no coverage for those and it fails the codecov check, then it is also working

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
