### PR TITLE
fix(app-check): validate provider name and error on unrecognized values

### DIFF
--- a/packages/app-check/__tests__/appcheck.test.ts
+++ b/packages/app-check/__tests__/appcheck.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import { Platform } from 'react-native';
 
 import {
   initializeAppCheck,
@@ -24,6 +25,69 @@ describe('appCheck()', function () {
       expect(() => initializeAppCheck(undefined, undefined)).toThrow(
         'Invalid configuration: no options defined.',
       );
+    });
+
+    describe('provider name validation', function () {
+      it('throws on invalid android provider name', function () {
+        const provider = new ReactNativeFirebaseAppCheckProvider();
+        provider.configure({
+          android: { provider: 'invalidProvider' as any },
+        });
+        expect(() => initializeAppCheck(undefined, { provider })).toThrow(
+          'Invalid App Check provider "invalidProvider". Valid android providers are: debug, playIntegrity.',
+        );
+      });
+
+      it('does not throw validation error for valid android provider names', function () {
+        for (const name of ['debug', 'playIntegrity']) {
+          const provider = new ReactNativeFirebaseAppCheckProvider();
+          provider.configure({
+            android: { provider: name as any },
+          });
+          try {
+            initializeAppCheck(undefined, { provider });
+          } catch (e: any) {
+            expect(e.message).not.toContain('Invalid App Check provider');
+          }
+        }
+      });
+
+      describe('apple platform', function () {
+        let originalOS: string;
+
+        beforeEach(function () {
+          originalOS = Platform.OS;
+          Platform.OS = 'ios' as any;
+        });
+
+        afterEach(function () {
+          Platform.OS = originalOS as any;
+        });
+
+        it('throws on invalid apple provider name', function () {
+          const provider = new ReactNativeFirebaseAppCheckProvider();
+          provider.configure({
+            apple: { provider: 'appAttestWithDebugProviderFallback' as any },
+          });
+          expect(() => initializeAppCheck(undefined, { provider })).toThrow(
+            'Invalid App Check provider "appAttestWithDebugProviderFallback". Valid apple providers are: debug, deviceCheck, appAttest, appAttestWithDeviceCheckFallback.',
+          );
+        });
+
+        it('does not throw validation error for valid apple provider names', function () {
+          for (const name of ['debug', 'deviceCheck', 'appAttest', 'appAttestWithDeviceCheckFallback']) {
+            const provider = new ReactNativeFirebaseAppCheckProvider();
+            provider.configure({
+              apple: { provider: name as any },
+            });
+            try {
+              initializeAppCheck(undefined, { provider });
+            } catch (e: any) {
+              expect(e.message).not.toContain('Invalid App Check provider');
+            }
+          }
+        });
+      });
     });
 
     it('`getToken` function is properly exposed to end user', function () {

--- a/packages/app-check/__tests__/appcheck.test.ts
+++ b/packages/app-check/__tests__/appcheck.test.ts
@@ -75,7 +75,12 @@ describe('appCheck()', function () {
         });
 
         it('does not throw validation error for valid apple provider names', function () {
-          for (const name of ['debug', 'deviceCheck', 'appAttest', 'appAttestWithDeviceCheckFallback']) {
+          for (const name of [
+            'debug',
+            'deviceCheck',
+            'appAttest',
+            'appAttestWithDeviceCheckFallback',
+          ]) {
             const provider = new ReactNativeFirebaseAppCheckProvider();
             provider.configure({
               apple: { provider: name as any },

--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckProvider.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckProvider.java
@@ -91,11 +91,12 @@ public class ReactNativeFirebaseAppCheckProvider implements AppCheckProvider {
       }
 
       if (delegateProvider == null) {
-        Log.e(
-            LOGTAG,
+        String message =
             "Unknown provider name \""
                 + providerName
-                + "\". Valid providers are: debug, playIntegrity.");
+                + "\". Valid providers are: debug, playIntegrity.";
+        Log.e(LOGTAG, message);
+        throw new IllegalArgumentException(message);
       }
     } catch (Exception e) {
       // This will bubble up and result in a rejected promise with the underlying message

--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckProvider.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckProvider.java
@@ -91,8 +91,11 @@ public class ReactNativeFirebaseAppCheckProvider implements AppCheckProvider {
       }
 
       if (delegateProvider == null) {
-        Log.e(LOGTAG, "Unknown provider name \"" + providerName
-            + "\". Valid providers are: debug, playIntegrity.");
+        Log.e(
+            LOGTAG,
+            "Unknown provider name \""
+                + providerName
+                + "\". Valid providers are: debug, playIntegrity.");
       }
     } catch (Exception e) {
       // This will bubble up and result in a rejected promise with the underlying message

--- a/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckProvider.java
+++ b/packages/app-check/android/src/main/java/io/invertase/firebase/appcheck/ReactNativeFirebaseAppCheckProvider.java
@@ -89,6 +89,11 @@ public class ReactNativeFirebaseAppCheckProvider implements AppCheckProvider {
       if ("playIntegrity".equals(providerName)) {
         delegateProvider = PlayIntegrityAppCheckProviderFactory.getInstance().create(app);
       }
+
+      if (delegateProvider == null) {
+        Log.e(LOGTAG, "Unknown provider name \"" + providerName
+            + "\". Valid providers are: debug, playIntegrity.");
+      }
     } catch (Exception e) {
       // This will bubble up and result in a rejected promise with the underlying message
       throw new RuntimeException(e.getMessage());

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.mm
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.mm
@@ -76,10 +76,18 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAppCheck)
   FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
   DLog(@"appName/providerName/debugToken: %@/%@/%@", firebaseApp.name, providerName,
        (debugToken == nil ? @"null" : @"(not shown)"));
-  [[RNFBAppCheckModule sharedInstance].providerFactory configure:firebaseApp
-                                                    providerName:providerName
-                                                      debugToken:debugToken];
-  resolve([NSNull null]);
+  @try {
+    [[RNFBAppCheckModule sharedInstance].providerFactory configure:firebaseApp
+                                                      providerName:providerName
+                                                        debugToken:debugToken];
+    resolve([NSNull null]);
+  } @catch (NSException *exception) {
+    [RNFBSharedUtils rejectPromiseWithUserInfo:reject
+                                      userInfo:(NSMutableDictionary *)@{
+                                        @"code" : @"unknown",
+                                        @"message" : exception.reason ?: @"internal-error",
+                                      }];
+  }
 }
 
 - (void)setTokenAutoRefreshEnabled:(NSString *)appName

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
@@ -76,14 +76,12 @@
   }
 
   if (self.delegateProvider == nil) {
-    NSString *message = [NSString
-        stringWithFormat:@"Unknown provider name \"%@\". Valid providers are: debug, "
-                         @"deviceCheck, appAttest, appAttestWithDeviceCheckFallback.",
-                         providerName ?: @"(null)"];
+    NSString *message =
+        [NSString stringWithFormat:@"Unknown provider name \"%@\". Valid providers are: debug, "
+                                    "deviceCheck, appAttest, appAttestWithDeviceCheckFallback.",
+                                   providerName ?: @"(null)"];
     NSLog(@"RNFBAppCheck: %@", message);
-    @throw [NSException exceptionWithName:@"RNFBAppCheckException"
-                                   reason:message
-                                 userInfo:nil];
+    @throw [NSException exceptionWithName:@"RNFBAppCheckException" reason:message userInfo:nil];
   }
 }
 

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
@@ -73,6 +73,12 @@
       self.delegateProvider = [[FIRDeviceCheckProvider alloc] initWithApp:app];
     }
   }
+
+  if (self.delegateProvider == nil) {
+    NSLog(@"RNFBAppCheck: Unknown provider name \"%@\". Valid providers are: debug, deviceCheck, "
+          @"appAttest, appAttestWithDeviceCheckFallback.",
+          providerName);
+  }
 }
 
 - (void)getTokenWithCompletion:(nonnull void (^)(FIRAppCheckToken *_Nullable,

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
@@ -36,7 +36,8 @@
 
   DLog(@"appName %@", app.name);
 
-  // - determine if debugToken is provided via nullable arg
+  self.delegateProvider = nil;
+
   if ([providerName isEqualToString:@"debug"]) {
     // The firebase-ios-sdk debug app check provider will take a token from environment if it
     // exists:
@@ -75,9 +76,14 @@
   }
 
   if (self.delegateProvider == nil) {
-    NSLog(@"RNFBAppCheck: Unknown provider name \"%@\". Valid providers are: debug, deviceCheck, "
-          @"appAttest, appAttestWithDeviceCheckFallback.",
-          providerName);
+    NSString *message = [NSString
+        stringWithFormat:@"Unknown provider name \"%@\". Valid providers are: debug, "
+                         @"deviceCheck, appAttest, appAttestWithDeviceCheckFallback.",
+                         providerName ?: @"(null)"];
+    NSLog(@"RNFBAppCheck: %@", message);
+    @throw [NSException exceptionWithName:@"RNFBAppCheckException"
+                                   reason:message
+                                 userInfo:nil];
   }
 }
 

--- a/packages/app-check/lib/index.ts
+++ b/packages/app-check/lib/index.ts
@@ -133,6 +133,12 @@ class FirebaseAppCheckModule extends FirebaseModule<typeof nativeModuleName> {
           'Invalid configuration: no android provider configured while on android platform.',
         );
       }
+      const validAndroidProviders = ['debug', 'playIntegrity'];
+      if (!validAndroidProviders.includes(provider.providerOptions.android.provider)) {
+        throw new Error(
+          `Invalid App Check provider "${provider.providerOptions.android.provider}". Valid android providers are: ${validAndroidProviders.join(', ')}.`,
+        );
+      }
       return this.native.configureProvider(
         provider.providerOptions.android.provider,
         provider.providerOptions.android.debugToken,
@@ -142,6 +148,17 @@ class FirebaseAppCheckModule extends FirebaseModule<typeof nativeModuleName> {
       if (!isString(provider.providerOptions?.apple?.provider)) {
         throw new Error(
           'Invalid configuration: no apple provider configured while on apple platform.',
+        );
+      }
+      const validAppleProviders = [
+        'debug',
+        'deviceCheck',
+        'appAttest',
+        'appAttestWithDeviceCheckFallback',
+      ];
+      if (!validAppleProviders.includes(provider.providerOptions.apple.provider)) {
+        throw new Error(
+          `Invalid App Check provider "${provider.providerOptions.apple.provider}". Valid apple providers are: ${validAppleProviders.join(', ')}.`,
         );
       }
       return this.native.configureProvider(

--- a/packages/app-check/lib/index.ts
+++ b/packages/app-check/lib/index.ts
@@ -49,7 +49,12 @@ import { ReactNativeFirebaseAppCheckProvider } from './providers';
 
 const nativeModuleName = 'NativeRNFBTurboAppCheck';
 
-const VALID_APPLE_PROVIDERS = ['debug', 'deviceCheck', 'appAttest', 'appAttestWithDeviceCheckFallback'];
+const VALID_APPLE_PROVIDERS = [
+  'debug',
+  'deviceCheck',
+  'appAttest',
+  'appAttestWithDeviceCheckFallback',
+];
 const VALID_ANDROID_PROVIDERS = ['debug', 'playIntegrity'];
 
 /**

--- a/packages/app-check/lib/index.ts
+++ b/packages/app-check/lib/index.ts
@@ -49,6 +49,9 @@ import { ReactNativeFirebaseAppCheckProvider } from './providers';
 
 const nativeModuleName = 'NativeRNFBTurboAppCheck';
 
+const VALID_APPLE_PROVIDERS = ['debug', 'deviceCheck', 'appAttest', 'appAttestWithDeviceCheckFallback'];
+const VALID_ANDROID_PROVIDERS = ['debug', 'playIntegrity'];
+
 /**
  * Type guard to check if a provider has providerOptions.
  * This provides proper type narrowing for providers that support platform-specific configuration.
@@ -61,6 +64,29 @@ function hasProviderOptions(
     'providerOptions' in provider &&
     provider.providerOptions !== undefined
   );
+}
+
+function validateProviderName(options: AppCheckOptions): void {
+  if (!hasProviderOptions(options.provider)) {
+    return;
+  }
+  const provider = options.provider;
+  if (Platform.OS === 'android') {
+    const name = provider.providerOptions?.android?.provider;
+    if (isString(name) && !VALID_ANDROID_PROVIDERS.includes(name)) {
+      throw new Error(
+        `Invalid App Check provider "${name}". Valid android providers are: ${VALID_ANDROID_PROVIDERS.join(', ')}.`,
+      );
+    }
+  }
+  if (Platform.OS === 'ios' || Platform.OS === 'macos') {
+    const name = provider.providerOptions?.apple?.provider;
+    if (isString(name) && !VALID_APPLE_PROVIDERS.includes(name)) {
+      throw new Error(
+        `Invalid App Check provider "${name}". Valid apple providers are: ${VALID_APPLE_PROVIDERS.join(', ')}.`,
+      );
+    }
+  }
 }
 
 class FirebaseAppCheckModule extends FirebaseModule<typeof nativeModuleName> {
@@ -133,12 +159,6 @@ class FirebaseAppCheckModule extends FirebaseModule<typeof nativeModuleName> {
           'Invalid configuration: no android provider configured while on android platform.',
         );
       }
-      const validAndroidProviders = ['debug', 'playIntegrity'];
-      if (!validAndroidProviders.includes(provider.providerOptions.android.provider)) {
-        throw new Error(
-          `Invalid App Check provider "${provider.providerOptions.android.provider}". Valid android providers are: ${validAndroidProviders.join(', ')}.`,
-        );
-      }
       return this.native.configureProvider(
         provider.providerOptions.android.provider,
         provider.providerOptions.android.debugToken,
@@ -148,17 +168,6 @@ class FirebaseAppCheckModule extends FirebaseModule<typeof nativeModuleName> {
       if (!isString(provider.providerOptions?.apple?.provider)) {
         throw new Error(
           'Invalid configuration: no apple provider configured while on apple platform.',
-        );
-      }
-      const validAppleProviders = [
-        'debug',
-        'deviceCheck',
-        'appAttest',
-        'appAttestWithDeviceCheckFallback',
-      ];
-      if (!validAppleProviders.includes(provider.providerOptions.apple.provider)) {
-        throw new Error(
-          `Invalid App Check provider "${provider.providerOptions.apple.provider}". Valid apple providers are: ${validAppleProviders.join(', ')}.`,
         );
       }
       return this.native.configureProvider(
@@ -284,6 +293,7 @@ export function initializeAppCheck(app?: FirebaseApp, options?: AppCheckOptions)
   if (!isObject(options)) {
     throw new Error('Invalid configuration: no options defined.');
   }
+  validateProviderName(options);
   const appCheck = getModularAppCheck(app);
   void (appCheck as AppCheckInternal).initializeAppCheck(options);
   return appCheck;


### PR DESCRIPTION
### Description

Validate React Native Firebase App Check provider names before configuring the native provider.

Previously, unsupported provider names such as `appAttestWithDebugProviderFallback` could be passed through without a clear JS-side error, leaving native App Check configured without a matching delegate provider and making the resulting App Check behavior difficult to diagnose. This change adds runtime validation for the supported Android and Apple provider names, plus native diagnostic logging if an unknown provider still reaches the native layer.

Supported provider names are now enforced as:

- Android: `debug`, `playIntegrity`
- Apple: `debug`, `deviceCheck`, `appAttest`, `appAttestWithDeviceCheckFallback`

### Related issues

- Fixes #9008

### Release Summary

Validate App Check provider names at initialization and throw a clear error for unsupported Android or Apple provider values.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Validated the App Check provider-name checks with the focused Jest suite and JS linting.

```bash
yarn lint:js
# passed

yarn tests:jest --watchman=false packages/app-check/__tests__/appcheck.test.ts
# Test Suites: 1 passed, 1 total
# Tests: 12 passed, 12 total

git diff --check main...HEAD
# passed
yarn lint:ios:check could not be completed locally due to a formatter tool spawn error: spawn Unknown system error -86.
```