### PR TITLE
style(docs): lint fixes from docs.page audit

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -61,13 +61,13 @@
     {
       "group": "AI Logic",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/social/firebase-logo.png",
+      "icon": "//firebase.google.com/static/images/icons/firebase-ai-logic.svg",
       "pages": [{ "title": "Usage", "href": "/ai/usage" }]
     },
     {
       "group": "Analytics",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/analytics.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/run_analytics.svg",
       "pages": [
         { "title": "Usage", "href": "/analytics/usage" },
         { "title": "Screen Tracking", "href": "/analytics/screen-tracking" },
@@ -80,19 +80,19 @@
     {
       "group": "App Check",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/social/firebase-logo.png",
+      "icon": "//firebase.google.com/static/images/products/icons/build_app_check.svg",
       "pages": [{ "title": "Usage", "href": "/app-check/usage" }]
     },
     {
       "group": "App Distribution",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/app-distribution.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/run_app_distribution.svg",
       "pages": [{ "title": "Usage", "href": "/app-distribution/usage" }]
     },
     {
       "group": "Authentication",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/authentication.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/build_auth.svg",
       "pages": [
         { "title": "Usage", "href": "/auth/usage" },
         { "title": "Social Auth", "href": "/auth/social-auth" },
@@ -104,7 +104,7 @@
     {
       "group": "Cloud Firestore",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/cloud-firestore.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/build_firestore.svg",
       "pages": [
         { "title": "Usage", "href": "/firestore/usage" },
         { "title": "Usage with Emulator", "href": "/firestore/emulator" },
@@ -119,7 +119,7 @@
     {
       "group": "Cloud Functions",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/cloud-functions.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/build_functions.svg",
       "pages": [
         { "title": "Usage", "href": "/functions/usage" },
         {
@@ -131,7 +131,7 @@
     {
       "group": "Cloud Messaging",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/cloud-messaging.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/run_cloud_messaging.svg",
       "pages": [
         { "title": "Usage", "href": "/messaging/usage" },
         { "title": "iOS Project Setup", "href": "/messaging/usage/ios-setup" },
@@ -144,7 +144,7 @@
     {
       "group": "Cloud Storage",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/cloud-storage.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/build_storage.svg",
       "pages": [{ "title": "Usage", "href": "/storage/usage" }]
     },
     {
@@ -160,7 +160,7 @@
     {
       "group": "Crashlytics",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/crashlytics.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/run_crashlytics.svg",
       "pages": [
         { "title": "Usage", "href": "/crashlytics/usage" },
         { "title": "Viewing crash reports", "href": "/crashlytics/crash-reports" }
@@ -169,7 +169,7 @@
     {
       "group": "Realtime Database",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/realtime-database.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/build_realtime_database.svg",
       "pages": [
         { "title": "Usage", "href": "/database/usage" },
         { "title": "Offline Support", "href": "/database/offline-support" },
@@ -179,7 +179,7 @@
     {
       "group": "In-App Messaging",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/in-app-messaging.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/run_in_app_messaging.svg",
       "pages": [{ "title": "Usage", "href": "/in-app-messaging/usage" }]
     },
     {
@@ -191,19 +191,19 @@
     {
       "group": "ML",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/ml-kit.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/build_ml.svg",
       "pages": [{ "title": "Usage", "href": "/ml/usage" }]
     },
     {
       "group": "Remote Config",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/remote-config.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/run_remote_config.svg",
       "pages": [{ "title": "Usage", "href": "/remote-config/usage" }]
     },
     {
       "group": "Performance Monitoring",
       "tab": "root",
-      "icon": "//static.invertase.io/assets/firebase/performance-monitoring.svg",
+      "icon": "//firebase.google.com/static/images/products/icons/run_performance.svg",
       "pages": [
         { "title": "Usage", "href": "/perf/usage" },
         { "title": "Axios Integration", "href": "/perf/axios-integration" },

--- a/docs/ai/usage/index.mdx
+++ b/docs/ai/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: AI Logic
 description: Installation and getting started with Firebase AI Logic.
-icon: //firebase.google.com/static/images/icons/firebase-ai-logic.svg
 next: /analytics/usage
 previous: /faqs-and-tips
 ---

--- a/docs/analytics/usage/index.mdx
+++ b/docs/analytics/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Analytics
 description: Installation and getting started with Analytics.
-icon: //firebase.google.com/static/images/products/icons/run_analytics.svg
 next: /analytics/screen-tracking
 previous: /ai/usage
 ---

--- a/docs/analytics/usage/installation/android.mdx
+++ b/docs/analytics/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate Analytics into your Android application.
-next: /analytics/usage/installation/ios
-previous: /analytics/usage
 ---
 
 # Android Manual Installation

--- a/docs/analytics/usage/installation/ios.mdx
+++ b/docs/analytics/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate Analytics into your iOS application.
-next: /analytics/usage/installation/android
-previous: /analytics/usage
 ---
 
 # iOS Manual Installation

--- a/docs/app-check/usage/index.mdx
+++ b/docs/app-check/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: App Check
 description: Installation and getting started with App Check.
-icon: //firebase.google.com/static/images/products/icons/build_app_check.svg
 next: /app-distribution/usage
 previous: /analytics/screen-tracking
 ---

--- a/docs/app-distribution/usage/index.mdx
+++ b/docs/app-distribution/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: App Distribution
 description: Installation and getting started with App Distribution.
-icon: //firebase.google.com/static/images/products/icons/run_app_distribution.svg
 next: /auth/usage
 previous: /app-check/usage
 ---

--- a/docs/app/usage.mdx
+++ b/docs/app/usage.mdx
@@ -1,7 +1,6 @@
 ---
 title: Core/App
 description: Functionality & examples of using the Core/App dependency with React Native Firebase.
-icon: //static.invertase.io/assets/social/firebase-logo.png
 next: /app/json-config
 previous: /storage/usage
 ---

--- a/docs/auth/usage/index.mdx
+++ b/docs/auth/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Authentication
 description: Installation and getting started with Authentication.
-icon: //firebase.google.com/static/images/products/icons/build_auth.svg
 next: /auth/social-auth
 previous: /app-distribution/usage
 ---

--- a/docs/auth/usage/installation/android.mdx
+++ b/docs/auth/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate Authentication into your Android application.
-next: /auth/usage/installation/ios
-previous: /auth/usage
 ---
 
 # Android Manual Installation

--- a/docs/auth/usage/installation/ios.mdx
+++ b/docs/auth/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate Authentication into your iOS application.
-next: /auth/usage/installation/android
-previous: /auth/usage
 ---
 
 # iOS Manual Installation

--- a/docs/crashlytics/usage/index.mdx
+++ b/docs/crashlytics/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Crashlytics
 description: Installation and getting started with Crashlytics.
-icon: //firebase.google.com/static/images/products/icons/run_crashlytics.svg
 next: /crashlytics/crash-reports
 previous: /app/utils
 ---

--- a/docs/crashlytics/usage/installation/android.mdx
+++ b/docs/crashlytics/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate Crashlytics into your Android application.
-next: /crashlytics/usage/installation/ios
-previous: /crashlytics/usage
 ---
 
 # Android Installation

--- a/docs/crashlytics/usage/installation/ios.mdx
+++ b/docs/crashlytics/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate Crashlytics into your iOS application.
-next: /crashlytics/usage/installation/android
-previous: /crashlytics/usage
 ---
 
 # iOS Manual Installation

--- a/docs/database/usage/index.mdx
+++ b/docs/database/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Realtime Database
 description: Installation and getting started with Realtime Database.
-icon: //firebase.google.com/static/images/products/icons/build_realtime_database.svg
 next: /database/offline-support
 previous: /crashlytics/crash-reports
 ---

--- a/docs/database/usage/installation/android.mdx
+++ b/docs/database/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Setup
 description: Manually integrate Realtime Database into your Android application.
-next: /database/usage/installation/ios
-previous: /database/usage
 ---
 
 # Android Manual Linking

--- a/docs/database/usage/installation/ios.mdx
+++ b/docs/database/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Setup
 description: Manually integrate Realtime Database into your iOS application.
-next: /database/usage/installation/android
-previous: /database/usage
 ---
 
 # iOS Manual Linking

--- a/docs/firestore/usage/index.mdx
+++ b/docs/firestore/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloud Firestore
 description: Installation and getting started with Firestore.
-icon: //firebase.google.com/static/images/products/icons/build_firestore.svg
 next: /firestore/emulator
 previous: /auth/multi-factor-auth
 ---

--- a/docs/firestore/usage/installation/android.mdx
+++ b/docs/firestore/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate Cloud Firestore into your Android application.
-next: /firestore/usage/installation/ios
-previous: /firestore/usage
 ---
 
 # Android Manual Installation

--- a/docs/firestore/usage/installation/ios.mdx
+++ b/docs/firestore/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: Cloud Firestore iOS Integration
 description: Manually integrate Cloud Firestore into your iOS application.
-next: /firestore/usage/installation/android
-previous: /firestore/usage
 ---
 
 # iOS Manual Linking

--- a/docs/functions/usage/index.mdx
+++ b/docs/functions/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloud Functions
 description: Installation and getting started with Cloud Functions.
-icon: //firebase.google.com/static/images/products/icons/build_functions.svg
 next: /functions/writing-deploying-functions
 previous: /firestore/pagination
 ---

--- a/docs/functions/usage/installation/android.mdx
+++ b/docs/functions/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Setup
 description: Manually integrate Cloud Functions into your Android application.
-next: /functions/usage/installation/ios
-previous: /functions/usage
 ---
 
 # Android Manual Installation

--- a/docs/functions/usage/installation/ios.mdx
+++ b/docs/functions/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Setup
 description: Manually integrate Cloud Functions into your iOS application.
-next: /functions/usage/installation/android
-previous: /functions/usage
 ---
 
 # iOS Manual Linking

--- a/docs/in-app-messaging/usage/index.mdx
+++ b/docs/in-app-messaging/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: In App Messaging
 description: Installation and getting started with In App Messaging.
-icon: //firebase.google.com/static/images/products/icons/run_in_app_messaging.svg
 next: /installations/usage
 previous: /database/presence-detection
 ---

--- a/docs/in-app-messaging/usage/installation/android.mdx
+++ b/docs/in-app-messaging/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate Firebase In-App Messaging into your Android application.
-next: /in-app-messaging/usage/installation/ios
-previous: /in-app-messaging/usage
 ---
 
 # Android Manual Installation

--- a/docs/in-app-messaging/usage/installation/ios.mdx
+++ b/docs/in-app-messaging/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Setup
 description: Manually integrateFirebase In-App Messaging into your iOS application.
-next: /in-app-messaging/usage/installation/android
-previous: /in-app-messaging/usage
 ---
 
 # iOS Manual Installation

--- a/docs/install-android.mdx
+++ b/docs/install-android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate React Native Firebase into your Android application.
-next: /install-ios
-previous: /
 ---
 
 # Android Manual Installation

--- a/docs/install-ios.mdx
+++ b/docs/install-ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate React Native Firebase into your iOS application.
-next: /auth/usage/installation/android
-previous: /auth/usage
 ---
 
 # iOS Manual Installation

--- a/docs/installations/usage/index.mdx
+++ b/docs/installations/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Installations
 description: Installation and getting started with Installations.
-icon: //static.invertase.io/assets/social/firebase-logo.png
 next: /ml/usage
 previous: /in-app-messaging/usage
 ---

--- a/docs/messaging/usage/index.mdx
+++ b/docs/messaging/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloud Messaging
 description: Installation and getting started with Cloud Messaging.
-icon: //firebase.google.com/static/images/products/icons/run_cloud_messaging.svg
 next: /messaging/usage/ios-setup
 previous: /functions/writing-deploying-functions
 ---

--- a/docs/messaging/usage/installation/android.mdx
+++ b/docs/messaging/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Setup
 description: Manually integrate Messaging into your Android application.
-next: /messaging/usage/installation/ios
-previous: /messaging/usage
 ---
 
 # Android Manual Linking

--- a/docs/messaging/usage/installation/ios.mdx
+++ b/docs/messaging/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate Messaging into your iOS application.
-next: /messaging/usage/installation/android
-previous: /messaging/usage
 ---
 
 # iOS Manual Installation

--- a/docs/ml/usage/index.mdx
+++ b/docs/ml/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: ML
 description: Installation and getting started with ML.
-icon: //firebase.google.com/static/images/products/icons/build_ml.svg
 next: /remote-config/usage
 previous: /installations/usage
 ---

--- a/docs/ml/usage/installation/android.mdx
+++ b/docs/ml/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate ML into your Android application.
-next: /ml/usage/installation/ios
-previous: /ml/usage
 ---
 
 # Android Manual Installation

--- a/docs/ml/usage/installation/ios.mdx
+++ b/docs/ml/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate ML APIs into your iOS application.
-next: /ml/usage/installation/android
-previous: /ml/usage
 ---
 
 # iOS Manual Installation

--- a/docs/perf/usage/index.mdx
+++ b/docs/perf/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Performance Monitoring
 description: Installation and getting started with Performance Monitoring.
-icon: //firebase.google.com/static/images/products/icons/run_performance.svg
 next: /perf/axios-integration
 previous: /remote-config/usage
 ---

--- a/docs/perf/usage/installation/android.mdx
+++ b/docs/perf/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Setup
 description: Manually integrate Performance Monitoring into your Android application.
-next: /perf/usage/installation/ios
-previous: /perf/usage
 ---
 
 # Android Manual Installation

--- a/docs/perf/usage/installation/ios.mdx
+++ b/docs/perf/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate Performance Monitoring into your iOS application.
-next: /perf/usage/installation/android
-previous: /perf/usage
 ---
 
 # iOS Manual Installation

--- a/docs/phone-number-verification/usage/index.mdx
+++ b/docs/phone-number-verification/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Phone Number Verification
 description: Installation and getting started with Phone Number Verification.
-icon: //static.invertase.io/assets/social/firebase-logo.png
 next: /vertexai/usage
 previous: /perf/ky-integration
 ---

--- a/docs/reference.css
+++ b/docs/reference.css
@@ -14,9 +14,9 @@
   --dim-container-main-margin-y: 0px;
   --reference-column-padding-top: 1.5rem;
   --reference-content-padding-x: 2rem;
-  --reference-nav-nested-indent: .8rem;
+  --reference-nav-nested-indent: 0.8rem;
   --reference-nav-item-padding-y: 0.3rem;
-  --reference-header-logo: url("https://static.invertase.io/assets/react-native-firebase-favicon.png");
+  --reference-header-logo: url('https://static.invertase.io/assets/react-native-firebase-favicon.png');
   --reference-header-logo-size: 1.75rem;
   --reference-nav-active-radius: 0.375rem;
   --reference-nav-hover-bg: lab(98% 0 0);
@@ -30,7 +30,7 @@
 }
 
 .tsd-toolbar-contents > .title::before {
-  content: "";
+  content: '';
   width: var(--reference-header-logo-size);
   height: var(--reference-header-logo-size);
   flex-shrink: 0;
@@ -41,7 +41,8 @@
   font-size: var(--reference-header-actions-font-size);
 }
 
-footer, .tsd-filter-visibility {
+footer,
+.tsd-filter-visibility {
   display: none;
 }
 
@@ -102,76 +103,76 @@ footer, .tsd-filter-visibility {
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) {
+  :root:not([data-theme='light']) {
     --reference-nav-hover-bg: lab(100% 0 0 / 5%);
   }
 }
 
-:root[data-theme="dark"] {
+:root[data-theme='dark'] {
   --reference-nav-hover-bg: lab(100% 0 0 / 5%);
 }
 
 @media (prefers-color-scheme: dark) {
-  :root:not([data-theme="light"]) .col-content,
-  :root:not([data-theme="light"]) .site-menu,
-  :root:not([data-theme="light"]) .page-menu,
-  :root:not([data-theme="light"]) #tsd-sidebar-links {
+  :root:not([data-theme='light']) .col-content,
+  :root:not([data-theme='light']) .site-menu,
+  :root:not([data-theme='light']) .page-menu,
+  :root:not([data-theme='light']) #tsd-sidebar-links {
     --color-text: var(--reference-dark-body-text);
   }
 
-  :root:not([data-theme="light"]) .col-content {
+  :root:not([data-theme='light']) .col-content {
     color: var(--reference-dark-body-text);
   }
 
-  :root:not([data-theme="light"]) .col-content :is(h1, h2, h3, h4, h5, h6) {
+  :root:not([data-theme='light']) .col-content :is(h1, h2, h3, h4, h5, h6) {
     color: var(--dark-color-text);
   }
 }
 
-:root[data-theme="dark"] .col-content,
-:root[data-theme="dark"] .site-menu,
-:root[data-theme="dark"] .page-menu,
-:root[data-theme="dark"] #tsd-sidebar-links {
+:root[data-theme='dark'] .col-content,
+:root[data-theme='dark'] .site-menu,
+:root[data-theme='dark'] .page-menu,
+:root[data-theme='dark'] #tsd-sidebar-links {
   --color-text: var(--reference-dark-body-text);
 }
 
-:root[data-theme="dark"] .col-content {
+:root[data-theme='dark'] .col-content {
   color: var(--reference-dark-body-text);
 }
 
-:root[data-theme="dark"] .col-content :is(h1, h2, h3, h4, h5, h6) {
+:root[data-theme='dark'] .col-content :is(h1, h2, h3, h4, h5, h6) {
   color: var(--dark-color-text);
 }
 
 @media (prefers-color-scheme: light) {
-  :root:not([data-theme="dark"]) .col-content,
-  :root:not([data-theme="dark"]) .site-menu,
-  :root:not([data-theme="dark"]) .page-menu,
-  :root:not([data-theme="dark"]) #tsd-sidebar-links {
+  :root:not([data-theme='dark']) .col-content,
+  :root:not([data-theme='dark']) .site-menu,
+  :root:not([data-theme='dark']) .page-menu,
+  :root:not([data-theme='dark']) #tsd-sidebar-links {
     --color-text: var(--reference-light-body-text);
   }
 
-  :root:not([data-theme="dark"]) .col-content {
+  :root:not([data-theme='dark']) .col-content {
     color: var(--reference-light-body-text);
   }
 
-  :root:not([data-theme="dark"]) .col-content :is(h1, h2, h3, h4, h5, h6) {
+  :root:not([data-theme='dark']) .col-content :is(h1, h2, h3, h4, h5, h6) {
     color: var(--light-color-text);
   }
 }
 
-:root[data-theme="light"] .col-content,
-:root[data-theme="light"] .site-menu,
-:root[data-theme="light"] .page-menu,
-:root[data-theme="light"] #tsd-sidebar-links {
+:root[data-theme='light'] .col-content,
+:root[data-theme='light'] .site-menu,
+:root[data-theme='light'] .page-menu,
+:root[data-theme='light'] #tsd-sidebar-links {
   --color-text: var(--reference-light-body-text);
 }
 
-:root[data-theme="light"] .col-content {
+:root[data-theme='light'] .col-content {
   color: var(--reference-light-body-text);
 }
 
-:root[data-theme="light"] .col-content :is(h1, h2, h3, h4, h5, h6) {
+:root[data-theme='light'] .col-content :is(h1, h2, h3, h4, h5, h6) {
   color: var(--light-color-text);
 }
 

--- a/docs/releases/index.mdx
+++ b/docs/releases/index.mdx
@@ -1,8 +1,6 @@
 ---
 title: Release notes
 description: View the latest release notes for React Native Firebase
-next: /migrating-to-v6
-previous: /typescript
 ---
 
 Starting from version `10.0.0`, React Native Firebase packages share a single common version, with aggregated release notes available:

--- a/docs/releases/v6.4.0.mdx
+++ b/docs/releases/v6.4.0.mdx
@@ -1,7 +1,6 @@
 ---
 title: v6.4.0
 description: 'Messaging focused release with features, bug fixes and documentation updates.'
-date: 2020-04-03
 ---
 
 ## Features

--- a/docs/remote-config/usage/index.mdx
+++ b/docs/remote-config/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Remote Config
 description: Installation and getting started with Remote Config.
-icon: //firebase.google.com/static/images/products/icons/run_remote_config.svg
 next: /perf/usage
 previous: /ml/usage
 ---

--- a/docs/remote-config/usage/installation/android.mdx
+++ b/docs/remote-config/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate Remote Config into your Android application.
-next: /remote-config/usage/installation/ios
-previous: /remote-config/usage
 ---
 
 # Android Manual Installation

--- a/docs/remote-config/usage/installation/ios.mdx
+++ b/docs/remote-config/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate Remote Config into your iOS application.
-next: /remote-config/usage/installation/android
-previous: /remote-config/usage
 ---
 
 # iOS Manual Installation

--- a/docs/storage/usage/index.mdx
+++ b/docs/storage/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Cloud Storage
 description: Installation and getting started with Storage.
-icon: //firebase.google.com/static/images/products/icons/build_storage.svg
 next: /app/usage
 previous: /messaging/server-integration
 ---

--- a/docs/storage/usage/installation/android.mdx
+++ b/docs/storage/usage/installation/android.mdx
@@ -1,8 +1,6 @@
 ---
 title: Android Installation
 description: Manually integrate Cloud Storage into your Android application.
-next: /storage/usage/installation/ios
-previous: /storage/usage
 ---
 
 # Android Manual Installation

--- a/docs/storage/usage/installation/ios.mdx
+++ b/docs/storage/usage/installation/ios.mdx
@@ -1,8 +1,6 @@
 ---
 title: iOS Installation
 description: Manually integrate Cloud Storage into your iOS application.
-next: /storage/usage/installation/android
-previous: /storage/usage
 ---
 
 # iOS Manual Installation

--- a/docs/vertexai/usage/index.mdx
+++ b/docs/vertexai/usage/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: VertexAI
 description: Installation and getting started with VertexAI.
-icon: //static.invertase.io/assets/social/firebase-logo.png
 next: /migrating-to-v6
 previous: /phone-number-verification/usage
 ---


### PR DESCRIPTION
## Summary

Follow-up lint from a docs.page audit — no functional changes.

- Move sidebar icons from per-page frontmatter into `docs.json` navigation config
- Remove redundant `icon` fields from usage page frontmatter
- Prettier/formatting fixes in `docs/reference.css`
- Fix up some vestigial next/previous links in unused files
- Clear up last remaining unknown frontmatter

## Test plan

- [ ] Visual verification at https://rnfirebase.io/~docs-link-audit