### PR TITLE
test(android): repair android coverage upload

### DIFF
--- a/.github/workflows/scripts/android-e2e-detox.sh
+++ b/.github/workflows/scripts/android-e2e-detox.sh
@@ -25,8 +25,9 @@ nohup ./.github/workflows/scripts/resource-monitor-android.sh &
 
 yarn tests:android:test-cover --headless || TEST_EXIT=$?
 
-cleanup_android_e2e
-trap - EXIT
-
+# Pull coverage.ec and run Jacoco while the emulator and app filesDir are still
+# intact. cleanup_android_e2e (emu kill) must run only after post-e2e — reordering
+# here regressed native uploads when this script replaced the inline CI script.
 yarn tests:android:post-e2e-coverage || true
+
 exit "$TEST_EXIT"

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -284,6 +284,7 @@ jobs:
         with:
           files: tests/android/app/build/reports/jacoco/jacocoAndroidTestReport/jacocoAndroidTestReport.xml
           flags: android-native
+          disable_search: true
           verbose: true
 
       - name: Upload Emulator Log

--- a/tests/e2e/firebase.test.js
+++ b/tests/e2e/firebase.test.js
@@ -19,7 +19,7 @@ const { execSync, spawn } = require('child_process');
 const net = require('net');
 const path = require('path');
 
-const { pullIosCoverage } = require('../scripts/pull-native-coverage');
+const { pullIosCoverage, pullAndroidCoverageWithRetry } = require('../scripts/pull-native-coverage');
 const { recordE2eCloudMetricFromHost } = require('../../packages/app/e2e/cloud-metrics');
 
 const E2E_TEST_PROJECT = 'react-native-firebase-testing';
@@ -1000,6 +1000,18 @@ describe('Jet Tests', function () {
         pullIosCoverage(deviceId, { testsDir });
       } catch (e) {
         throw new Error(`Failed to download native coverage data: ${e.message}`);
+      }
+    } else if (platform === 'android') {
+      const pulled = await pullAndroidCoverageWithRetry(deviceId, {
+        softFail: true,
+        testsDir,
+        retries: 5,
+        intervalMs: 1000,
+      });
+      if (!pulled) {
+        console.warn(
+          '[native-coverage] Android .ec not pulled on Jet close; post-e2e will retry',
+        );
       }
     }
   });

--- a/tests/scripts/pull-native-coverage.js
+++ b/tests/scripts/pull-native-coverage.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 const TEST_APP_PACKAGE = 'com.invertase.testing';
-const ANDROID_COVERAGE_EMU_PATH = `/data/user/0/${TEST_APP_PACKAGE}/files/coverage.ec`;
+const ANDROID_COVERAGE_RELATIVE_PATH = 'files/coverage.ec';
 
 function getAdbBinary() {
   return process.env.ANDROID_HOME
@@ -41,7 +41,7 @@ function androidCoverageFileExists(deviceId) {
 
   try {
     execSync(
-      `${adb} ${serial} shell "run-as ${TEST_APP_PACKAGE} test -f ${ANDROID_COVERAGE_EMU_PATH}"`,
+      `${adb} ${serial} shell "run-as ${TEST_APP_PACKAGE} test -f ${ANDROID_COVERAGE_RELATIVE_PATH}"`,
       { stdio: 'pipe' },
     );
     return true;
@@ -60,7 +60,7 @@ function pullAndroidCoverage(deviceId, options = {}) {
 
   try {
     execSync(
-      `${adb} ${serial} shell "run-as ${TEST_APP_PACKAGE} cat ${ANDROID_COVERAGE_EMU_PATH} > ${emuDest}"`,
+      `${adb} ${serial} shell "run-as ${TEST_APP_PACKAGE} cat ${ANDROID_COVERAGE_RELATIVE_PATH} > ${emuDest}"`,
     );
     fs.mkdirSync(localDestDir, { recursive: true });
     execSync(`${adb} ${serial} pull ${emuDest} ${localDestFile}`);
@@ -92,7 +92,7 @@ async function pullAndroidCoverageWithRetry(deviceId, options = {}) {
       }
     } else if (attempt === 1 || attempt % 5 === 0) {
       console.log(
-        `[native-coverage] Waiting for ${ANDROID_COVERAGE_EMU_PATH} (attempt ${attempt}/${retries})`,
+        `[native-coverage] Waiting for ${ANDROID_COVERAGE_RELATIVE_PATH} (attempt ${attempt}/${retries})`,
       );
     }
 
@@ -181,8 +181,19 @@ async function main() {
 
   if (args.includes('--android-post-e2e')) {
     const deviceId = resolveAndroidDeviceId();
+    const testsDir = path.resolve(__dirname, '..');
+    const localDestFile = path.join(
+      testsDir,
+      'android/app/build/output/coverage/emulator_coverage.ec',
+    );
     console.log(`[native-coverage] Post-e2e Android coverage on ${deviceId}`);
-    const pulled = await pullAndroidCoverageWithRetry(deviceId, { softFail: true });
+    let pulled = null;
+    if (fs.existsSync(localDestFile)) {
+      console.log(`[native-coverage] Using existing ${localDestFile} from Jet-close pull`);
+      pulled = localDestFile;
+    } else {
+      pulled = await pullAndroidCoverageWithRetry(deviceId, { softFail: true, testsDir });
+    }
     const reportOk = runJacocoAndroidTestReport();
     if (!pulled) {
       console.warn('[native-coverage] Jacoco report may be empty (no coverage.ec pulled)');


### PR DESCRIPTION
### Description

Android native coverage was flushing `coverage.ec` successfully but CI never uploaded Jacoco: `android-e2e-detox.sh` ran emulator cleanup before `post-e2e-coverage`, so `run-as` could not read the file. Also pull `.ec` on Jet close (iOS parity) and set `disable_search: true` on the `android-native` Codecov upload so a missing Jacoco XML cannot fall back to TS lcov.

### Related issues

Coverage examination worktree — no linked issue.

### Release Summary

N/A (CI/test harness only)

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- [ ] Android E2E CI: confirm `[native-coverage] Coverage data downloaded` and Jacoco XML upload under `android-native` flag (not TS lcov fallback)