### PR TITLE
fix(app-check, ios): do not default to the debug provider in release builds

### DIFF
--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.m
@@ -32,10 +32,26 @@
   }
 
   if (self.providers[app.name] == nil) {
-    DLog(@"provider initializing (with default to debug) for app %@", app.name);
+    // This pre-configure default must not be "debug" in release builds. The Expo config
+    // plugin emits `RNFBAppCheckModule.sharedInstance()` BEFORE `FirebaseApp.configure()`
+    // in AppDelegate, so FIRAppCheckInterop — registered with
+    // FIRInstantiationTimingAlwaysEager — instantiates a provider from inside configure(),
+    // while providers[app.name] is still nil. Defaulting to debug therefore installs
+    // FIRAppCheckDebugProvider on release builds, which exchanges an unregistered debug
+    // token against firebaseappcheck.googleapis.com: 403 "App attestation failed", and 429
+    // once the per-project debug-token quota saturates. See discussion #7518.
+    //
+    // DEBUG builds keep the debug default, which local development with debug tokens
+    // relies on.
+#if DEBUG
+    NSString *defaultProviderName = @"debug";
+#else
+    NSString *defaultProviderName = @"appAttestWithDeviceCheckFallback";
+#endif
+    DLog(@"provider initializing (with default to %@) for app %@", defaultProviderName, app.name);
     self.providers[app.name] = [RNFBAppCheckProvider new];
     RNFBAppCheckProvider *provider = self.providers[app.name];
-    [provider configure:app providerName:@"debug" debugToken:nil];
+    [provider configure:app providerName:defaultProviderName debugToken:nil];
   }
 
   return self.providers[app.name];


### PR DESCRIPTION

### Description

On iOS, release builds using the Expo config plugin exchange App Check **debug** tokens against `firebaseappcheck.googleapis.com`, getting `403 App attestation failed` and then `429` once the per-project debug-token quota (60/min, not adjustable) saturates.

The config plugin emits `RNFBAppCheckModule.sharedInstance()` **before** `FirebaseApp.configure()` in `AppDelegate`. `sharedInstance()` registers the provider factory with a nil `providers` dictionary; `configure()` then instantiates `FIRAppCheckInterop` eagerly (`FIRInstantiationTimingAlwaysEager`), which calls `createProviderWithApp:` while `providers[app.name]` is still nil. The factory defaults that case to `@"debug"`, so release builds get `FIRAppCheckDebugProvider` and exchange an unregistered token.

This changes the pre-configure default to `appAttestWithDeviceCheckFallback` outside `DEBUG` builds, matching what the JS layer configures moments later anyway. `DEBUG` builds keep the debug default, which local development with debug tokens relies on. `RNFBAppCheckProvider` already handles the iOS 14 / tvOS 15 availability fallback for that provider name.

Fixing the factory rather than the plugin's line order means the outcome holds regardless of who calls the factory or in what sequence, so it survives future plugin and SDK changes. **The ordering is arguably the deeper fix**, but changing the emitted `AppDelegate` affects every consumer, and I can't test that blast radius across Objective-C and Swift AppDelegates and older plugin versions — so I've left it alone and described it in the issue instead. Happy to follow up if you'd prefer that direction, or a different non-debug default.

Android is unaffected — `ReactNativeFirebaseAppCheckProviderFactory.create()` throws rather than defaulting to debug.

The debug default dates to `ee7df855` ("feat(app-check): add custom factory/provider", 2023-01-19) and is unchanged on `main`.

**On tests:** there is no existing jest or e2e coverage for `RNFBAppCheckProviderFactory` — it is native Objective-C with no test target in this package, and the behaviour needs a release-configuration build to observe. I have left the test checkboxes unticked rather than claim coverage that does not exist; happy to add one if you can point me at where it should live.

### Related issues

Fixes #9116

Previously reported, uncaused, in discussion [#7518](https://github.com/invertase/react-native-firebase/discussions/7518) (open since 2023-12-19) and [StackOverflow 77673428](https://stackoverflow.com/questions/77673428/react-native-with-firebase-appcheck-uses-exchangedebugtoken-url-in-release-build). Both threads assume a race condition; the misconfiguration is deterministic — only the exchange timing varies, which is why it presents as intermittent.

### Release Summary

iOS: App Check no longer installs the debug provider in release builds, which caused `exchangeDebugToken` 403/429 traffic and could saturate the project's debug-token quota.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

