### PR TITLE
fix(auth, perf): correctly export expo config plugin, add test for same

### DIFF
--- a/packages/app/__tests__/expoPluginPackageExports.test.ts
+++ b/packages/app/__tests__/expoPluginPackageExports.test.ts
@@ -1,0 +1,58 @@
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+import { describe, expect, it } from '@jest/globals';
+
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+
+/**
+ * Canonical list of packages that ship an Expo config plugin (`app.plugin.js`).
+ * Update deliberately when adding a new plugin package.
+ */
+const PACKAGES_WITH_EXPO_CONFIG_PLUGIN = [
+  'analytics',
+  'app',
+  'app-check',
+  'app-distribution',
+  'auth',
+  'crashlytics',
+  'messaging',
+  'perf',
+] as const;
+
+const APP_PLUGIN_EXPORT = './app.plugin.js';
+
+function discoverPackageNamesWithAppPlugin(): string[] {
+  return readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .filter(name => existsSync(join(PACKAGES_DIR, name, 'app.plugin.js')));
+}
+
+function readPackageJson(packageDir: string): { exports?: Record<string, unknown> } {
+  return JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'));
+}
+
+describe('Expo config plugin package exports', function () {
+  it('matches the canonical list of packages with app.plugin.js', function () {
+    const discovered = discoverPackageNamesWithAppPlugin().sort();
+    const expected = [...PACKAGES_WITH_EXPO_CONFIG_PLUGIN].sort();
+
+    expect(discovered).toEqual(expected);
+  });
+
+  describe.each(PACKAGES_WITH_EXPO_CONFIG_PLUGIN)('%s', function (name) {
+    const dir = join(PACKAGES_DIR, name);
+
+    it('exports ./app.plugin.js from package.json', function () {
+      const pkg = readPackageJson(dir);
+
+      expect(pkg.exports?.[APP_PLUGIN_EXPORT]).toBe(APP_PLUGIN_EXPORT);
+    });
+
+    it('has app.plugin.js at the package root', function () {
+      expect(existsSync(join(dir, 'app.plugin.js'))).toBe(true);
+    });
+  });
+});

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -51,6 +51,7 @@
       "types": "./dist/typescript/lib/index.d.ts",
       "default": "./dist/module/index.js"
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "react-native-builder-bob": {

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -52,6 +52,7 @@
       "types": "./dist/typescript/lib/index.d.ts",
       "default": "./dist/module/index.js"
     },
+    "./app.plugin.js": "./app.plugin.js",
     "./package.json": "./package.json"
   },
   "react-native-builder-bob": {


### PR DESCRIPTION
### Description

`@react-native-firebase/auth` was migrated to `package.json` `exports` in v25 but omitted the `./app.plugin.js` subpath. Expo resolves config plugins via that export; without it, `expo prebuild` fails to load the auth plugin.

While adding a Jest guard for this class of packaging mistake, the same missing export was found in `@react-native-firebase/perf`.

### Related issues

- Fixes #9072

### Release Summary

Fix Expo config plugin resolution for auth and perf when using package `exports`.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- `yarn tests:jest packages/app/__tests__/expoPluginPackageExports.test.ts`