### PR TITLE
docs(firestore): add pipelines overview and SDK compatibility pages

### DIFF
--- a/.agents/.gitignore
+++ b/.agents/.gitignore
@@ -1,0 +1,1 @@
+reports

--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -23,6 +23,7 @@ authenticator
 AuthSettings
 autolinking
 Autolinking
+allowlist
 AVD
 axios
 Axios
@@ -39,10 +40,12 @@ callables
 CarPlay
 CDN
 Changelog
+changelogs
 checkForUpdate
 CLI
 CocoaPods
 codebase
+composable
 config
 Config
 config-plugin
@@ -50,6 +53,8 @@ CP-User
 crashlytics
 Crashlytics
 CustomProvider
+deduplicate
+Deduplicate
 datastore
 debugToken
 DebugView
@@ -82,6 +87,8 @@ FirebaseApp
 FirebaseCore
 firestore
 Firestore
+geospatial
+Geospatial
 freeform
 GDPR
 GDPR-compliant
@@ -100,6 +107,7 @@ IDFA
 Imagen
 installable
 integrations
+interop
 Intellisense
 IntelliSense
 interstitials
@@ -191,6 +199,8 @@ screenview
 scrollable
 SDK
 SDK.
+subcollection
+Subcollection
 SDK51
 SDKs
 SDKs.

--- a/docs.json
+++ b/docs.json
@@ -106,6 +106,11 @@
         { "title": "Usage with Emulator", "href": "/firestore/emulator" },
         { "title": "Usage with FlatLists", "href": "/firestore/usage-with-flatlists" },
         { "title": "Implementing Pagination", "href": "/firestore/pagination" },
