### PR TITLE
chore(ci): grant pull-requests write to issue labeler workflow

### DIFF
--- a/.github/workflows/issue-labels.yaml
+++ b/.github/workflows/issue-labels.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   label-op-response:


### PR DESCRIPTION
### Description

Fixes a permissions regression from #9058 where `issue-labels.yaml` was scoped to `issues: write` only after replacing `secrets.GH_TOKEN` with the default `GITHUB_TOKEN`.

When a PR author replies on an **open pull request**, the labeler calls `issues.addLabels` / `issues.removeLabel`. GitHub requires `pull-requests: write` for PRs (403: `Resource not accessible by integration`; `x-accepted-github-permissions: issues=write; pull_requests=write`).

Adds `pull-requests: write` to match `stale.yml` in the same PR.

### Related issues

- Regression from #9058

### Release Summary

N/A — CI workflow only.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- [ ] Merge and post an OP comment on an open PR → expect `Needs Attention` added and `blocked: customer-response` removed
- [ ] Post an OP comment on a closed/merged PR → expect standard bot comment (also needs `pull-requests: write` for `createComment`)

### Missed label updates since #9058 merged (2026-06-20)

Audited 43 labeler runs since merge. **4 open-PR OP replies** failed at the label step with 403; labels were not applied:

| PR | Title | State | Failed run |
| --- | --- | --- | --- |
| [#9062](https://github.com/invertase/react-native-firebase/pull/9062) | style(docs): lint fixes from docs.page audit | MERGED | [run](https://github.com/invertase/react-native-firebase/actions/runs/27974761504) |
| [#9063](https://github.com/invertase/react-native-firebase/pull/9063) | docs: convert all code examples to modular API | MERGED | [run](https://github.com/invertase/react-native-firebase/actions/runs/27976663554) |
| [#9065](https://github.com/invertase/react-native-firebase/pull/9065) | feat(ai): implement Firebase JS SDK 12.15.0 portable API parity | MERGED | [run](https://github.com/invertase/react-native-firebase/actions/runs/27991230890) |
| [#9068](https://github.com/invertase/react-native-firebase/pull/9068) | docs(firestore): add pipelines overview and SDK compatibility pages | OPEN | [run](https://github.com/invertase/react-native-firebase/actions/runs/28063100888) |

Expected automation for each: add **`Needs Attention`**, remove **`blocked: customer-response`** (if present). None currently have labels.

**Also failed (closed PR path, not labels):** [#9057](https://github.com/invertase/react-native-firebase/pull/9057) — OP comment on merged PR; bot reply not posted ([run](https://github.com/invertase/react-native-firebase/actions/runs/28062634643)).

Issue-only OP replies succeeded (e.g. #9066, #9067, #9069) — `issues: write` is sufficient for issues.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
