### PR TITLE
test(ios): correct testing app bundle id to io.invertase.testing

### DIFF
--- a/.github/workflows/scripts/boot-simulator.sh
+++ b/.github/workflows/scripts/boot-simulator.sh
@@ -82,7 +82,7 @@ kill_resolved_simulator() {
 
   log_boot_status "phase=kill_resolved udid=${udid} device=\"${device}\""
   killall Simulator 2>/dev/null || true
-  xcrun simctl terminate "$udid" com.invertase.testing 2>/dev/null || true
+  xcrun simctl terminate "$udid" io.invertase.testing 2>/dev/null || true
   xcrun simctl shutdown "$udid" 2>/dev/null || true
   xcrun simctl shutdown "$device" 2>/dev/null || true
 }

--- a/okf-bundle/ci-workflows/ios.md
+++ b/okf-bundle/ci-workflows/ios.md
@@ -144,7 +144,7 @@ rg 'No script URL provided|com\.facebook\.react\.log' sim-app.log
 rg -i 'invertase|FrontBoard|unknown' sim-app.log
 ```
 
-Long `datamigrator` activity with no `com.invertase.testing` means migration/pre-boot install not done.
+Long `datamigrator` activity with no `io.invertase.testing` means migration/pre-boot install not done.
 
 ### Detox configuration
 
@@ -448,7 +448,7 @@ Failed to transform failure: Bundle was not loaded from Metro.
 
 ```
 FBSOpenApplicationServiceErrorDomain