+        { "title": "Pipelines", "href": "/firestore/pipelines" },
+        {
+          "title": "Pipeline SDK compatibility",
+          "href": "/firestore/pipelines/sdk-compatibility"
+        },
         {
           "title": "Building a \"TODO\" app",
           "href": "https://invertase.io/blog/getting-started-with-cloud-firestore-on-react-native"

--- a/docs/firestore/pagination.mdx
+++ b/docs/firestore/pagination.mdx
@@ -1,7 +1,7 @@
 ---
 title: Pagination
 description: Pagination example using Cloud Firestore.
-next: /functions/usage
+next: /firestore/pipelines
 previous: /firestore/usage-with-flatlists
 ---
 

--- a/docs/firestore/pipelines/index.mdx
+++ b/docs/firestore/pipelines/index.mdx
@@ -1,0 +1,166 @@
+---
+title: Pipelines
+description: Firestore pipeline queries in React Native Firebase - overview, requirements, and getting started.
+next: /firestore/pipelines/sdk-compatibility
+previous: /firestore/pagination
+---
+
+Firestore **pipeline queries** let you run multi-stage read operations (filter, project, aggregate, vector search, and more) against Cloud Firestore using a fluent, composable API. React Native Firebase exposes the same modular pipeline surface as the [firebase-js-sdk](https://firebase.google.com/docs/reference/js/firestore_pipelines) so you can reuse patterns from web documentation and samples.
+
+Pipeline support in React Native Firebase is marked **@beta** in TypeScript. APIs may evolve as Firebase ships new pipeline features.
+
+<YouTube id="sYY1NweSlEc" />
+
+# What are pipeline queries?
+
+Traditional Firestore queries are collection-scoped and limited to a single query shape. **Pipelines** chain **stages** (for example `where`, `select`, `aggregate`, `findNearest`) on a **source** (collection, collection group, documents list, or an existing query). Each stage transforms the result of the previous stage.
+
+Google's upstream resources:
+
+- [Get started with pipeline queries](https://firebase.google.com/docs/firestore/pipelines/get-started-with-pipelines)
+- [firebase-js-sdk pipeline reference](https://firebase.google.com/docs/reference/js/firestore_pipelines)
+- [Introducing pipeline operations (Firebase blog, Jan 2026)](https://firebase.blog/posts/2026/01/firestore-enterprise-pipeline-operations/)
+
+For a full list of which firebase-js-sdk exports are available in React Native Firebase today, see [SDK compatibility](/firestore/pipelines/sdk-compatibility).
+
+# Requirements
+
+## Firestore Enterprise edition
+
+Pipeline `execute()` requires a **Firestore Enterprise** database. Standard edition databases reject pipeline execution. Create an Enterprise database in the Firebase console or with the Firebase CLI before testing pipelines in your project.
+
+## Cloud execution (not the local emulator)
+
+The Firestore emulator used for most React Native Firebase e2e tests runs in **Standard** edition mode and does **not** faithfully execute pipeline queries. Plan to develop and test pipelines against a **live Enterprise database** in your Firebase project.
+
+The emulator may gain additional Enterprise pipeline support over time, but React Native Firebase pipeline integration tests today run against a dedicated cloud database (`pipelines-e2e` on the public testing project), not the local emulator.
+
+# Installation
+
+Pipelines ship inside `@react-native-firebase/firestore`. Install the app and Firestore modules as described in [Cloud Firestore usage](/firestore/usage):
+
+```bash
+yarn add @react-native-firebase/app @react-native-firebase/firestore
+cd ios && pod install
+```
+
+Expression helpers and types are imported from the pipelines entry point:
+
+```js
+import { getFirestore } from '@react-native-firebase/firestore';
+import { field, constant, execute } from '@react-native-firebase/firestore/pipelines';
+```
+
+You can also call `getFirestore().pipeline()` on any Firestore instance to start building a pipeline from a source stage.
+
+# Basic example
+
+This example reads documents from a collection, keeps rows where `score` is at least 10, projects two fields, and sorts by score descending. Adjust the database id and collection path for your Enterprise database.
+
+```js
+import { getFirestore } from '@react-native-firebase/firestore';
+import { field, execute } from '@react-native-firebase/firestore/pipelines';
+
+const db = getFirestore(); // use a named Enterprise database id if needed
+
+const pipeline = db
+  .pipeline()
+  .collection('books')
+  .where(field('score').greaterThanOrEqual(10))
+  .select(field('title'), field('score'))
+  .sort({ ordering: [{ fieldPath: 'score', direction: 'desc' }] });
+
+const snapshot = await execute(pipeline);
+snapshot.results.forEach(row => {
+  console.log(row.data());
+});
+```
+
+`execute()` returns a `PipelineSnapshot` with a `results` array of pipeline rows. Iterate `snapshot.results` or access individual entries by index.
+
+# Supported stages and sources
+
+React Native Firebase supports these **source** types:
+
+| Source            | Description                                                      |
+| ----------------- | ---------------------------------------------------------------- |
+| `collection`      | Documents in a collection path                                   |
+| `collectionGroup` | Documents across a collection id                                 |
+| `database`        | Database-scoped pipeline source                                  |
+| `documents`       | Explicit document paths                                          |
+| `query`           | Pipeline created from an existing Firestore query (`createFrom`) |
+
+These **stage** types are available on the pipeline builder:
+
+| Stage                        | Purpose                                          |
+| ---------------------------- | ------------------------------------------------ |
+| `where`                      | Filter rows                                      |
+| `select`                     | Project fields                                   |
+| `addFields` / `removeFields` | Add or drop computed fields                      |
+| `sort`                       | Order results                                    |
+| `limit` / `offset`           | Paginate                                         |
+| `aggregate`                  | Group and reduce                                 |
+| `distinct`                   | Deduplicate                                      |
+| `findNearest`                | Vector similarity search (requires vector index) |
+| `replaceWith`                | Replace row shape                                |
+| `sample`                     | Random sample                                    |
+| `union`                      | Combine pipelines                                |
+| `unnest`                     | Expand array fields into rows                    |
+
+## Vector search with `findNearest`
+
+The `findNearest` stage runs vector similarity search over an indexed embedding field. Use the same **lowercase** `distanceMeasure` values as the [firebase-js-sdk pipeline reference](https://firebase.google.com/docs/reference/js/firestore_pipelines): `'euclidean'`, `'cosine'`, or `'dot_product'`.
+
+Create a [vector index](https://firebase.google.com/docs/firestore/pipelines/get-started-with-pipelines) on your Enterprise database before running this query.
+
+```js
+import { getFirestore } from '@react-native-firebase/firestore';
+import { execute } from '@react-native-firebase/firestore/pipelines';
+
+const db = getFirestore(); // Enterprise database with a vector index on `embedding`
+
+const queryVector = [1.0, 0.0, 0.0];
+
+const snapshot = await execute(
+  db
+    .pipeline()
+    .collection('products')
+    .findNearest({
+      field: 'embedding',
+      vectorValue: queryVector,
+      distanceMeasure: 'euclidean',
+      limit: 5,
+    })
+    .select('name'),
+);
+
+snapshot.results.forEach(row => {
+  console.log(row.data().name);
+});
+```
+
+Newer firebase-js-sdk stage helpers such as `subcollection` and `parent` are not yet exposed — see [SDK compatibility](/firestore/pipelines/sdk-compatibility).
+
+# Platform notes
+
+| Platform    | Runtime                       | Notes                                                                        |
+| ----------- | ----------------------------- | ---------------------------------------------------------------------------- |
+| **Android** | Native Firebase Android SDK   | Full native pipeline execution                                               |
+| **iOS**     | Native Firebase iOS SDK       | Some expression helpers are not yet supported on iOS; see compatibility page |
+| **macOS**   | firebase-js-sdk (web interop) | Same API shape as web; requires network access to Firestore                  |
+
+On **iOS**, pipelines that use unsupported expression functions fail before execution with a clear error listing the function names. The compatibility page lists the current set.
+
+On **macOS**, pipeline execution goes through the web Firebase SDK bundled for React Native macOS targets. Behavior should match web pipeline queries for the same database and rules.
+
+# TypeScript
+
+Pipeline types and expression helpers are exported from `@react-native-firebase/firestore/pipelines`. The `firestore.pipeline()` method is augmented on `Firestore` when you import the firestore module.
+
+Run `yarn compare:types` in the React Native Firebase repository to see tracked differences between our public types and the firebase-js-sdk pipelines declarations.
+
+# Next steps
+
+- Review [SDK compatibility](/firestore/pipelines/sdk-compatibility) before porting firebase-js-sdk pipeline samples.
+- Read Firebase's [get started guide](https://firebase.google.com/docs/firestore/pipelines/get-started-with-pipelines) for index setup, vector search, and security rules considerations.
+- For classic collection queries, continue with [Cloud Firestore usage](/firestore/usage).

--- a/docs/firestore/pipelines/sdk-compatibility.mdx
+++ b/docs/firestore/pipelines/sdk-compatibility.mdx
@@ -1,0 +1,99 @@
+---
+title: Pipeline SDK compatibility
+description: How React Native Firebase Firestore pipelines compare to the firebase-js-sdk pipelines API.
+next: /functions/usage
+previous: /firestore/pipelines
+---
+
+React Native Firebase aims to be a **drop-in replacement** for the [firebase-js-sdk Firestore pipelines module](https://firebase.google.com/docs/reference/js/firestore_pipelines) on React Native targets. Most expression helpers, stage builders, and types match the JS SDK. This page summarizes deliberate gaps so you can plan migrations from web samples.
+
+CI enforces parity through `yarn compare:types` and the `firestore-pipelines` allowlist in the repository. When a gap closes, the allowlist entry is removed and this page should be updated.
+
+# Summary
+
+| Category                                                                    | Status                                                                |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Core pipeline builder (`pipeline()`, stages, `execute()`)                   | **Supported** on Android, iOS, and macOS                              |
+| Expression helpers (aggregates, strings, arrays, maps, timestamps, vectors) | **Mostly supported** — see gaps below                                 |
+| Newer firebase-js-sdk helpers (2025–2026)                                   | **Partial** — tracked in "Not yet available"                          |
+| firebase-js-sdk `Type` export                                               | **React Native Firebase only** — use `isType()` with our `Type` union |
+
+# Not yet available in React Native Firebase
+
+These firebase-js-sdk pipeline exports are **not** exposed yet. They are listed in the repository compare-types allowlist until implemented:
+
+| Export                      | Kind       | Notes                          |
+| --------------------------- | ---------- | ------------------------------ |
+| `coalesce`                  | Expression | Null-coalescing helper         |
+| `currentDocument`           | Expression | Document context helper        |
+| `documentMatches`           | Expression | Document matching helper       |
+| `geoDistance`               | Expression | Geospatial distance            |
+| `ifNull`                    | Expression | Null handling                  |
+| `score`                     | Expression | Full-text search score         |
+| `switchOn`                  | Expression | Conditional switch             |
+| `timestampDiff`             | Expression | Timestamp arithmetic           |
+| `timestampExtract`          | Expression | Timestamp field extraction     |
+| `subcollection`             | Stage      | Subcollection source stage     |
+| `parent`                    | Stage      | Parent document stage          |
+| `DefineStageOptions`        | Type       | Options for define stage       |
+| `SearchStageOptions`        | Type       | Full-text search stage options |
+| `SubcollectionStageOptions` | Type       | Subcollection stage options    |
+| `TimePart`                  | Type       | Timestamp extraction part      |
+| `TimeUnit`                  | Type       | Timestamp unit                 |
+
+If you depend on one of these, follow [Firebase pipeline release notes](https://firebase.google.com/support/release-notes/js) and React Native Firebase changelogs, or open a feature request with your use case.
+
+# Same name, slightly different shape
+
+These exports exist in both SDKs but differ in typing or optional parameters:
+
+| Export            | Difference                                                            |
+| ----------------- | --------------------------------------------------------------------- |
+| `constant`        | firebase-js-sdk added optional `preferIntegers`; not yet on RNFB      |
+| `isType`          | RNFB accepts the local `Type` alias; JS SDK accepts a broader string  |
+| `ExpressionType`  | JS SDK includes newer `PipelineValue` kind                            |
+| `StageOptions`    | Equivalent runtime shape; declaration formatting differs              |
+| `TimeGranularity` | RNFB uses `isoWeek` / `isoYear`; JS SDK also lists lowercase variants |
+
+# React Native Firebase only
+
+| Export | Notes                                                                   |
+| ------ | ----------------------------------------------------------------------- |
+| `Type` | Local type discriminator union used with `isType()` and related helpers |
+
+# iOS expression limitations
+
+Even when an expression helper is exported from `@react-native-firebase/firestore/pipelines`, the **iOS native runtime** may not implement it yet. Using these functions in a pipeline on iOS throws before `execute()` completes:
+
+| Function            | Status on iOS |
+| ------------------- | ------------- |
+| `arrayGet`          | Not supported |
+| `conditional`       | Not supported |
+| `round`             | Not supported |
+| `stringRepeat`      | Not supported |
+| `substring`         | Not supported |
+| `timestampAdd`      | Not supported |
+| `timestampSubtract` | Not supported |
+| `trunc`             | Not supported |
+
+**Android** and **macOS** do not apply this check; macOS uses the web SDK path. Prefer testing pipeline samples on Android or macOS when they use the functions above until iOS parity lands.
+
+The list is defined in `packages/firestore/lib/pipelines/pipeline_support.ts` and kept in sync with `RNFBFirestorePipelineNodeBuilder.swift`.
+
+# Platform execution matrix
+
+| Platform | Execution backend               | Pipeline database  |
+| -------- | ------------------------------- | ------------------ |
+| Android  | Native Android Firestore SDK    | Enterprise (cloud) |
+| iOS      | Native iOS Firestore SDK        | Enterprise (cloud) |
+| macOS    | firebase-js-sdk via web interop | Enterprise (cloud) |
+
+All platforms require network access to your Firestore Enterprise database for pipeline `execute()`. The local Firestore emulator is not a supported target for pipeline development today.
+
+# Staying up to date
+
+- Upstream API reference: [firebase-js-sdk `firestore/pipelines`](https://firebase.google.com/docs/reference/js/firestore_pipelines)
+- RNFB import path: `@react-native-firebase/firestore/pipelines`
+- Repository parity config: `.github/scripts/compare-types/configs/firestore-pipelines.ts`
+
+When a row in the tables above is resolved in a release, it will be removed from the compare-types allowlist. Check release notes and this page after upgrading `@react-native-firebase/firestore`.

--- a/docs/functions/usage/index.mdx
+++ b/docs/functions/usage/index.mdx
@@ -2,7 +2,7 @@
 title: Cloud Functions
 description: Installation and getting started with Cloud Functions.
 next: /functions/writing-deploying-functions
-previous: /firestore/pagination
+previous: /firestore/pipelines/sdk-compatibility
 ---
 
 # Installation

--- a/docs/migrating-to-v25.mdx
+++ b/docs/migrating-to-v25.mdx
@@ -410,7 +410,7 @@ await initializeAppCheck(getApp(), {
 
 Version 25 aligns `@react-native-firebase/auth` TypeScript types with the firebase-js-sdk modular API. Runtime behavior is largely unchanged, but TypeScript consumers should review the following breaking changes.
 
-For maintainers and coding agents: the living triage matrix is [`okf-bundle/packages/auth/compare-types-triage.md`](../okf-bundle/packages/auth/compare-types-triage.md). Run `yarn compare:types auth` after public API edits and update `.github/scripts/compare-types/configs/auth.ts` when differences are intentional.
+For maintainers and coding agents: the living triage matrix is [`okf-bundle/packages/auth/compare-types-triage.md`](https://github.com/invertase/react-native-firebase/blob/main/okf-bundle/packages/auth/compare-types-triage.md). Run `yarn compare:types auth` after public API edits and update `.github/scripts/compare-types/configs/auth.ts` when differences are intentional.
 
 ## Platform matrix (read before changing Auth)
 

--- a/docs/typescript.mdx
+++ b/docs/typescript.mdx
@@ -41,7 +41,7 @@ Published types are built to `packages/<module>/dist/typescript/` (for example `
 
 Modular Auth source: [`packages/auth/lib/modular.ts`](https://github.com/invertase/react-native-firebase/blob/main/packages/auth/lib/modular.ts).
 
-Public API reference (generated from source JSDoc): [reference API](/reference).
+Public API reference (generated from source JSDoc): [reference API](https://reference.rnfirebase.io/modules.html).
 
 ## Definitions per module
 
@@ -53,4 +53,4 @@ Each package exports its own types from the package root. Examples:
 | Firestore | `FirebaseFirestoreTypes` namespace (namespaced) + modular helpers from `@react-native-firebase/firestore` |
 | App Check | `AppCheck`, `AppCheckTokenResult`, …                                                                      |
 
-For Auth v25 alignment details and intentional firebase-js-sdk differences, see the [Auth compare:types triage](../okf-bundle/packages/auth/compare-types-triage.md) knowledge document and [`yarn compare:types auth`](https://github.com/invertase/react-native-firebase/blob/main/.github/scripts/compare-types/configs/auth.ts) registry.
+For Auth v25 alignment details and intentional firebase-js-sdk differences, see the [Auth compare:types triage](https://github.com/invertase/react-native-firebase/blob/main/okf-bundle/packages/auth/compare-types-triage.md) knowledge document and [`yarn compare:types auth`](https://github.com/invertase/react-native-firebase/blob/main/.github/scripts/compare-types/configs/auth.ts) registry.


### PR DESCRIPTION
### Description

Adds user-facing Firestore Pipelines documentation: overview page with Enterprise requirements, platform notes, upstream links, YouTube embed, and a `findNearest` vector search example using lowercase `distanceMeasure` values; SDK compatibility table vs firebase-js-sdk; sidebar entries under Cloud Firestore. Also fixes broken okf-bundle and `/reference` links in existing docs.

### Related issues

- #9017

### Release Summary

Document Firestore Pipelines (`@react-native-firebase/firestore/pipelines`) for Enterprise users, including firebase-js-sdk parity notes and vector search guidance.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- [x] `yarn lint:js`
- [x] `yarn lint:markdown`
- [x] `yarn lint:spellcheck`
- [x] `audit-docs.page` mechanical audit (docs.page CLI, frontmatter, next/previous, Prettier) — all stages passed
- [x] Visual review: https://rnfirebase.io/~pipeline-docs

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter