### PR TITLE
fix(messaging): willPresentNotification custom notification to work alongside default notification

### DIFF
--- a/okf-bundle/index.md
+++ b/okf-bundle/index.md
@@ -31,3 +31,4 @@ okf_version: "0.1"
 
 * [Auth](/packages/auth/index.md) — modular API type parity, platform matrix, `compare:types`
 * [Firestore](/packages/firestore/index.md) — Pipelines architecture, parity, e2e coverage
+* [Messaging](/packages/messaging/index.md) — iOS `UNUserNotificationCenter` delegate forwarding, `completionHandler` contract

--- a/okf-bundle/packages/messaging/index.md
+++ b/okf-bundle/packages/messaging/index.md
@@ -1,0 +1,13 @@
+# @react-native-firebase/messaging
+
+Knowledge for FCM messaging native behavior, primarily the iOS `UNUserNotificationCenter` delegate-forwarding chain shared with the host app's `AppDelegate`.
+
+## Documents
+
+* [iOS UNUserNotificationCenter delegate forwarding](ios-notification-delegate-forwarding.md) — `completionHandler` exactly-once contract, delegate chaining design, regression history (#8754 → #8786 → #9049)
+
+## Related repository files
+
+* [`packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m`](../../../packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m) — foreground `willPresentNotification` / `didReceiveNotificationResponse` delegate forwarding
+* [`packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m`](../../../packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m) — background/remote-notification `AppDelegate` swizzling
+* [`packages/messaging/lib/index.ts`](../../../packages/messaging/lib/index.ts) — JS entry, headless task registration

--- a/okf-bundle/packages/messaging/index.md
+++ b/okf-bundle/packages/messaging/index.md
@@ -4,7 +4,7 @@ Knowledge for FCM messaging native behavior, primarily the iOS `UNUserNotificati
 
 ## Documents
 
-* [iOS UNUserNotificationCenter delegate forwarding](ios-notification-delegate-forwarding.md) — `completionHandler` exactly-once contract, delegate chaining design, regression history (#8754 → #8786 → #9049)
+* [iOS UNUserNotificationCenter delegate forwarding](ios-notification-delegate-forwarding.md) — `completionHandler` exactly-once contract, delegate chaining design, regression history (#8754 → #8786 → #9049 / #9050)
 
 ## Related repository files
 

--- a/okf-bundle/packages/messaging/ios-notification-delegate-forwarding.md
+++ b/okf-bundle/packages/messaging/ios-notification-delegate-forwarding.md
@@ -1,0 +1,66 @@
+---
+type: Reference
+title: iOS UNUserNotificationCenter delegate forwarding
+description: Design and regression history for RNFB's iOS foreground-notification delegate chaining and the completionHandler exactly-once contract.
+tags: [messaging, ios, notifications, delegate, completionHandler, regression]
+timestamp: 2026-07-09T00:00:00Z
+---
+
+# iOS UNUserNotificationCenter delegate forwarding
+
+**Policy:** [OKF documentation and commit policy](../../documentation-policy.md).
+
+`RNFBMessagingUNUserNotificationCenter` (`packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m`) installs itself as `[UNUserNotificationCenter currentNotificationCenter].delegate` and stores whatever delegate the host app had set (`_originalDelegate`), forwarding calls to it so RNFB and the app's own `AppDelegate`/`UNUserNotificationCenterDelegate` can coexist.
+
+## The contract
+
+`completionHandler` blocks passed by `UNUserNotificationCenterDelegate` methods (`willPresentNotification:withCompletionHandler:`, `didReceiveNotificationResponse:withCompletionHandler:`) **must be invoked exactly once** — never zero times (notification silently never presents / action never completes), never more than once (undefined behavior; a second invocation is a no-op at best and can assert/crash depending on iOS version).
+
+Because RNFB forwards the *same* completion handler reference to `_originalDelegate`, whichever side calls it first "wins" the presentation decision, and any second call breaks the contract. This means: when an original delegate exists and implements the callback, ownership of the handler must pass to it exclusively — RNFB must not also call it.
+
+`didReceiveNotificationResponse:withCompletionHandler:` already gets this right via a plain `if`/`else`:
+
+```165:171:packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+  if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
+    [_originalDelegate userNotificationCenter:center
+               didReceiveNotificationResponse:response
+                        withCompletionHandler:completionHandler];
+  } else {
+    completionHandler();
+  }
+```
+
+`willPresentNotification:withCompletionHandler:` follows the same shape ([current implementation](../../../packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m)):
+
+```142:153:packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+  // completionHandler must be invoked exactly once. If the original delegate
+  // implements willPresentNotification, defer to it entirely - it owns the
+  // completionHandler contract (and may call it asynchronously). Only fall
+  // back to our own presentationOptions when there is no original delegate
+  // to hand off to.
+  if (_originalDelegate != nil && originalDelegateRespondsTo.willPresentNotification) {
+    [_originalDelegate userNotificationCenter:center
+                      willPresentNotification:notification
+                        withCompletionHandler:completionHandler];
+  } else {
+    completionHandler(presentationOptions);
+  }
+```
+
+**Trade-off (accepted):** when the host app implements `willPresentNotification`, RNFB's own `messaging_ios_foreground_presentation_options` (from `firebase.json`) is not applied — the app owns presentation entirely once it opts in by implementing the delegate method. This matches the exactly-once contract and is the pre-regression (pre-#8786) behavior for the delegation branch.
+
+## Regression history
+
+| # | Change | Effect |
+|---|--------|--------|
+| Pre-[#8786](https://github.com/invertase/react-native-firebase/pull/8786) | `gcm.message_id` branch called `completionHandler(presentationOptions)` immediately, **then** unconditionally forwarded the same handler to `_originalDelegate` if present | **[#8754](https://github.com/invertase/react-native-firebase/issues/8754):** RNFB's own presentation choice always "won" (consumed first) — the host app's custom `willPresentNotification` logic had no effect, since the handler was already spent by the time it ran |
+| [#8786](https://github.com/invertase/react-native-firebase/pull/8786) (merged 2026-01-29) | Removed the early call inside the `gcm.message_id` branch; changed the delegation branch from `if/else` to `if` + an **unconditional** trailing `completionHandler(presentationOptions)` | Fixed #8754's ordering, but broke the exactly-once contract: when `_originalDelegate` responds to `willPresentNotification` and calls `completionHandler` itself (sync or async), RNFB calls it again right after |
+| **[#9049](https://github.com/invertase/react-native-firebase/issues/9049)** (reported 2026-06-11) | Regression from #8786 | `completionHandler` invoked twice whenever the host app implements `willPresentNotification`; breaks apps that resolve presentation options asynchronously, since RNFB's trailing call fires independently of the app's own timing |
+| **Fix (this pass)** | Restored `if`/`else` mutual exclusivity for the delegation branch (matching `didReceiveNotificationResponse`); kept #8786's removal of the early `gcm.message_id` call | Exactly-once in all cases; original delegate's decision (sync or async) is respected when present; RNFB's `firebase.json` presentation options apply only when there is no original delegate to defer to |
+
+No wrapping/timeout guard (`__block BOOL handled`, `dispatch_after` fallback) was adopted — mutual exclusivity is sufficient and avoids an arbitrary timeout that would either fire too early for legitimately slow app logic or leave the app waiting if it forgets to call the handler (the app's own responsibility per the standard `UNUserNotificationCenterDelegate` contract, same as it would be with no RNFB in the chain at all).
+
+## Related repository files
+
+* [`RNFBMessaging+UNUserNotificationCenter.m`](../../../packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m) — delegate install (`observe`), `originalDelegateRespondsTo` capability bits, both delegate methods
+* [`RNFBMessaging+UNUserNotificationCenter.h`](../../../packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.h) — `_originalDelegate` storage

--- a/okf-bundle/packages/messaging/ios-notification-delegate-forwarding.md
+++ b/okf-bundle/packages/messaging/ios-notification-delegate-forwarding.md
@@ -2,7 +2,7 @@
 type: Reference
 title: iOS UNUserNotificationCenter delegate forwarding
 description: Design and regression history for RNFB's iOS foreground-notification delegate chaining and the completionHandler exactly-once contract.
-tags: [messaging, ios, notifications, delegate, completionHandler, regression]
+tags: [messaging, ios, notifications, delegate, completionHandler, regression, expo-notifications]
 timestamp: 2026-07-09T00:00:00Z
 ---
 
@@ -20,7 +20,7 @@ Because RNFB forwards the *same* completion handler reference to `_originalDeleg
 
 `didReceiveNotificationResponse:withCompletionHandler:` already gets this right via a plain `if`/`else`:
 
