### PR TITLE
docs(messaging): update token registration examples

### DIFF
--- a/docs/messaging/notifications.mdx
+++ b/docs/messaging/notifications.mdx
@@ -207,15 +207,16 @@ function App() {
 
 To send messages to a device, you would need the FCM token for it, which you can get using the `getToken(messaging)` method. An example is available on '[Notifee pages](https://notifee.app/react-native/docs/integrations/fcm)'.
 
+On iOS, React Native Firebase Messaging automatically registers the device with APNs by default. You only need to
+manually call `registerDeviceForRemoteMessages(messaging)` before `getToken(messaging)` if you disabled
+auto-registration with `messaging_ios_auto_register_for_remote_messages` in `firebase.json`, or if you otherwise call
+`getToken(messaging)` before the app has registered for remote messages. See
+[Auto Registration (iOS)](/messaging/usage#auto-registration-ios) for the manual registration example.
+
 ```jsx
-import {
-  getMessaging,
-  registerDeviceForRemoteMessages,
-  getToken,
-} from '@react-native-firebase/messaging';
+import { getMessaging, getToken } from '@react-native-firebase/messaging';
 
 const messaging = getMessaging();
-await registerDeviceForRemoteMessages(messaging);
 const token = await getToken(messaging);
 // save the token to the db
 ```

--- a/docs/messaging/notifications.mdx
+++ b/docs/messaging/notifications.mdx
@@ -214,9 +214,15 @@ auto-registration with `messaging_ios_auto_register_for_remote_messages` in `fir
 [Auto Registration (iOS)](/messaging/usage#auto-registration-ios) for the manual registration example.
 
 ```jsx
-import { getMessaging, getToken } from '@react-native-firebase/messaging';
+import {
+  getMessaging,
+  registerDeviceForRemoteMessages,
+  getToken,
+} from '@react-native-firebase/messaging';
 
 const messaging = getMessaging();
+// Optional: not needed in most cases, and a no-op if already registered.
+await registerDeviceForRemoteMessages(messaging);
 const token = await getToken(messaging);
 // save the token to the db
 ```

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -112,7 +112,7 @@
           "type": "string"
         },
         "messaging_ios_auto_register_for_remote_messages": {
-          "description": "Whether RNFirebase Messaging automatically calls `[[UIApplication sharedApplication] registerForRemoteNotifications];`\nautomatically on app launch (recommended) - defaults to true.\n If set to false; make sure to call `firebase.messaging().registerDeviceForRemoteMessages()`\nearly on in your app startup - otherwise you will NOT receive remote messages/notifications\nin your app.\n",
+          "description": "Whether RNFirebase Messaging automatically calls `[[UIApplication sharedApplication] registerForRemoteNotifications];`\nautomatically on app launch (recommended) - defaults to true.\n If set to false; make sure to call `registerDeviceForRemoteMessages(getMessaging())`\nearly on in your app startup - otherwise you will NOT receive remote messages/notifications\nin your app.\n",
           "type": "boolean"
         },
         "messaging_ios_foreground_presentation_options": {

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -112,7 +112,7 @@
           "type": "string"
         },
         "messaging_ios_auto_register_for_remote_messages": {
-          "description": "Whether RNFirebase Messaging automatically calls `[[UIApplication sharedApplication] registerForRemoteNotifications];`\nautomatically on app launch (recommended) - defaults to true.\n If set to false; make sure to call `registerDeviceForRemoteMessages(getMessaging())`\nearly on in your app startup - otherwise you will NOT receive remote messages/notifications\nin your app.\n",
+          "description": "Whether RNFirebase Messaging automatically calls `[[UIApplication sharedApplication] registerForRemoteNotifications];`\non app launch (recommended) - defaults to true.\n If set to false, make sure to call `registerDeviceForRemoteMessages(getMessaging())`\nearly on in your app startup - otherwise you will NOT receive remote messages/notifications\nin your app.\n",
           "type": "boolean"
         },
         "messaging_ios_foreground_presentation_options": {

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
@@ -131,8 +131,7 @@ RCT_EXPORT_MODULE(NativeRNFBTurboMessaging)
                                         @"message" : @"You must be registered for remote "
                                                      @"messages before calling "
                                                      @"getToken, see "
-                                                     @"messaging()."
-                                                     @"registerDeviceForRemoteMessages().",
+                                                     @"registerDeviceForRemoteMessages(getMessaging()).",
                                       }];
     return;
   }
@@ -199,8 +198,7 @@ RCT_EXPORT_MODULE(NativeRNFBTurboMessaging)
                                           @"message" : @"You must be registered for remote "
                                                        @"messages before "
                                                        @"calling getAPNSToken, see "
-                                                       @"messaging()."
-                                                       @"registerDeviceForRemoteMessages().",
+                                                       @"registerDeviceForRemoteMessages(getMessaging()).",
                                         }];
       return;
     }

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
@@ -125,14 +125,15 @@ RCT_EXPORT_MODULE(NativeRNFBTurboMessaging)
          resolve:(RCTPromiseResolveBlock)resolve
           reject:(RCTPromiseRejectBlock)reject {
   if ([UIApplication sharedApplication].isRegisteredForRemoteNotifications == NO) {
-    [RNFBSharedUtils rejectPromiseWithUserInfo:reject
-                                      userInfo:(NSMutableDictionary *)@{
-                                        @"code" : @"unregistered",
-                                        @"message" : @"You must be registered for remote "
-                                                     @"messages before calling "
-                                                     @"getToken, see "
-                                                     @"registerDeviceForRemoteMessages(getMessaging()).",
-                                      }];
+    [RNFBSharedUtils
+        rejectPromiseWithUserInfo:reject
+                         userInfo:(NSMutableDictionary *)@{
+                           @"code" : @"unregistered",
+                           @"message" : @"You must be registered for remote "
+                                        @"messages before calling "
+                                        @"getToken, see "
+                                        @"registerDeviceForRemoteMessages(getMessaging()).",
+                         }];
     return;
   }
 
@@ -192,14 +193,15 @@ RCT_EXPORT_MODULE(NativeRNFBTurboMessaging)
          @"Use setAPNSToken in testing if needed.");
 #endif
     if ([UIApplication sharedApplication].isRegisteredForRemoteNotifications == NO) {
-      [RNFBSharedUtils rejectPromiseWithUserInfo:reject
-                                        userInfo:(NSMutableDictionary *)@{
-                                          @"code" : @"unregistered",
-                                          @"message" : @"You must be registered for remote "
-                                                       @"messages before "
-                                                       @"calling getAPNSToken, see "
-                                                       @"registerDeviceForRemoteMessages(getMessaging()).",
-                                        }];
+      [RNFBSharedUtils
+          rejectPromiseWithUserInfo:reject
+                           userInfo:(NSMutableDictionary *)@{
+                             @"code" : @"unregistered",
+                             @"message" : @"You must be registered for remote "
+                                          @"messages before "
+                                          @"calling getAPNSToken, see "
+                                          @"registerDeviceForRemoteMessages(getMessaging()).",
+                           }];
       return;
     }
     resolve([NSNull null]);


### PR DESCRIPTION
## Summary

Fixes #8710 by updating the Cloud Messaging token registration guidance to use the modular API consistently.

- Clarifies that iOS auto-registration is enabled by default before the `getToken(messaging)` example
- Keeps the defensive `registerDeviceForRemoteMessages(messaging)` call in the device token example and labels it as optional and a no-op if already registered
- Updates the iOS unregistered error messages and `firebase.json` schema description from `messaging().registerDeviceForRemoteMessages()` to `registerDeviceForRemoteMessages(getMessaging())`

## Verification

- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('packages/app/firebase-schema.json','utf8')); console.log('firebase-schema.json ok')"`
- `rg -n "messaging\\(\\)\\.registerDeviceForRemoteMessages|messaging\\(\\)\\.getToken|firebase\\.messaging\\(\\)\\.registerDeviceForRemoteMessages" docs/messaging packages/messaging packages/app/firebase-schema.json`
- `npx --yes prettier@3.8.3 --check docs/messaging/notifications.mdx packages/app/firebase-schema.json`

Note: I attempted to run a targeted `clang-format --style=Google -n -Werror packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm` check, but `clang-format` is not installed in this local environment.
