### PR TITLE
fix(remote-config, ios): ensure fetchActivate() match fetch() + activate() behavior

### DIFF
--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -59,6 +59,82 @@ describe('remoteConfig()', function () {
         const { getRemoteConfig, fetchAndActivate } = remoteConfigModular;
         (await fetchAndActivate(getRemoteConfig())).should.be.a.Boolean();
       });
+
+      // Regression test for https://github.com/invertase/react-native-firebase/issues/7779
+      // On iOS, fetchAndActivate() used to always resolve `true` whenever the underlying fetch
+      // succeeded, even when the fetched values were identical to what was already active
+      // (i.e. nothing new was actually activated). This must be consistent with fetch() + activate(),
+      // and with the boolean returned by activate() itself, on both platforms.
+      it('returns false when there is nothing new to activate', async function () {
+        const { getRemoteConfig, fetchAndActivate } = remoteConfigModular;
+        const remoteConfig = getRemoteConfig();
+        remoteConfig.settings = { minimumFetchIntervalMillis: 0 };
+
+        // Make sure the current remote values are fetched + activated first.
+        await fetchAndActivate(remoteConfig);
+
+        // Calling again immediately with no server-side template changes must not report
+        // that anything was activated, matching fetch() + activate() and matching Android.
+        const activatedAgain = await fetchAndActivate(remoteConfig);
+        activatedAgain.should.equal(false);
+      });
+
+      it('is consistent with fetch() followed by activate()', async function () {
+        const { getRemoteConfig, fetchConfig, fetchAndActivate, activate } = remoteConfigModular;
+        const remoteConfig = getRemoteConfig();
+        remoteConfig.settings = { minimumFetchIntervalMillis: 0 };
+
+        // Get into a known "fully activated, no pending changes" state.
+        await fetchAndActivate(remoteConfig);
+
+        // With no new remote values, fetch() + activate() should report nothing changed...
+        await fetchConfig(remoteConfig);
+        const activatedViaSeparateCalls = await activate(remoteConfig);
+        activatedViaSeparateCalls.should.equal(false);
+
+        // ...and fetchAndActivate() must agree.
+        const activatedViaFetchAndActivate = await fetchAndActivate(remoteConfig);
+        activatedViaFetchAndActivate.should.equal(activatedViaSeparateCalls);
+      });
+
+      it('returns true only once new remote values have actually been fetched and activated', async function () {
+        const { getRemoteConfig, fetchAndActivate, getValue } = remoteConfigModular;
+        const remoteConfig = getRemoteConfig();
+        remoteConfig.settings = { minimumFetchIntervalMillis: 0 };
+        const paramName = 'fetchAndActivateTest' + Date.now();
+        const paramValue = 'value' + Date.now();
+
+        // Get into a known "fully activated, no pending changes" state first.
+        await fetchAndActivate(remoteConfig);
+        (await fetchAndActivate(remoteConfig)).should.equal(false);
+
+        try {
+          const response = await FirebaseHelpers.updateRemoteConfigTemplate({
+            operations: { add: [{ name: paramName, value: paramValue }] },
+          });
+          should(response.result !== undefined).equal(true, 'response result not defined');
+
+          // A newly published template can take a little while to propagate to the fetch
+          // backend, so poll fetchAndActivate() until it reports the new value was activated,
+          // rather than asserting on the very next call.
+          let activated = false;
+          const deadline = Date.now() + 60000;
+          while (Date.now() < deadline) {
+            activated = await fetchAndActivate(remoteConfig);
+            if (activated && getValue(remoteConfig, paramName).asString() === paramValue) {
+              break;
+            }
+            await Utils.sleep(2000);
+          }
+
+          activated.should.equal(true);
+          getValue(remoteConfig, paramName).asString().should.equal(paramValue);
+        } finally {
+          await FirebaseHelpers.updateRemoteConfigTemplate({
+            operations: { delete: [paramName] },
+          });
+        }
+      });
     });
 
     describe('activate()', function () {

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
@@ -205,42 +205,41 @@ RCT_EXPORT_MODULE(NativeRNFBTurboConfig)
   // in-use config values.
   FIRApp *firebaseApp = firebaseAppForName(appName);
   __weak RNFBConfigModule *weakSelf = self;
-  FIRRemoteConfigFetchCompletion fetchCompletion =
-      ^(FIRRemoteConfigFetchStatus status, NSError *__nullable error) {
-        RNFBConfigModule *strongSelf = weakSelf;
-        if (!strongSelf) {
-          return;
-        }
+  FIRRemoteConfigFetchCompletion fetchCompletion = ^(FIRRemoteConfigFetchStatus status,
+                                                     NSError *__nullable error) {
+    RNFBConfigModule *strongSelf = weakSelf;
+    if (!strongSelf) {
+      return;
+    }
 
-        if (error) {
-          [RNFBSharedUtils
-              rejectPromiseWithUserInfo:reject
-                               userInfo:[@{
-                                 @"code" : convertFIRRemoteConfigFetchStatusToNSString(status),
-                                 @"message" :
-                                     convertFIRRemoteConfigFetchStatusToNSStringDescription(status)
-                               } mutableCopy]];
-          return;
-        }
+    if (error) {
+      [RNFBSharedUtils
+          rejectPromiseWithUserInfo:reject
+                           userInfo:[@{
+                             @"code" : convertFIRRemoteConfigFetchStatusToNSString(status),
+                             @"message" :
+                                 convertFIRRemoteConfigFetchStatusToNSStringDescription(status)
+                           } mutableCopy]];
+      return;
+    }
 
-        [[FIRRemoteConfig remoteConfigWithApp:firebaseApp]
-            activateWithCompletion:^(BOOL changed, NSError *_Nullable activateError) {
-              if (activateError) {
-                if (activateError.userInfo &&
-                    activateError.userInfo[@"ActivationFailureReason"] != nil &&
-                    [activateError.userInfo[@"ActivationFailureReason"]
-                        containsString:@"already activated"]) {
-                  resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(NO)])
-                                              firebaseApp:firebaseApp]);
-                } else {
-                  [RNFBSharedUtils rejectPromiseWithNSError:reject error:activateError];
-                }
-              } else {
-                resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(changed)])
-                                            firebaseApp:firebaseApp]);
-              }
-            }];
-      };
+    [[FIRRemoteConfig remoteConfigWithApp:firebaseApp]
+        activateWithCompletion:^(BOOL changed, NSError *_Nullable activateError) {
+          if (!activateError) {
+            resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(changed)])
+                                        firebaseApp:firebaseApp]);
+            return;
+          }
+          if (activateError.userInfo && activateError.userInfo[@"ActivationFailureReason"] != nil &&
+              [activateError.userInfo[@"ActivationFailureReason"]
+                  containsString:@"already activated"]) {
+            resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(NO)])
+                                        firebaseApp:firebaseApp]);
+            return;
+          }
+          [RNFBSharedUtils rejectPromiseWithNSError:reject error:activateError];
+        }];
+  };
 
   [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithCompletionHandler:fetchCompletion];
 }

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
@@ -188,66 +188,13 @@ RCT_EXPORT_MODULE(NativeRNFBTurboConfig)
   }
 }
 
