### PR TITLE
docs(ai): update model identifiers to current recommendations

### DIFF
--- a/docs/ai/usage/index.mdx
+++ b/docs/ai/usage/index.mdx
@@ -35,7 +35,7 @@ If you need to call the Gemini API directly from your mobile or web app — rath
 
 ## Generate text from text-only input
 
-You can call the Gemini API with input that includes only text. For these calls, you need to use a model that supports text-only prompts (like Gemini 1.5 Pro).
+You can call the Gemini API with input that includes only text. For these calls, you need to use a model that supports text-only prompts (like Gemini 3.1 Flash-Lite).
 
 Use `generateContent()` which waits for the entire response before returning.
 
@@ -53,7 +53,7 @@ function App() {
         onPress={async () => {
           const app = getApp();
           const ai = getAI(app);
-          const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+          const model = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
           const result = await model.generateContent('What is 2 + 2?');
 
@@ -81,7 +81,7 @@ function App() {
         onPress={async () => {
           const app = getApp();
           const ai = getAI(app);
-          const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+          const model = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
           const result = await model.generateContentStream('Write a short poem');
 
@@ -123,7 +123,7 @@ function App() {
         onPress={async () => {
           const app = getApp();
           const ai = getAI(app);
-          const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+          const model = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
           const prompt = 'What can you see?';
           const base64Emoji =
             'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=';
@@ -180,7 +180,7 @@ function App() {
             },
           });
           const model = getGenerativeModel(ai, {
-            model: 'gemini-1.5-flash',
+            model: 'gemini-3.1-flash-lite',
             generationConfig: {
               responseMimeType: 'application/json',
               responseSchema: jsonSchema,
@@ -216,7 +216,7 @@ function App() {
         onPress={async () => {
           const app = getApp();
           const ai = getAI(app);
-          const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+          const model = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
           const chat = model.startChat({
             history: [
@@ -319,7 +319,7 @@ function App() {
           const app = getApp();
           const ai = getAI(app);
           const model = getGenerativeModel(ai, {
-            model: 'gemini-1.5-flash',
+            model: 'gemini-3.1-flash-lite',
             tools: fetchWeatherTool,
           });
 
@@ -364,6 +364,8 @@ Generative AI models break down data into units called tokens for processing. Ea
 
 The below shows you how to get an estimate of token count and the number of billable characters for a request.
 
+On newer Gemini models (for example, `gemini-3.1-flash-lite`), `totalBillableCharacters` may be **undefined**. Check for its presence before logging or billing on that field.
+
 ```js
 import React from 'react';
 import { AppRegistry, Button, Text, View } from 'react-native';
@@ -378,14 +380,15 @@ function App() {
         onPress={async () => {
           const app = getApp();
           const ai = getAI(app);
-          const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+          const model = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
           // Count tokens & billable character for text input
           const { totalTokens, totalBillableCharacters } = await model.countTokens(
             'Write a story about a magic backpack.',
           );
-          console.log(
-            `Total tokens: ${totalTokens}, total billable characters: ${totalBillableCharacters}`,
-          );
+          console.log(`Total tokens: ${totalTokens}`);
+          if (totalBillableCharacters !== undefined) {
+            console.log(`Total billable characters: ${totalBillableCharacters}`);
+          }
 
           // Count tokens & billable character for multi-modal input
           const prompt = "What's in this picture?";
@@ -396,9 +399,10 @@ function App() {
             prompt,
             imagePart,
           ]);
-          console.log(
-            `Total tokens: ${totalTokens}, total billable characters: ${totalBillableCharacters}`,
-          );
+          console.log(`Total tokens: ${totalTokens}`);
+          if (totalBillableCharacters !== undefined) {
+            console.log(`Total billable characters: ${totalBillableCharacters}`);
+          }
         }}
       />
     </View>
@@ -406,39 +410,9 @@ function App() {
 }
 ```
 
-## Generating images from text
+## Generating images from text
 
-You can ask an Imagen model to generate a single image or multiple image by prompting with text:
-
-```js
-<Button
-  title="generate image using Imagen model"
-  onPress={async () => {
-    const app = getApp();
-    const ai = getAI(app);
-
-    const model = getImagenModel(ai, {
-      model: 'imagen-3.0-generate-002',
-      // Can also Configure the model to generate multiple images for each request
-      // See: https://firebase.google.com/docs/ai-logic/model-parameters
-      // generationConfig: {
-      //   numberOfImages: 4
-      // }
-    });
-
-    const prompt = 'Generate an image of London bridge with sharks in the water at sunset';
-
-    const result = await model.generateImages(prompt);
-    // creates a base64 encoded image you can render
-    const image = result.images[0].bytesBase64Encoded;
-
-    // If you wish to have an image generated and uploaded to your Firebase Storage bucket,
-    // you can do the following instead:
-    const gcsURI = 'gs://[PROJECT NAME].appspot.com/[DIRECTORY TO STORE IMAGE]';
-    const result = await model.generateImagesGCS(prompt, gcsURI);
-  }}
-/>
-```
+Imagen models are deprecated and scheduled for shutdown around June 2026. Use a Gemini image model such as `gemini-3.1-flash-lite-image` with `getGenerativeModel()` instead. See [Generate images with Gemini models](#generate-images-with-gemini-models) below.
 
 ## Generate images with Gemini models
 
@@ -467,7 +441,7 @@ function App() {
           const app = getApp();
           const ai = getAI(app);
           const model = getGenerativeModel(ai, {
-            model: 'gemini-2.0-flash-preview-image-generation',
+            model: 'gemini-3.1-flash-lite-image',
             generationConfig: {
               responseModalities: [ResponseModality.IMAGE],
               imageConfig: {
@@ -509,7 +483,7 @@ function App() {
           const app = getApp();
           const ai = getAI(app);
           const model = getGenerativeModel(ai, {
-            model: 'gemini-2.0-flash',
+            model: 'gemini-3.1-flash-lite',
             tools: [{ googleMaps: {} }],
             toolConfig: {
               retrievalConfig: {
@@ -550,7 +524,7 @@ function App() {
           const app = getApp();
           const ai = getAI(app);
           const model = getGenerativeModel(ai, {
-            model: 'gemini-2.0-flash',
+            model: 'gemini-3.1-flash-lite',
             tools: [{ googleSearch: {} }],
             toolConfig: {
               retrievalConfig: {
@@ -594,7 +568,7 @@ function App() {
           const app = getApp();
           const ai = getAI(app);
           const liveModel = getLiveGenerativeModel(ai, {
-            model: 'gemini-2.0-flash-live-preview-04-09',
+            model: 'gemini-2.5-flash-native-audio-preview-12-2025',
             generationConfig: { temperature: 0.8 },
           });
 
@@ -643,7 +617,7 @@ function App() {
           const app = getApp();
           const ai = getAI(app);
           const liveModel = getLiveGenerativeModel(ai, {
-            model: 'gemini-2.0-flash-live-preview-04-09',
+            model: 'gemini-2.5-flash-native-audio-preview-12-2025',
             generationConfig: {
               contextWindowCompression: {
                 triggerTokens: 100000,
@@ -683,7 +657,7 @@ function App() {
           const app = getApp();
           const ai = getAI(app);
           const liveModel = getLiveGenerativeModel(ai, {
-            model: 'gemini-2.0-flash-live-preview-04-09',
+            model: 'gemini-2.5-flash-native-audio-preview-12-2025',
           });
 
           let resumptionHandle;
@@ -793,7 +767,7 @@ function App() {
           };
 
           const ai = getAI(app, options);
-          const model = getGenerativeModel(ai, { model: 'gemini-1.5-flash' });
+          const model = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
           const result = await model.generateContent('What is 2 + 2?');
 

--- a/packages/ai/__tests__/googleai-mappers.test.ts
+++ b/packages/ai/__tests__/googleai-mappers.test.ts
@@ -45,7 +45,7 @@ import {
 import { BackendName, getMockResponse } from './test-utils/mock-response';
 import { SpiedFunction } from 'jest-mock';
 
-const fakeModel = 'models/gemini-pro';
+const fakeModel = 'models/gemini-3.1-flash-lite';
 
 const fakeContents: Content[] = [{ role: 'user', parts: [{ text: 'hello' }] }];
 

--- a/packages/ai/__tests__/live-generative-model.test.ts
+++ b/packages/ai/__tests__/live-generative-model.test.ts
@@ -131,7 +131,7 @@ describe('LiveGenerativeModel', function () {
     const model = new LiveGenerativeModel(
       fakeAI,
       {
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash-native-audio-preview-12-2025',
         generationConfig: { temperature: 0.8 },
         systemInstruction: { role: 'system', parts: [{ text: 'Be a pirate' }] },
       },
@@ -153,7 +153,7 @@ describe('LiveGenerativeModel', function () {
     const model = new LiveGenerativeModel(
       fakeAI,
       {
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash-native-audio-preview-12-2025',
         generationConfig: {
           temperature: 0.8,
           inputAudioTranscription: {},
@@ -183,7 +183,7 @@ describe('LiveGenerativeModel', function () {
     const model = new LiveGenerativeModel(
       fakeAI,
       {
-        model: 'gemini-pro',
+        model: 'gemini-2.5-flash-native-audio-preview-12-2025',
         generationConfig: {
           temperature: 0.8,
           contextWindowCompression: { triggerTokens: 1000 },

--- a/packages/ai/e2e/fetch.e2e.js
+++ b/packages/ai/e2e/fetch.e2e.js
@@ -35,7 +35,7 @@ globalThis.RNFB_VERTEXAI_EMULATOR_URL = true;
 describe('ai()', function () {
   describe('fetch requests', function () {
     it('should fetch', async function () {
-      const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-1.5-flash' });
+      const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-3.1-flash-lite' });
       const result = await model.generateContent("What is google's mission statement?");
       const text = result.response.text();
       // See vertexAI function emulator for response
@@ -45,7 +45,7 @@ describe('ai()', function () {
     });
 
     it('should fetch stream', async function () {
-      const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-1.5-flash' });
+      const model = getGenerativeModel(fakeVertexAI, { model: 'gemini-3.1-flash-lite' });
       // See vertexAI function emulator for response
       const poem = [
         'The wind whispers secrets through the trees,',

--- a/packages/ai/lib/index.ts
+++ b/packages/ai/lib/index.ts
@@ -117,6 +117,10 @@ export function getGenerativeModel(
 /**
  * Returns an {@link ImagenModel} class with methods for using Imagen.
  *
+ * @deprecated Imagen models are deprecated. Use {@link getGenerativeModel} with a Gemini image
+ * model such as `gemini-3.1-flash-lite-image` instead. See the
+ * {@link https://firebase.google.com/docs/ai-logic/generate-images-gemini | Gemini image generation guide}.
+ *
  * Only Imagen 3 models (named `imagen-3.0-*`) are supported.
  *
  * @param ai - An {@link AI} instance.
@@ -182,6 +186,10 @@ export function getTemplateGenerativeModel(
 
 /**
  * Returns a {@link TemplateImagenModel} class for executing server-side Imagen templates.
+ *
+ * @deprecated Imagen models are deprecated. Use {@link getGenerativeModel} with a Gemini image
+ * model such as `gemini-3.1-flash-lite-image` instead. See the
+ * {@link https://firebase.google.com/docs/ai-logic/generate-images-gemini | Gemini image generation guide}.
  *
  * @param ai - An {@link AI} instance.
  * @param requestOptions - Additional options to use when making requests.

--- a/packages/ai/lib/models/ai-model.ts
+++ b/packages/ai/lib/models/ai-model.ts
@@ -29,8 +29,8 @@ import { initApiSettings } from './utils';
  */
 export abstract class AIModel {
   /**
-   * The fully qualified model resource name to use for generating images
-   * (for example, `publishers/google/models/imagen-3.0-generate-002`).
+   * The fully qualified model resource name (for example, `gemini-3.1-flash-lite` for text or
+   * `publishers/google/models/gemini-3.1-flash-lite-image` for image models).
    */
   readonly model: string;
 

--- a/packages/ai/lib/models/imagen-model.ts
+++ b/packages/ai/lib/models/imagen-model.ts
@@ -37,12 +37,15 @@ import { mergeRequestOptions } from '../requests/request-options';
  *
  * This class provides methods for generating images using the Imagen model.
  *
+ * @deprecated Imagen models are deprecated. Use {@link getGenerativeModel} with a Gemini image
+ * model such as `gemini-3.1-flash-lite-image` instead.
+ *
  * @example
  * ```javascript
  * const imagen = new ImagenModel(
  *   ai,
  *   {
- *     model: 'imagen-3.0-generate-002'
+ *     model: 'imagen-3.0-generate-002' // legacy; prefer gemini-3.1-flash-lite-image
  *   }
  * );
  *

--- a/packages/ai/lib/models/template-imagen-model.ts
+++ b/packages/ai/lib/models/template-imagen-model.ts
@@ -28,6 +28,9 @@ import { initApiSettings } from './utils';
  *
  * This class should only be instantiated with {@link getTemplateImagenModel}.
  *
+ * @deprecated Imagen models are deprecated. Use {@link getGenerativeModel} with a Gemini image
+ * model such as `gemini-3.1-flash-lite-image` instead.
+ *
  * @beta
  */
 export class TemplateImagenModel {

--- a/packages/ai/lib/types/imagen/requests.ts
+++ b/packages/ai/lib/types/imagen/requests.ts
@@ -25,7 +25,12 @@ import { ImagenImageFormat } from '../../requests/imagen-image-format';
 export interface ImagenModelParams {
   /**
    * The Imagen model to use for generating images.
-   * For example: `imagen-3.0-generate-002`.
+   *
+   * @deprecated Imagen models are deprecated. Use {@link getGenerativeModel} with a Gemini
+   * image model such as `gemini-3.1-flash-lite-image` instead. See the
+   * {@link https://firebase.google.com/docs/ai-logic/generate-images-gemini | Gemini image generation guide}.
+   *
+   * For example: `imagen-3.0-generate-002` (legacy; prefer Gemini image models).
    *
    * Only Imagen 3 models (named `imagen-3.0-*`) are supported.
    *

--- a/packages/ai/lib/types/responses.ts
+++ b/packages/ai/lib/types/responses.ts
@@ -562,7 +562,7 @@ export interface CountTokensResponse {
    */
   totalTokens: number;
   /**
-   * @deprecated Use `totalTokens` instead. This property is undefined when using models greater than `gemini-1.5-*`.
+   * @deprecated Use `totalTokens` instead. This property is undefined when using newer Gemini models.
    *
    * The total number of billable characters counted across all instances
    * from the request.

--- a/tests/local-tests/ai/ai.tsx
+++ b/tests/local-tests/ai/ai.tsx
@@ -6,7 +6,6 @@ import {
   getAI,
   getGenerativeModel,
   Schema,
-  getImagenModel,
   AI,
   GenerativeModel,
   GenerateContentResult,
@@ -107,7 +106,7 @@ export function AITestComponent() {
           try {
             const app = getApp();
             const ai: AI = getAI(app);
-            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
             const result: GenerateContentResult = await model.generateContent('What is 2 + 2?');
 
@@ -123,7 +122,7 @@ export function AITestComponent() {
           try {
             const app = getApp();
             const ai: AI = getAI(app, { backend: new GoogleAIBackend() });
-            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
             const result: GenerateContentStreamResult = await model.generateContentStream(
               'Write me a short, funny rap',
@@ -154,7 +153,7 @@ export function AITestComponent() {
           try {
             const app = getApp();
             const ai: AI = getAI(app);
-            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
             const mediaDetails: MediaDetails | null = getMediaDetails(selectedOption);
             if (!mediaDetails) return;
 
@@ -199,7 +198,7 @@ export function AITestComponent() {
               },
             });
             const model: GenerativeModel = getGenerativeModel(ai, {
-              model: 'gemini-2.5-flash',
+              model: 'gemini-3.1-flash-lite',
               generationConfig: {
                 responseMimeType: 'application/json',
                 responseSchema: jsonSchema,
@@ -222,7 +221,7 @@ export function AITestComponent() {
           try {
             const app = getApp();
             const ai: AI = getAI(app);
-            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
             const chat: ChatSession = model.startChat({
               history: [
@@ -261,7 +260,7 @@ export function AITestComponent() {
           try {
             const app = getApp();
             const ai: AI = getAI(app);
-            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+            const model: GenerativeModel = getGenerativeModel(ai, { model: 'gemini-3.1-flash-lite' });
 
             const result = await model.countTokens('What is 2 + 2?');
 
@@ -343,7 +342,7 @@ export function AITestComponent() {
             const app = getApp();
             const ai: AI = getAI(app);
             const model: GenerativeModel = getGenerativeModel(ai, {
-              model: 'gemini-2.5-flash',
+              model: 'gemini-3.1-flash-lite',
               // @ts-ignore
               tools: fetchWeatherTool,
             });
@@ -384,21 +383,25 @@ export function AITestComponent() {
         }}
       />
       <Button
-        title="Generate image using Imagen"
+        title="Generate image with Gemini"
         onPress={async (): Promise<void> => {
           try {
             const app = getApp();
             const ai: AI = getAI(app);
 
-            const model = getImagenModel(ai, {
-              model: 'imagen-3.0-generate-002',
+            const model: GenerativeModel = getGenerativeModel(ai, {
+              model: 'gemini-3.1-flash-lite-image',
+              generationConfig: {
+                responseModalities: [ResponseModality.IMAGE],
+              },
             });
 
             const prompt: string = 'Generate an image of London bridge with sharks in the water';
 
-            const result = await model.generateImages(prompt);
-            const images = result;
-            console.log('Generated images:', images);
+            const result = await model.generateContent(prompt);
+            const parts = result.response.candidates?.[0]?.content?.parts ?? [];
+            const imagePart = parts.find(part => part.inlineData?.mimeType?.startsWith('image/'));
+            console.log('Generated image mime type:', imagePart?.inlineData?.mimeType);
           } catch (e) {
             console.error(e);
           }
@@ -411,7 +414,7 @@ export function AITestComponent() {
             const app = getApp();
             const ai: AI = getAI(app, { backend: new VertexAIBackend('us-central1') });
             const model: LiveGenerativeModel = getLiveGenerativeModel(ai, {
-              model: 'gemini-2.0-flash-live-preview-04-09',
+              model: 'gemini-2.5-flash-native-audio-preview-12-2025',
               generationConfig: {
                 responseModalities: [ResponseModality.TEXT],
               },

--- a/tests/local-tests/vertexai/vertexai.js
+++ b/tests/local-tests/vertexai/vertexai.js
@@ -94,7 +94,7 @@ export function VertexAITestComponent() {
           try {
             const app = getApp();
             const vertexai = getVertexAI(app);
-            const model = getGenerativeModel(vertexai, { model: 'gemini-1.5-flash' });
+            const model = getGenerativeModel(vertexai, { model: 'gemini-3.1-flash-lite' });
 
             const result = await model.generateContent('What is 2 + 2?');
 
@@ -110,7 +110,7 @@ export function VertexAITestComponent() {
           try {
             const app = getApp();
             const vertexai = getVertexAI(app);
-            const model = getGenerativeModel(vertexai, { model: 'gemini-1.5-flash' });
+            const model = getGenerativeModel(vertexai, { model: 'gemini-3.1-flash-lite' });
 
             const result = await model.generateContentStream('Write me a short, funny rap');
 
@@ -136,7 +136,7 @@ export function VertexAITestComponent() {
           try {
             const app = getApp();
             const vertexai = getVertexAI(app);
-            const model = getGenerativeModel(vertexai, { model: 'gemini-1.5-flash' });
+            const model = getGenerativeModel(vertexai, { model: 'gemini-3.1-flash-lite' });
             const mediaDetails = getMediaDetails(selectedOption);
             if (!mediaDetails) return;
 
@@ -181,7 +181,7 @@ export function VertexAITestComponent() {
               },
             });
             const model = getGenerativeModel(vertexai, {
-              model: 'gemini-1.5-flash',
+              model: 'gemini-3.1-flash-lite',
               generationConfig: {
                 responseMimeType: 'application/json',
                 responseSchema: jsonSchema,
@@ -203,7 +203,7 @@ export function VertexAITestComponent() {
           try {
             const app = getApp();
             const vertexai = getVertexAI(app);
-            const model = getGenerativeModel(vertexai, { model: 'gemini-1.5-flash' });
+            const model = getGenerativeModel(vertexai, { model: 'gemini-3.1-flash-lite' });
 
             const chat = model.startChat({
               history: [
@@ -242,7 +242,7 @@ export function VertexAITestComponent() {
           try {
             const app = getApp();
             const vertexai = getVertexAI(app);
-            const model = getGenerativeModel(vertexai, { model: 'gemini-1.5-flash' });
+            const model = getGenerativeModel(vertexai, { model: 'gemini-3.1-flash-lite' });
 
             const result = await model.countTokens('What is 2 + 2?');
 
@@ -302,7 +302,7 @@ export function VertexAITestComponent() {
             const app = getApp();
             const vertexai = getVertexAI(app);
             const model = getGenerativeModel(vertexai, {
-              model: 'gemini-1.5-flash',
+              model: 'gemini-3.1-flash-lite',
               tools: fetchWeatherTool,
             });
 


### PR DESCRIPTION
## Summary
- Refresh AI Logic docs, examples, tests, and JSDoc to use current Gemini model IDs instead of shutdown or deprecated models (`gemini-1.5-flash`, `gemini-2.0-*`, `imagen-3.0-generate-002`, etc.).
- Standardize on `gemini-3.1-flash-lite` for general text/multimodal examples and `gemini-3.1-flash-lite-image` for image generation; Live API examples use `gemini-2.5-flash-native-audio-preview-12-2025`.
- Mark Imagen APIs (`getImagenModel`, `getTemplateImagenModel`, related types) as `@deprecated` with migration guidance to Gemini Image models, and document that `totalBillableCharacters` may be undefined on newer models.

## Test plan
- [x] `yarn lint:js`
- [x] `yarn lint:markdown`
- [x] `yarn lint:spellcheck`
- [x] `yarn tests:jest --watchman=false packages/ai` (325 tests)
- [x] `yarn compare:types` (ai package documented)