### PR TITLE
fix(app, android)!: run makeGooglePlayServicesAvailable on main thread

### DIFF
--- a/docs/migrating-to-v26.mdx
+++ b/docs/migrating-to-v26.mdx
@@ -217,6 +217,20 @@ getUtils().FilePath.DOCUMENT_DIRECTORY;
 FilePath.DOCUMENT_DIRECTORY;
 ```
 
+## Breaking: Android Play Services availability Promise behavior
+
+On Android, `makePlayServicesAvailable()` now rejects when the Play Services availability task is canceled or fails. Previously, the call always resolved even when the update flow was not completed. Update callers to handle rejection:
+
+```js
+import { getUtils } from '@react-native-firebase/app';
+
+try {
+  await getUtils().makePlayServicesAvailable();
+} catch (error) {
+  // Handle canceled or failed Play Services update
+}
+```
+
 # Machine Learning (ML)
 
 The namespaced API for `@react-native-firebase/ml` has been **removed**. This package is **modular-only** — use `getML(app?)`.

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/NativeRNFBTurboUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/NativeRNFBTurboUtils.java
@@ -28,6 +28,7 @@ import com.facebook.fbreact.specs.NativeRNFBTurboUtilsSpec;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -103,12 +104,35 @@ public class NativeRNFBTurboUtils extends NativeRNFBTurboUtilsSpec {
     int status = isGooglePlayServicesAvailable();
 
     if (status != ConnectionResult.SUCCESS) {
-      Activity activity = getCurrentActivity();
-      if (activity != null) {
-        GoogleApiAvailability.getInstance().makeGooglePlayServicesAvailable(activity);
-      }
+      UiThreadUtil.runOnUiThread(
+          () -> {
+            Activity activity = getCurrentActivity();
+            if (activity != null) {
+              GoogleApiAvailability.getInstance()
+                  .makeGooglePlayServicesAvailable(activity)
+                  .addOnCompleteListener(
+                      task -> {
+                        if (task.isSuccessful()) {
+                          promise.resolve(null);
+                        } else if (task.isCanceled()) {
+                          promise.reject(
+                              "play-services-update-canceled",
+                              "Play Services update was canceled by the user");
+                        } else {
+                          Exception e = task.getException();
+                          promise.reject(
+                              "play-services-update-failed",
+                              e != null ? e.getMessage() : "Unknown error",
+                              e);
+                        }
+                      });
+            } else {
+              promise.resolve(null);
+            }
+          });
+    } else {
+      promise.resolve(null);
     }
-    promise.resolve(null);
   }
 
   private int isGooglePlayServicesAvailable() {


### PR DESCRIPTION
## Summary

- `GoogleApiAvailability.makeGooglePlayServicesAvailable()` requires main thread execution but was being called from a React Native background queue, causing `IllegalStateException` on some Android devices.
- Wraps the call in `UiThreadUtil.runOnUiThread()` in both the legacy module (`ReactNativeFirebaseUtilsModule`) and the Turbo module (`NativeRNFBTurboUtils`).
- In the Turbo module, the `Promise` is now wired to the Google `Task` result via `addOnCompleteListener`, handling success, cancellation, and failure so the JS promise always settles.
- Scope is limited to `makeGooglePlayServicesAvailable`; adjacent Play Services UI methods (`promptForPlayServices`, `resolutionForPlayServices`) are not changed in this PR.

Fixes #8948

## Test plan

- [ ] Build and run on an Android device without Google Play Services (or with outdated Play Services) and call `androidMakePlayServicesAvailable()` — should show the update dialog without crashing
- [ ] Dismiss the update dialog — JS promise should reject with `play-services-update-canceled`
- [ ] Verify normal flow on a device with current Play Services — should resolve immediately