### PR TITLE
fix(messaging, android): ignore non-message broadcasts in messaging receiver

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingReceiver.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingReceiver.java
@@ -26,6 +26,22 @@ public class ReactNativeFirebaseMessagingReceiver extends BroadcastReceiver {
       Log.e(TAG, "broadcast intent received with no extras");
       return;
     }
+    // Mirror the routing guards of the official FirebaseMessagingService: the
+    // c2dm RECEIVE action also carries control broadcasts (deleted_messages,
+    // send_event, send_error) and non-message intents such as the wrapped
+    // NOTIFICATION_DISMISS analytics intent that FCM attaches as deleteIntent
+    // to notifications it displays itself. The official SDK routes those to
+    // dedicated callbacks and never surfaces them through onMessageReceived;
+    // without these guards they are emitted to JS as empty remote messages.
+    String messageType = intent.getExtras().getString("message_type");
+    if (messageType != null && !"gcm".equals(messageType)) {
+      Log.d(TAG, "broadcast ignored, non-message type: " + messageType);
+      return;
+    }
+    if (intent.getExtras().getString("google.message_id") == null) {
+      Log.d(TAG, "broadcast ignored, no google.message_id (not an FCM message)");
+      return;
+    }
     RemoteMessage remoteMessage = new RemoteMessage(intent.getExtras());
     ReactNativeFirebaseEventEmitter emitter = ReactNativeFirebaseEventEmitter.getSharedInstance();
 

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingReceiver.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingReceiver.java
@@ -33,12 +33,12 @@ public class ReactNativeFirebaseMessagingReceiver extends BroadcastReceiver {
     // to notifications it displays itself. The official SDK routes those to
     // dedicated callbacks and never surfaces them through onMessageReceived;
     // without these guards they are emitted to JS as empty remote messages.
-    String messageType = intent.getExtras().getString("message_type");
+    String messageType = intent.getStringExtra("message_type");
     if (messageType != null && !"gcm".equals(messageType)) {
       Log.d(TAG, "broadcast ignored, non-message type: " + messageType);
       return;
     }
-    if (intent.getExtras().getString("google.message_id") == null) {
+    if (intent.getStringExtra("google.message_id") == null) {
       Log.d(TAG, "broadcast ignored, no google.message_id (not an FCM message)");
       return;
     }


### PR DESCRIPTION
### Description

`ReactNativeFirebaseMessagingReceiver` listens on the raw `com.google.android.c2dm.intent.RECEIVE` action and blindly converts **every** broadcast it receives into a `RemoteMessage` emitted to JS (`onMessageReceived` / background handler). That channel is not message-only, and this produces phantom empty messages in JS.

**Root cause (verified in both SDKs' sources).** The official `FirebaseMessagingService` ([`handleMessageIntent`](https://github.com/firebase/firebase-android-sdk/blob/3f01b025b5b651d084902c96168fea89bdb0f50d/firebase-messaging/src/main/java/com/google/firebase/messaging/FirebaseMessagingService.java)) applies two routing guards before ever calling `onMessageReceived`:

1. `message_type` present and ≠ `"gcm"` → routed to dedicated callbacks (`onDeletedMessages`, `onMessageSent`, `onSendError`) — these are control broadcasts, not messages;
2. intents that are not FCM-delivered messages are never surfaced as messages. Every message actually delivered by FCM carries a server-stamped `google.message_id`.

The RNFB receiver has neither guard. The most visible consequence: since [firebase/firebase-android-sdk#5410](https://github.com/firebase/firebase-android-sdk/pull/5410) (firebase-messaging 23.3.0+, late 2023), when FCM displays a notification itself, it attaches a `NOTIFICATION_DISMISS` analytics intent as `deleteIntent`, wrapped as an implicit package-scoped broadcast **on that same c2dm action**. So **every notification swipe-to-dismiss fabricates an empty `RemoteMessage`** (no `messageId`, no `data`, no `notification`) delivered to the app's JS message handlers. This is exactly what #8040 reported (closed stale without a fix).

Real-world impact: in our production app (~25k Android devices), these phantom messages hit our push payload validation and accounted for **~600k error logs / 30 days — ~23% of all app error logs** — drowning real signal.

**Fix.** Reproduce the two entry guards of the official routing at the top of `onReceive`:

- `message_type` present and ≠ `"gcm"` → ignore;
- no `google.message_id` extra → ignore (not an FCM-delivered message).

The guards are safe by construction: every FCM-delivered message (data-only, notification, high/normal priority, console tests) carries `google.message_id`. The official pipeline (notification display, dismiss analytics, `onDeletedMessages`) is untouched — it flows through the Firebase SDK's own `FirebaseInstanceIdReceiver`, which keeps receiving the same broadcasts.

### Related issues

- Fixes #8040

### Release Summary

fix(messaging, android): ignore non-message c2dm broadcasts (control broadcasts, notification-dismiss analytics intents) instead of emitting them to JS as empty messages

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

No automated tests added: the package has no Android unit-test harness, and the e2e suite has no mechanism to inject `com.google.android.c2dm.intent.RECEIVE` broadcasts (the dismiss `deleteIntent` is fired by the OS notification tray, which Detox cannot drive). Happy to add coverage if you can point me at a preferred approach.

Manual repro (matches #8040):

1. Send a notification-type message (e.g. from the Firebase console) while the app is foregrounded, so FCM displays the notification itself.
2. Swipe the notification away.
3. Before this change: `onMessageReceived` fires with an empty `RemoteMessage` (no `messageId`, no `data`, no `notification`). After: nothing is emitted, and logcat shows `broadcast ignored, no google.message_id (not an FCM message)`.

Field evidence — we ship this exact change as a `patch-package` patch on `@react-native-firebase/messaging@25.1.0` in our app; verified on real devices:

- Swiping an FCM-displayed notification no longer emits an empty message to JS (logcat shows the ignore guard firing instead).
- Data-only pushes, notification pushes, and Firebase console test messages all still arrive — they all carry `google.message_id`.
- `onDeletedMessages` still works: the Firebase SDK's own `FirebaseInstanceIdReceiver` receives the same broadcasts and routes `deleted_messages` through `FirebaseMessagingService`, which RNFB subclasses.

🔥