-```165:171:packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+```174:180:packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
   if (_originalDelegate != nil && originalDelegateRespondsTo.didReceiveNotificationResponse) {
     [_originalDelegate userNotificationCenter:center
                didReceiveNotificationResponse:response
@@ -32,22 +32,32 @@ Because RNFB forwards the *same* completion handler reference to `_originalDeleg
 
 `willPresentNotification:withCompletionHandler:` follows the same shape ([current implementation](../../../packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m)):
 
-```142:153:packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+```142:159:packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
   // completionHandler must be invoked exactly once. If the original delegate
   // implements willPresentNotification, defer to it entirely - it owns the
   // completionHandler contract (and may call it asynchronously). Only fall
   // back to our own presentationOptions when there is no original delegate
   // to hand off to.
-  if (_originalDelegate != nil && originalDelegateRespondsTo.willPresentNotification) {
-    [_originalDelegate userNotificationCenter:center
-                      willPresentNotification:notification
-                        withCompletionHandler:completionHandler];
+  //
+  // _originalDelegate is weak, so it is captured into a strong local first -
+  // otherwise it could be deallocated between the nil-check and the message
+  // send (turning the send into a no-op) and completionHandler would never
+  // be called at all.
+  id<UNUserNotificationCenterDelegate> strongOriginalDelegate = _originalDelegate;
+  if (strongOriginalDelegate != nil && originalDelegateRespondsTo.willPresentNotification) {
+    [strongOriginalDelegate userNotificationCenter:center
+                           willPresentNotification:notification
+                             withCompletionHandler:completionHandler];
   } else {
     completionHandler(presentationOptions);
   }
 ```
 
 **Trade-off (accepted):** when the host app implements `willPresentNotification`, RNFB's own `messaging_ios_foreground_presentation_options` (from `firebase.json`) is not applied — the app owns presentation entirely once it opts in by implementing the delegate method. This matches the exactly-once contract and is the pre-regression (pre-#8786) behavior for the delegation branch.
+
+**Weak-reference note:** `_originalDelegate` is declared `@property(nonatomic, nullable, weak)`. A bare `if (_originalDelegate != nil && ...)` followed by a separate message send re-reads the weak property twice — a TOCTOU window where deallocation between the two reads turns the send into a silent no-op, which would violate exactly-once in the *zero-calls* direction. Capture into a strong local (`strongOriginalDelegate`) before the check so both the check and the send observe the same retained reference.
+
+**Not exclusive to the host app's own `AppDelegate`:** any library that installs itself as `[UNUserNotificationCenter currentNotificationCenter].delegate` before RNFB's `observe` runs becomes `_originalDelegate` and is subject to this same contract — e.g. `expo-notifications`' native delegate (`EXNotificationCenterDelegate` / `NotificationCenterManager`, depending on SDK version), which forwards `willPresentNotification` to the JS `Notifications.setNotificationHandler` callback. See [#9050](#regression-history) below.
 
 ## Regression history
 
@@ -56,7 +66,8 @@ Because RNFB forwards the *same* completion handler reference to `_originalDeleg
 | Pre-[#8786](https://github.com/invertase/react-native-firebase/pull/8786) | `gcm.message_id` branch called `completionHandler(presentationOptions)` immediately, **then** unconditionally forwarded the same handler to `_originalDelegate` if present | **[#8754](https://github.com/invertase/react-native-firebase/issues/8754):** RNFB's own presentation choice always "won" (consumed first) — the host app's custom `willPresentNotification` logic had no effect, since the handler was already spent by the time it ran |
 | [#8786](https://github.com/invertase/react-native-firebase/pull/8786) (merged 2026-01-29) | Removed the early call inside the `gcm.message_id` branch; changed the delegation branch from `if/else` to `if` + an **unconditional** trailing `completionHandler(presentationOptions)` | Fixed #8754's ordering, but broke the exactly-once contract: when `_originalDelegate` responds to `willPresentNotification` and calls `completionHandler` itself (sync or async), RNFB calls it again right after |
 | **[#9049](https://github.com/invertase/react-native-firebase/issues/9049)** (reported 2026-06-11) | Regression from #8786 | `completionHandler` invoked twice whenever the host app implements `willPresentNotification`; breaks apps that resolve presentation options asynchronously, since RNFB's trailing call fires independently of the app's own timing |
-| **Fix (this pass)** | Restored `if`/`else` mutual exclusivity for the delegation branch (matching `didReceiveNotificationResponse`); kept #8786's removal of the early `gcm.message_id` call | Exactly-once in all cases; original delegate's decision (sync or async) is respected when present; RNFB's `firebase.json` presentation options apply only when there is no original delegate to defer to |
+| **[#9050](https://github.com/invertase/react-native-firebase/issues/9050)** (reported 2026-06-12) | Same regression from #8786, different `_originalDelegate` — `expo-notifications`' native delegate, not a hand-written `AppDelegate` | `expo-notifications` local notifications stopped showing in the foreground: its delegate decides presentation via the JS `setNotificationHandler` callback and calls `completionHandler` once, then RNFB's unconditional trailing call fires again with the default (unset) `messaging_ios_foreground_presentation_options` (`None`), suppressing the notification. Setting that config to a non-empty list "fixed" it only because it made the *second*, otherwise-suppressing call also request presentation — the reported workaround. Confirmed by version bracketing: `v23.8.4` (pre-#8786, unaffected per report) tagged 2026-01-24; `v24.1.1` (post-#8786, affected per report) tagged 2026-06-10 |
+| **Fix (this pass)** | Restored `if`/`else` mutual exclusivity for the delegation branch (matching `didReceiveNotificationResponse`); kept #8786's removal of the early `gcm.message_id` call; captured `_originalDelegate` into a strong local to close the weak-reference TOCTOU race (flagged in PR review) | Exactly-once in all cases; original delegate's decision (sync or async) is respected when present, regardless of whether it's the host app's own `AppDelegate` or a library's delegate (e.g. `expo-notifications`); RNFB's `firebase.json` presentation options apply only when there is no original delegate to defer to |
 
 No wrapping/timeout guard (`__block BOOL handled`, `dispatch_after` fallback) was adopted — mutual exclusivity is sufficient and avoids an arbitrary timeout that would either fire too early for legitimately slow app logic or leave the app waiting if it forgets to call the handler (the app's own responsibility per the standard `UNUserNotificationCenterDelegate` contract, same as it would be with no RNFB in the chain at all).
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -144,10 +144,16 @@ struct {
   // completionHandler contract (and may call it asynchronously). Only fall
   // back to our own presentationOptions when there is no original delegate
   // to hand off to.
-  if (_originalDelegate != nil && originalDelegateRespondsTo.willPresentNotification) {
-    [_originalDelegate userNotificationCenter:center
-                      willPresentNotification:notification
-                        withCompletionHandler:completionHandler];
+  //
+  // _originalDelegate is weak, so it is captured into a strong local first -
+  // otherwise it could be deallocated between the nil-check and the message
+  // send (turning the send into a no-op) and completionHandler would never
+  // be called at all.
+  id<UNUserNotificationCenterDelegate> strongOriginalDelegate = _originalDelegate;
+  if (strongOriginalDelegate != nil && originalDelegateRespondsTo.willPresentNotification) {
+    [strongOriginalDelegate userNotificationCenter:center
+                           willPresentNotification:notification
+                             withCompletionHandler:completionHandler];
   } else {
     completionHandler(presentationOptions);
   }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -139,15 +139,18 @@ struct {
     }
   }
 
+  // completionHandler must be invoked exactly once. If the original delegate
+  // implements willPresentNotification, defer to it entirely - it owns the
+  // completionHandler contract (and may call it asynchronously). Only fall
+  // back to our own presentationOptions when there is no original delegate
+  // to hand off to.
   if (_originalDelegate != nil && originalDelegateRespondsTo.willPresentNotification) {
     [_originalDelegate userNotificationCenter:center
                       willPresentNotification:notification
                         withCompletionHandler:completionHandler];
+  } else {
+    completionHandler(presentationOptions);
   }
-
-  // Don't consume completionHandler before the _originalDelegate has been
-  // processed
-  completionHandler(presentationOptions);
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center


### PR DESCRIPTION
### Description

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request properly. -->
<!-- Explain the **motivation** for making this change e.g. what existing problem does the pull request solve? -->

PR #8786 changed `RNFBMessagingUNUserNotificationCenter`'s `willPresentNotification:withCompletionHandler:` to call `completionHandler` **unconditionally after** forwarding to `_originalDelegate` (when one exists and responds), instead of the previous `if`/`else`. Since `completionHandler` is the same block reference forwarded to the original delegate, this causes it to be invoked **twice** whenever a host app (or a library that installs its own `UNUserNotificationCenterDelegate`, e.g. `expo-notifications`) implements `willPresentNotification` itself — violating the "call exactly once" contract of `UNUserNotificationCenterDelegate`.

This PR restores mutual exclusivity (`if`/`else`), matching the pattern already used by the sibling `didReceiveNotificationResponse:withCompletionHandler:` method: defer entirely to the original delegate when one exists and responds, otherwise apply RNFB's own `messaging_ios_foreground_presentation_options` config. It also captures the `weak` `_originalDelegate` into a strong local before use, closing a race where it could deallocate between the nil-check and the message send (which would otherwise make `completionHandler` never fire at all).

Also adds OKF documentation (`okf-bundle/packages/messaging/`) covering the delegate-forwarding design, the `completionHandler` exactly-once contract, and this regression's history.

### Related issues

<!-- If this PR fixes an issue, include "Fixes #issueNumber" to automatically close the issue when the PR is merged. -->

- Fixes #9049
- Fixes #9050 — same root cause: RNFB was forwarding to `expo-notifications`' own `UNUserNotificationCenterDelegate` (which decides local-notification presentation via the JS `setNotificationHandler` callback) and then calling `completionHandler` a second time with RNFB's own (default `None`) presentation options, suppressing the notification. The `messaging_ios_foreground_presentation_options` workaround described in that issue "fixed" it only because it made the second, otherwise-suppressing call also request presentation.

### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

Fixed iOS `willPresentNotification` calling `completionHandler` twice when a host app or another library (e.g. `expo-notifications`) implements its own `UNUserNotificationCenterDelegate`, which could suppress foreground notifications or double-invoke the completion handler.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

- `clang-format --style=Google -n -Werror` passes clean on the changed file.
- Traced the fix against both regressions: verified `#8786`'s diff reintroduced the unconditional trailing `completionHandler` call, and confirmed `v23.8.4` (pre-#8786, unaffected) vs `v24.1.1` (post-#8786, affected) release dates bracket both #9049 and #9050's reported break windows.

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