-- (void)fetchAndActivate:(NSString *)appName
-                 resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject {
-  // NOTE: We deliberately do not use `-[FIRRemoteConfig fetchAndActivateWithCompletionHandler:]`
-  // here. Its `FIRRemoteConfigFetchAndActivateStatus` result only reflects whether the fetch
-  // succeeded (`SuccessFetchedFromRemote`) vs fell back to previously fetched data
-  // (`SuccessUsingPreFetchedData`) - it does NOT reflect whether activation actually changed any
-  // config values, so it reports `SuccessFetchedFromRemote` (=> we'd resolve `true`) even when the
-  // fetched values are identical to what's already active. See
-  // https://github.com/invertase/react-native-firebase/issues/7779
-  //
-  // Instead we perform the fetch + activate ourselves and resolve with the `changed` BOOL from
-  // `activateWithCompletion:`, which matches the semantics of our own `activate()` method as well
-  // as the Android implementation, both of which resolve `true` only when activation changed the
-  // in-use config values.
-  FIRApp *firebaseApp = firebaseAppForName(appName);
-  __weak RNFBConfigModule *weakSelf = self;
-  FIRRemoteConfigFetchCompletion fetchCompletion = ^(FIRRemoteConfigFetchStatus status,
-                                                     NSError *__nullable error) {
-    RNFBConfigModule *strongSelf = weakSelf;
-    if (!strongSelf) {
-      return;
-    }
-
-    if (error) {
-      [RNFBSharedUtils
-          rejectPromiseWithUserInfo:reject
-                           userInfo:[@{
-                             @"code" : convertFIRRemoteConfigFetchStatusToNSString(status),
-                             @"message" :
-                                 convertFIRRemoteConfigFetchStatusToNSStringDescription(status)
-                           } mutableCopy]];
-      return;
-    }
-
-    [[FIRRemoteConfig remoteConfigWithApp:firebaseApp]
-        activateWithCompletion:^(BOOL changed, NSError *_Nullable activateError) {
-          if (!activateError) {
-            resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(changed)])
-                                        firebaseApp:firebaseApp]);
-            return;
-          }
-          if (activateError.userInfo && activateError.userInfo[@"ActivationFailureReason"] != nil &&
-              [activateError.userInfo[@"ActivationFailureReason"]
-                  containsString:@"already activated"]) {
-            resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(NO)])
-                                        firebaseApp:firebaseApp]);
-            return;
-          }
-          [RNFBSharedUtils rejectPromiseWithNSError:reject error:activateError];
-        }];
-  };
-
-  [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithCompletionHandler:fetchCompletion];
-}
-
-- (void)activate:(NSString *)appName
-         resolve:(RCTPromiseResolveBlock)resolve
-          reject:(RCTPromiseRejectBlock)reject {
-  FIRApp *firebaseApp = firebaseAppForName(appName);
+// Shared by `activate:` and `fetchAndActivate:` below - resolves with the `changed` BOOL from
+// `-[FIRRemoteConfig activateWithCompletion:]`, treating the SDK's "already activated" error as a
+// non-error `false` result rather than a rejection, since it just means there was nothing new to
+// activate.
+- (void)rnfb_activateRemoteConfig:(FIRApp *)firebaseApp
+                          resolve:(RCTPromiseResolveBlock)resolve
+                           reject:(RCTPromiseRejectBlock)reject {
   [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] activateWithCompletion:^(
                                                          BOOL changed, NSError *_Nullable error) {
     if (error) {
@@ -261,6 +208,54 @@ RCT_EXPORT_MODULE(NativeRNFBTurboConfig)
       resolve([self resultWithConstants:@([RCTConvert BOOL:@(changed)]) firebaseApp:firebaseApp]);
     }
   }];
+}
+
+- (void)fetchAndActivate:(NSString *)appName
+                 resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject {
+  // NOTE: We deliberately do not use `-[FIRRemoteConfig fetchAndActivateWithCompletionHandler:]`
+  // here. Its `FIRRemoteConfigFetchAndActivateStatus` result only reflects whether the fetch
+  // succeeded (`SuccessFetchedFromRemote`) vs fell back to previously fetched data
+  // (`SuccessUsingPreFetchedData`) - it does NOT reflect whether activation actually changed any
+  // config values, so it reports `SuccessFetchedFromRemote` (=> we'd resolve `true`) even when the
+  // fetched values are identical to what's already active. See
+  // https://github.com/invertase/react-native-firebase/issues/7779
+  //
+  // Instead we perform the fetch ourselves and hand off to the same activation + resolution logic
+  // `activate()` uses, so `fetchAndActivate()` resolves `true` only when activation changed the
+  // in-use config values - matching `activate()`'s own semantics as well as the Android
+  // implementation.
+  FIRApp *firebaseApp = firebaseAppForName(appName);
+  __weak RNFBConfigModule *weakSelf = self;
+  FIRRemoteConfigFetchCompletion fetchCompletion =
+      ^(FIRRemoteConfigFetchStatus status, NSError *__nullable error) {
+        RNFBConfigModule *strongSelf = weakSelf;
+        if (!strongSelf) {
+          return;
+        }
+
+        if (error) {
+          [RNFBSharedUtils
+              rejectPromiseWithUserInfo:reject
+                               userInfo:[@{
+                                 @"code" : convertFIRRemoteConfigFetchStatusToNSString(status),
+                                 @"message" :
+                                     convertFIRRemoteConfigFetchStatusToNSStringDescription(status)
+                               } mutableCopy]];
+          return;
+        }
+
+        [strongSelf rnfb_activateRemoteConfig:firebaseApp resolve:resolve reject:reject];
+      };
+
+  [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithCompletionHandler:fetchCompletion];
+}
+
+- (void)activate:(NSString *)appName
+         resolve:(RCTPromiseResolveBlock)resolve
+          reject:(RCTPromiseRejectBlock)reject {
+  FIRApp *firebaseApp = firebaseAppForName(appName);
+  [self rnfb_activateRemoteConfig:firebaseApp resolve:resolve reject:reject];
 }
 
 - (void)setConfigSettings:(NSString *)appName

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
@@ -191,27 +191,58 @@ RCT_EXPORT_MODULE(NativeRNFBTurboConfig)
 - (void)fetchAndActivate:(NSString *)appName
                  resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject {
+  // NOTE: We deliberately do not use `-[FIRRemoteConfig fetchAndActivateWithCompletionHandler:]`
+  // here. Its `FIRRemoteConfigFetchAndActivateStatus` result only reflects whether the fetch
+  // succeeded (`SuccessFetchedFromRemote`) vs fell back to previously fetched data
+  // (`SuccessUsingPreFetchedData`) - it does NOT reflect whether activation actually changed any
+  // config values, so it reports `SuccessFetchedFromRemote` (=> we'd resolve `true`) even when the
+  // fetched values are identical to what's already active. See
+  // https://github.com/invertase/react-native-firebase/issues/7779
+  //
+  // Instead we perform the fetch + activate ourselves and resolve with the `changed` BOOL from
+  // `activateWithCompletion:`, which matches the semantics of our own `activate()` method as well
+  // as the Android implementation, both of which resolve `true` only when activation changed the
+  // in-use config values.
   FIRApp *firebaseApp = firebaseAppForName(appName);
-  FIRRemoteConfigFetchAndActivateCompletion completionHandler =
-      ^(FIRRemoteConfigFetchAndActivateStatus status, NSError *__nullable error) {
-        if (error) {
-          if (error.userInfo && error.userInfo[@"ActivationFailureReason"] != nil &&
-              [error.userInfo[@"ActivationFailureReason"] containsString:@"already activated"]) {
-            resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
-          } else {
-            [RNFBSharedUtils rejectPromiseWithNSError:reject error:error];
-          }
-        } else {
-          if (status == FIRRemoteConfigFetchAndActivateStatusSuccessFetchedFromRemote) {
-            resolve([self resultWithConstants:@([RCTConvert BOOL:@(YES)]) firebaseApp:firebaseApp]);
-            return;
-          }
-          resolve([self resultWithConstants:@([RCTConvert BOOL:@(NO)]) firebaseApp:firebaseApp]);
+  __weak RNFBConfigModule *weakSelf = self;
+  FIRRemoteConfigFetchCompletion fetchCompletion =
+      ^(FIRRemoteConfigFetchStatus status, NSError *__nullable error) {
+        RNFBConfigModule *strongSelf = weakSelf;
+        if (!strongSelf) {
+          return;
         }
+
+        if (error) {
+          [RNFBSharedUtils
+              rejectPromiseWithUserInfo:reject
+                               userInfo:[@{
+                                 @"code" : convertFIRRemoteConfigFetchStatusToNSString(status),
+                                 @"message" :
+                                     convertFIRRemoteConfigFetchStatusToNSStringDescription(status)
+                               } mutableCopy]];
+          return;
+        }
+
+        [[FIRRemoteConfig remoteConfigWithApp:firebaseApp]
+            activateWithCompletion:^(BOOL changed, NSError *_Nullable activateError) {
+              if (activateError) {
+                if (activateError.userInfo &&
+                    activateError.userInfo[@"ActivationFailureReason"] != nil &&
+                    [activateError.userInfo[@"ActivationFailureReason"]
+                        containsString:@"already activated"]) {
+                  resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(NO)])
+                                              firebaseApp:firebaseApp]);
+                } else {
+                  [RNFBSharedUtils rejectPromiseWithNSError:reject error:activateError];
+                }
+              } else {
+                resolve([strongSelf resultWithConstants:@([RCTConvert BOOL:@(changed)])
+                                            firebaseApp:firebaseApp]);
+              }
+            }];
       };
 
