### PR TITLE
fix(firestore, android): firestore instance cache key mismatch

### DIFF
--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
@@ -50,7 +50,7 @@ public class UniversalFirebaseFirestoreCommon {
 
     setFirestoreSettings(instance, firestoreKey);
 
-    instanceCache.put(appName, new WeakReference<FirebaseFirestore>(instance));
+    instanceCache.put(firestoreKey, new WeakReference<FirebaseFirestore>(instance));
 
     return instance;
   }

--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreCommon.java
@@ -26,10 +26,14 @@ import com.google.firebase.firestore.remote.FirestoreChannel;
 import io.invertase.firebase.app.ReactNativeFirebaseVersion;
 import io.invertase.firebase.common.UniversalFirebasePreferences;
 import java.lang.ref.WeakReference;
-import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class UniversalFirebaseFirestoreCommon {
-  static WeakHashMap<String, WeakReference<FirebaseFirestore>> instanceCache = new WeakHashMap<>();
+  // Values are already wrapped in WeakReference, so a WeakHashMap (weak keys) is not needed here
+  // and is actively harmful: firestoreKey is a freshly concatenated String with no other strong
+  // reference, so it would be eligible for GC almost immediately, evicting the cache entry.
+  static ConcurrentHashMap<String, WeakReference<FirebaseFirestore>> instanceCache =
+      new ConcurrentHashMap<>();
 
   static String createFirestoreKey(String appName, String databaseId) {
     return appName + ":" + databaseId;

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -125,69 +125,31 @@ describe('firestore()', function () {
     });
 
     describe('issue 8981 - android firestore instance cache key mismatch', function () {
-      // A real, already-provisioned second database in the test project - see
-      // packages/firestore/e2e/SecondDatabase/*.e2e.js.
-      const SECOND_DATABASE_ID = 'second-rnfb';
-
-      it('does not throw when switching databases on the same app and reapplying settings', async function () {
+      it('does not reapply settings to an already-started native instance', async function () {
         if (Platform.other) {
-          // Not supported on web lite sdk - no persistent native instance cache to break
           return;
         }
 
         const { initializeApp, deleteApp } = modular;
-        const { getFirestore, doc, setDoc, getDoc } = firestoreModular;
+        const { doc, getFirestore, setDoc } = firestoreModular;
 
-        // A dedicated, dynamically created app guarantees Firestore instances that have
-        // never been started before this test runs.
         const appName = `firestoreIssue8981${FirebaseHelpers.id}`;
         const app = await initializeApp(FirebaseHelpers.app.config(), appName);
+        const db = getFirestore(app);
+        const emulatorSettings = {
+          host: `${getE2eEmulatorHost()}:8080`,
+          ssl: false,
+        };
 
         try {
-          // Same app, two different database IDs.
-          //
-          // Regression test for https://github.com/invertase/react-native-firebase/issues/8981:
-          // on Android, `UniversalFirebaseFirestoreCommon.getFirestoreForApp()` read the
-          // instance cache keyed by `appName:databaseId` but wrote it back keyed by
-          // `appName` alone. Both databases therefore collided on a single cache slot
-          // that could never actually be hit on lookup (which always includes the
-          // `:databaseId` suffix) - switching from one database to another and back
-          // never protects either instance's settings from being re-derived.
-          const defaultDb = getFirestore(app);
-          const secondDb = getFirestore(app, SECOND_DATABASE_ID);
+          await db.settings({ ...emulatorSettings, cacheSizeBytes: 1048576 });
+          await setDoc(doc(db, `${COLLECTION}/issue8981`), { value: 1 });
 
-          // Start the default database with an initial settings value.
-          await defaultDb.settings({ cacheSizeBytes: 1048576 });
-          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981Default`), { value: 1 });
-
-          // Switch to the second database under the *same* app and start it too - this
-          // is the "different db ID hitting the same app" half of the bug: both native
-          // calls are keyed by the same broken, appName-only cache slot.
-          await secondDb.settings({ cacheSizeBytes: 2097152 });
-          await setDoc(doc(secondDb, `${COLLECTION}/issue8981Second`), { value: 2 });
-
-          // Switch back to the default database and reapply *different* settings to an
-          // already-started instance. Android's `FirebaseFirestore.setFirestoreSettings()`
-          // only throws when the newly-derived settings actually differ from what's
-          // already active (identical settings passed repeatedly are an explicit no-op
-          // in the native SDK) - so this value change is what deterministically triggers
-          // `IllegalStateException: FirebaseFirestore has already been started...` before
-          // the fix, once the cache-miss-on-every-call bug re-applies it natively.
-          await defaultDb.settings({ cacheSizeBytes: 5242880 });
-          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981Default`), { value: 3 });
-
-          const [snap1, snap2] = await Promise.all([
-            getDoc(doc(defaultDb, `${COLLECTION}/issue8981Default`)),
-            getDoc(doc(secondDb, `${COLLECTION}/issue8981Second`)),
-          ]);
-          snap1.data().value.should.equal(3);
-          snap2.data().value.should.equal(2);
+          await db.settings({ ...emulatorSettings, cacheSizeBytes: 5242880 });
+          await setDoc(doc(db, `${COLLECTION}/issue8981`), { value: 2 });
         } catch (e) {
-          // Fail explicitly with the regression context rather than letting the native
-          // `IllegalStateException` (surfaced here as a rejected promise) bubble up with a
-          // generic message - see https://github.com/invertase/react-native-firebase/issues/8981.
           throw new Error(
-            `Regression in issue 8981: switching database on the same app and reapplying settings should not throw, but got: ${e}`,
+            `Regression in issue 8981: Firestore re-applied settings to an already-started native instance: ${e}`,
           );
         } finally {
           await deleteApp(app);

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -186,7 +186,7 @@ describe('firestore()', function () {
           // Fail explicitly with the regression context rather than letting the native
           // `IllegalStateException` (surfaced here as a rejected promise) bubble up with a
           // generic message - see https://github.com/invertase/react-native-firebase/issues/8981.
-          fail(
+          throw new Error(
             `Regression in issue 8981: switching database on the same app and reapplying settings should not throw, but got: ${e}`,
           );
         } finally {

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -124,6 +124,55 @@ describe('firestore()', function () {
       });
     });
 
+    describe('issue 8981 - android firestore instance cache key mismatch', function () {
+      it('does not throw when settings are reapplied on an already-started instance', async function () {
+        if (Platform.other) {
+          // Not supported on web lite sdk - no persistent native instance cache to break
+          return;
+        }
+
+        const { initializeApp, deleteApp } = modular;
+        const { getFirestore, doc, setDoc, getDoc } = firestoreModular;
+
+        // A dedicated, dynamically created app guarantees a Firestore instance that has
+        // never been started before this test runs, so the first `setDoc()` below is
+        // genuinely the first native operation performed against it.
+        const appName = `firestoreIssue8981${FirebaseHelpers.id}`;
+        const app = await initializeApp(FirebaseHelpers.app.config(), appName);
+
+        try {
+          const db = getFirestore(app);
+          const docRef1 = doc(db, `${COLLECTION}/issue8981/first`);
+          const docRef2 = doc(db, `${COLLECTION}/issue8981/second`);
+
+          // Queue an initial settings value, then perform a real operation - this starts
+          // the native Firestore instance for the very first time, applying the settings.
+          await db.settings({ cacheSizeBytes: 1048576 });
+          await setDoc(docRef1, { value: 1 });
+
+          // Queue a *different* settings value, then perform another operation on the
+          // same already-started instance.
+          //
+          // Regression test for https://github.com/invertase/react-native-firebase/issues/8981:
+          // on Android, `UniversalFirebaseFirestoreCommon.getFirestoreForApp()` read the
+          // instance cache keyed by `appName:databaseId` but wrote it keyed by `appName`
+          // alone, so the cache lookup could never hit. Every native call therefore
+          // re-derived and reapplied settings via `setFirestoreSettings()` against an
+          // instance that had already been started, throwing
+          // `IllegalStateException: FirebaseFirestore has already been started...`
+          // whenever the newly-derived settings differed from what was already active.
+          await db.settings({ cacheSizeBytes: 2097152 });
+          await setDoc(docRef2, { value: 2 });
+
+          const [snap1, snap2] = await Promise.all([getDoc(docRef1), getDoc(docRef2)]);
+          snap1.data().value.should.equal(1);
+          snap2.data().value.should.equal(2);
+        } finally {
+          await deleteApp(app);
+        }
+      });
+    });
+
     describe('number type consistency', function () {
       before(async function () {
         // FIXME:

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -158,13 +158,13 @@ describe('firestore()', function () {
 
           // Start the default database with an initial settings value.
           await defaultDb.settings({ cacheSizeBytes: 1048576 });
-          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981/default`), { value: 1 });
+          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981Default`), { value: 1 });
 
           // Switch to the second database under the *same* app and start it too - this
           // is the "different db ID hitting the same app" half of the bug: both native
           // calls are keyed by the same broken, appName-only cache slot.
           await secondDb.settings({ cacheSizeBytes: 2097152 });
-          await setDoc(doc(secondDb, `${COLLECTION}/issue8981/second`), { value: 2 });
+          await setDoc(doc(secondDb, `${COLLECTION}/issue8981Second`), { value: 2 });
 
           // Switch back to the default database and reapply *different* settings to an
           // already-started instance. Android's `FirebaseFirestore.setFirestoreSettings()`
@@ -174,11 +174,11 @@ describe('firestore()', function () {
           // `IllegalStateException: FirebaseFirestore has already been started...` before
           // the fix, once the cache-miss-on-every-call bug re-applies it natively.
           await defaultDb.settings({ cacheSizeBytes: 5242880 });
-          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981/default`), { value: 3 });
+          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981Default`), { value: 3 });
 
           const [snap1, snap2] = await Promise.all([
-            getDoc(doc(defaultDb, `${COLLECTION}/issue8981/default`)),
-            getDoc(doc(secondDb, `${COLLECTION}/issue8981/second`)),
+            getDoc(doc(defaultDb, `${COLLECTION}/issue8981Default`)),
+            getDoc(doc(secondDb, `${COLLECTION}/issue8981Second`)),
           ]);
           snap1.data().value.should.equal(3);
           snap2.data().value.should.equal(2);

--- a/packages/firestore/e2e/issues.e2e.js
+++ b/packages/firestore/e2e/issues.e2e.js
@@ -125,7 +125,11 @@ describe('firestore()', function () {
     });
 
     describe('issue 8981 - android firestore instance cache key mismatch', function () {
-      it('does not throw when settings are reapplied on an already-started instance', async function () {
+      // A real, already-provisioned second database in the test project - see
+      // packages/firestore/e2e/SecondDatabase/*.e2e.js.
+      const SECOND_DATABASE_ID = 'second-rnfb';
+
+      it('does not throw when switching databases on the same app and reapplying settings', async function () {
         if (Platform.other) {
           // Not supported on web lite sdk - no persistent native instance cache to break
           return;
@@ -134,39 +138,57 @@ describe('firestore()', function () {
         const { initializeApp, deleteApp } = modular;
         const { getFirestore, doc, setDoc, getDoc } = firestoreModular;
 
-        // A dedicated, dynamically created app guarantees a Firestore instance that has
-        // never been started before this test runs, so the first `setDoc()` below is
-        // genuinely the first native operation performed against it.
+        // A dedicated, dynamically created app guarantees Firestore instances that have
+        // never been started before this test runs.
         const appName = `firestoreIssue8981${FirebaseHelpers.id}`;
         const app = await initializeApp(FirebaseHelpers.app.config(), appName);
 
         try {
-          const db = getFirestore(app);
-          const docRef1 = doc(db, `${COLLECTION}/issue8981/first`);
-          const docRef2 = doc(db, `${COLLECTION}/issue8981/second`);
-
-          // Queue an initial settings value, then perform a real operation - this starts
-          // the native Firestore instance for the very first time, applying the settings.
-          await db.settings({ cacheSizeBytes: 1048576 });
-          await setDoc(docRef1, { value: 1 });
-
-          // Queue a *different* settings value, then perform another operation on the
-          // same already-started instance.
+          // Same app, two different database IDs.
           //
           // Regression test for https://github.com/invertase/react-native-firebase/issues/8981:
           // on Android, `UniversalFirebaseFirestoreCommon.getFirestoreForApp()` read the
-          // instance cache keyed by `appName:databaseId` but wrote it keyed by `appName`
-          // alone, so the cache lookup could never hit. Every native call therefore
-          // re-derived and reapplied settings via `setFirestoreSettings()` against an
-          // instance that had already been started, throwing
-          // `IllegalStateException: FirebaseFirestore has already been started...`
-          // whenever the newly-derived settings differed from what was already active.
-          await db.settings({ cacheSizeBytes: 2097152 });
-          await setDoc(docRef2, { value: 2 });
+          // instance cache keyed by `appName:databaseId` but wrote it back keyed by
+          // `appName` alone. Both databases therefore collided on a single cache slot
+          // that could never actually be hit on lookup (which always includes the
+          // `:databaseId` suffix) - switching from one database to another and back
+          // never protects either instance's settings from being re-derived.
+          const defaultDb = getFirestore(app);
+          const secondDb = getFirestore(app, SECOND_DATABASE_ID);
 
-          const [snap1, snap2] = await Promise.all([getDoc(docRef1), getDoc(docRef2)]);
-          snap1.data().value.should.equal(1);
+          // Start the default database with an initial settings value.
+          await defaultDb.settings({ cacheSizeBytes: 1048576 });
+          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981/default`), { value: 1 });
+
+          // Switch to the second database under the *same* app and start it too - this
+          // is the "different db ID hitting the same app" half of the bug: both native
+          // calls are keyed by the same broken, appName-only cache slot.
+          await secondDb.settings({ cacheSizeBytes: 2097152 });
+          await setDoc(doc(secondDb, `${COLLECTION}/issue8981/second`), { value: 2 });
+
+          // Switch back to the default database and reapply *different* settings to an
+          // already-started instance. Android's `FirebaseFirestore.setFirestoreSettings()`
+          // only throws when the newly-derived settings actually differ from what's
+          // already active (identical settings passed repeatedly are an explicit no-op
+          // in the native SDK) - so this value change is what deterministically triggers
+          // `IllegalStateException: FirebaseFirestore has already been started...` before
+          // the fix, once the cache-miss-on-every-call bug re-applies it natively.
+          await defaultDb.settings({ cacheSizeBytes: 5242880 });
+          await setDoc(doc(defaultDb, `${COLLECTION}/issue8981/default`), { value: 3 });
+
+          const [snap1, snap2] = await Promise.all([
+            getDoc(doc(defaultDb, `${COLLECTION}/issue8981/default`)),
+            getDoc(doc(secondDb, `${COLLECTION}/issue8981/second`)),
+          ]);
+          snap1.data().value.should.equal(3);
           snap2.data().value.should.equal(2);
+        } catch (e) {
+          // Fail explicitly with the regression context rather than letting the native
+          // `IllegalStateException` (surfaced here as a rejected promise) bubble up with a
+          // generic message - see https://github.com/invertase/react-native-firebase/issues/8981.
+          fail(
+            `Regression in issue 8981: switching database on the same app and reapplying settings should not throw, but got: ${e}`,
+          );
         } finally {
           await deleteApp(app);
         }

--- a/tests/app.js
+++ b/tests/app.js
@@ -204,7 +204,8 @@ function loadTests(_) {
     }
 
     if (platformSupportedModules.includes('firestore')) {
-      require('../packages/firestore/e2e/Pipeline.e2e.js');
+      const firestoreTests = require.context('../packages/firestore/e2e', true, /\.e2e\.js$/);
+      firestoreTests.keys().forEach(firestoreTests);
     }
     if (platformSupportedModules.includes('perf')) {
       const perfTests = require.context('../packages/perf/e2e', true, /\.e2e\.js$/);


### PR DESCRIPTION
### Description

UniversalFirebaseFirestoreCommon.getFirestoreForApp() on Android read the instance cache using the key appName:databaseId but wrote it back using only appName, so the cache lookup could never hit — for the default database or any custom database.

Because of this, every native Firestore call re-derived and reapplied settings via setFirestoreSettings() against the same underlying FirebaseFirestore instance. Once that instance had already been used, reapplying settings that differ from what's currently active throws:

IllegalStateException: FirebaseFirestore has already been started and its settings can no longer be changed.
This surfaced in production (Crashlytics) when firestore.settings(...) was called during app startup while document listeners were mounting concurrently. Fix: write the cache entry using the same firestoreKey that's used to read it, matching the (already-correct) iOS implementation.

### Related issues

fixes #8981 


### Release Summary

<!-- An optional description that you want to appear on the generated changelog -->

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [ ] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [ ] No



### Test Plan

<!-- Demonstrate the code you've added is solid, e.g. test logs or screenshots. -->

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
