### PR TITLE
fix(deps): remove unsupported semver cooldown keys from github-actions dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,8 +25,5 @@ updates:
       interval: 'daily'
     cooldown:
       default-days: 7
-      semver-major-days: 7
-      semver-minor-days: 7
-      semver-patch-days: 7
     labels:
       - 'dependencies'


### PR DESCRIPTION
### Description

`.github/dependabot.yml`'s config-validation check has been failing on every PR since #9056 merged, because the `github-actions` package-ecosystem entry was given the same `semver-major-days`/`semver-minor-days`/`semver-patch-days` cooldown keys as the `npm` entry, but Dependabot only supports those granular semver-based cooldown keys for ecosystems with semver releases. `github-actions` isn't one of them, so every PR shows a failing (non-blocking) `.github/dependabot.yml` check with:

```
The property '#/updates/1/cooldown/semver-major-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-minor-days' is not supported for the package ecosystem 'github-actions'.
The property '#/updates/1/cooldown/semver-patch-days' is not supported for the package ecosystem 'github-actions'.
```

This drops those three unsupported keys from the `github-actions` block, keeping `default-days: 7` (still enforces the same cooldown, just not broken down per semver bump type, which `github-actions` doesn't support anyway since Action releases aren't reliably semver).

Found while investigating an unrelated failing check on #9018.

### Related issues

N/A

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [x] `Other` (config-only, no platform code)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No