-  [[FIRRemoteConfig remoteConfigWithApp:firebaseApp]
-      fetchAndActivateWithCompletionHandler:completionHandler];
+  [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] fetchWithCompletionHandler:fetchCompletion];
 }
 
 - (void)activate:(NSString *)appName


### PR DESCRIPTION

### Description

On iOS, `remoteConfig().fetchAndActivate()` always resolved `true`, even when nothing new was fetched/activated. This is inconsistent with a separate `fetch()` + `activate()` call, and inconsistent with Android's `fetchAndActivate()`, which correctly resolves `false` when there's nothing new.

**Root cause:** the iOS implementation used the Firebase iOS SDK's `-[FIRRemoteConfig fetchAndActivateWithCompletionHandler:]` and mapped its `FIRRemoteConfigFetchAndActivateStatus` result to a boolean (`SuccessFetchedFromRemote` → `true`, else → `false`). That status only reflects whether the *fetch* succeeded — it ignores the `changed` BOOL returned by the SDK's own `activateWithCompletion:`, which is the actual "did activation change anything" signal. Since `activateWithCompletion:` essentially never errors in modern SDK versions, the status was almost always `SuccessFetchedFromRemote`, so RNFB always resolved `true`.

**Fix:** `fetchAndActivate:` in `RNFBConfigModule.mm` now performs the fetch + activate itself (mirroring what the SDK does internally) and resolves with the `changed` BOOL from `activateWithCompletion:`, using the same "already activated" error-handling special case already present in RNFB's own `activate:` method. This matches Android's semantics and iOS's own `activate()` semantics.