-Application "com.invertase.testing" is unknown to FrontBoard
+Application "io.invertase.testing" is unknown to FrontBoard
 ```
 
 Often preceded by `[rnfb-e2e] terminateApp ... elapsed=60000ms` (or similar) in `detox-step-*_log`.

--- a/okf-bundle/testing/running-e2e.md
+++ b/okf-bundle/testing/running-e2e.md
@@ -625,7 +625,7 @@ Do **not** treat this redbox as a missing TurboModule registration until the ref
 - **iOS** — `xcrun simctl spawn booted log stream --level debug --style compact --predicate 'process == "testing"'`; silent hangs: `sample <pid>` on `testing`. Metro redbox **`Requiring unknown module "undefined"`** → [TurboModule stale toolchain](#turbomodule-stale-toolchain-blocking), not registration checklist alone.
 - **Android** — `adb logcat` (filter your tags)
 
-**Benign noise:** iOS Detox `EXEC_FAIL "xcrun simctl terminate … com.invertase.testing" … found nothing to terminate` — app wasn't running; ignore.
+**Benign noise:** iOS Detox `EXEC_FAIL "xcrun simctl terminate … io.invertase.testing" … found nothing to terminate` — app wasn't running; ignore.
 
 **Cloud API pressure** — Installations / Remote Config failures with FIS 503 or “Too many server requests” are live-project quota on **any** platform, not emulator issues. See [Firebase testing project — CI triage](firebase-testing-project.md#ci-triage-cloud-api-quota-pressure).
 

--- a/packages/app-check/e2e/appcheck.e2e.js
+++ b/packages/app-check/e2e/appcheck.e2e.js
@@ -230,6 +230,7 @@ describe('appCheck()', function () {
           },
           apple: {
             provider: 'debug',
+            debugToken: getRandomToken(),
           },
           web: {
             provider: 'debug',

--- a/packages/auth/e2e/auth.e2e.js
+++ b/packages/auth/e2e/auth.e2e.js
@@ -1100,7 +1100,7 @@ describe('auth() modular', function () {
 
           const successfulKeychain = await useUserAccessGroup(
             defaultAuth,
-            'YYX2P3XVJ7.com.invertase.testing',
+            'YYX2P3XVJ7.io.invertase.testing',
           ); // iOS signing team is YYX2P3XVJ7
 
           should.not.exist(successfulKeychain);

--- a/scripts/tart/lib/boot-simulator.sh
+++ b/scripts/tart/lib/boot-simulator.sh
@@ -110,7 +110,7 @@ kill_resolved_simulator() {
 
   log_boot_status "phase=kill_resolved udid=${udid} device=\"${device}\""
   killall Simulator 2>/dev/null || true
-  xcrun simctl terminate "$udid" com.invertase.testing 2>/dev/null || true
+  xcrun simctl terminate "$udid" io.invertase.testing 2>/dev/null || true
   xcrun simctl shutdown "$udid" 2>/dev/null || true
   xcrun simctl shutdown "$device" 2>/dev/null || true
 }

--- a/tests/e2e/firebase.test.js
+++ b/tests/e2e/firebase.test.js
@@ -210,7 +210,7 @@ function logLaunchInstallState(label) {
 
     try {
       const container = execSync(
-        `/usr/bin/xcrun simctl get_app_container ${udid} com.invertase.testing 2>&1`,
+        `/usr/bin/xcrun simctl get_app_container ${udid} io.invertase.testing 2>&1`,
         { encoding: 'utf8', timeout: 15000 },
       ).trim();
       console.log(`[rnfb-e2e] install-state label=${label} udid=${udid} container=${container}`);
@@ -227,7 +227,7 @@ function logLaunchInstallState(label) {
         timeout: 30000,
       });
       const invertaseLine =
-        apps.split('\n').find(line => line.includes('com.invertase.testing')) || '(not listed)';
+        apps.split('\n').find(line => line.includes('io.invertase.testing')) || '(not listed)';
       console.log(`[rnfb-e2e] install-state label=${label} listapps=${invertaseLine.trim()}`);
     } catch (err) {
       console.warn(

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -163,7 +163,7 @@ global.FirebaseHelpers = {
     config() {
       if (global.Platform.ios) {
         return {
-          clientId: '448618578101-28tsenal97nceuij1msj7iuqinv48t02.apps.googleusercontent.com',
+          clientId: '448618578101-4km55qmv55tguvnivgjdiegb3r0jquv5.apps.googleusercontent.com',
           androidClientId:
             '448618578101-pdjje2lkv3p941e03hkrhfa7459cr2v8.apps.googleusercontent.com',
           appId: '1:448618578101:ios:3e76955ab6d49ecaac3efc',

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -166,7 +166,7 @@ global.FirebaseHelpers = {
           clientId: '448618578101-28tsenal97nceuij1msj7iuqinv48t02.apps.googleusercontent.com',
           androidClientId:
             '448618578101-pdjje2lkv3p941e03hkrhfa7459cr2v8.apps.googleusercontent.com',
-          appId: '1:448618578101:ios:cc6c1dc7a65cc83c',
+          appId: '1:448618578101:ios:3e76955ab6d49ecaac3efc',
           apiKey: 'AIzaSyAHAsf51D0A407EklG1bs-5wA7EbyfNFg0',
           authDomain: 'react-native-firebase-testing.firebaseapp.com',
           databaseURL: 'https://react-native-firebase-testing.firebaseio.com',

--- a/tests/ios/GoogleService-Info.plist
+++ b/tests/ios/GoogleService-Info.plist
@@ -2,14 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AD_UNIT_ID_FOR_BANNER_TEST</key>
-	<string>ca-app-pub-3940256099942544/2934735716</string>
-	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
-	<string>ca-app-pub-3940256099942544/4411468910</string>
 	<key>CLIENT_ID</key>
-	<string>448618578101-28tsenal97nceuij1msj7iuqinv48t02.apps.googleusercontent.com</string>
+	<string>448618578101-4km55qmv55tguvnivgjdiegb3r0jquv5.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.448618578101-28tsenal97nceuij1msj7iuqinv48t02</string>
+	<string>com.googleusercontent.apps.448618578101-4km55qmv55tguvnivgjdiegb3r0jquv5</string>
+	<key>ANDROID_CLIENT_ID</key>
+	<string>448618578101-a9p7bj5jlakabp22fo3cbkj7nsmag24e.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
 	<string>AIzaSyAHAsf51D0A407EklG1bs-5wA7EbyfNFg0</string>
 	<key>GCM_SENDER_ID</key>
@@ -17,23 +15,23 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.invertase.testing</string>
+	<string>io.invertase.testing</string>
 	<key>PROJECT_ID</key>
 	<string>react-native-firebase-testing</string>
 	<key>STORAGE_BUCKET</key>
 	<string>react-native-firebase-testing.appspot.com</string>
 	<key>IS_ADS_ENABLED</key>
-	<true></true>
+	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
 	<false></false>
 	<key>IS_APPINVITE_ENABLED</key>
-	<false></false>
+	<true></true>
 	<key>IS_GCM_ENABLED</key>
 	<true></true>
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:448618578101:ios:cc6c1dc7a65cc83c</string>
+	<string>1:448618578101:ios:3e76955ab6d49ecaac3efc</string>
 	<key>DATABASE_URL</key>
 	<string>https://react-native-firebase-testing.firebaseio.com</string>
 </dict>

--- a/tests/ios/testing.xcodeproj/project.pbxproj
+++ b/tests/ios/testing.xcodeproj/project.pbxproj
@@ -476,7 +476,7 @@
 					"-ObjC",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -profile-generate -profile-coverage-mapping";
-				PRODUCT_BUNDLE_IDENTIFIER = com.invertase.testing;
+				PRODUCT_BUNDLE_IDENTIFIER = io.invertase.testing;
 				PRODUCT_NAME = testing;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
@@ -535,7 +535,7 @@
 					"-ObjC",
 				);
 				OTHER_SWIFT_FLAGS = "$(inherited) -profile-generate -profile-coverage-mapping";
-				PRODUCT_BUNDLE_IDENTIFIER = com.invertase.testing;
+				PRODUCT_BUNDLE_IDENTIFIER = io.invertase.testing;
 				PRODUCT_NAME = testing;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ENABLE_EXPLICIT_MODULES = NO;

--- a/tests/ios/testing/Info.plist
+++ b/tests/ios/testing/Info.plist
@@ -26,7 +26,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>com.googleusercontent.apps.305229645282-9i07a33r4sj2fmrshnmh8jkh52dgpdve</string>
-				<string>com.googleusercontent.apps.448618578101-28tsenal97nceuij1msj7iuqinv48t02</string>
+				<string>com.googleusercontent.apps.448618578101-4km55qmv55tguvnivgjdiegb3r0jquv5</string>
 			</array>
 		</dict>
 		<dict>

--- a/tests/ios/testing/testing.entitlements
+++ b/tests/ios/testing/testing.entitlements
@@ -14,7 +14,7 @@
 	</array>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.invertase.testing</string>
+		<string>$(AppIdentifierPrefix)io.invertase.testing</string>
 	</array>
 </dict>
 </plist>

--- a/tests/local-tests/auth/README-apple-full-name.md
+++ b/tests/local-tests/auth/README-apple-full-name.md
@@ -21,7 +21,7 @@ hand-typed fake one.
 
 ## One-time setup
 
-1. **Apple Developer account**: ensure the app's App ID (`com.invertase.testing`, team `YYX2P3XVJ7`
+1. **Apple Developer account**: ensure the app's App ID (`io.invertase.testing`, team `YYX2P3XVJ7`
    per the existing Xcode project) has the **Sign in with Apple** capability enabled at
    [developer.apple.com](https://developer.apple.com/account/resources/identifiers/list) →
    Identifiers → your App ID → capabilities. If you're using your own team/App ID for local
@@ -33,11 +33,6 @@ hand-typed fake one.
      build you still need it enabled on the App ID above so a matching provisioning profile can
      be issued (automatic signing will regenerate the profile once the capability is enabled).
      Simulator builds do not require a real provisioning profile.
-   - Note: at the time of writing, `com.invertase.testing` is not the App ID actually registered
-     on the Apple Developer Portal for this team (`io.invertase.testing` is) — a separate PR
-     tracks correcting `PRODUCT_BUNDLE_IDENTIFIER` and `GoogleService-Info.plist` to match. Until
-     that lands, real-device testing needs a locally-modified bundle id/provisioning profile;
-     Simulator builds are unaffected.
 
 2. **Firebase console**: enable the **Apple** sign-in provider for the test project
    (`react-native-firebase-testing`) under Authentication → Sign-in method.

--- a/tests/scripts/pull-native-coverage.js
+++ b/tests/scripts/pull-native-coverage.js
@@ -2,7 +2,9 @@ const { execSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const TEST_APP_PACKAGE = 'com.invertase.testing';
+// Android applicationId stays com.invertase.testing; iOS PRODUCT_BUNDLE_IDENTIFIER is io.invertase.testing.
+const ANDROID_TEST_APP_PACKAGE = 'com.invertase.testing';
+const IOS_TEST_APP_BUNDLE_ID = 'io.invertase.testing';
 const ANDROID_COVERAGE_RELATIVE_PATH = 'files/coverage.ec';
 
 function getAdbBinary() {
@@ -41,7 +43,7 @@ function androidCoverageFileExists(deviceId) {
 
   try {
     execSync(
-      `${adb} ${serial} shell "run-as ${TEST_APP_PACKAGE} test -f ${ANDROID_COVERAGE_RELATIVE_PATH}"`,
+      `${adb} ${serial} shell "run-as ${ANDROID_TEST_APP_PACKAGE} test -f ${ANDROID_COVERAGE_RELATIVE_PATH}"`,
       { stdio: 'pipe' },
     );
     return true;
@@ -60,7 +62,7 @@ function pullAndroidCoverage(deviceId, options = {}) {
 
   try {
     execSync(
-      `${adb} ${serial} shell "run-as ${TEST_APP_PACKAGE} cat ${ANDROID_COVERAGE_RELATIVE_PATH} > ${emuDest}"`,
+      `${adb} ${serial} shell "run-as ${ANDROID_TEST_APP_PACKAGE} cat ${ANDROID_COVERAGE_RELATIVE_PATH} > ${emuDest}"`,
     );
     fs.mkdirSync(localDestDir, { recursive: true });
     execSync(`${adb} ${serial} pull ${emuDest} ${localDestFile}`);
@@ -112,9 +114,12 @@ async function pullAndroidCoverageWithRetry(deviceId, options = {}) {
 function pullIosCoverage(deviceId, options = {}) {
   const testsDir = options.testsDir || path.resolve(__dirname, '..');
   const localDestDir = path.join(testsDir, 'ios/build/output/coverage');
-  const container = execSync(`xcrun simctl get_app_container ${deviceId} ${TEST_APP_PACKAGE} data`, {
-    encoding: 'utf8',
-  }).trim();
+  const container = execSync(
+    `xcrun simctl get_app_container ${deviceId} ${IOS_TEST_APP_BUNDLE_ID} data`,
+    {
+      encoding: 'utf8',
+    },
+  ).trim();
   fs.mkdirSync(localDestDir, { recursive: true });
 
   const profrawList = execSync(


### PR DESCRIPTION
## Summary
- The testing app's iOS bundle id (`com.invertase.testing`) is not registered on the team's Apple Developer Portal, only `io.invertase.testing` is, so Xcode cannot provision/build the app for on-device testing.
- Updates `PRODUCT_BUNDLE_IDENTIFIER` in `tests/ios/testing.xcodeproj/project.pbxproj`, the `keychain-access-groups` entitlement, and the Google Sign-In URL scheme in `Info.plist` to match.
- Re-downloads `GoogleService-Info.plist` for the `io.invertase.testing` Firebase iOS app so Firebase/Google Sign-In config matches the corrected bundle id.
- Updates the two iOS-specific `com.invertase.testing` references in `tests/e2e/firebase.test.js` (simulator app-container/listapps checks). Android identifiers are untouched since the Android `applicationId`/package namespace is a separate, unaffected value.
