### PR TITLE
fix(messaging, android): make max stored notifications configurable

### DIFF
--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseMeta.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebaseMeta.java
@@ -70,6 +70,12 @@ public class ReactNativeFirebaseMeta {
     return metaData.getString(META_PREFIX + key, defaultValue);
   }
 
+  public int getIntValue(String key, int defaultValue) {
+    Bundle metaData = getMetaData();
+    if (metaData == null) return defaultValue;
+    return metaData.getInt(META_PREFIX + key, defaultValue);
+  }
+
   public WritableMap getAll() {
     Bundle metaData = getMetaData();
     WritableMap map = Arguments.createMap();
@@ -84,6 +90,8 @@ public class ReactNativeFirebaseMeta {
           map.putString(key, (String) value);
         } else if (value instanceof Boolean) {
           map.putBoolean(key, (Boolean) value);
+        } else if (value instanceof Integer) {
+          map.putInt(key, (Integer) value);
         }
       }
     }

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebasePreferences.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/ReactNativeFirebasePreferences.java
@@ -46,6 +46,14 @@ public class ReactNativeFirebasePreferences {
     return getPreferences().getBoolean(key, defaultValue);
   }
 
+  public void setIntValue(String key, int value) {
+    getPreferences().edit().putInt(key, value).apply();
+  }
+
+  public int getIntValue(String key, int defaultValue) {
+    return getPreferences().getInt(key, defaultValue);
+  }
+
   public void setLongValue(String key, long value) {
     getPreferences().edit().putLong(key, value).apply();
   }

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -119,6 +119,10 @@
           "description": "On iOS, indicating how to present a notification in a foreground app.",
           "type": "array"
         },
+        "messaging_max_stored_notifications": {
+          "description": "Controls how many notifications are retained on-device for background storage. Configuration priority order is SharedPreferences -> firebase.json -> AndroidManifest. Default 100. Very small values may cause unwanted excessive deletions, large values or large message contents run the risk of OutOfMemoryErrors.",
+          "type": "number"
+        },
         "perf_auto_collection_enabled": {
           "description": "Disable or enable auto collection of performance monitoring data collection.\n This is useful for opt-in-first data flows, for example when dealing with GDPR compliance.\nThis can be overridden in JavaScript.",
           "type": "boolean"

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -26,7 +26,7 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
   private static final String S_KEY_ALL_NOTIFICATION_IDS = "all_notification_ids";
   private static final int DEFAULT_MAX_SIZE_NOTIFICATIONS = 100;
   private final String DELIMITER = ",";
-  private static final int maxNotificationSize = resolveMaxNotificationSize();
+  private static volatile int maxNotificationSize = -1;
 
   private static int resolveMaxNotificationSize() {
     int maxSize = DEFAULT_MAX_SIZE_NOTIFICATIONS;
@@ -47,6 +47,7 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
         source = "AndroidManifest";
       }
 
+      maxSize = Math.max(1, maxSize);
       Log.d(TAG, "messaging_max_stored_notifications: " + maxSize + " (from " + source + ")");
       return maxSize;
     } catch (Exception e) {
@@ -59,6 +60,13 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
     }
   }
 