### Related issues

- Fixes #7779

### Release Summary

fix(remote-config, ios): `fetchAndActivate()` now correctly resolves `false` when there is nothing new to activate, matching Android and matching `fetch()` + `activate()`.

### Test Plan

Added 3 new e2e tests to `packages/remote-config/e2e/config.e2e.js` (in the existing `fetchAndActivate()` describe block), designed as regression tests that would have failed against the old iOS behavior:

1. `returns false when there is nothing new to activate` — calls `fetchAndActivate()` twice in a row with no server-side template change; second call must resolve `false`.
2. `is consistent with fetch() followed by activate()` — asserts `fetchAndActivate()` agrees with a separate `fetchConfig()` + `activate()` call when nothing changed.
3. `returns true only once new remote values have actually been fetched and activated` — publishes a new remote config parameter via the existing cloud-function test helper (`FirebaseHelpers.updateRemoteConfigTemplate` / `testFunctionRemoteConfigUpdateV2`), then polls `fetchAndActivate()` for up to 60s (template publish → fetch-backend propagation isn't instant) asserting it eventually returns `true` and the new value is visible via `getValue()`. Cleans up the published parameter afterwards.


### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android` (unchanged, regression-tested for parity)
  - [x] `iOS`
  - [x] `Other` (macOS, web — validates test logic against firebase-js-sdk)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [x] I have updated TypeScript types that are affected by my change. (n/a — no public API/type change)
- This is a breaking change;
  - [ ] Yes
  - [x] No



---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter