### PR TITLE
fix(ios): wire prebuilt React-Core and allow non-modular React imports for use_frameworks! (RN 0.84+)

### DIFF
--- a/packages/analytics/RNFBAnalytics.podspec
+++ b/packages/analytics/RNFBAnalytics.podspec
@@ -39,6 +39,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/app-check/RNFBAppCheck.podspec
+++ b/packages/app-check/RNFBAppCheck.podspec
@@ -34,6 +34,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/app-distribution/RNFBAppDistribution.podspec
+++ b/packages/app-distribution/RNFBAppDistribution.podspec
@@ -33,6 +33,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -44,6 +44,22 @@ Pod::Spec.new do |s|
     s.dependency "React-Core"
   end
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if (ENV.include?('FIREBASE_SDK_VERSION'))
     Pod::UI.puts "#{s.name}: Found Firebase SDK version in environment '#{ENV['FIREBASE_SDK_VERSION']}'"
     $FirebaseSDKVersion = ENV['FIREBASE_SDK_VERSION']

--- a/packages/auth/RNFBAuth.podspec
+++ b/packages/auth/RNFBAuth.podspec
@@ -42,6 +42,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/crashlytics/RNFBCrashlytics.podspec
+++ b/packages/crashlytics/RNFBCrashlytics.podspec
@@ -40,6 +40,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/database/RNFBDatabase.podspec
+++ b/packages/database/RNFBDatabase.podspec
@@ -47,6 +47,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/firestore/RNFBFirestore.podspec
+++ b/packages/firestore/RNFBFirestore.podspec
@@ -46,6 +46,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   # Fail fast for old architecture users, but safely in case the variable goes away
   # completely in future react-native versions
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')

--- a/packages/functions/RNFBFunctions.podspec
+++ b/packages/functions/RNFBFunctions.podspec
@@ -36,6 +36,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   # Fail fast for old architecture users, but safely in case the variable goes away
   # completely in future react-native versions
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')

--- a/packages/in-app-messaging/RNFBInAppMessaging.podspec
+++ b/packages/in-app-messaging/RNFBInAppMessaging.podspec
@@ -36,6 +36,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/installations/RNFBInstallations.podspec
+++ b/packages/installations/RNFBInstallations.podspec
@@ -36,6 +36,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/messaging/RNFBMessaging.podspec
+++ b/packages/messaging/RNFBMessaging.podspec
@@ -34,6 +34,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/ml/RNFBML.podspec
+++ b/packages/ml/RNFBML.podspec
@@ -37,6 +37,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/perf/RNFBPerf.podspec
+++ b/packages/perf/RNFBPerf.podspec
@@ -36,6 +36,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/remote-config/RNFBRemoteConfig.podspec
+++ b/packages/remote-config/RNFBRemoteConfig.podspec
@@ -36,6 +36,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end

--- a/packages/storage/RNFBStorage.podspec
+++ b/packages/storage/RNFBStorage.podspec
@@ -34,6 +34,22 @@ Pod::Spec.new do |s|
 
   install_modules_dependencies(s);
 
+  # RN 0.83+ (default on 0.84+) ships a prebuilt React-Core (RCT_USE_PREBUILT_RNCORE=1).
+  # Wire it up so the legacy <React/...> header imports resolve against the prebuilt
+  # framework. Guarded for older react-native versions where the helper is absent.
+  if defined?(add_rncore_dependency)
+    add_rncore_dependency(s)
+  end
+
+  # RNFB's Objective-C sources import <React/...> headers non-modularly. When a consumer
+  # builds with use_frameworks! (Expo's default, and required by the firebase-ios-sdk),
+  # RNFB is compiled as a framework module and Clang rejects those imports with
+  # -Wnon-modular-include-in-framework-module ("must be imported from module 'React'").
+  # Allow them so the framework module validates. Merge so any existing config is kept.
+  s.pod_target_xcconfig = (s.to_hash["pod_target_xcconfig"] || {}).merge({
+    "CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES" => "YES",
+  })
+
   if defined?(ENV["RCT_NEW_ARCH_ENABLED"]) != nil && (ENV["RCT_NEW_ARCH_ENABLED"] == '0')
      raise "#{s.name} requires New Architecture. Enable New Architecture to use this module"
   end


### PR DESCRIPTION
## Description

React Native 0.83+ ships a **prebuilt React-Core** and enables it by default on 0.84+ (`RCT_USE_PREBUILT_RNCORE=1`). This breaks `react-native-firebase` iOS builds in two ways:

1. **Header resolution** — the legacy `<React/...>` imports in RNFB's Objective-C sources (`RCTConvert.h`, `RCTBridgeModule.h`, `RCTEventEmitter.h`, …) need the prebuilt React-Core wired via React Native's `add_rncore_dependency` helper.

2. **Framework module validation** — when a consumer builds with `use_frameworks!` (Expo's default, and required by the `firebase-ios-sdk`), each RNFB pod is compiled as a **framework module**. Clang then rejects the non-modular `<React/...>` includes with:

   ```
   error: 'React/RCTConvert.h' must be imported from module 'React' before it is required
   [-Werror,-Wnon-modular-include-in-framework-module]
   ```

Both are fixed here across all 16 package podspecs:

- Call `add_rncore_dependency(s)`, guarded with `if defined?(...)` so older `react-native` versions are unaffected.
- Set `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES`, **merged** into any existing `pod_target_xcconfig` so per-package settings (e.g. generated TurboModule header search paths in analytics/auth/firestore/storage/etc.) are preserved rather than overwritten.

## Related

- Closes the same class of issue as #8883.
- Alternative to #9024, rebased on current `main`; uses a non-destructive `.merge` on `pod_target_xcconfig` to avoid clobbering the newer per-package `HEADER_SEARCH_PATHS` entries.

## Effect for consumers

Removes the need for the common workarounds:
- `ENV['RCT_USE_PREBUILT_RNCORE'] = '0'` (forces React-Core to rebuild from source — slow clean builds)
- `expo-build-properties` `forceStaticLinking` listing every RNFB package

## Test plan

- [x] `pod install` with `use_frameworks! :linkage => :static` + `$RNFirebaseAsStaticFramework = true` on RN 0.84.x, default `RCT_USE_PREBUILT_RNCORE` (prebuilt), New Architecture.
- [x] Clean iOS build of an app using `@react-native-firebase/{app,analytics,crashlytics,messaging}` — compiles without the `RCT_USE_PREBUILT_RNCORE=0` workaround.
- [x] Ruby syntax check on all podspecs (`ruby -c`) — passing.