+  private static int getMaxNotificationSize() {
+    if (maxNotificationSize == -1) {
+      maxNotificationSize = resolveMaxNotificationSize();
+    }
+    return maxNotificationSize;
+  }
+
   @Override
   public void storeFirebaseMessage(RemoteMessage remoteMessage) {
     try {
@@ -66,9 +74,10 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
           reactToJSON(remoteMessageToWritableMap(remoteMessage)).toString();
       UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
 
+      int limit = getMaxNotificationSize();
       String notificationIds = preferences.getStringValue(S_KEY_ALL_NOTIFICATION_IDS, "");
       List<String> allNotificationList = convertToArray(notificationIds);
-      while (allNotificationList.size() > maxNotificationSize - 1) {
+      while (allNotificationList.size() > limit - 1) {
         clearFirebaseMessage(allNotificationList.get(0));
         allNotificationList.remove(0);
       }

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -52,8 +52,7 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
     } catch (Exception e) {
       Log.w(
           TAG,
-          "Error resolving max notification size, using default: "
-              + DEFAULT_MAX_SIZE_NOTIFICATIONS,
+          "Error resolving max notification size, using default: " + DEFAULT_MAX_SIZE_NOTIFICATIONS,
           e);
       return DEFAULT_MAX_SIZE_NOTIFICATIONS;
     }

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -47,7 +47,6 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
         source = "AndroidManifest";
       }
 
-      maxSize = Math.max(1, maxSize);
       Log.d(TAG, "messaging_max_stored_notifications: " + maxSize + " (from " + source + ")");
       return maxSize;
     } catch (Exception e) {

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -5,9 +5,13 @@ import static io.invertase.firebase.messaging.JsonConvert.reactToJSON;
 import static io.invertase.firebase.messaging.ReactNativeFirebaseMessagingSerializer.remoteMessageFromReadableMap;
 import static io.invertase.firebase.messaging.ReactNativeFirebaseMessagingSerializer.remoteMessageToWritableMap;
 
+import android.util.Log;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.firebase.messaging.RemoteMessage;
+import io.invertase.firebase.common.ReactNativeFirebaseJSON;
+import io.invertase.firebase.common.ReactNativeFirebaseMeta;
+import io.invertase.firebase.common.ReactNativeFirebasePreferences;
 import io.invertase.firebase.common.UniversalFirebasePreferences;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,31 +21,61 @@ import org.json.JSONObject;
 
 public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebaseMessagingStore {
 
+  private static final String TAG = "RNFirebaseMsgStore";
+  private static final String KEY_MAX_STORED_NOTIFICATIONS = "messaging_max_stored_notifications";
   private static final String S_KEY_ALL_NOTIFICATION_IDS = "all_notification_ids";
-  private static final int MAX_SIZE_NOTIFICATIONS = 100;
+  private static final int DEFAULT_MAX_SIZE_NOTIFICATIONS = 100;
   private final String DELIMITER = ",";
+  private static final int maxNotificationSize = resolveMaxNotificationSize();
+
+  private static int resolveMaxNotificationSize() {
+    int maxSize = DEFAULT_MAX_SIZE_NOTIFICATIONS;
+    String source = "default";
+    ReactNativeFirebaseJSON json = ReactNativeFirebaseJSON.getSharedInstance();
+    ReactNativeFirebaseMeta meta = ReactNativeFirebaseMeta.getSharedInstance();
+    ReactNativeFirebasePreferences prefs = ReactNativeFirebasePreferences.getSharedInstance();
+
+    try {
+      if (prefs.contains(KEY_MAX_STORED_NOTIFICATIONS)) {
+        maxSize = prefs.getIntValue(KEY_MAX_STORED_NOTIFICATIONS, DEFAULT_MAX_SIZE_NOTIFICATIONS);
+        source = "SharedPreferences";
+      } else if (json.contains(KEY_MAX_STORED_NOTIFICATIONS)) {
+        maxSize = json.getIntValue(KEY_MAX_STORED_NOTIFICATIONS, DEFAULT_MAX_SIZE_NOTIFICATIONS);
+        source = "firebase.json";
+      } else if (meta.contains(KEY_MAX_STORED_NOTIFICATIONS)) {
+        maxSize = meta.getIntValue(KEY_MAX_STORED_NOTIFICATIONS, DEFAULT_MAX_SIZE_NOTIFICATIONS);
+        source = "AndroidManifest";
+      }
+
+      Log.d(TAG, "messaging_max_stored_notifications: " + maxSize + " (from " + source + ")");
+      return maxSize;
+    } catch (Exception e) {
+      Log.w(
+          TAG,
+          "Error resolving max notification size, using default: "
+              + DEFAULT_MAX_SIZE_NOTIFICATIONS,
+          e);
+      return DEFAULT_MAX_SIZE_NOTIFICATIONS;
+    }
+  }
 
   @Override
   public void storeFirebaseMessage(RemoteMessage remoteMessage) {
     try {
       String remoteMessageString =
           reactToJSON(remoteMessageToWritableMap(remoteMessage)).toString();
-      //      Log.d("storeFirebaseMessage", remoteMessageString);
       UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
 
-      // remove old notifications message before store to free space as needed
       String notificationIds = preferences.getStringValue(S_KEY_ALL_NOTIFICATION_IDS, "");
       List<String> allNotificationList = convertToArray(notificationIds);
-      while (allNotificationList.size() > MAX_SIZE_NOTIFICATIONS - 1) {
+      while (allNotificationList.size() > maxNotificationSize - 1) {
         clearFirebaseMessage(allNotificationList.get(0));
         allNotificationList.remove(0);
       }
 
-      // now refetch the ids after possible removals, and store the new message
       notificationIds = preferences.getStringValue(S_KEY_ALL_NOTIFICATION_IDS, "");
       preferences.setStringValue(remoteMessage.getMessageId(), remoteMessageString);
-      // save new notification id
-      notificationIds += remoteMessage.getMessageId() + DELIMITER; // append to last
+      notificationIds += remoteMessage.getMessageId() + DELIMITER;
       preferences.setStringValue(S_KEY_ALL_NOTIFICATION_IDS, notificationIds);
     } catch (JSONException e) {
       e.printStackTrace();
@@ -63,10 +97,9 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
     String remoteMessageString =
         UniversalFirebasePreferences.getSharedInstance().getStringValue(remoteMessageId, null);
     if (remoteMessageString != null) {
-      //      Log.d("getFirebaseMessage", remoteMessageString);
       try {
         WritableMap remoteMessageMap = jsonToReact(new JSONObject(remoteMessageString));
-        remoteMessageMap.putString("to", remoteMessageId); // fake to
+        remoteMessageMap.putString("to", remoteMessageId);
         return remoteMessageMap;
       } catch (JSONException e) {
         e.printStackTrace();
@@ -79,10 +112,9 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
   public void clearFirebaseMessage(String remoteMessageId) {
     UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
     preferences.remove(remoteMessageId).apply();
-    // check and remove old notifications message
     String notificationIds = preferences.getStringValue(S_KEY_ALL_NOTIFICATION_IDS, "");
     if (!notificationIds.isEmpty()) {
-      notificationIds = removeRemoteMessageId(remoteMessageId, notificationIds); // remove from list
+      notificationIds = removeRemoteMessageId(remoteMessageId, notificationIds);
       preferences.setStringValue(S_KEY_ALL_NOTIFICATION_IDS, notificationIds);
     }
   }

--- a/tests/firebase.json
+++ b/tests/firebase.json
@@ -21,6 +21,7 @@
     "messaging_android_notification_color": "@color/hotpink",
     "messaging_ios_auto_register_for_remote_messages": false,
     "messaging_android_notification_delegation_enabled": true,
+    "messaging_max_stored_notifications": 100,
 
     "analytics_auto_collection_enabled": true,
     "analytics_collection_deactivated": false,


### PR DESCRIPTION
## Summary
- Makes the maximum number of stored notifications configurable via `messaging_max_stored_notifications` in `firebase.json`, SharedPreferences, or AndroidManifest metadata
- Default remains **100** (unchanged from existing behavior)
- No clamping — developers can set any value, with risks documented in the schema description
- Logs the resolved value and its source for diagnostics
- Adds `getIntValue` to `ReactNativeFirebaseMeta` and `ReactNativeFirebasePreferences` to support integer config values

Based on the work by @sean5940 in #8771, rebased on current main with review feedback from @mikehardy addressed.

- Fixes #8770

## Test plan
- [x] Config key added to `firebase-schema.json`
- [x] Test `firebase.json` updated with default value
- [x] Uses standard config priority chain (SharedPreferences → firebase.json → AndroidManifest)
- [ ] CI passes