### PR TITLE
fix(auth): export revokeToken in modular API for Sign in with Apple

### DIFF
--- a/.github/scripts/compare-types/configs/auth.ts
+++ b/.github/scripts/compare-types/configs/auth.ts
@@ -152,6 +152,11 @@ const config: PackageConfig = {
         'RN Firebase-specific native auth domain helper on iOS/Android. Other/All: auth.config from firebase-js-sdk may cover this instead (see auth.config in migration guide).',
     },
     {
+      name: 'revokeToken',
+      reason:
+        'RN Firebase-specific Sign in with Apple authorization-code revocation helper. iOS: native revokeTokenWithAuthorizationCode. Android/Web: bridge no-op. Distinct from firebase-js-sdk revokeAccessToken (web-only OAuth token revocation).',
+    },
+    {
       name: 'AdditionalUserInfoNative',
       reason:
         'RN Firebase extension type: firebase-js-sdk AdditionalUserInfo core fields plus index signature for extra native bridge keys. Use when typing values from getAdditionalUserInfo or UserCredential.additionalUserInfo that may include provider-specific native fields.',

--- a/docs/migrating-to-v25.mdx
+++ b/docs/migrating-to-v25.mdx
@@ -500,6 +500,12 @@ These modular helpers are exported for firebase-js-sdk API parity. **On iOS/Andr
 - `verifyPhoneNumber(auth, phoneNumber, ...)` — **iOS/Android only** native listener flow (force-resend, auto-verification callbacks). On Other platforms use `signInWithPhoneNumber` / firebase-js-sdk `PhoneAuthProvider` instead.
 - `signInWithPhoneNumber(auth, phoneNumber, appVerifier?)` — modular API no longer accepts the former `forceResend` fourth argument from React Native Firebase; use `verifyPhoneNumber` when you need the native listener / force-resend behavior.
 
+## Sign in with Apple
+
+- `revokeToken(auth, authorizationCode)` — React Native Firebase-specific modular helper for Apple's account-deletion requirement. **Supported on iOS** (native `revokeTokenWithAuthorizationCode`). Android and Web bridges resolve without performing revocation.
+- Do not confuse with `revokeAccessToken` — that is firebase-js-sdk web-only OAuth token revocation and always throws on iOS/Android.
+- The namespaced `firebase.auth().revokeToken(authorizationCode)` API remains available but is deprecated.
+
 ## Auth instance surface
 
 - `auth.tenantId = 'tenant-id'` is now supported (delegates to `setTenantId`).

--- a/packages/auth/lib/modular.ts
+++ b/packages/auth/lib/modular.ts
@@ -537,6 +537,20 @@ export function revokeAccessToken(_auth: Auth, _token: string): Promise<void> {
 }
 
 /**
+ * Revokes a user's Sign in with Apple token.
+ *
+ * @remarks
+ * React Native Firebase-specific API required by Apple's account-deletion guidelines.
+ * **Supported on iOS** via the native `revokeTokenWithAuthorizationCode` bridge.
+ * On Android and Web the bridge resolves without performing revocation (no-op).
+ * Distinct from firebase-js-sdk {@link revokeAccessToken}, which revokes OAuth access tokens on Web only.
+ */
+export function revokeToken(auth: Auth, authorizationCode: string): Promise<void> {
+  const authInternal = getAuthInternal(auth);
+  return callAuthMethod(authInternal, authInternal.revokeToken, authorizationCode);
+}
+
+/**
  * Sends a password reset email to the given address.
  */
 export function sendPasswordResetEmail(

--- a/packages/auth/lib/types/internal.ts
+++ b/packages/auth/lib/types/internal.ts
@@ -416,6 +416,7 @@ export type AuthInternal = Auth & {
     forceResend?: boolean,
   ): PhoneAuthListener;
   verifyPasswordResetCode(code: string): Promise<string>;
+  revokeToken(authorizationCode: string): Promise<void>;
   native: RNFBAuthModule;
   emitter: EventEmitter;
   eventNameForApp(...args: Array<string | number>): string;

--- a/packages/auth/type-test.ts
+++ b/packages/auth/type-test.ts
@@ -25,6 +25,7 @@ import auth, {
   GoogleAuthProvider,
   getMultiFactorResolver,
   getRedirectResult,
+  revokeToken,
   initializeAuth,
   isSignInWithEmailLink,
   multiFactor,
@@ -353,6 +354,7 @@ setLanguageCode(modularAuth, 'fr');
 useUserAccessGroup(modularAuth, 'group.example');
 verifyPasswordResetCode(modularAuth, 'oob-code').then((email: string) => console.log(email));
 getCustomAuthDomain(modularAuth).then((domain: string) => console.log(domain));
+revokeToken(modularAuth, 'authorization-code');
 validatePassword(modularAuth, 'password123').then((status: PasswordValidationStatus) =>
   console.log(status.isValid),
 );


### PR DESCRIPTION
### Description

v25 modular auth omitted the `revokeToken(auth, authorizationCode)` export even though the native iOS bridge, namespaced API, and docs (`social-auth.mdx`) still expected it. Users following the modular migration hit a missing import / TypeScript error.

This restores the documented modular helper, adds `AuthInternal` typing, updates the v25 migration guide, and registers the RN-specific API in `compare:types`.

### Related issues

- Fixes #9070

### Release Summary

Restores the modular `revokeToken` export for Sign in with Apple account-deletion flows (iOS native revocation; Android/Web bridge no-op unchanged).

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Local validation in worktree:

- [x] `yarn install`
- [x] `yarn tsc:compile`
- [x] `yarn tsc:compile:consumer`
- [x] `yarn lint:js`
- [x] `yarn compare:types auth`
- [x] `yarn reference:api` (generates `revokeToken` API reference page)
- [x] `packages/auth/type-test.ts` updated for modular `revokeToken` import/call

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter