### PR TITLE
docs: use page#fragment anchors, not just bare #fragment anchors

### DIFF
--- a/docs/auth/social-auth.mdx
+++ b/docs/auth/social-auth.mdx
@@ -374,7 +374,7 @@ with the new authentication state of the user.
 
 If you are testing this feature on an android emulator ensure that the emulate is either the Google APIs or Google Play flavor.
 
-> If you need Credential Manager on Android without a paid license, use [`react-native-nitro-google-signin`](#react-native-nitro-google-signin) instead of upgrading to Universal Sign-In.
+> If you need Credential Manager on Android without a paid license, use [`react-native-nitro-google-signin`](/auth/social-auth#react-native-nitro-google-signin) instead of upgrading to Universal Sign-In.
 
 ## Microsoft
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,7 +40,7 @@ Similarly you can install other React Native Firebase modules such as for Authen
 
 The recommended approach to configure React Native Firebase is to use [Expo Config Plugins](https://docs.expo.dev/config-plugins/introduction/). You will add React Native Firebase modules to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.json` or `app.config.js`. See the note below to determine which modules require Config Plugin configurations.
 
-If you are instead manually adjusting your Android and iOS projects (this is not recommended), follow the same instructions as [React Native CLI projects](#Installation for React Native CLI (non-Expo) projects).
+If you are instead manually adjusting your Android and iOS projects (this is not recommended), follow the same instructions as [React Native CLI projects](/#installation-for-react-native-cli-non-expo-projects).
 
 To enable Firebase on the native Android and iOS platforms, create and download Service Account files for each platform from your Firebase project. Then provide paths to the downloaded `google-services.json` and `GoogleService-Info.plist` files in the following `app.json` fields: [`expo.android.googleServicesFile`](https://docs.expo.io/versions/latest/config/app/#googleservicesfile-1) and [`expo.ios.googleServicesFile`](https://docs.expo.io/versions/latest/config/app/#googleservicesfile). See the example configuration below.
 

--- a/docs/migrating-to-v25.mdx
+++ b/docs/migrating-to-v25.mdx
@@ -9,6 +9,23 @@ Version 25 completes the TypeScript alignment started in v24. Modular types acro
 
 If you upgraded to v24 for Firestore only, see [Migrating to v24](/migrating-to-v24) first — Firestore breaking changes remain in v24.
 
+## Table of contents
+
+- [Why we made these changes](/migrating-to-v25#why-we-made-these-changes)
+- [Agent-assisted migration](/migrating-to-v25#agent-assisted-migration)
+- [Who is affected](/migrating-to-v25#who-is-affected)
+- [General pattern](/migrating-to-v25#general-pattern)
+- [Tooling & native SDKs](/migrating-to-v25#tooling--native-sdks)
+- [Cloud Storage](/migrating-to-v25#cloud-storage)
+- [Realtime Database](/migrating-to-v25#realtime-database)
+- [Remote Config](/migrating-to-v25#remote-config)
+- [Performance Monitoring](/migrating-to-v25#performance-monitoring)
+- [Installations](/migrating-to-v25#installations)
+- [App Check](/migrating-to-v25#app-check)
+- [Firebase Auth](/migrating-to-v25#firebase-auth)
+- [Cloud Messaging](/migrating-to-v25#cloud-messaging)
+- [Automated migration checklist](/migrating-to-v25#automated-migration-checklist)
+
 ## Why we made these changes
 
 React Native Firebase aims to be a drop-in replacement for the [firebase-js-sdk](https://firebase.google.com/docs/web/setup) — with native extensions and performance where the platform allows. At the JavaScript level we have always tracked the modular API closely, but our TypeScript declarations had diverged: namespaces specific to React Native Firebase, instance-style typings, and helper names that did not match the SDK.
@@ -24,7 +41,7 @@ Most apps behave the same after updating package versions; the work is primarily
 
 ## Agent-assisted migration
 
-This guide is written to be **complete enough for an automated first pass**. We recommend feeding this document to your coding agent, then asking it to analyze your codebase against each relevant section below and produce a concrete change list (or PR) for the packages you use. The [Automated migration checklist](#automated-migration-checklist) at the end is structured for that workflow.
+This guide is written to be **complete enough for an automated first pass**. We recommend feeding this document to your coding agent, then asking it to analyze your codebase against each relevant section below and produce a concrete change list (or PR) for the packages you use. The [Automated migration checklist](/migrating-to-v25#automated-migration-checklist) at the end is structured for that workflow.
 
 ## Who is affected
 
@@ -42,23 +59,6 @@ Across v25 package migrations:
 2. Prefer **free functions** (`getToken(appCheck)`, `trace(perf, name)`) over instance methods on service objects.
 3. `Firebase*Types` namespaces remain for namespaced compatibility but are **deprecated** for new code.
 4. Namespaced APIs (`firebase.auth()`, `storage()`) still work; modular is the typed source of truth.
-
-## Table of contents
-
-- [Why we made these changes](#why-we-made-these-changes)
-- [Agent-assisted migration](#agent-assisted-migration)
-- [Who is affected](#who-is-affected)
-- [General pattern](#general-pattern)
-- [Tooling & native SDKs](#tooling--native-sdks)
-- [Cloud Storage](#cloud-storage)
-- [Realtime Database](#realtime-database)
-- [Remote Config](#remote-config)
-- [Performance Monitoring](#performance-monitoring)
-- [Installations](#installations)
-- [App Check](#app-check)
-- [Firebase Auth](#firebase-auth)
-- [Cloud Messaging](#cloud-messaging)
-- [Automated migration checklist](#automated-migration-checklist)
 
 # Tooling & native SDKs
 


### PR DESCRIPTION
### Description

docs.page resolves bare `#fragment` intra-page links to the site root (`rnfirebase.io/#fragment`) instead of the current page. That breaks table-of-contents and in-page cross-references — links look valid in markdown but navigate to the wrong place.

This PR qualifies all affected anchors with their page route (`/page#fragment`):

- **`migrating-to-v25.mdx`** — moves the table of contents to the top of the guide and fixes 15 bare `#` TOC links plus the in-text “Automated migration checklist” link
- **`index.mdx`** — fixes the Expo → React Native CLI cross-link (also corrected a malformed anchor with parentheses)
- **`auth/social-auth.mdx`** — fixes the `react-native-nitro-google-signin` intra-page reference

### Related issues

N/A

### Release Summary

N/A (docs only)

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- [x] Manual review on the docs preview: https://rnfirebase.io/~v25-migration-guide-edits
- [x] On `/migrating-to-v25`, confirm the table of contents appears at the top and each TOC item scrolls to the correct section
- [x] On `/migrating-to-v25`, confirm the “Automated migration checklist” in-body link jumps to the checklist section
- [x] On `/`, confirm the Expo section link to “React Native CLI projects” scrolls to the CLI installation section
- [x] On `/auth/social-auth`, confirm the `react-native-nitro-google-signin` callout link scrolls to that subsection