### PR TITLE
docs: convert all code examples to modular API

### DIFF
--- a/docs/ai/usage/index.mdx
+++ b/docs/ai/usage/index.mdx
@@ -444,8 +444,8 @@ For mobile and web apps, you need to protect the Gemini API and your project res
 import React from 'react';
 import { AppRegistry, Button, Text, View } from 'react-native';
 import { getApp } from '@react-native-firebase/app';
-import auth from '@react-native-firebase/auth';
-import appCheck from '@react-native-firebase/app-check';
+import { getAuth } from '@react-native-firebase/auth';
+import { initializeAppCheck } from '@react-native-firebase/app-check';
 import { getAI, getGenerativeModel, GoogleAIBackend } from '@react-native-firebase/ai';
 
 function App() {
@@ -455,10 +455,10 @@ function App() {
         title="use App Check and pass into getAI()"
         onPress={async () => {
           const app = getApp();
-          // Can also pass an instance of auth which will pass in an auth token if a user is signed-in
-          const authInstance = auth(app);
-          const appCheckInstance = appCheck(app);
-          // Configure appCheck instance as per docs....
+          const authInstance = getAuth(app);
+          const appCheckInstance = await initializeAppCheck(app, {
+            // Configure App Check as per docs...
+          });
           const options = {
             appCheck: appCheckInstance,
             auth: authInstance,

--- a/docs/analytics/screen-tracking.mdx
+++ b/docs/analytics/screen-tracking.mdx
@@ -17,7 +17,7 @@ access to the current navigation state when a screen changes, allowing you to us
 method the Analytics library provides:
 
 ```jsx
-import analytics from '@react-native-firebase/analytics';
+import { getAnalytics, logScreenView } from '@react-native-firebase/analytics';
 import { NavigationContainer } from '@react-navigation/native';
 
 const App = () => {
@@ -34,7 +34,7 @@ const App = () => {
         const currentRouteName = navigationRef.current.getCurrentRoute().name;
 
         if (previousRouteName !== currentRouteName) {
-          await analytics().logScreenView({
+          await logScreenView(getAnalytics(), {
             screen_name: currentRouteName,
             screen_class: currentRouteName,
           });
@@ -60,12 +60,12 @@ for React Native apps. To manually track screens, you need to setup a `component
 [`logScreenView`](https://invertase.github.io/react-native-firebase/_react-native-firebase/analytics/modular/logScreenView.html) method the Analytics library provides:
 
 ```js
-import analytics from '@react-native-firebase/analytics';
+import { getAnalytics, logScreenView } from '@react-native-firebase/analytics';
 import { Navigation } from 'react-native-navigation';
 
 Navigation.events().registerComponentDidAppearListener(async ({ componentName, componentType }) => {
   if (componentType === 'Component') {
-    await analytics().logScreenView({
+    await logScreenView(getAnalytics(), {
       screen_name: componentName,
       screen_class: componentName,
     });

--- a/docs/analytics/usage/index.mdx
+++ b/docs/analytics/usage/index.mdx
@@ -57,7 +57,7 @@ Below is an example showing how a custom event can be logged. Please be aware th
 ```jsx
 import react, { useEffect } from 'react';
 import { View, Button } from 'react-native';
-import analytics from '@react-native-firebase/analytics';
+import { getAnalytics, logEvent } from '@react-native-firebase/analytics';
 
 function App() {
   return (
@@ -65,7 +65,7 @@ function App() {
       <Button
         title="Add To Basket"
         onPress={async () =>
-          await analytics().logEvent('basket', {
+          await logEvent(getAnalytics(), 'basket', {
             id: 3745092,
             item: 'mens grey t-shirt',
             description: ['round neck', 'long sleeved'],
@@ -90,7 +90,7 @@ Below is a sample of how to use one of the predefined methods the Analytics modu
 ```jsx
 import react, { useEffect } from 'react';
 import { View, Button } from 'react-native';
-import analytics from '@react-native-firebase/analytics';
+import { getAnalytics, logSelectContent } from '@react-native-firebase/analytics';
 
 function App() {
   return (
@@ -100,7 +100,7 @@ function App() {
         // Logs in the firebase analytics console as "select_content" event
         // only accepts the two object properties which accept strings.
         onPress={async () =>
-          await analytics().logSelectContent({
+          await logSelectContent(getAnalytics(), {
             content_type: 'clothing',
             item_id: 'abcd',
           })
@@ -139,9 +139,9 @@ if FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE has been set to FirebaseAnaly
 iOS if ConsentType.analyticsStorage has been set to ConsentStatus.denied.
 
 ```jsx
-import analytics from '@react-native-firebase/analytics';
+import { getAnalytics, getAppInstanceId } from '@react-native-firebase/analytics';
 // ...
-const appInstanceId = await analytics().getAppInstanceId();
+const appInstanceId = await getAppInstanceId(getAnalytics());
 ```
 
 ### Web / Other platform instance id
@@ -227,17 +227,17 @@ on the `firebase.json` file at the root of your project directory.
 To re-enable analytics (e.g. once you have the users consent), call the `setAnalyticsCollectionEnabled` method:
 
 ```js
-import { firebase } from '@react-native-firebase/analytics';
+import { getAnalytics, setAnalyticsCollectionEnabled } from '@react-native-firebase/analytics';
 // ...
-await firebase.analytics().setAnalyticsCollectionEnabled(true);
+await setAnalyticsCollectionEnabled(getAnalytics(), true);
 ```
 
 To update user's consent (e.g. once you have the users consent), call the `setConsent` method:
 
 ```js
-import { firebase } from '@react-native-firebase/analytics';
+import { getAnalytics, setConsent } from '@react-native-firebase/analytics';
 // ...
-await firebase.analytics().setConsent({
+await setConsent(getAnalytics(), {
   analytics_storage: true,
   ad_storage: true,
   ad_user_data: true,

--- a/docs/app/usage.mdx
+++ b/docs/app/usage.mdx
@@ -36,7 +36,7 @@ The module exposes an `initializeApp` method which accepts arguments containing 
 apps:
 
 ```js
-import firebase from '@react-native-firebase/app';
+import { initializeApp } from '@react-native-firebase/app';
 
 // Your secondary Firebase project credentials...
 const credentials = {
@@ -53,13 +53,13 @@ const config = {
   name: 'SECONDARY_APP',
 };
 
-await firebase.initializeApp(credentials, config);
+await initializeApp(credentials, config);
 ```
 
 Note that if you use multiple platforms, you will need to use the credentials relevant to that platform:
 
 ```js
-import firebase from '@react-native-firebase/app';
+import { initializeApp } from '@react-native-firebase/app';
 import { Platform } from 'react-native';
 
 // Your secondary Firebase project credentials for Android...
@@ -94,13 +94,15 @@ const config = {
   name: 'SECONDARY_APP',
 };
 
-await firebase.initializeApp(credentials, config);
+await initializeApp(credentials, config);
 ```
 
 Once created, you can confirm the app instance has been created by accessing the `apps` property on the module:
 
 ```js
-const apps = firebase.apps;
+import { getApps } from '@react-native-firebase/app';
+
+const apps = getApps();
 
 apps.forEach(app => {
   console.log('App name: ', app.name);
@@ -112,24 +114,21 @@ apps.forEach(app => {
 You can switch app instances at any time whilst developing by calling the `app` method with the name of the secondary app:
 
 ```js
-import firebase from '@react-native-firebase/app';
-import '@react-native-firebase/auth';
+import { getApp } from '@react-native-firebase/app';
+import { getAuth } from '@react-native-firebase/auth';
 
-// Example using auth
-firebase.app('SECONDARY_APP').auth().currentUser;
+getAuth(getApp('SECONDARY_APP')).currentUser;
 ```
 
 Or pass the secondary app instance you created above directly to the desired module, for example:
 
 ```js
-import firebase from '@react-native-firebase/app';
-import auth from '@react-native-firebase/auth';
+import { getApp, initializeApp } from '@react-native-firebase/app';
+import { getAuth } from '@react-native-firebase/auth';
 
-// create secondary app as described above
-const secondaryApp = await firebase.initializeApp(credentials, config);
+const secondaryApp = await initializeApp(credentials, config);
 
-// Example using auth with passing the secondary app instance
-auth(secondaryApp).currentUser;
+getAuth(secondaryApp).currentUser;
 ```
 
 ## Deleting instances
@@ -137,5 +136,5 @@ auth(secondaryApp).currentUser;
 You can delete any secondary instances by calling the `delete` method on the instance:
 
 ```js
-await firebase.app('SECONDARY_APP').delete();
+await getApp('SECONDARY_APP').delete();
 ```

--- a/docs/app/utils.mdx
+++ b/docs/app/utils.mdx
@@ -36,11 +36,11 @@ data collection. Such functionality can be carried out by taking advantage of th
 
 ```js
 import { utils } from '@react-native-firebase/app';
-import analytics from '@react-native-firebase/analytics';
+import { getAnalytics, setAnalyticsCollectionEnabled } from '@react-native-firebase/analytics';
 
 async function bootstrap() {
   if (utils().isRunningInTestLab) {
-    await analytics().setAnalyticsCollectionEnabled(false);
+    await setAnalyticsCollectionEnabled(getAnalytics(), false);
   }
 }
 ```

--- a/docs/crashlytics/usage/index.mdx
+++ b/docs/crashlytics/usage/index.mdx
@@ -59,14 +59,22 @@ There are various methods to set attributes for the crash report, in order to pr
 ```js
 import React, { useEffect } from 'react';
 import { View, Button } from 'react-native';
-import crashlytics from '@react-native-firebase/crashlytics';
+import {
+  getCrashlytics,
+  log,
+  setUserId,
+  setAttribute,
+  setAttributes,
+  crash,
+} from '@react-native-firebase/crashlytics';
 
 async function onSignIn(user) {
-  crashlytics().log('User signed in.');
+  const crashlytics = getCrashlytics();
+  log(crashlytics, 'User signed in.');
   await Promise.all([
-    crashlytics().setUserId(user.uid),
-    crashlytics().setAttribute('credits', String(user.credits)),
-    crashlytics().setAttributes({
+    setUserId(crashlytics, user.uid),
+    setAttribute(crashlytics, 'credits', String(user.credits)),
+    setAttributes(crashlytics, {
       role: 'admin',
       followers: '13',
       email: user.email,
@@ -77,7 +85,7 @@ async function onSignIn(user) {
 
 export default function App() {
   useEffect(() => {
-    crashlytics().log('App mounted.');
+    log(getCrashlytics(), 'App mounted.');
   }, []);
 
   return (
@@ -93,7 +101,7 @@ export default function App() {
           })
         }
       />
-      <Button title="Test Crash" onPress={() => crashlytics().crash()} />
+      <Button title="Test Crash" onPress={() => crash(getCrashlytics())} />
     </View>
   );
 }
@@ -107,7 +115,7 @@ Crashlytics using the `recordError` method. This will also provide you with the 
 ```jsx
 import React, { useState, useEffect } from 'react';
 import { View, Text } from 'react-native';
-import crashlytics from '@react-native-firebase/crashlytics';
+import { getCrashlytics, log, recordError } from '@react-native-firebase/crashlytics';
 
 const users = [];
 
@@ -115,21 +123,20 @@ export default function App() {
   const [userCounts, setUserCounts] = useState(null);
 
   function updateUserCounts() {
-    crashlytics().log('Updating user count.');
+    const crashlytics = getCrashlytics();
+    log(crashlytics, 'Updating user count.');
     try {
       if (users) {
-        // An empty array is truthy, but not actually true.
-        // Therefore the array was never initialized.
         setUserCounts(userCounts.push(users.length));
       }
     } catch (error) {
-      crashlytics().recordError(error);
+      recordError(crashlytics, error);
       console.log(error);
     }
   }
 
   useEffect(() => {
-    crashlytics().log('App mounted.');
+    log(getCrashlytics(), 'App mounted.');
     if (users == true) setUserCounts([]);
     updateUserCounts();
   }, []);
@@ -158,21 +165,25 @@ This can be done throughout the app with a simple method call to `setCrashlytics
 ```jsx
 import React, { useState } from 'react';
 import { View, Button, Text } from 'react-native';
-import crashlytics from '@react-native-firebase/crashlytics';
+import {
+  getCrashlytics,
+  setCrashlyticsCollectionEnabled,
+  crash,
+} from '@react-native-firebase/crashlytics';
 
 export default function App() {
-  const [enabled, setEnabled] = useState(crashlytics().isCrashlyticsCollectionEnabled);
+  const [enabled, setEnabled] = useState(getCrashlytics().isCrashlyticsCollectionEnabled);
 
   async function toggleCrashlytics() {
-    await crashlytics()
-      .setCrashlyticsCollectionEnabled(!enabled)
-      .then(() => setEnabled(crashlytics().isCrashlyticsCollectionEnabled));
+    const crashlytics = getCrashlytics();
+    await setCrashlyticsCollectionEnabled(crashlytics, !enabled);
+    setEnabled(crashlytics.isCrashlyticsCollectionEnabled);
   }
 
   return (
     <View>
       <Button title="Toggle Crashlytics" onPress={toggleCrashlytics} />
-      <Button title="Crash" onPress={() => crashlytics().crash()} />
+      <Button title="Crash" onPress={() => crash(getCrashlytics())} />
       <Text>Crashlytics is currently {enabled ? 'enabled' : 'disabled'}</Text>
     </View>
   );

--- a/docs/database/offline-support.mdx
+++ b/docs/database/offline-support.mdx
@@ -11,27 +11,27 @@ and automatically managed by the Firebase SDKs.
 # Enabling Persistence
 
 Persistence is disabled by default when using Realtime Database, however it
-[can be changed to be enabled by default in the firebase.json](/database/usage#enabling-persistence). You can also enable persistence programmatically, by calling the `setPersistenceEnabled`
+[can be changed to be enabled by default in the firebase.json](/database/usage#enabling-persistence). You can also enable persistence programmatically, by calling `setPersistenceEnabled`
 as early on in your application code as possible:
 
 ```js
 // index.js
 import { AppRegistry } from 'react-native';
-import database from '@react-native-firebase/database';
+import { getDatabase, setPersistenceEnabled } from '@react-native-firebase/database';
 
-database().setPersistenceEnabled(true);
+setPersistenceEnabled(getDatabase(), true);
 
 AppRegistry.registerComponent('app', () => App);
 ```
 
 # Going offline
 
-The API provides a `goOffline` method to force the Realtime Database SDK to go offline, which can be useful for testing.
+The API provides a `goOffline` function to force the Realtime Database SDK to go offline, which can be useful for testing.
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, goOffline } from '@react-native-firebase/database';
 
-await database().goOffline();
+goOffline(getDatabase());
 ```
 
 Once offline, all operations will continue to execute, instead using a local instance of your database to perform writes to.
@@ -39,33 +39,30 @@ For example, we write to a record which has a listener whilst offline allowing t
 
 ```jsx
 import React, { useEffect } from 'react';
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, onValue, goOffline, set } from '@react-native-firebase/database';
 
 function App() {
   useEffect(() => {
-    const userAgeRef = database().ref('/users/123/age');
+    const db = getDatabase();
+    const userAgeRef = ref(db, '/users/123/age');
 
-    userAgeRef.on('value', snapshot => {
+    onValue(userAgeRef, snapshot => {
       console.log('Users age: ', snapshot.val());
     });
 
-    database()
-      .goOffline()
-      .then(() => {
-        return userRef.set(32);
-      })
-      .then(() => {
-        console.log('User updated whilst offline.');
-      });
+    goOffline(db);
+    set(userAgeRef, 32).then(() => {
+      console.log('User updated whilst offline.');
+    });
   }, []);
 }
 ```
 
-The above code will first execute the `on` listener with data from the remote database.
+The above code will first execute the `onValue` listener with data from the remote database.
 
-Once offline, the `set` method on the reference node will `locally` be set to a new value.
+Once offline, `set` on the reference node will `locally` be set to a new value.
 
-The `on` listener
+The `onValue` listener
 however will now subscribe to the local database and provide the new value.
 
 This provides the ability to write code which works in both an online and offline environment without worrying about
@@ -73,23 +70,23 @@ data synchronization.
 
 # Going online
 
-The `goOnline` method re-connects the Realtime Database with the remote database. Any locally written changes performed
+The `goOnline` function re-connects the Realtime Database with the remote database. Any locally written changes performed
 whilst offline will be automatically synchronized with the remote database.
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, goOnline } from '@react-native-firebase/database';
 
-await database().goOnline();
+goOnline(getDatabase());
 ```
 
 # Local persistence size
 
 By default Firebase Database will use up to `10MB` of disk space to cache data. If the cache grows beyond this size,
 Firebase Database will start removing data that hasn't been recently used. If you find that your application caches too
-little or too much data, call the `setPersistenceCacheSizeBytes` method to update the default cache size:
+little or too much data, call `setPersistenceCacheSizeBytes` to update the default cache size:
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, setPersistenceCacheSizeBytes } from '@react-native-firebase/database';
 
-database().setPersistenceCacheSizeBytes(2000000); // 2MB
+setPersistenceCacheSizeBytes(getDatabase(), 2000000); // 2MB
 ```

--- a/docs/database/presence-detection.mdx
+++ b/docs/database/presence-detection.mdx
@@ -22,18 +22,18 @@ Whenever the application opens, [write a new value](/database/usage#writing-data
 
 ```jsx
 import React, { useEffect } from 'react';
-import auth from '@react-native-firebase/auth';
-import database from '@react-native-firebase/database';
+import { getAuth } from '@react-native-firebase/auth';
+import { getDatabase, ref, set } from '@react-native-firebase/database';
 
 function App() {
   useEffect(() => {
     // Assuming user is logged in
-    const userId = auth().currentUser.uid;
-
-    const reference = database().ref(`/online/${userId}`);
+    const userId = getAuth().currentUser.uid;
+    const db = getDatabase();
+    const reference = ref(db, `/online/${userId}`);
 
     // Set the /users/:userId value to true
-    reference.set(true).then(() => console.log('Online presence set'));
+    set(reference, true).then(() => console.log('Online presence set'));
   }, []);
 }
 ```
@@ -49,28 +49,27 @@ If the device suddenly goes offline, or is quit, the app can no longer execute c
 Realtime Database API provides a way to execute code on the Firebase servers whenever the connection between an app & server
 is lost.
 
-The `onDisconnect` method on a reference returns a new [`OnDisconnect`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/OnDisconnect.html) instance. This instance
+The `onDisconnect` function returns a new [`OnDisconnect`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/OnDisconnect.html) instance. This instance
 provides functionality to remove or set data whenever a client disconnects. Using the
 [`remove`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/OnDisconnect.html#remove) method we can remove the node on the database if the client disconnects:
 
 ```jsx
 import React, { useEffect } from 'react';
-import auth from '@react-native-firebase/auth';
-import database from '@react-native-firebase/database';
+import { getAuth } from '@react-native-firebase/auth';
+import { getDatabase, ref, set, onDisconnect } from '@react-native-firebase/database';
 
 function App() {
   useEffect(() => {
     // Assuming user is logged in
-    const userId = auth().currentUser.uid;
-
-    const reference = database().ref(`/online/${userId}`);
+    const userId = getAuth().currentUser.uid;
+    const db = getDatabase();
+    const reference = ref(db, `/online/${userId}`);
 
     // Set the /users/:userId value to true
-    reference.set(true).then(() => console.log('Online presence set'));
+    set(reference, true).then(() => console.log('Online presence set'));
 
     // Remove the node whenever the client disconnects
-    reference
-      .onDisconnect()
+    onDisconnect(reference)
       .remove()
       .then(() => console.log('On disconnect function configured.'));
   }, []);

--- a/docs/database/usage/index.mdx
+++ b/docs/database/usage/index.mdx
@@ -41,23 +41,22 @@ To learn more, view the [Firebase Realtime Database documentation](https://fireb
 A core concept to understanding Realtime Database are references - a reference to a specific node within your database. A node
 can be a specific property or sub-nodes.
 
-To create a [`Reference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/Reference.html), call the `ref` method:
+To create a [`Reference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/Reference.html), use the `ref` function:
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, ref } from '@react-native-firebase/database';
 
-const reference = database().ref('/users/123');
+const db = getDatabase();
+const reference = ref(db, '/users/123');
 ```
 
 NOTE: To get a reference to a database other than a 'us-central1' default database, you must pass the database URL. You can find your Realtime Database URL in the Realtime Database section of the Firebase console.
 
 ```js
-import { firebase } from '@react-native-firebase/database';
+import { getDatabase, ref } from '@react-native-firebase/database';
 
-const reference = firebase
-  .app()
-  .database('https://<databaseName>.<region>.firebasedatabase.app/')
-  .ref('/users/123');
+const db = getDatabase(undefined, 'https://<databaseName>.<region>.firebasedatabase.app/');
+const reference = ref(db, '/users/123');
 ```
 
 ## Reading data
@@ -69,54 +68,49 @@ The snapshot includes information such as whether the reference node exists, it'
 
 ### One-time read
 
-To read the value once, call the `once` method on a reference:
+To read the value once, use `get`:
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, get } from '@react-native-firebase/database';
 
-database()
-  .ref('/users/123')
-  .once('value')
-  .then(snapshot => {
-    console.log('User data: ', snapshot.val());
-  });
+const db = getDatabase();
+get(ref(db, '/users/123')).then(snapshot => {
+  console.log('User data: ', snapshot.val());
+});
 ```
 
 ### Realtime changes
 
-To setup an active listener to react to any changes to the node and it's children, call the `on` method with an event handler:
+To setup an active listener to react to any changes to the node and it's children, use `onValue`:
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, onValue } from '@react-native-firebase/database';
 
-database()
-  .ref('/users/123')
-  .on('value', snapshot => {
-    console.log('User data: ', snapshot.val());
-  });
+const db = getDatabase();
+onValue(ref(db, '/users/123'), snapshot => {
+  console.log('User data: ', snapshot.val());
+});
 ```
 
 The event handler will be called straight away with the snapshot data, and further called when any changes to the node
 occur.
 
-You can unsubscribe from events by calling the `off` method. To unsubscribe from specific events, call the `off` method
-with the function that the event handler returned. This can be used within any `useEffect` hooks to automatically unsubscribe
+You can unsubscribe by calling the function returned from `onValue`. This can be used within any `useEffect` hooks to automatically unsubscribe
 when the hook needs to unsubscribe itself:
 
 ```jsx
 import React, { useEffect } from 'react';
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, onValue } from '@react-native-firebase/database';
 
 function User({ userId }) {
   useEffect(() => {
-    const onValueChange = database()
-      .ref(`/users/${userId}`)
-      .on('value', snapshot => {
-        console.log('User data: ', snapshot.val());
-      });
+    const db = getDatabase();
+    const unsubscribe = onValue(ref(db, `/users/${userId}`), snapshot => {
+      console.log('User data: ', snapshot.val());
+    });
 
     // Stop listening for updates when no longer required
-    return () => database().ref(`/users/${userId}`).off('value', onValueChange);
+    return () => unsubscribe();
   }, [userId]);
 }
 ```
@@ -124,26 +118,25 @@ function User({ userId }) {
 #### Additional events
 
 The above example demonstrates how to subscribe to events whenever a value within the node changes. In some cases, you
-may need to only subscribe to events whenever a child node is added/changed/moved/removed. This can be achieved by passing
-a different [`EventType`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/EventType.html) to the `on` method.
+may need to only subscribe to events whenever a child node is added/changed/moved/removed. This can be achieved using
+a different listener such as [`onChildAdded`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/EventType.html).
 
 If you are listening to a node with many children, only listening to data you care about helps reduce network bandwidth
 and speeds up your application.
 
 ```jsx
 import React, { useEffect } from 'react';
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, onChildAdded } from '@react-native-firebase/database';
 
 function User({ userId }) {
   useEffect(() => {
-    const onChildAdd = database()
-      .ref('/users')
-      .on('child_added', snapshot => {
-        console.log('A new node has been added', snapshot.val());
-      });
+    const db = getDatabase();
+    const unsubscribe = onChildAdded(ref(db, '/users'), snapshot => {
+      console.log('A new node has been added', snapshot.val());
+    });
 
     // Stop listening for updates when no longer required
-    return () => database().ref('/users').off('child_added', onChildAdd);
+    return () => unsubscribe();
   }, [userId]);
 }
 ```
@@ -158,9 +151,9 @@ If your application requires more advanced query capabilities, it is recommended
 #### Ordering
 
 By default, results are ordered based on the node [keys](/database/usage#database-keys). If however you are using custom keys you can use
-one of the `orderByX` methods to order your data.
+the `orderByX` query constraints with `query` to order your data.
 
-For example, if all of the nodes children are scalar values (string, number or boolean) you can use the `orderByValue` method,
+For example, if all of the nodes children are scalar values (string, number or boolean) you can use `orderByValue`,
 and Firebase will automatically order the results. The example below would return the `def` node before the `abc` node:
 
 ```js
@@ -173,26 +166,42 @@ and Firebase will automatically order the results. The example below would retur
  * }
  */
 
-const scores = database().ref('scores').orderByValue().once('value');
+import { getDatabase, ref, query, orderByValue, get } from '@react-native-firebase/database';
+
+const db = getDatabase();
+const scores = get(query(ref(db, 'scores'), orderByValue()));
 ```
 
 Please note that the ordering will not be respected if you do not use the `forEach` method provided on the `DataSnapshot`.
 
 #### Limiting
 
-You can limit the number of results returned from a query by using one of the `limitToX` methods. For example, to limit to the
+You can limit the number of results returned from a query by using `limitToFirst` or `limitToLast` query constraints. For example, to limit to the
 first 10 results:
 
 ```js
-const users = database().ref('users').limitToFirst(10).once('value');
+import { getDatabase, ref, query, limitToFirst, get } from '@react-native-firebase/database';
+
+const db = getDatabase();
+const users = get(query(ref(db, 'users'), limitToFirst(10)));
 ```
 
-Firebase also provides the ability to return the last set of results in a query via the `limitToLast` method.
+Firebase also provides the ability to return the last set of results in a query via `limitToLast`.
 
 Instead of limiting to a specific number of documents, you can also start from, or end at a specific reference node value:
 
 ```js
-await database().ref('users').orderByChild('age').startAt(21).once('value');
+import {
+  getDatabase,
+  ref,
+  query,
+  orderByChild,
+  startAt,
+  get,
+} from '@react-native-firebase/database';
+
+const db = getDatabase();
+await get(query(ref(db, 'users'), orderByChild('age'), startAt(21)));
 ```
 
 ## Writing data
@@ -202,58 +211,55 @@ practices on how to structure your data. We highly recommend reading the guide b
 
 ### Setting data
 
-The `set` method on a [`Reference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/FirebaseDatabaseTypes/Reference.html) overwrites all of the existing data at that reference node.
+The `set` function overwrites all of the existing data at that reference node.
 The value can be anything; a string, number, object etc:
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, set } from '@react-native-firebase/database';
 
-database()
-  .ref('/users/123')
-  .set({
-    name: 'Ada Lovelace',
-    age: 31,
-  })
-  .then(() => console.log('Data set.'));
+const db = getDatabase();
+set(ref(db, '/users/123'), {
+  name: 'Ada Lovelace',
+  age: 31,
+}).then(() => console.log('Data set.'));
 ```
 
 If you set the value to `null`, Firebase will automatically class the node as removed, and delete it from the database.
 
 ### Updating data
 
-Rather than overwriting all existing data, the `update` method provides the ability to update any existing data on the reference node.
+Rather than overwriting all existing data, the `update` function provides the ability to update any existing data on the reference node.
 Firebase will automatically merge the data depending on what currently exists.
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, update } from '@react-native-firebase/database';
 
-database()
-  .ref('/users/123')
-  .update({
-    age: 32,
-  })
-  .then(() => console.log('Data updated.'));
+const db = getDatabase();
+update(ref(db, '/users/123'), {
+  age: 32,
+}).then(() => console.log('Data updated.'));
 ```
 
 ### Pushing data
 
 Currently the examples have only demonstrated working with known reference node keys (e.g. `/users/123`). In some cases,
-you may not have a suitable id or may want Firebase to automatically create a node with a generated key. The `push` method
+you may not have a suitable id or may want Firebase to automatically create a node with a generated key. The `push` function
 returns a [`ThenableReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/database/ThenableReference.html), allowing you to observe a node before it is
 sent to remote Firebase database.
 
-The `push` method will automatically generate a new key if one is not provided:
+`push` will automatically generate a new key if one is not provided:
 
 ```js
-const newReference = database().ref('/users').push();
+import { getDatabase, ref, push, set } from '@react-native-firebase/database';
+
+const db = getDatabase();
+const newReference = push(ref(db, '/users'));
 
 console.log('Auto generated key: ', newReference.key);
 
-newReference
-  .set({
-    age: 32,
-  })
-  .then(() => console.log('Data updated.'));
+set(newReference, {
+  age: 32,
+}).then(() => console.log('Data updated.'));
 ```
 
 The keys generated are ordered to the current time, so the list of items returned from Firebase will be chronologically
@@ -261,16 +267,20 @@ sorted by default.
 
 ## Removing data
 
-To remove data, you can call the `remove` method on a reference:
+To remove data, use the `remove` function:
 
 ```js
-await database().ref('/users/123').remove();
+import { getDatabase, ref, remove } from '@react-native-firebase/database';
+
+await remove(ref(getDatabase(), '/users/123'));
 ```
 
 Optionally, you can also set the value of a reference node to `null` to remove it from the database:
 
 ```js
-await database().ref('/users/123').set(null);
+import { getDatabase, ref, set } from '@react-native-firebase/database';
+
+await set(ref(getDatabase(), '/users/123'), null);
 ```
 
 ## Transactions
@@ -288,16 +298,16 @@ causing the actual number to not be consistent.
 Transactions remove this issue by atomically updating the value on the server. If the value changes whilst the transaction
 is executing, it will retry. This always ensures the value on the server is used rather than the client value.
 
-To execute a new transaction, call the `transaction` method on a reference:
+To execute a new transaction, call `runTransaction`:
 
 ```js
-import database from '@react-native-firebase/database';
+import { getDatabase, ref, runTransaction } from '@react-native-firebase/database';
 
 function onPostLike(postId) {
-  const reference = database().ref(`/likes/${postId}`);
+  const db = getDatabase();
+  const reference = ref(db, `/likes/${postId}`);
 
-  // Execute transaction
-  return reference.transaction(currentLikes => {
+  return runTransaction(reference, currentLikes => {
     if (currentLikes === null) return 1;
     return currentLikes + 1;
   });
@@ -319,15 +329,15 @@ Please follow the Firebase Realtime Database documentation on [security](https:/
 
 # Using a secondary database
 
-If the default installed Firebase instance needs to address a different database within the same project, call the database method on the default app with passing the database URL.
+If the default installed Firebase instance needs to address a different database within the same project, pass the database URL to `getDatabase`.
 For example:
 
 ```js
-import { firebase } from '@react-native-firebase/database';
+import { getDatabase, ref } from '@react-native-firebase/database';
 
-const database = firebase.app().database('https://path-to-database.firebaseio.com');
+const db = getDatabase(undefined, 'https://path-to-database.firebaseio.com');
 
-database.ref();
+ref(db);
 ```
 
 ## Connect to a database of a secondary app
@@ -337,15 +347,15 @@ If you want to address a database from a different Firebase project, you will ne
 For example:
 
 ```js
-import database, { firebase } from '@react-native-firebase/database';
+import { initializeApp } from '@react-native-firebase/app';
+import { getDatabase, ref } from '@react-native-firebase/database';
 
 // create a secondary app
-const secondaryApp = await firebase.initializeApp(credentials, config);
+const secondaryApp = await initializeApp(credentials, config);
 
-// pass the secondary app instance to the database module
-const secondaryDatabase = database(secondaryApp);
+const secondaryDb = getDatabase(secondaryApp);
 
-secondaryDatabase.ref();
+ref(secondaryDb);
 ```
 
 # firebase.json

--- a/docs/firestore/emulator.mdx
+++ b/docs/firestore/emulator.mdx
@@ -29,15 +29,15 @@ You need to configure the following property as soon as possible in the startup 
 
 ```jsx
 import '@react-native-firebase/app';
-import firestore from '@react-native-firebase/firestore';
+import { connectFirestoreEmulator, getFirestore } from '@react-native-firebase/firestore';
 
 // set the host and the port property to connect to the emulator
 // set these before any read/write operations occur to ensure it doesn't affect your Cloud Firestore data!
 if (__DEV__) {
-  firestore().useEmulator('localhost', 8080);
+  connectFirestoreEmulator(getFirestore(), 'localhost', 8080);
 }
 
-const db = firestore();
+const db = getFirestore();
 ```
 
 # Clear locally stored emulator data

--- a/docs/firestore/pagination.mdx
+++ b/docs/firestore/pagination.mdx
@@ -17,9 +17,10 @@ import React, { useState } from 'react';
 import type { Node } from 'react';
 import { Text, View, Button, Alert } from 'react-native';
 
-import firestore from '@react-native-firebase/firestore';
+import { collection, getFirestore } from '@react-native-firebase/firestore';
 
-const userCollection = firestore().collection('Users');
+const db = getFirestore();
+const usersRef = collection(db, 'Users');
 
 const App: () => Node = () => {
   const [lastDocument, setLastDocument] = useState();
@@ -39,9 +40,18 @@ import React, { useState } from 'react';
 import type { Node } from 'react';
 import { Text, View, Button, Alert } from 'react-native';
 
-import firestore from '@react-native-firebase/firestore';
+import {
+  collection,
+  getDocs,
+  getFirestore,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+} from '@react-native-firebase/firestore';
 
-const userCollection = firestore().collection('Users');
+const db = getFirestore();
+const usersRef = collection(db, 'Users');
 
 const App: () => Node = () => {
   const [lastDocument, setLastDocument] = useState();
@@ -49,17 +59,16 @@ const App: () => Node = () => {
 
   function LoadData() {
     console.log('LOAD');
-    let query = userCollection.orderBy('age'); // sort the data
+    const constraints = [orderBy('age')]; // sort the data
     if (lastDocument !== undefined) {
-      query = query.startAfter(lastDocument); // fetch data following the last document accessed
+      constraints.push(startAfter(lastDocument)); // fetch data following the last document accessed
     }
-    query.limit(3) // limit to your page size, 3 is just an example
-        .get()
-        .then(querySnapshot => {
-          setLastDocument(querySnapshot.docs[querySnapshot.docs.length - 1]);
-          MakeUserData(querySnapshot.docs);
-        });
-    }
+    constraints.push(limit(3)); // limit to your page size, 3 is just an example
+
+    getDocs(query(usersRef, ...constraints)).then(querySnapshot => {
+      setLastDocument(querySnapshot.docs[querySnapshot.docs.length - 1]);
+      MakeUserData(querySnapshot.docs);
+    });
   }
 
   return (
@@ -109,9 +118,18 @@ import React, { useState } from 'react';
 import type { Node } from 'react';
 import { Text, View, Button, Alert } from 'react-native';
 
-import firestore from '@react-native-firebase/firestore';
+import {
+  collection,
+  getDocs,
+  getFirestore,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+} from '@react-native-firebase/firestore';
 
-const userCollection = firestore().collection('Users');
+const db = getFirestore();
+const usersRef = collection(db, 'Users');
 
 const App: () => Node = () => {
   const [lastDocument, setLastDocument] = useState();
@@ -119,17 +137,16 @@ const App: () => Node = () => {
 
   function LoadData() {
     console.log('LOAD');
-    let query = userCollection.orderBy('age'); // sort the data
+    const constraints = [orderBy('age')]; // sort the data
     if (lastDocument !== undefined) {
-      query = query.startAfter(lastDocument); // fetch data following the last document accessed
+      constraints.push(startAfter(lastDocument)); // fetch data following the last document accessed
     }
-    query.limit(3) // limit to your page size, 3 is just an example
-        .get()
-        .then(querySnapshot => {
-          setLastDocument(querySnapshot.docs[querySnapshot.docs.length - 1]);
-          MakeUserData(querySnapshot.docs);
-        });
-    }
+    constraints.push(limit(3)); // limit to your page size, 3 is just an example
+
+    getDocs(query(usersRef, ...constraints)).then(querySnapshot => {
+      setLastDocument(querySnapshot.docs[querySnapshot.docs.length - 1]);
+      MakeUserData(querySnapshot.docs);
+    });
   }
 
   function MakeUserData(docs) {

--- a/docs/firestore/usage-with-flatlists.mdx
+++ b/docs/firestore/usage-with-flatlists.mdx
@@ -42,18 +42,18 @@ the "Users" collection documents:
 ```jsx
 import React, { useState, useEffect } from 'react';
 import { ActivityIndicator } from 'react-native';
-import firestore from '@react-native-firebase/firestore';
+import { collection, getFirestore, onSnapshot } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 function Users() {
   const [loading, setLoading] = useState(true); // Set loading to true on component mount
   const [users, setUsers] = useState([]); // Initial empty array of users
 
   useEffect(() => {
-    const subscriber = firestore()
-      .collection('Users')
-      .onSnapshot(() => {
-        // see next step
-      });
+    const subscriber = onSnapshot(collection(db, 'Users'), () => {
+      // see next step
+    });
 
     // Unsubscribe from events when no longer in use
     return () => subscriber();
@@ -75,21 +75,19 @@ we can use the `id` of a document:
 
 ```js
 useEffect(() => {
-  const subscriber = firestore()
-    .collection('Users')
-    .onSnapshot(querySnapshot => {
-      const users = [];
+  const subscriber = onSnapshot(collection(db, 'Users'), querySnapshot => {
+    const users = [];
 
-      querySnapshot.forEach(documentSnapshot => {
-        users.push({
-          ...documentSnapshot.data(),
-          key: documentSnapshot.id,
-        });
+    querySnapshot.forEach(documentSnapshot => {
+      users.push({
+        ...documentSnapshot.data(),
+        key: documentSnapshot.id,
       });
-
-      setUsers(users);
-      setLoading(false);
     });
+
+    setUsers(users);
+    setLoading(false);
+  });
 
   // Unsubscribe from events when no longer in use
   return () => subscriber();
@@ -106,7 +104,9 @@ With the raw user data in local state, we can now pass this to the `FlatList`:
 ```jsx
 import React, { useState, useEffect } from 'react';
 import { ActivityIndicator, FlatList, View, Text } from 'react-native';
-import firestore from '@react-native-firebase/firestore';
+import { collection, getFirestore, onSnapshot } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 function Users() {
   // ...

--- a/docs/firestore/usage/index.mdx
+++ b/docs/firestore/usage/index.mdx
@@ -40,27 +40,30 @@ latency or Internet connectivity.
 ## Collections & Documents
 
 Cloud Firestore stores data within "documents", which are contained within "collections", and documents can also contain
-collections. For example, we could store a list of our users documents within a "Users" collection. The `collection` method
+collections. For example, we could store a list of our users documents within a "Users" collection. The `collection` function
 allows us to reference a collection within our code:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, getFirestore } from '@react-native-firebase/firestore';
 
-const usersCollection = firestore().collection('Users');
+const db = getFirestore();
+const usersCollection = collection(db, 'Users');
 ```
 
-The `collection` method returns a [`CollectionReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/CollectionReference.html) class, which provides
+The `collection` function returns a [`CollectionReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/CollectionReference.html) class, which provides
 properties and methods to query and fetch the data from Cloud Firestore. We can also directly reference a single document
-on the collection by calling the `doc` method:
+on the collection by calling the `doc` function:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, doc, getFirestore } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 // Get user document with an ID of ABC
-const userDocument = firestore().collection('Users').doc('ABC');
+const userDocument = doc(collection(db, 'Users'), 'ABC');
 ```
 
-The `doc` method returns a [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html).
+The `doc` function returns a [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html).
 
 A document can contain different types of data, including scalar values (strings, booleans, numbers), arrays (lists) and
 objects (maps) along with specific Cloud Firestore data such as [Timestamps](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/modular/Timestamp.html),
@@ -73,23 +76,26 @@ realtime updates when the data within a query changes.
 
 ### One-time read
 
-To read a collection or document once, call the `get` method on a [`CollectionReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/CollectionReference.html)
-or [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html):
+To read a collection or document once, call `getDocs` on a [`CollectionReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/CollectionReference.html)
+or `getDoc` on a [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html):
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, doc, getDoc, getDocs, getFirestore } from '@react-native-firebase/firestore';
 
-const users = await firestore().collection('Users').get();
-const user = await firestore().collection('Users').doc('ABC').get();
+const db = getFirestore();
+const users = await getDocs(collection(db, 'Users'));
+const user = await getDoc(doc(collection(db, 'Users'), 'ABC'));
 ```
 
 ### Realtime changes
 
-To setup an active listener to react to any changes to the query, call the `onSnapshot` method with an event handler callback.
+To setup an active listener to react to any changes to the query, call `onSnapshot` with an event handler callback.
 For example, to watch the entire "Users" collection for when any documents are changed (removed, added, modified):
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, getFirestore, onSnapshot } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 function onResult(QuerySnapshot) {
   console.log('Got Users collection result.');
@@ -99,24 +105,23 @@ function onError(error) {
   console.error(error);
 }
 
-firestore().collection('Users').onSnapshot(onResult, onError);
+onSnapshot(collection(db, 'Users'), onResult, onError);
 ```
 
-The `onSnapshot` method also returns a function, allowing you to unsubscribe from events. This can be used within any
+`onSnapshot` also returns a function, allowing you to unsubscribe from events. This can be used within any
 `useEffect` hooks to automatically unsubscribe when the hook needs to unsubscribe itself:
 
 ```js
 import React, { useEffect } from 'react';
-import firestore from '@react-native-firebase/firestore';
+import { collection, doc, getFirestore, onSnapshot } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 function User({ userId }) {
   useEffect(() => {
-    const subscriber = firestore()
-      .collection('Users')
-      .doc(userId)
-      .onSnapshot(documentSnapshot => {
-        console.log('User data: ', documentSnapshot.data());
-      });
+    const subscriber = onSnapshot(doc(collection(db, 'Users'), userId), documentSnapshot => {
+      console.log('User data: ', documentSnapshot.data());
+    });
 
     // Stop listening for updates when no longer required
     return () => subscriber();
@@ -124,7 +129,7 @@ function User({ userId }) {
 }
 ```
 
-Realtime changes via the `onSnapshot` method can be applied to both collections and documents.
+Realtime changes via `onSnapshot` can be applied to both collections and documents.
 
 ### Snapshots
 
@@ -142,18 +147,17 @@ and more.
 To access the documents within a `QuerySnapshot`, call the `forEach` method:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, getDocs, getFirestore } from '@react-native-firebase/firestore';
 
-firestore()
-  .collection('Users')
-  .get()
-  .then(querySnapshot => {
-    console.log('Total users: ', querySnapshot.size);
+const db = getFirestore();
 
-    querySnapshot.forEach(documentSnapshot => {
-      console.log('User ID: ', documentSnapshot.id, documentSnapshot.data());
-    });
+getDocs(collection(db, 'Users')).then(querySnapshot => {
+  console.log('Total users: ', querySnapshot.size);
+
+  querySnapshot.forEach(documentSnapshot => {
+    console.log('User ID: ', documentSnapshot.id, documentSnapshot.data());
   });
+});
 ```
 
 Each child document of a `QuerySnapshot` is a [`QueryDocumentSnapshot`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/QueryDocumentSnapshot.html), which
@@ -168,33 +172,32 @@ to view a documents data, metadata and whether a document actually exists.
 To view a documents data, call the `data` method on the snapshot:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, doc, getDoc, getFirestore } from '@react-native-firebase/firestore';
 
-firestore()
-  .collection('Users')
-  .doc('ABC')
-  .get()
-  .then(documentSnapshot => {
-    console.log('User exists: ', documentSnapshot.exists);
+const db = getFirestore();
 
-    if (documentSnapshot.exists) {
-      console.log('User data: ', documentSnapshot.data());
-    }
-  });
+getDoc(doc(collection(db, 'Users'), 'ABC')).then(documentSnapshot => {
+  console.log('User exists: ', documentSnapshot.exists);
+
+  if (documentSnapshot.exists) {
+    console.log('User data: ', documentSnapshot.data());
+  }
+});
 ```
 
 A snapshot also provides a helper function to easily access deeply nested data within a document. Call the `get` method
 with a dot-notated path:
 
 ```js
+import { collection, doc, getDoc, getFirestore } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
 function getUserZipCode(documentSnapshot) {
   return documentSnapshot.get('info.address.zipcode');
 }
 
-firestore()
-  .collection('Users')
-  .doc('ABC')
-  .get()
+getDoc(doc(collection(db, 'Users'), 'ABC'))
   .then(documentSnapshot => getUserZipCode(documentSnapshot))
   .then(zipCode => {
     console.log('Users zip code is: ', zipCode);
@@ -207,69 +210,81 @@ Cloud Firestore offers advanced capabilities for querying collections.
 
 #### Filtering
 
-To filter documents within a collection, the `where` method can be chained onto a collection reference. Filtering supports
+To filter documents within a collection, pass `where` constraints to `query`. Filtering supports
 equality checks and "in" queries. For example, to filter users where their age is greater or equal than 18 years old:
 
 ```js
-firestore()
-  .collection('Users')
-  // Filter results
-  .where('age', '>=', 18)
-  .get()
-  .then(querySnapshot => {
-    /* ... */
-  });
+import { collection, getDocs, getFirestore, query, where } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+getDocs(query(collection(db, 'Users'), where('age', '>=', 18))).then(querySnapshot => {
+  /* ... */
+});
 ```
 
 Cloud Firestore also supports array membership queries. For example, to filter users who speak both English (en) or
 French (fr), use the `in` filter:
 
 ```js
-firestore()
-  .collection('Users')
-  // Filter results
-  .where('languages', 'in', ['en', 'fr'])
-  .get()
-  .then(querySnapshot => {
+getDocs(query(collection(db, 'Users'), where('languages', 'in', ['en', 'fr']))).then(
+  querySnapshot => {
     /* ... */
-  });
+  },
+);
 ```
 
 To learn more about all of the querying capabilities Cloud Firestore has to offer, view the
 [Firebase documentation](https://firebase.google.com/docs/firestore/query-data/queries).
 
-It is now possible to use the `Filter` instance to make queries. They can be used with the existing query API.
-For example, you could chain like so:
+You can combine multiple filters using `and()` and `or()` composite constraints.
+For example:
 
 ```js
-const snapshot = await firestore()
-  .collection('Users')
-  .where(Filter('user', '==', 'Tim'))
-  .where('email', '==', 'tim@example.com')
-  .get();
+import {
+  and,
+  collection,
+  getDocs,
+  getFirestore,
+  or,
+  query,
+  where,
+} from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+const snapshot = await getDocs(
+  query(
+    collection(db, 'Users'),
+    where('user', '==', 'Tim'),
+    where('email', '==', 'tim@example.com'),
+  ),
+);
 ```
 
-You can use the `Filter.and()` static method to make logical AND queries:
+You can use the `and()` function to make logical AND queries:
 
 ```js
-const snapshot = await firestore()
-  .collection('Users')
-  .where(Filter.and(Filter('user', '==', 'Tim'), Filter('email', '==', 'tim@example.com')))
-  .get();
+const snapshot = await getDocs(
+  query(
+    collection(db, 'Users'),
+    and(where('user', '==', 'Tim'), where('email', '==', 'tim@example.com')),
+  ),
+);
 ```
 
-You can use the `Filter.or()` static method to make logical OR queries:
+You can use the `or()` function to make logical OR queries:
 
 ```js
-const snapshot = await firestore()
-  .collection('Users')
-  .where(
-    Filter.or(
-      Filter.and(Filter('user', '==', 'Tim'), Filter('email', '==', 'tim@example.com')),
-      Filter.and(Filter('user', '==', 'Dave'), Filter('email', '==', 'dave@example.com')),
+const snapshot = await getDocs(
+  query(
+    collection(db, 'Users'),
+    or(
+      and(where('user', '==', 'Tim'), where('email', '==', 'tim@example.com')),
+      and(where('user', '==', 'Dave'), where('email', '==', 'dave@example.com')),
     ),
-  )
-  .get();
+  ),
+);
 ```
 
 For an understanding of what queries are possible, please consult the query limitation documentation on the official
@@ -277,55 +292,72 @@ For an understanding of what queries are possible, please consult the query limi
 
 #### Limiting
 
-To limit the number of documents returned from a query, use the `limit` method on a collection reference:
+To limit the number of documents returned from a query, use the `limit` constraint:
 
 ```js
-firestore()
-  .collection('Users')
-  // Filter results
-  .where('age', '>=', 18)
-  // Limit results
-  .limit(20)
-  .get()
-  .then(querySnapshot => {
-    /* ... */
-  });
+import {
+  collection,
+  getDocs,
+  getFirestore,
+  limit,
+  query,
+  where,
+} from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+getDocs(query(collection(db, 'Users'), where('age', '>=', 18), limit(20))).then(querySnapshot => {
+  /* ... */
+});
 ```
 
 The above example both filters the users by age and limits the documents returned to 20.
 
 #### Ordering
 
-To order the documents by a specific value, use the `orderBy` method:
+To order the documents by a specific value, use the `orderBy` constraint:
 
 ```js
-firestore()
-  .collection('Users')
-  // Order results
-  .orderBy('age', 'desc')
-  .get()
-  .then(querySnapshot => {
-    /* ... */
-  });
+import {
+  collection,
+  getDocs,
+  getFirestore,
+  orderBy,
+  query,
+} from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+getDocs(query(collection(db, 'Users'), orderBy('age', 'desc'))).then(querySnapshot => {
+  /* ... */
+});
 ```
 
 The above example orders all user in the snapshot by age in descending order.
 
 #### Start/End
 
-To start and/or end the query at a specific point within the collection, you can pass either a value to the `startAt`,
-`endAt`, `startAfter` or `endBefore` methods. You must specify an order to use pointers, for example:
+To start and/or end the query at a specific point within the collection, you can pass either a value to `startAt`,
+`endAt`, `startAfter` or `endBefore`. You must specify an order to use pointers, for example:
 
 ```js
-firestore()
-  .collection('Users')
-  .orderBy('age', 'desc')
-  .startAt(18)
-  .endAt(30)
-  .get()
-  .then(querySnapshot => {
+import {
+  collection,
+  endAt,
+  getDocs,
+  getFirestore,
+  orderBy,
+  query,
+  startAt,
+} from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+getDocs(query(collection(db, 'Users'), orderBy('age', 'desc'), startAt(18), endAt(30))).then(
+  querySnapshot => {
     /* ... */
-  });
+  },
+);
 ```
 
 The above query orders the users by age in descending order, but only returns users whose age is between 18 and 30.
@@ -333,16 +365,25 @@ The above query orders the users by age in descending order, but only returns us
 You can further specify a [`DocumentSnapshot`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentSnapshot.html) instead of a specific value. For example:
 
 ```js
-const userDocumentSnapshot = await firestore().collection('Users').doc('DEF').get();
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  getFirestore,
+  orderBy,
+  query,
+  startAt,
+} from '@react-native-firebase/firestore';
 
-firestore()
-  .collection('Users')
-  .orderBy('age', 'desc')
-  .startAt(userDocumentSnapshot)
-  .get()
-  .then(querySnapshot => {
+const db = getFirestore();
+const userDocumentSnapshot = await getDoc(doc(collection(db, 'Users'), 'DEF'));
+
+getDocs(query(collection(db, 'Users'), orderBy('age', 'desc'), startAt(userDocumentSnapshot))).then(
+  querySnapshot => {
     /* ... */
-  });
+  },
+);
 ```
 
 The above query orders the users by age in descending order, however only returns documents whose order starts at the user
@@ -363,73 +404,66 @@ For a more in-depth look at what is possible when writing data to Firestore plea
 
 ## Adding documents
 
-To add a new document to a collection, use the `add` method on a [`CollectionReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/CollectionReference.html):
+To add a new document to a collection, use `addDoc` with a [`CollectionReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/CollectionReference.html):
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { addDoc, collection, getFirestore } from '@react-native-firebase/firestore';
 
-firestore()
-  .collection('Users')
-  .add({
-    name: 'Ada Lovelace',
-    age: 30,
-  })
-  .then(() => {
-    console.log('User added!');
-  });
+const db = getFirestore();
+
+addDoc(collection(db, 'Users'), {
+  name: 'Ada Lovelace',
+  age: 30,
+}).then(() => {
+  console.log('User added!');
+});
 ```
 
-The `add` method adds the new document to your collection with a random unique ID. If you'd like to specify your own ID,
-call the `set` method on a [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html) instead:
+`addDoc` adds the new document to your collection with a random unique ID. If you'd like to specify your own ID,
+call `setDoc` with a [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html) instead:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, doc, getFirestore, setDoc } from '@react-native-firebase/firestore';
 
-firestore()
-  .collection('Users')
-  .doc('ABC')
-  .set({
-    name: 'Ada Lovelace',
-    age: 30,
-  })
-  .then(() => {
-    console.log('User added!');
-  });
+const db = getFirestore();
+
+setDoc(doc(collection(db, 'Users'), 'ABC'), {
+  name: 'Ada Lovelace',
+  age: 30,
+}).then(() => {
+  console.log('User added!');
+});
 ```
 
 ### Updating documents
 
-The `set` method exampled above replaces any existing data on a given [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html).
-if you'd like to update a document instead, use the `update` method:
+The `setDoc` example above replaces any existing data on a given [`DocumentReference`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/types/firestore/DocumentReference.html).
+if you'd like to update a document instead, use `updateDoc`:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, doc, getFirestore, updateDoc } from '@react-native-firebase/firestore';
 
-firestore()
-  .collection('Users')
-  .doc('ABC')
-  .update({
-    age: 31,
-  })
-  .then(() => {
-    console.log('User updated!');
-  });
+const db = getFirestore();
+
+updateDoc(doc(collection(db, 'Users'), 'ABC'), {
+  age: 31,
+}).then(() => {
+  console.log('User updated!');
+});
 ```
 
 The method also provides support for updating deeply nested values via dot-notation:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, doc, getFirestore, updateDoc } from '@react-native-firebase/firestore';
 
-firestore()
-  .collection('Users')
-  .doc('ABC')
-  .update({
-    'info.address.zipcode': 94040,
-  })
-  .then(() => {
-    console.log('User updated!');
-  });
+const db = getFirestore();
+
+updateDoc(doc(collection(db, 'Users'), 'ABC'), {
+  'info.address.zipcode': 94040,
+}).then(() => {
+  console.log('User updated!');
+});
 ```
 
 #### Field values
@@ -441,55 +475,66 @@ To store [`GeoPoint`](https://invertase.github.io/react-native-firebase/_react-n
 class:
 
 ```js
-firestore()
-  .doc('users/ABC')
-  .update({
-    'info.address.location': new firestore.GeoPoint(53.483959, -2.244644),
-  });
+import { doc, GeoPoint, getFirestore, updateDoc } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+updateDoc(doc(db, 'users', 'ABC'), {
+  'info.address.location': new GeoPoint(53.483959, -2.244644),
+});
 ```
 
 To store raw [Bytes](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/modular/Bytes.html#frombase64string) (for example of a `Base64` image string), provide the string to the static
 `fromBase64String` method on the class:
 
 ```js
-firestore()
-  .doc('users/ABC')
-  .update({
-    'info.avatar': Bytes.fromBase64String('data:image/png;base64,iVBOR...'),
-  });
-```
+import { Bytes, doc, getFirestore, updateDoc } from '@react-native-firebase/firestore';
 
-When storing timestamps, it is recommended you use the `serverTimestamp` static method on the [`FieldValue`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/modular/FieldValue.html)
-class. When written to the database, the Firebase servers will write a new timestamp based on their time, rather than the clients. This helps
-resolve any data consistency issues with different client timezones:
+const db = getFirestore();
 
-```js
-firestore().doc('users/ABC').update({
-  createdAt: firestore.FieldValue.serverTimestamp(),
+updateDoc(doc(db, 'users', 'ABC'), {
+  'info.avatar': Bytes.fromBase64String('data:image/png;base64,iVBOR...'),
 });
 ```
 
-Cloud Firestore also allows for storing arrays. To help manage the values with an array (adding or removing) the API
-exposes an `arrayUnion` and `arrayRemove` methods on the [`FieldValue`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/modular/FieldValue.html) class.
+When storing timestamps, it is recommended you use `serverTimestamp()`. When written to the database, the Firebase servers will write a new timestamp based on their time, rather than the clients. This helps
+resolve any data consistency issues with different client timezones:
+
+```js
+import { doc, getFirestore, serverTimestamp, updateDoc } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+updateDoc(doc(db, 'users', 'ABC'), {
+  createdAt: serverTimestamp(),
+});
+```
+
+Cloud Firestore also allows for storing arrays. To help manage the values with an array (adding or removing), the API
+exposes `arrayUnion` and `arrayRemove` helpers.
 
 To add a new value to an array (if value does not exist, will not add duplicate values):
 
 ```js
-firestore()
-  .doc('users/ABC')
-  .update({
-    fcmTokens: firestore.FieldValue.arrayUnion('ABCDE123456'),
-  });
+import { arrayUnion, doc, getFirestore, updateDoc } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+updateDoc(doc(db, 'users', 'ABC'), {
+  fcmTokens: arrayUnion('ABCDE123456'),
+});
 ```
 
 To remove a value from the array (if the value exists):
 
 ```js
-firestore()
-  .doc('users/ABC')
-  .update({
-    fcmTokens: firestore.FieldValue.arrayRemove('ABCDE123456'),
-  });
+import { arrayRemove, doc, getFirestore, updateDoc } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+updateDoc(doc(db, 'users', 'ABC'), {
+  fcmTokens: arrayRemove('ABCDE123456'),
+});
 ```
 
 ## Removing data
@@ -510,12 +555,21 @@ At this time, you cannot delete an entire collection without use of a Firebase A
 > If a document contains any sub-collections, these will not be deleted from database. You must delete
 > any sub-collections yourself.
 
-If you need to remove a specific property with a document, rather than the document itself, you can use the `delete`
-method on the [`FieldValue`](https://invertase.github.io/react-native-firebase/_react-native-firebase/firestore/modular/FieldValue.html) class:
+If you need to remove a specific property with a document, rather than the document itself, you can use `deleteField`:
 
 ```js
-firestore().collection('Users').doc('ABC').update({
-  fcmTokens: firestore.FieldValue.delete(),
+import {
+  collection,
+  deleteField,
+  doc,
+  getFirestore,
+  updateDoc,
+} from '@react-native-firebase/firestore';
+
+const db = getFirestore();
+
+updateDoc(doc(collection(db, 'Users'), 'ABC'), {
+  fcmTokens: deleteField(),
 });
 ```
 
@@ -544,16 +598,18 @@ causing the actual number to not be consistent.
 Transactions remove this issue by atomically updating the value on the server. If the value changes whilst the transaction
 is executing, it will retry. This always ensures the value on the server is used rather than the client value.
 
-To execute a new transaction, call the `runTransaction` method:
+To execute a new transaction, call `runTransaction`:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { doc, getFirestore, runTransaction } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 function onPostLike(postId) {
   // Create a reference to the post
-  const postReference = firestore().doc(`posts/${postId}`);
+  const postReference = doc(db, 'posts', postId);
 
-  return firestore().runTransaction(async transaction => {
+  return runTransaction(db, async transaction => {
     // Get post data first
     const postSnapshot = await transaction.get(postReference);
 
@@ -575,21 +631,23 @@ onPostLike('ABC')
 ## Batch write
 
 If you do not need to read any documents in your operation set, you can execute multiple write operations as a single batch
-that contains any combination of `set`, `update`, or `delete` operations. A batch of writes completes atomically and can
+that contains any combination of `setDoc`, `updateDoc`, or `deleteDoc` operations. A batch of writes completes atomically and can
 write to multiple documents.
 
-First, create a new batch instance via the `batch` method, perform operations on the batch and finally commit it once ready.
+First, create a new batch instance via `writeBatch`, perform operations on the batch and finally commit it once ready.
 The example below shows how to delete all documents in a collection in a single operation:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { collection, getDocs, getFirestore, writeBatch } from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 async function massDeleteUsers() {
   // Get all users
-  const usersQuerySnapshot = await firestore().collection('Users').get();
+  const usersQuerySnapshot = await getDocs(collection(db, 'Users'));
 
   // Create a new batch instance
-  const batch = firestore().batch();
+  const batch = writeBatch(db);
 
   usersQuerySnapshot.forEach(documentSnapshot => {
     batch.delete(documentSnapshot.ref);
@@ -613,13 +671,14 @@ database which synchronizes automatically with the server. Firestore functionali
 automatically handles data migration to the server when they regain connectivity.
 
 This functionality is enabled by default, however it can be disabled if you need it to be disabled (e.g. on apps containing
-sensitive information). The `settings()` method must be called before any Firestore interaction is performed, otherwise it will only take effect on the next app launch:
+sensitive information). `initializeFirestore` must be called before any Firestore interaction is performed, otherwise it will only take effect on the next app launch:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import { getApp } from '@react-native-firebase/app';
+import { initializeFirestore } from '@react-native-firebase/firestore';
 
 async function bootstrap() {
-  await firestore().settings({
+  await initializeFirestore(getApp(), {
     persistence: false, // disable offline persistence
   });
 }
@@ -631,20 +690,29 @@ Cloud Firestore data bundles are static data files built by you from Cloud Fires
 and published by you on a CDN, hosting service or other solution. Once a bundle is loaded, a client app can query documents
 from the local cache or the backend.
 
-To load and query data bundles, use the `loadBundle` and `namedQuery` methods:
+To load and query data bundles, use `loadBundle` and `namedQuery`:
 
 ```js
-import firestore from '@react-native-firebase/firestore';
+import {
+  getDocsFromCache,
+  getFirestore,
+  loadBundle,
+  namedQuery,
+} from '@react-native-firebase/firestore';
+
+const db = getFirestore();
 
 // load the bundle contents
 const response = await fetch('https://api.example.com/bundles/latest-stories');
 const bundle = await response.text();
-await firestore().loadBundle(bundle);
+await loadBundle(db, bundle);
 
 // query the results from the cache
-// note: omitting "source: cache" will query the Firestore backend
-const query = firestore().namedQuery('latest-stories-query');
-const snapshot = await query.get({ source: 'cache' });
+// note: use getDocsFromCache to query the local cache only
+const storiesQuery = await namedQuery(db, 'latest-stories-query');
+if (storiesQuery) {
+  const snapshot = await getDocsFromCache(storiesQuery);
+}
 ```
 
 You can build data bundles with the Admin SDK. For more information about building and serving data bundles, see Firebase Firestore main documentation on [Data bundles](https://firebase.google.com/docs/firestore/bundles) as well as their "[Bundle Solutions](https://firebase.google.com/docs/firestore/solutions/serve-bundles)" page

--- a/docs/functions/usage/index.mdx
+++ b/docs/functions/usage/index.mdx
@@ -53,12 +53,10 @@ Whilst developing your application with Cloud Functions, it is possible to run t
 To call the emulated functions in the **default** region, call the `useEmulator` method exposed by the library:
 
 ```js
-import functions from '@react-native-firebase/functions';
+import { connectFunctionsEmulator, getFunctions } from '@react-native-firebase/functions';
 
-// Use a local emulator in development
 if (__DEV__) {
-  // If you are running on a physical device, replace http://localhost with the local ip of your PC. (http://192.168.x.x)
-  functions().useEmulator('localhost', 5001);
+  connectFunctionsEmulator(getFunctions(), 'localhost', 5001);
 }
 ```
 
@@ -82,19 +80,17 @@ exports.listProducts = functions.https.onCall(() => {
 Within the React Native application, the list of products returned can be directly accessed:
 
 ```jsx
-import functions from '@react-native-firebase/functions';
+import { getFunctions, httpsCallable } from '@react-native-firebase/functions';
 
 function App() {
   const [loading, setLoading] = useState(true);
   const [products, setProducts] = useState([]);
 
   useEffect(() => {
-    functions()
-      .httpsCallable('listProducts')()
-      .then(response => {
-        setProducts(response.data);
-        setLoading(false);
-      });
+    httpsCallable(getFunctions(), 'listProducts')().then(response => {
+      setProducts(response.data);
+      setLoading(false);
+    });
   }, []);
 
   if (loading) {
@@ -110,11 +106,14 @@ function App() {
 If you need to deploy Functions in a region other than the default one, modified statements need to be used.
 
 ```javascript
-import { firebase } from '@react-native-firebase/functions';
+import {
+  connectFunctionsEmulator,
+  getFunctions,
+  httpsCallable,
+} from '@react-native-firebase/functions';
+import { getApp } from '@react-native-firebase/app';
 
-// Emulator statement
-firebase.app().functions('region_name').useEmulator('localhost', 5001);
+connectFunctionsEmulator(getFunctions(getApp(), 'region_name'), 'localhost', 5001);
 
-// function calling statement
-firebase.app().functions('region_name').httpsCallable('listProducts')({ abc: 123 }).then();
+httpsCallable(getFunctions(getApp(), 'region_name'), 'listProducts')({ abc: 123 }).then();
 ```

--- a/docs/functions/writing-deploying-functions.mdx
+++ b/docs/functions/writing-deploying-functions.mdx
@@ -192,15 +192,13 @@ https://us-central1-rnfirebase-demo-23aa8.cloudfunctions.net/listProducts
 Once your function has been deployed you can now call it through the React Native Firebase Functions SDK in your application:
 
 ```js
-import { firebase } from '@react-native-firebase/functions';
+import { getFunctions, httpsCallable } from '@react-native-firebase/functions';
 
-// ...
-
-// note the name of our deployed function, 'listProducts', is referenced here:
-const { data } = await firebase.functions().httpsCallable('listProducts')({
+const { data } = await httpsCallable(
+  getFunctions(),
+  'listProducts',
+)({
   page: 1,
   limit: 15,
 });
-
-// ...
 ```

--- a/docs/in-app-messaging/usage/index.mdx
+++ b/docs/in-app-messaging/usage/index.mdx
@@ -60,16 +60,18 @@ a use case for controlling the flow of messages:
 > The suppressed state is not persisted between restarts, so ensure it is called as early as possible.
 
 ```jsx
-import inAppMessaging from '@react-native-firebase/in-app-messaging';
+import {
+  getInAppMessaging,
+  setMessagesDisplaySuppressed,
+} from '@react-native-firebase/in-app-messaging';
 
 async function bootstrap() {
-  await inAppMessaging().setMessagesDisplaySuppressed(true);
+  await setMessagesDisplaySuppressed(getInAppMessaging(), true);
 }
 
 async function onSetup(user) {
   await setupUser(user);
-  // Allow user to receive messages now setup is complete
-  inAppMessaging().setMessagesDisplaySuppressed(false);
+  await setMessagesDisplaySuppressed(getInAppMessaging(), false);
 }
 ```
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -26,7 +26,7 @@ Integration with Expo is possible when using a [development build](https://docs.
 
 _NOTE:_ React Native Firebase cannot be used in the pre-compiled [Expo Go app](https://docs.expo.dev/workflow/overview/#expo-go-an-optional-tool-for-learning) because React Native Firebase uses native code that is not compiled into Expo Go.
 
-> **Warning:** If you are using `expo-dev-client`, native crashes (such as those triggered by `crashlytics().crash()`) will **not** be reported to Firebase Crashlytics during development. This is because `expo-dev-client` provides a custom error overlay that catches and displays errors before they are sent to Firebase. To test native crash reporting, you must remove `expo-dev-client` and run your app in a standard release or debug build without the custom error overlay.
+> **Warning:** If you are using `expo-dev-client`, native crashes (such as those triggered by `crash(getCrashlytics())`) will **not** be reported to Firebase Crashlytics during development. This is because `expo-dev-client` provides a custom error overlay that catches and displays errors before they are sent to Firebase. To test native crash reporting, you must remove `expo-dev-client` and run your app in a standard release or debug build without the custom error overlay.
 
 To create a new Expo project, see the [Get started](https://docs.expo.dev/get-started/create-a-project/) guide in Expo documentation.
 

--- a/docs/messaging/ios-permissions.mdx
+++ b/docs/messaging/ios-permissions.mdx
@@ -24,10 +24,11 @@ must be requested from your users in order to display remote notifications from 
 `requestPermission` API:
 
 ```js
-import messaging from '@react-native-firebase/messaging';
+import { getMessaging, requestPermission } from '@react-native-firebase/messaging';
 
 async function requestUserPermission() {
-  const authorizationStatus = await messaging().requestPermission();
+  const messaging = getMessaging();
+  const authorizationStatus = await requestPermission(messaging);
 
   if (authorizationStatus) {
     console.log('Permission status:', authorizationStatus);
@@ -47,7 +48,11 @@ Although overall notification permission can be granted, the permissions can be 
 Settings are used by the device to control notifications behavior, for example alerting the user with sound. When requesting permission, you can provide a custom object of settings if you wish to override the defaults. This is demonstrated in the following example:
 
 ```js
-await messaging().requestPermission({
+import { getMessaging, requestPermission } from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
+
+await requestPermission(messaging, {
   sound: false,
   announcement: true,
   // ... other permission settings
@@ -79,14 +84,19 @@ API used above resolves an enum that returns the current status.
 For example:
 
 ```js
-import messaging from '@react-native-firebase/messaging';
+import {
+  getMessaging,
+  requestPermission,
+  AuthorizationStatus,
+} from '@react-native-firebase/messaging';
 
 async function checkApplicationPermission() {
-  const authorizationStatus = await messaging().requestPermission();
+  const messaging = getMessaging();
+  const authorizationStatus = await requestPermission(messaging);
 
-  if (authorizationStatus === messaging.AuthorizationStatus.AUTHORIZED) {
+  if (authorizationStatus === AuthorizationStatus.AUTHORIZED) {
     console.log('User has notification permissions enabled.');
-  } else if (authorizationStatus === messaging.AuthorizationStatus.PROVISIONAL) {
+  } else if (authorizationStatus === AuthorizationStatus.PROVISIONAL) {
     console.log('User has provisional notification permissions.');
   } else {
     console.log('User has notification permissions disabled');
@@ -94,13 +104,13 @@ async function checkApplicationPermission() {
 }
 ```
 
-The value returned is a number value, which can be mapped to one of the following values from `messaging.AuthorizationStatus`:
+The value returned is a number value, which can be mapped to one of the following values from `AuthorizationStatus`:
 
-- `-1` = `messaging.AuthorizationStatus.NOT_DETERMINED`: Permission has not yet been requested for your application.
-- `0` = `messaging.AuthorizationStatus.DENIED`: The user has denied notification permissions.
-- `1` = `messaging.AuthorizationStatus.AUTHORIZED`: The user has accept the permission & it is enabled.
-- `2` = `messaging.AuthorizationStatus.PROVISIONAL`: [Provisional authorization](/messaging/ios-permissions#provisional-authorization) has been granted.
-- `3` = `messaging.AuthorizationStatus.EPHEMERAL`: The app is authorized to create notifications for a limited amount of time. Used for app clips.
+- `-1` = `AuthorizationStatus.NOT_DETERMINED`: Permission has not yet been requested for your application.
+- `0` = `AuthorizationStatus.DENIED`: The user has denied notification permissions.
+- `1` = `AuthorizationStatus.AUTHORIZED`: The user has accept the permission & it is enabled.
+- `2` = `AuthorizationStatus.PROVISIONAL`: [Provisional authorization](/messaging/ios-permissions#provisional-authorization) has been granted.
+- `3` = `AuthorizationStatus.EPHEMERAL`: The app is authorized to create notifications for a limited amount of time. Used for app clips.
 
 To help improve the chances of the user granting your app permission, it is recommended that permission is requested at a time which makes
 sense during the flow of your application (e.g. starting a new chat), where the user would expect to receive such notifications.
@@ -117,7 +127,9 @@ permission to be instantly granted without displaying a dialog to your user. The
 To enable provisional notifications, pass an object to the `requestPermission` method, with the `provisional` key set to `true`:
 
 ```js
-await messaging().requestPermission({
+import { getMessaging, requestPermission } from '@react-native-firebase/messaging';
+
+await requestPermission(getMessaging(), {
   provisional: true,
 });
 ```
@@ -131,7 +143,9 @@ Devices on iOS 12+ can provide a button in iOS Notifications Settings _(at OS le
 1. Request `providesAppNotificationSettings` permissions:
 
 ```typescript
-await messaging().requestPermission({ providesAppNotificationSettings: true });
+import { getMessaging, requestPermission } from '@react-native-firebase/messaging';
+
+await requestPermission(getMessaging(), { providesAppNotificationSettings: true });
 ```
 
 2. Handle interaction when app is in background state:
@@ -139,11 +153,13 @@ await messaging().requestPermission({ providesAppNotificationSettings: true });
 ```typescript
 // index.js
 import { AppRegistry } from 'react-native'
-import messaging from '@react-native-firebase/messaging'
+import { getMessaging, setOpenSettingsForNotificationsHandler } from '@react-native-firebase/messaging'
+
+const messaging = getMessaging();
 
 ...
 
-messaging().setOpenSettingsForNotificationsHandler(async () => {
+setOpenSettingsForNotificationsHandler(messaging, async () => {
     // Set persistent value, using the MMKV package just as an example of how you might do it
     MMKV.setBool(openSettingsForNotifications, true)
 })
@@ -173,11 +189,13 @@ const App = () => {
 
 ```typescript
 // App.tsx
+import { getMessaging, getDidOpenSettingsForNotification } from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
 
 const App = () => {
   useEffect(() => {
-        messaging()
-            .getDidOpenSettingsForNotification()
+        getDidOpenSettingsForNotification(messaging)
             .then(async didOpenSettingsForNotification => {
                 if (didOpenSettingsForNotification) {
                     navigate('NotificationsSettingsScreen')

--- a/docs/messaging/notifications.mdx
+++ b/docs/messaging/notifications.mdx
@@ -113,12 +113,17 @@ we can set an initial route when the app is opened from a quit state, and push t
 ```jsx
 import React, { useState, useEffect } from 'react';
 import { Linking, ActivityIndicator } from 'react-native';
-import messaging from '@react-native-firebase/messaging';
+import {
+  getMessaging,
+  getInitialNotification,
+  onNotificationOpenedApp,
+} from '@react-native-firebase/messaging';
 import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
 const Stack = createStackNavigator();
 const NAVIGATION_IDS = ['home', 'post', 'settings'];
+const messaging = getMessaging();
 
 function buildDeepLinkFromNotificationData(data): string | null {
   const navigationId = data?.navigationId;
@@ -156,7 +161,7 @@ const linking = {
       return url;
     }
     //getInitialNotification: When the application is opened from a quit state.
-    const message = await messaging().getInitialNotification();
+    const message = await getInitialNotification(messaging);
     const deeplinkURL = buildDeepLinkFromNotificationData(message?.data);
     if (typeof deeplinkURL === 'string') {
       return deeplinkURL;
@@ -169,7 +174,7 @@ const linking = {
     const linkingSubscription = Linking.addEventListener('url', onReceiveURL);
 
     //onNotificationOpenedApp: When the application is running, but in the background.
-    const unsubscribe = messaging().onNotificationOpenedApp(remoteMessage => {
+    const unsubscribe = onNotificationOpenedApp(messaging, remoteMessage => {
       const url = buildDeepLinkFromNotificationData(remoteMessage.data)
       if (typeof url === 'string') {
         listener(url)
@@ -200,11 +205,18 @@ function App() {
 
 # Getting a Device Token
 
-To send messages to a device, you would need the FCM token for it, which you can get using the `messaging().getToken()` method. An example is available on '[Notifee pages](https://notifee.app/react-native/docs/integrations/fcm)'.
+To send messages to a device, you would need the FCM token for it, which you can get using the `getToken(messaging)` method. An example is available on '[Notifee pages](https://notifee.app/react-native/docs/integrations/fcm)'.
 
 ```jsx
-await messaging().registerDeviceForRemoteMessages();
-const token = await messaging().getToken();
+import {
+  getMessaging,
+  registerDeviceForRemoteMessages,
+  getToken,
+} from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
+await registerDeviceForRemoteMessages(messaging);
+const token = await getToken(messaging);
 // save the token to the db
 ```
 

--- a/docs/messaging/server-integration.mdx
+++ b/docs/messaging/server-integration.mdx
@@ -35,39 +35,36 @@ device token (if using a different push notification provider, such as Amazon SN
 
 ```jsx
 import React, { useEffect } from 'react';
-import messaging from '@react-native-firebase/messaging';
-import auth from '@react-native-firebase/auth';
-import firestore from '@react-native-firebase/firestore';
+import { getMessaging, getToken, onTokenRefresh } from '@react-native-firebase/messaging';
+import { getAuth } from '@react-native-firebase/auth';
+import { getFirestore, doc, updateDoc, arrayUnion } from '@react-native-firebase/firestore';
 import { Platform } from 'react-native';
 
 async function saveTokenToDatabase(token) {
   // Assume user is already signed in
-  const userId = auth().currentUser.uid;
+  const userId = getAuth().currentUser.uid;
 
   // Add the token to the users datastore
-  await firestore()
-    .collection('users')
-    .doc(userId)
-    .update({
-      tokens: firestore.FieldValue.arrayUnion(token),
-    });
+  await updateDoc(doc(getFirestore(), 'users', userId), {
+    tokens: arrayUnion(token),
+  });
 }
 
 function App() {
   useEffect(() => {
+    const messaging = getMessaging();
+
     // Get the device token
-    messaging()
-      .getToken()
-      .then(token => {
-        return saveTokenToDatabase(token);
-      });
+    getToken(messaging).then(token => {
+      return saveTokenToDatabase(token);
+    });
 
     // If using other push notification providers (ie Amazon SNS, etc)
     // you may need to get the APNs token instead for iOS:
-    // if(Platform.OS == 'ios') { messaging().getAPNSToken().then(token => { return saveTokenToDatabase(token); }); }
+    // if(Platform.OS == 'ios') { getAPNSToken(messaging).then(token => { return saveTokenToDatabase(token); }); }
 
     // Listen to whether the token changes
-    return messaging().onTokenRefresh(token => {
+    return onTokenRefresh(messaging, token => {
       saveTokenToDatabase(token);
     });
   }, []);
@@ -79,7 +76,7 @@ when the `App` component runs and immediately gets the token. It also listens to
 the token.
 
 Inside of the `saveTokenToDatabase` method, we store the token on a record specifically relating to the current user. You may also
-notice that the token is being added via the `FieldValue.arrayUnion` method. A user can have more than one token (for example using 2 devices)
+notice that the token is being added via the `arrayUnion` method. A user can have more than one token (for example using 2 devices)
 so it's important to ensure that we store all tokens in the database.
 
 ## Using tokens
@@ -150,9 +147,13 @@ Back within our application, as explained in the [Usage](/messaging/usage) docum
 [`RemoteMessage`](https://invertase.github.io/react-native-firebase/_react-native-firebase/messaging/types/messaging/RemoteMessage.html) payload containing the message details sent from the server:
 
 ```jsx
+import { useEffect } from 'react';
+import { getMessaging, onMessage } from '@react-native-firebase/messaging';
+
 function App() {
   useEffect(() => {
-    const unsubscribe = messaging().onMessage(async remoteMessage => {
+    const messaging = getMessaging();
+    const unsubscribe = onMessage(messaging, async remoteMessage => {
       const owner = JSON.parse(remoteMessage.data.owner);
       const user = JSON.parse(remoteMessage.data.user);
       const picture = JSON.parse(remoteMessage.data.picture);

--- a/docs/messaging/usage/index.mdx
+++ b/docs/messaging/usage/index.mdx
@@ -96,13 +96,17 @@ iOS prevents messages containing notification (or 'alert') payloads from being d
 This module provides a `requestPermission` method which triggers a native permission dialog requesting the user's permission:
 
 ```js
-import messaging from '@react-native-firebase/messaging';
+import {
+  getMessaging,
+  requestPermission,
+  AuthorizationStatus,
+} from '@react-native-firebase/messaging';
 
 async function requestUserPermission() {
-  const authStatus = await messaging().requestPermission();
+  const messaging = getMessaging();
+  const authStatus = await requestPermission(messaging);
   const enabled =
-    authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
-    authStatus === messaging.AuthorizationStatus.PROVISIONAL;
+    authStatus === AuthorizationStatus.AUTHORIZED || authStatus === AuthorizationStatus.PROVISIONAL;
 
   if (enabled) {
     console.log('Authorization status:', authStatus);
@@ -192,11 +196,12 @@ each time a message is delivered'
 ```js
 import React, { useEffect } from 'react';
 import { Alert } from 'react-native';
-import messaging from '@react-native-firebase/messaging';
+import { getMessaging, onMessage } from '@react-native-firebase/messaging';
 
 function App() {
   useEffect(() => {
-    const unsubscribe = messaging().onMessage(async remoteMessage => {
+    const messaging = getMessaging();
+    const unsubscribe = onMessage(messaging, async remoteMessage => {
       Alert.alert('A new FCM message arrived!', JSON.stringify(remoteMessage));
     });
 
@@ -225,11 +230,13 @@ To setup a background handler, call the `setBackgroundMessageHandler` outside of
 ```jsx
 // index.js
 import { AppRegistry } from 'react-native';
-import messaging from '@react-native-firebase/messaging';
+import { getMessaging, setBackgroundMessageHandler } from '@react-native-firebase/messaging';
 import App from './App';
 
+const messaging = getMessaging();
+
 // Register background handler
-messaging().setBackgroundMessageHandler(async remoteMessage => {
+setBackgroundMessageHandler(messaging, async remoteMessage => {
   console.log('Message handled in the background!', remoteMessage);
 });
 
@@ -315,10 +322,12 @@ you can configure your `AppDelegate.m` file (see instructions below) to inject a
 ```jsx
 // index.js
 import { AppRegistry } from 'react-native';
-import messaging from '@react-native-firebase/messaging';
+import { getMessaging, setBackgroundMessageHandler } from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
 
 // Handle background messages using setBackgroundMessageHandler
-messaging().setBackgroundMessageHandler(async remoteMessage => {
+setBackgroundMessageHandler(messaging, async remoteMessage => {
   console.log('Message handled in the background!', remoteMessage);
 });
 
@@ -359,11 +368,13 @@ self.initialProps = [RNFBMessagingModule addCustomPropsToUserProps:nil withLaunc
 - For projects that use react-native-navigation (or if you just don't want to mess with your launchProperties) you can use the `getIsHeadless` method (iOS only) from messaging like so:
 
 ```jsx
-messaging()
-  .getIsHeadless()
-  .then(isHeadless => {
-    // do sth with isHeadless
-  });
+import { getMessaging, getIsHeadless } from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
+
+getIsHeadless(messaging).then(isHeadless => {
+  // do sth with isHeadless
+});
 ```
 
 On Android, the `isHeadless` prop will not exist.
@@ -399,9 +410,11 @@ documentation.
 To subscribe a device, call the `subscribeToTopic` method with the topic name (must not include "/"):
 
 ```js
-messaging()
-  .subscribeToTopic('weather')
-  .then(() => console.log('Subscribed to topic!'));
+import { getMessaging, subscribeToTopic } from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
+
+subscribeToTopic(messaging, 'weather').then(() => console.log('Subscribed to topic!'));
 ```
 
 #### Unsubscribing to topics
@@ -409,9 +422,11 @@ messaging()
 To unsubscribe from a topic, call the `unsubscribeFromTopic` method with the topic name:
 
 ```js
-messaging()
-  .unsubscribeFromTopic('weather')
-  .then(() => console.log('Unsubscribed fom the topic!'));
+import { getMessaging, unsubscribeFromTopic } from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
+
+unsubscribeFromTopic(messaging, 'weather').then(() => console.log('Unsubscribed fom the topic!'));
 ```
 
 # firebase.json
@@ -436,10 +451,10 @@ Once auto-registration is disabled you must manually call `registerDeviceForRemo
 early as possible in your application startup;
 
 ```js
-import messaging from '@react-native-firebase/messaging';
+import { getMessaging, registerDeviceForRemoteMessages } from '@react-native-firebase/messaging';
 
 async function registerAppWithFCM() {
-  await messaging().registerDeviceForRemoteMessages();
+  await registerDeviceForRemoteMessages(getMessaging());
 }
 ```
 
@@ -475,7 +490,7 @@ If you prefer to prevent Instance ID auto-generation, disable auto initializatio
 }
 ```
 
-To re-enable initialization (e.g. once requested permission) call the `messaging().setAutoInitEnabled(true)` method.
+To re-enable initialization (e.g. once requested permission) call the `setAutoInitEnabled(messaging, true)` method.
 
 ## Background handler timeout (Android)
 

--- a/docs/messaging/usage/messaging-with-xmpp.mdx
+++ b/docs/messaging/usage/messaging-with-xmpp.mdx
@@ -27,19 +27,29 @@ So what are we going to do?
 A common instance involves an implementation similar to the following.
 
 ```js
-firebase.messaging().onMessage(message => {
+import {
+  getMessaging,
+  onMessage,
+  onMessageSent,
+  onSendError,
+  sendMessage,
+} from '@react-native-firebase/messaging';
+
+const messaging = getMessaging();
+
+onMessage(messaging, message => {
   console.log('Received a message');
 });
 
-firebase.messaging().onMessageSent(message => {
+onMessageSent(messaging, message => {
   console.log('Sent a message');
 });
 
-firebase.messaging().onSendError(message => {
+onSendError(messaging, message => {
   console.log('Received an Error');
 });
 
-firebase.messaging().sendMessage({
+sendMessage(messaging, {
   data: {
     foo: 'bar',
   },

--- a/docs/perf/axios-integration.mdx
+++ b/docs/perf/axios-integration.mdx
@@ -18,17 +18,21 @@ property on the axios instance. At this point, a new HTTP metric can be defined 
 
 ```js
 import axios from 'axios';
-import perf from '@react-native-firebase/perf';
+import { getPerformance, httpMetric } from '@react-native-firebase/perf';
 
 axios.interceptors.request.use(async function (config) {
   try {
-    const httpMetric = perf().newHttpMetric(config.url, config.method.toUpperCase());
-    config.metadata = { httpMetric };
+    const httpMetricInstance = httpMetric(
+      getPerformance(),
+      config.url,
+      config.method.toUpperCase(),
+    );
+    config.metadata = { httpMetric: httpMetricInstance };
 
     // add any extra metric attributes, if required
-    // httpMetric.putAttribute('userId', '12345678');
+    // httpMetricInstance.putAttribute('userId', '12345678');
 
-    await httpMetric.start();
+    await httpMetricInstance.start();
   } finally {
     return config;
   }

--- a/docs/perf/ky-integration.mdx
+++ b/docs/perf/ky-integration.mdx
@@ -17,7 +17,7 @@ Before HTTP requests are sent out of the React Native environment, a number of f
 We can use this `beforeRequest` hook to create our HTTP metric.
 
 ```js
-import perf from '@react-native-firebase/perf';
+import { getPerformance, httpMetric } from '@react-native-firebase/perf';
 import ky from 'ky';
 
 const getContentLength = headers => {
@@ -32,7 +32,7 @@ const api = ky.create({
     beforeRequest: [
       async (request, options) => {
         const { url, method } = request;
-        options.metric = await perf().newHttpMetric(url, method);
+        options.metric = httpMetric(getPerformance(), url, method);
 
         // add any extra metric attributes, if required
         // options.metric.putAttribute('userId', '12345678');
@@ -90,7 +90,7 @@ how long the request took, response codes & more. Such data can give you greater
 A working example is provided below. Please adjust and extend according to your use case.
 
 ```js
-import perf from '@react-native-firebase/perf';
+import { getPerformance, httpMetric } from '@react-native-firebase/perf';
 import ky from 'ky';
 
 const getContentLength = headers => {
@@ -107,7 +107,7 @@ const api = ky.create({
     beforeRequest: [
       async (request, options) => {
         const { url, method } = request;
-        options.metric = await perf().newHttpMetric(url, method);
+        options.metric = httpMetric(getPerformance(), url, method);
 
         // add any extra metric attributes, if required
         // options.metric.putAttribute('userId', '12345678');

--- a/docs/perf/usage/index.mdx
+++ b/docs/perf/usage/index.mdx
@@ -70,18 +70,16 @@ app code. All performance metrics are available on your Firebase [console](https
 Below is how you would measure the amount of time it would take to complete a specific task in your app code.
 
 ```jsx
-import perf from '@react-native-firebase/perf';
+import { getPerformance, trace } from '@react-native-firebase/perf';
 
 async function customTrace() {
-  // Define & start a trace
-  const trace = await perf().startTrace('custom_trace');
+  const perf = getPerformance();
+  const t = trace(perf, 'custom_trace');
 
-  // Define trace meta details
-  trace.putAttribute('user', 'abcd');
-  trace.putMetric('credits', 30);
-
-  // Stop the trace
-  await trace.stop();
+  await t.start();
+  t.putAttribute('user', 'abcd');
+  t.putMetric('credits', 30);
+  await t.stop();
 }
 ```
 
@@ -90,14 +88,12 @@ async function customTrace() {
 Record a custom screen rendering trace (slow frames / frozen frames)
 
 ```jsx
-import perf from '@react-native-firebase/perf';
+import { getPerformance, startScreenTrace } from '@react-native-firebase/perf';
 
 async function screenTrace() {
-  // Define & start a screen trace
   try {
-    const trace = await perf().startScreenTrace('FooScreen');
-    // Stop the trace
-    await trace.stop();
+    const screenTrace = await startScreenTrace(getPerformance(), 'FooScreen');
+    await screenTrace.stop();
   } catch (e) {
     // rejects if iOS or (Android == 8 || Android == 8.1)
     // or if hardware acceleration is off
@@ -110,31 +106,25 @@ async function screenTrace() {
 Below illustrates you would measure the latency of a HTTP request.
 
 ```jsx
-import perf from '@react-native-firebase/perf';
+import { getPerformance, httpMetric } from '@react-native-firebase/perf';
 
 async function getRequest(url) {
-  // Define the network metric
-  const metric = await perf().newHttpMetric(url, 'GET');
+  const metric = httpMetric(getPerformance(), url, 'GET');
 
-  // Define meta details
   metric.putAttribute('user', 'abcd');
 
-  // Start the metric
   await metric.start();
 
-  // Perform a HTTP request and provide response information
   const response = await fetch(url);
   metric.setHttpResponseCode(response.status);
   metric.setResponseContentType(response.headers.get('Content-Type'));
   metric.setResponsePayloadSize(response.headers.get('Content-Length'));
 
-  // Stop the metric
   await metric.stop();
 
   return response.json();
 }
 
-// Call API
 getRequest('https://api.com').then(json => {
   console.log(json);
 });
@@ -159,7 +149,7 @@ set the `perf_auto_collection_enabled` flag to `false`:
 To re-enable collection (e.g. once you have the users consent), call the `setPerformanceCollectionEnabled` method:
 
 ```js
-import { firebase } from '@react-native-firebase/perf';
+import { getPerformance } from '@react-native-firebase/perf';
 // ...
-await firebase.perf().setPerformanceCollectionEnabled(true);
+getPerformance().dataCollectionEnabled = true;
 ```

--- a/docs/platforms.mdx
+++ b/docs/platforms.mdx
@@ -76,15 +76,12 @@ implementation require a Async Storage implementation to be provided to
 enable persistence, React Native Firebase provides an API to set this implementation:
 
 ```js
-import firebase from '@react-native-firebase/app';
+import { initializeApp, setReactNativeAsyncStorage } from '@react-native-firebase/app';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-// Before initializing Firebase set the Async Storage implementation
-// that will be used to persist user sessions.
-firebase.setReactNativeAsyncStorage(AsyncStorage);
+setReactNativeAsyncStorage(AsyncStorage);
 
-// Then initialize Firebase as normal.
-await firebase.initializeApp({ ... });
+await initializeApp({ ... });
 ```
 
 > Note: we use `@react-native-async-storage/async-storage` as an example, you should use the Async Storage implementation that is appropriate for your platform that you are targeting.
@@ -107,13 +104,13 @@ App Check for other platforms only supports the `CustomProvider` provider. Here'
 - Create a custom provider in your app:
 
 ```js
-import firebase, { CustomProvider, initializeAppCheck } from '@react-native-firebase/app-check';
+import { getApp } from '@react-native-firebase/app';
+import { CustomProvider, initializeAppCheck } from '@react-native-firebase/app-check';
 
 const myCustomProvider = new CustomProvider({
   async getToken: () => {
-    // TODO: Get the token from your server, e.g. if using a cloud function call the function.
     const tokenFromServer = 'some-token-from-server';
-    const expirationFromServer = 1000 * 60 * 60; // 1 hour
+    const expirationFromServer = 1000 * 60 * 60;
     const appCheckToken = {
       token: tokenFromServer,
       expireTimeMillis: expirationFromServer * 1000
@@ -122,13 +119,9 @@ const myCustomProvider = new CustomProvider({
   }
 });
 
-// Configure the provider (modular API)
-initializeAppCheck(firebaseApp, {
+await initializeAppCheck(getApp(), {
   provider: myCustomProvider
 });
-
-// Or configure the provider (v8 API)
-firebase.appCheck().initializeAppCheck({ provider: myCustomProvider });
 ```
 
 ### Authentication

--- a/docs/remote-config/usage/index.mdx
+++ b/docs/remote-config/usage/index.mdx
@@ -55,17 +55,15 @@ Setting default values helps to ensure that both the local device & Firebase ser
 
 ```js
 import React, { useEffect } from 'react';
-import remoteConfig from '@react-native-firebase/remote-config';
+import { getRemoteConfig } from '@react-native-firebase/remote-config';
 
 function App() {
   useEffect(() => {
-    remoteConfig()
-      .setDefaults({
-        awesome_new_feature: 'disabled',
-      })
-      .then(() => {
-        console.log('Default values set.');
-      });
+    const remoteConfig = getRemoteConfig();
+    remoteConfig.defaultConfig = {
+      awesome_new_feature: 'disabled',
+    };
+    console.log('Default values set.');
   }, []);
 }
 ```
@@ -76,22 +74,22 @@ Before reading the values from Firebase, we first need to pull them from Firebas
 the device (activating). The `fetchAndActivate` API combines both tasks into a single flow:
 
 ```js
-import remoteConfig from '@react-native-firebase/remote-config';
+import { getRemoteConfig, fetchAndActivate } from '@react-native-firebase/remote-config';
 
-remoteConfig()
-  .setDefaults({
-    awesome_new_feature: 'disabled',
-  })
-  .then(() => remoteConfig().fetchAndActivate())
-  .then(fetchedRemotely => {
-    if (fetchedRemotely) {
-      console.log('Configs were retrieved from the backend and activated.');
-    } else {
-      console.log(
-        'No configs were fetched from the backend, and the local configs were already activated',
-      );
-    }
-  });
+const remoteConfig = getRemoteConfig();
+remoteConfig.defaultConfig = {
+  awesome_new_feature: 'disabled',
+};
+
+fetchAndActivate(remoteConfig).then(fetchedRemotely => {
+  if (fetchedRemotely) {
+    console.log('Configs were retrieved from the backend and activated.');
+  } else {
+    console.log(
+      'No configs were fetched from the backend, and the local configs were already activated',
+    );
+  }
+});
 ```
 
 ## Reading values
@@ -100,7 +98,9 @@ With the defaults set and the remote values fetched from Firebase, we can now us
 value and use a number of methods to retrieve the value (same API as Firebase Remote Config web SDK)
 
 ```js
-const awesomeNewFeature = remoteConfig().getValue('awesome_new_feature');
+import { getRemoteConfig, getValue } from '@react-native-firebase/remote-config';
+
+const awesomeNewFeature = getValue(getRemoteConfig(), 'awesome_new_feature');
 
 // resolves value to string
 if (awesomeNewFeature.asString() === 'enabled') {
@@ -122,7 +122,9 @@ if (awesomeNewFeature.asBoolean() === true) {
 The API also provides a `getAll` method to read all parameters at once rather than by key:
 
 ```js
-const parameters = remoteConfig().getAll();
+import { getAll, getRemoteConfig } from '@react-native-firebase/remote-config';
+
+const parameters = getAll(getRemoteConfig());
 
 Object.entries(parameters).forEach($ => {
   const [key, entry] = $;
@@ -139,7 +141,9 @@ been fetched & activated then the value will fallback to the default value set. 
 returned from the module was local or remote, the `getSource()` method can be conditionally checked:
 
 ```js
-const awesomeNewFeature = remoteConfig().getValue('awesome_new_feature');
+import { getRemoteConfig, getValue } from '@react-native-firebase/remote-config';
+
+const awesomeNewFeature = getValue(getRemoteConfig(), 'awesome_new_feature');
 
 if (awesomeNewFeature.getSource() === 'remote') {
   console.log('Parameter value was from the Firebase servers.');
@@ -159,8 +163,12 @@ You can however specify your own cache length by specifically calling the `fetch
 cache the values for:
 
 ```js
+import { fetchConfig, getRemoteConfig } from '@react-native-firebase/remote-config';
+
 // Fetch and cache for 5 minutes
-await remoteConfig().fetch(300);
+const remoteConfig = getRemoteConfig();
+remoteConfig.settings = { minimumFetchIntervalMillis: 300000 };
+await fetchConfig(remoteConfig);
 ```
 
 To bypass caching fully, you can pass a value of `0`. Be warned Firebase may start to reject your requests
@@ -169,9 +177,12 @@ if values are requested too frequently.
 You can also apply a global cache frequency by calling the `setConfigSettings` method with the `minimumFetchIntervalMillis` property:
 
 ```js
-await remoteConfig().setConfigSettings({
+import { getRemoteConfig } from '@react-native-firebase/remote-config';
+
+const remoteConfig = getRemoteConfig();
+remoteConfig.settings = {
   minimumFetchIntervalMillis: 30000,
-});
+};
 ```
 
 ## Real-time updates
@@ -193,20 +204,22 @@ in applications that attach one or more listeners for them.
 Here is an example of how to use the feature, with comments emphasizing the key points to know:
 
 ```js
+import { activate, getRemoteConfig, onConfigUpdate } from '@react-native-firebase/remote-config';
+
 // Add a config update listener where appropriate, perhaps in app startup, or a specific app area.
 // Multiple listeners are supported, so listeners may be screen-specific and only handle certain keys
 // depending on application requirements
 let remoteConfigListenerUnsubscriber = onConfigUpdate(getRemoteConfig(), {
-  next: (update) => {
+  next: update => {
     console.log('remote-config keys updated: ' + Array.from(update.getUpdatedKeys()));
 
     // If you use realtime updates, the SDK fetches the new config for you.
     // However, you must activate the new config so it is in effect
     activate(getRemoteConfig());
-  }
-  error: (error) => {
+  },
+  error: error => {
     console.log('remote-config listener subscription error: ' + error);
-  }
+  },
 });
 
 // unsubscribe the listener when no longer needed - remote config will close the network socket if there

--- a/docs/storage/usage/index.mdx
+++ b/docs/storage/usage/index.mdx
@@ -50,15 +50,15 @@ A reference is a local pointer to some file on your bucket. This can either be a
 which does not exist yet. To create a reference, use the `ref` method:
 
 ```js
-import storage from '@react-native-firebase/storage';
+import { getStorage, ref } from '@react-native-firebase/storage';
 
-const reference = storage().ref('black-t-shirt-sm.png');
+const reference = ref(getStorage(), 'black-t-shirt-sm.png');
 ```
 
 You can also specify a file located in a deeply nested directory:
 
 ```js
-const reference = storage().ref('/images/t-shirts/black-t-shirt-sm.png');
+const reference = ref(getStorage(), '/images/t-shirts/black-t-shirt-sm.png');
 ```
 
 ## Upload a file
@@ -72,20 +72,18 @@ import React, { useEffect } from 'react';
 import { View, Button } from 'react-native';
 
 import { utils } from '@react-native-firebase/app';
-import storage from '@react-native-firebase/storage';
+import { getStorage, ref, putFile } from '@react-native-firebase/storage';
 
 function App() {
-  // create bucket storage reference to not yet existing image
-  const reference = storage().ref('black-t-shirt-sm.png');
+  const storage = getStorage();
+  const reference = ref(storage, 'black-t-shirt-sm.png');
 
   return (
     <View>
       <Button
         onPress={async () => {
-          // path to existing file on filesystem
           const pathToFile = `${utils.FilePath.PICTURES_DIRECTORY}/black-t-shirt-sm.png`;
-          // uploads file
-          await reference.putFile(pathToFile);
+          await putFile(reference, pathToFile);
         }}
       />
     </View>
@@ -99,7 +97,7 @@ The `putFile` method returns a [`Task`](https://invertase.github.io/react-native
 such as the current upload progress:
 
 ```js
-const task = reference.putFile(pathToFile);
+const task = putFile(reference, pathToFile);
 
 task.on('state_changed', taskSnapshot => {
   console.log(`${taskSnapshot.bytesTransferred} transferred out of ${taskSnapshot.totalBytes}`);
@@ -113,7 +111,7 @@ task.then(() => {
 A task also provides the ability to pause & resume on-going operations:
 
 ```js
-const task = reference.putFile(pathToFile);
+const task = putFile(reference, pathToFile);
 
 task.pause();
 
@@ -128,9 +126,9 @@ files to a bucket, they are not automatically available for consumption via a HT
 need to call the `getDownloadURL` method on a reference:
 
 ```js
-import storage from '@react-native-firebase/storage';
+import { getStorage, ref, getDownloadURL } from '@react-native-firebase/storage';
 
-const url = await storage().ref('images/profile-1.png').getDownloadURL();
+const url = await getDownloadURL(ref(getStorage(), 'images/profile-1.png'));
 ```
 
 > Images uploaded manually via the Firebase Console automatically generate a download URL.
@@ -141,7 +139,7 @@ If you wish to view a full list of the current files & directories within a part
 the `list` method. The results are however paginated, and if more results are available you can pass a page token into the request:
 
 ```js
-import storage from '@react-native-firebase/storage';
+import { getStorage, ref } from '@react-native-firebase/storage';
 
 function listFilesAndDirectories(reference, pageToken) {
   return reference.list({ pageToken }).then(result => {
@@ -158,7 +156,7 @@ function listFilesAndDirectories(reference, pageToken) {
   });
 }
 
-const reference = storage().ref('images');
+const reference = ref(getStorage(), 'images');
 
 listFilesAndDirectories(reference).then(() => {
   console.log('Finished listing');
@@ -180,8 +178,9 @@ is passed to the `storage` instance. To switch buckets, provide the module with 
 Firebase Console, under Storage > Files.
 
 ```js
-import storage, { firebase } from '@react-native-firebase/storage';
+import { getStorage } from '@react-native-firebase/storage';
+import { getApp } from '@react-native-firebase/app';
 
-const defaultStorageBucket = storage();
-const secondaryStorageBucket = firebase.app().storage('gs://my-secondary-bucket.appspot.com');
+const defaultStorageBucket = getStorage();
+const secondaryStorageBucket = getStorage(getApp(), 'gs://my-secondary-bucket.appspot.com');
 ```

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -9,33 +9,13 @@ React Native Firebase ships TypeScript declarations for every module. From v25 o
 
 If you are setting up TypeScript in a new React Native app, see the official [TypeScript documentation](https://reactnative.dev/docs/typescript).
 
-## Namespaced API (default export)
+## Modular API
 
-The namespaced API remains the default entry point. Types are inferred automatically for most call sites:
-
-```tsx
-import auth from '@react-native-firebase/auth';
-
-function App() {
-  const user = auth().currentUser;
-
-  if (!user) {
-    return null;
-  }
-
-  return user.email;
-}
-```
-
-TypeScript flags `user.email` when `currentUser` may be `null` — narrow with a guard as above.
-
-## Modular API (v22+ / v25 types)
-
-Import modular helpers and types from the package root. Prefer these over the deprecated `FirebaseAuthTypes` namespace for new code:
+Import modular helpers and types from the package root:
 
 ```tsx
 import { useEffect, useState } from 'react';
-import auth, { getAuth, onAuthStateChanged, type User } from '@react-native-firebase/auth';
+import { getAuth, onAuthStateChanged, type User } from '@react-native-firebase/auth';
 
 function App() {
   const [user, setUser] = useState<User | null>(null);


### PR DESCRIPTION
## Summary
- Convert documentation code examples from namespaced APIs (`firestore()`, `messaging()`, etc.) to modular APIs (`getFirestore()`, `getMessaging()`, etc.) across 29 docs pages.

## Test plan
- [x] Spot-check examples at https://rnfirebase.io/~modular-documentation
- [x] `yarn lint:markdown`
- [x] `yarn lint:spellcheck`
- [x] `yarn lint:js`