### PR TITLE
fix(ios): set IPHONEOS_DEPLOYMENT_TARGET to 15.0 across all packages

### DIFF
--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -3,6 +3,7 @@
 Ad
 AdMob
 AirPods
+ai
 analytics
 Analytics
 args

--- a/docs/platforms.mdx
+++ b/docs/platforms.mdx
@@ -9,11 +9,10 @@ next: /faqs-and-tips
 
 By default React Native Firebase supports multiple platforms using the native Firebase SDK for the specific platform:
 
-| Platform | Minimum Version                      |
-| -------- | ------------------------------------ |
-| Android  | 5.0 (Lollipop) without Firebase Auth |
-|          | 6.0 (Marshmallow) with Firebase Auth |
-| iOS      | 13.0                                 |
+| Platform | Minimum Version            |
+| -------- | -------------------------- |
+| Android  | 6.0 (API 23 / Marshmallow) |
+| iOS      | 15.0                       |
 
 **Important** - To compile your application for Android, you will need a minimum JDK (Java Development Kit) version of `>= 17`.
 
@@ -27,24 +26,26 @@ these 'Other' platforms, e.g.;
 
 Below is a table outlining which Firebase modules are supported on each platform in React Native Firebase:
 
-| Firebase Service | Android | iOS | Other |
-| ---------------- | :-----: | :-: | :---: |
-| analytics        |   ✅    | ✅  |  ✅   |
-| app-check        |   ⚠️    | ⚠️  |  ⚠️   |
-| app-distribution |   ✅    | ✅  |  ❌   |
-| app              |   ✅    | ✅  |  ✅   |
-| auth             |   ✅    | ✅  |  ⚠️   |
-| crashlytics      |   ✅    | ✅  |  ❌   |
-| database         |   ✅    | ✅  |  ✅   |
-| firestore        |   ✅    | ✅  |  ⚠️   |
-| functions        |   ✅    | ✅  |  ✅   |
-| in-app-messaging |   ✅    | ✅  |  ❌   |
-| installations    |   ✅    | ✅  |  ❌   |
-| messaging        |   ✅    | ✅  |  ❌   |
-| ml               |   ✅    | ✅  |  ❌   |
-| perf             |   ✅    | ✅  |  ❌   |
-| remote-config    |   ✅    | ✅  |  ✅   |
-| storage          |   ✅    | ✅  |  ⚠️   |
+| Firebase Service          | Android | iOS | Other |
+| ------------------------- | :-----: | :-: | :---: |
+| ai                        |   ✅    | ✅  |  ✅   |
+| analytics                 |   ✅    | ✅  |  ✅   |
+| app                       |   ✅    | ✅  |  ✅   |
+| app-check                 |   ⚠️    | ⚠️  |  ⚠️   |
+| app-distribution          |   ✅    | ✅  |  ❌   |
+| auth                      |   ✅    | ✅  |  ⚠️   |
+| crashlytics               |   ✅    | ✅  |  ❌   |
+| database                  |   ✅    | ✅  |  ✅   |
+| firestore                 |   ✅    | ✅  |  ⚠️   |
+| functions                 |   ✅    | ✅  |  ✅   |
+| in-app-messaging          |   ✅    | ✅  |  ❌   |
+| installations             |   ✅    | ✅  |  ❌   |
+| messaging                 |   ✅    | ✅  |  ❌   |
+| ml                        |   ✅    | ✅  |  ❌   |
+| perf                      |   ✅    | ✅  |  ❌   |
+| phone-number-verification |   ✅    | ❌  |  ❌   |
+| remote-config             |   ✅    | ✅  |  ✅   |
+| storage                   |   ✅    | ✅  |  ⚠️   |
 
 - ✅ (supported)
 - ⚠️ (partial support) - see notes below

--- a/packages/analytics/ios/RNFBAnalytics.xcodeproj/project.pbxproj
+++ b/packages/analytics/ios/RNFBAnalytics.xcodeproj/project.pbxproj
@@ -163,7 +163,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -198,7 +198,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -260,7 +260,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -318,7 +318,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/app-check/ios/RNFBAppCheck.xcodeproj/project.pbxproj
+++ b/packages/app-check/ios/RNFBAppCheck.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/app-distribution/ios/RNFBAppDistribution.xcodeproj/project.pbxproj
+++ b/packages/app-distribution/ios/RNFBAppDistribution.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/app/ios/RNFBApp.xcodeproj/project.pbxproj
+++ b/packages/app/ios/RNFBApp.xcodeproj/project.pbxproj
@@ -218,7 +218,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -252,7 +252,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -310,7 +310,7 @@
 					"${SRCROOT}/../../../tests/ios/Pods/Headers/Public/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -374,7 +374,7 @@
 					"${SRCROOT}/../../../ios/Pods/Headers/Public/**",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/auth/ios/RNFBAuth.xcodeproj/project.pbxproj
+++ b/packages/auth/ios/RNFBAuth.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/crashlytics/ios/RNFBCrashlytics.xcodeproj/project.pbxproj
+++ b/packages/crashlytics/ios/RNFBCrashlytics.xcodeproj/project.pbxproj
@@ -169,7 +169,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -203,7 +203,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -264,7 +264,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -322,7 +322,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/database/ios/RNFBDatabase.xcodeproj/project.pbxproj
+++ b/packages/database/ios/RNFBDatabase.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -228,7 +228,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -289,7 +289,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -347,7 +347,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/firestore/ios/RNFBFirestore.xcodeproj/project.pbxproj
+++ b/packages/firestore/ios/RNFBFirestore.xcodeproj/project.pbxproj
@@ -200,7 +200,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -234,7 +234,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -295,7 +295,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -353,7 +353,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/functions/ios/RNFBFunctions.xcodeproj/project.pbxproj
+++ b/packages/functions/ios/RNFBFunctions.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/in-app-messaging/ios/RNFBFiam.xcodeproj/project.pbxproj
+++ b/packages/in-app-messaging/ios/RNFBFiam.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/installations/ios/RNFBInstallations.xcodeproj/project.pbxproj
+++ b/packages/installations/ios/RNFBInstallations.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/messaging/ios/RNFBMessaging.xcodeproj/project.pbxproj
+++ b/packages/messaging/ios/RNFBMessaging.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -228,7 +228,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -289,7 +289,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -347,7 +347,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -106,24 +106,13 @@ struct {
   // if list or banner is true, ignore `alert` property
   if (banner || list) {
     if (banner) {
-      if (@available(iOS 14, *)) {
-        presentationOptions |= UNNotificationPresentationOptionBanner;
-      } else {
-        // for iOS 13 we need to set `alert`
-        presentationOptions |= UNNotificationPresentationOptionAlert;
-      }
+      presentationOptions |= UNNotificationPresentationOptionBanner;
     }
 
     if (list) {
-      if (@available(iOS 14, *)) {
-        presentationOptions |= UNNotificationPresentationOptionList;
-      } else {
-        // for iOS 13 we need to set `alert`
-        presentationOptions |= UNNotificationPresentationOptionAlert;
-      }
+      presentationOptions |= UNNotificationPresentationOptionList;
     }
   } else if (alert) {
-    // TODO: Remove `alert` once iOS 14 becomes the minimum deployment target
     presentationOptions |= UNNotificationPresentationOptionAlert;
   }
 

--- a/packages/ml/ios/RNFBML.xcodeproj/project.pbxproj
+++ b/packages/ml/ios/RNFBML.xcodeproj/project.pbxproj
@@ -182,7 +182,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -216,7 +216,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -277,7 +277,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -335,7 +335,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/perf/ios/RNFBPerf.xcodeproj/project.pbxproj
+++ b/packages/perf/ios/RNFBPerf.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/remote-config/ios/RNFBConfig.xcodeproj/project.pbxproj
+++ b/packages/remote-config/ios/RNFBConfig.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/packages/storage/ios/RNFBStorage.xcodeproj/project.pbxproj
+++ b/packages/storage/ios/RNFBStorage.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -215,7 +215,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -276,7 +276,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -334,7 +334,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;

--- a/scripts/_TEMPLATE_/ios/RNFB_Template_.xcodeproj/project.pbxproj
+++ b/scripts/_TEMPLATE_/ios/RNFB_Template_.xcodeproj/project.pbxproj
@@ -159,7 +159,7 @@
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -193,7 +193,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-ObjC";
@@ -254,7 +254,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				OTHER_LDFLAGS = "$(inherited)";
@@ -312,7 +312,7 @@
 					"$(SRCROOT)/../../../node_modules/react-native-firebase/ios/**",
 					"$(SRCROOT)/../../../packages/app/ios/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				MACH_O_TYPE = staticlib;
 				ONLY_ACTIVE_ARCH = YES;


### PR DESCRIPTION
## Summary
- Updates `IPHONEOS_DEPLOYMENT_TARGET` from `10.0` to `15.0` in all 16 package pbxproj files and the `_TEMPLATE_` pbxproj
- Aligns with the `iosTarget: "15.0"` already declared in `packages/app/package.json` `sdkVersions`
- Prevents new packages generated from the template from reintroducing the stale `10.0` value

- Fixes #8882

## Test plan
- [x] Verified zero `IPHONEOS_DEPLOYMENT_TARGET = 10.0` values remain across all pbxproj files
- [x] `git diff --check` clean — no whitespace issues
- [ ] CI iOS build passes