### PR TITLE
feat(messaging): make expo plugin configurable for notification icon and color

### DIFF
--- a/packages/messaging/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/messaging/plugin/__tests__/androidPlugin.test.ts
@@ -8,6 +8,7 @@ import {
   expoNotificationsConfigWithoutPluginExample,
   pluginPropsConfigExample,
   pluginPropsConfigWithoutColorExample,
+  pluginPropsColorOnlyExample,
 } from './fixtures/expo-config-example';
 import manifestApplicationExample from './fixtures/application-example';
 import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
@@ -203,6 +204,27 @@ describe('Config Plugin Android Tests', function () {
         $: {
           'android:name': 'com.google.firebase.messaging.default_notification_icon',
           'android:resource': '@drawable/notification_icon',
+        },
+      });
+    });
+
+    it('color-only props fall through to expo-notifications for icon', async function () {
+      const config: ExpoConfig = JSON.parse(JSON.stringify(expoNotificationsConfigExample));
+      const manifestApplication: ManifestApplication = JSON.parse(
+        JSON.stringify(manifestApplicationExample),
+      );
+      setFireBaseMessagingAndroidManifest(config, manifestApplication, pluginPropsColorOnlyExample);
+      expect(manifestApplication['meta-data']).toContainEqual({
+        $: {
+          'android:name': 'com.google.firebase.messaging.default_notification_icon',
+          'android:resource': '@drawable/notification_icon',
+        },
+      });
+      expect(manifestApplication['meta-data']).toContainEqual({
+        $: {
+          'android:name': 'com.google.firebase.messaging.default_notification_color',
+          'android:resource': '@color/notification_icon_color',
+          'tools:replace': 'android:resource',
         },
       });
     });

--- a/packages/messaging/plugin/__tests__/androidPlugin.test.ts
+++ b/packages/messaging/plugin/__tests__/androidPlugin.test.ts
@@ -6,6 +6,8 @@ import {
   expoNotificationsConfigExample,
   expoNotificationsConfigWithoutColorExample,
   expoNotificationsConfigWithoutPluginExample,
+  pluginPropsConfigExample,
+  pluginPropsConfigWithoutColorExample,
 } from './fixtures/expo-config-example';
 import manifestApplicationExample from './fixtures/application-example';
 import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
@@ -137,6 +139,72 @@ describe('Config Plugin Android Tests', function () {
       expect(called).toBeTruthy();
       // eslint-disable-next-line no-console
       console.warn = warnOrig;
+    });
+  });
+
+  describe('plugin props config', () => {
+    it('applies changes to app/src/main/AndroidManifest.xml with icon and color from plugin props', async function () {
+      const config: ExpoConfig = JSON.parse(
+        JSON.stringify(expoNotificationsConfigWithoutPluginExample),
+      );
+      const manifestApplication: ManifestApplication = JSON.parse(
+        JSON.stringify(manifestApplicationExample),
+      );
+      setFireBaseMessagingAndroidManifest(config, manifestApplication, pluginPropsConfigExample);
+      expect(manifestApplication['meta-data']).toContainEqual({
+        $: {
+          'android:name': 'com.google.firebase.messaging.default_notification_icon',
+          'android:resource': '@drawable/notification_icon',
+        },
+      });
+      expect(manifestApplication['meta-data']).toContainEqual({
+        $: {
+          'android:name': 'com.google.firebase.messaging.default_notification_color',
+          'android:resource': '@color/notification_icon_color',
+          'tools:replace': 'android:resource',
+        },
+      });
+    });
+
+    it('applies changes to app/src/main/AndroidManifest.xml with icon only from plugin props', async function () {
+      const config: ExpoConfig = JSON.parse(
+        JSON.stringify(expoNotificationsConfigWithoutPluginExample),
+      );
+      const manifestApplication: ManifestApplication = JSON.parse(
+        JSON.stringify(manifestApplicationExample),
+      );
+      setFireBaseMessagingAndroidManifest(
+        config,
+        manifestApplication,
+        pluginPropsConfigWithoutColorExample,
+      );
+      expect(manifestApplication['meta-data']).toContainEqual({
+        $: {
+          'android:name': 'com.google.firebase.messaging.default_notification_icon',
+          'android:resource': '@drawable/notification_icon',
+        },
+      });
+      expect(manifestApplication['meta-data']).not.toContainEqual(
+        expect.objectContaining({
+          $: expect.objectContaining({
+            'android:name': 'com.google.firebase.messaging.default_notification_color',
+          }),
+        }),
+      );
+    });
+
+    it('plugin props take priority over expo-notifications config', async function () {
+      const config: ExpoConfig = JSON.parse(JSON.stringify(expoNotificationsConfigExample));
+      const manifestApplication: ManifestApplication = JSON.parse(
+        JSON.stringify(manifestApplicationExample),
+      );
+      setFireBaseMessagingAndroidManifest(config, manifestApplication, pluginPropsConfigExample);
+      expect(manifestApplication['meta-data']).toContainEqual({
+        $: {
+          'android:name': 'com.google.firebase.messaging.default_notification_icon',
+          'android:resource': '@drawable/notification_icon',
+        },
+      });
     });
   });
 });

--- a/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
@@ -59,6 +59,12 @@ const pluginPropsConfigWithoutColorExample: PluginConfigType = {
   },
 };
 
+const pluginPropsColorOnlyExample: PluginConfigType = {
+  android: {
+    notificationColor: '#1D172D',
+  },
+};
+
 export {
   expoConfigExample,
   expoNotificationsConfigExample,
@@ -66,4 +72,5 @@ export {
   expoNotificationsConfigWithoutPluginExample,
   pluginPropsConfigExample,
   pluginPropsConfigWithoutColorExample,
+  pluginPropsColorOnlyExample,
 };

--- a/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
+++ b/packages/messaging/plugin/__tests__/fixtures/expo-config-example.ts
@@ -1,4 +1,5 @@
 import { ExpoConfig } from '@expo/config-types';
+import { PluginConfigType } from '../../src/pluginConfig';
 
 /**
  * @type {import('@expo/config-types').ExpoConfig}
@@ -45,9 +46,24 @@ const expoNotificationsConfigWithoutPluginExample: ExpoConfig = {
   slug: 'fire-base-messaging-test',
 };
 
+const pluginPropsConfigExample: PluginConfigType = {
+  android: {
+    notificationIcon: 'IconAsset',
+    notificationColor: '#1D172D',
+  },
+};
+
+const pluginPropsConfigWithoutColorExample: PluginConfigType = {
+  android: {
+    notificationIcon: 'IconAsset',
+  },
+};
+
 export {
   expoConfigExample,
   expoNotificationsConfigExample,
   expoNotificationsConfigWithoutColorExample,
   expoNotificationsConfigWithoutPluginExample,
+  pluginPropsConfigExample,
+  pluginPropsConfigWithoutColorExample,
 };

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -33,7 +33,7 @@ export const withExpoPluginFirebaseNotification: ConfigPlugin<PluginConfigType |
 // Helper function to get notification icon and color from plugin props, expo-notifications, or config.notification
 const getNotificationConfig = (config: ExpoConfig, props?: PluginConfigType) => {
   // 1. Check props passed directly to @react-native-firebase/messaging plugin
-  if (props?.android?.notificationIcon || props?.android?.notificationColor) {
+  if (props?.android?.notificationIcon) {
     return {
       icon: props.android.notificationIcon,
       color: props.android.notificationColor,

--- a/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
+++ b/packages/messaging/plugin/src/android/setupFirebaseNotifationIcon.ts
@@ -1,6 +1,7 @@
 import { ConfigPlugin, withAndroidManifest } from '@expo/config-plugins';
 import { ManifestApplication } from '@expo/config-plugins/build/android/Manifest';
 import { ExpoConfig } from '@expo/config-types';
+import { PluginConfigType } from '../pluginConfig';
 
 /**
  * Determine whether a ManifestApplication has an attribute.
@@ -12,7 +13,10 @@ const hasMetaData = (application: ManifestApplication, metaData: string) => {
 /**
  * Create `com.google.firebase.messaging.default_notification_icon` and `com.google.firebase.messaging.default_notification_color`
  */
-export const withExpoPluginFirebaseNotification: ConfigPlugin = config => {
+export const withExpoPluginFirebaseNotification: ConfigPlugin<PluginConfigType | undefined> = (
+  config,
+  props,
+) => {
   return withAndroidManifest(config, async config => {
     // Add NS `xmlns:tools to handle boundary conditions.
     config.modResults.manifest.$ = {
@@ -21,14 +25,22 @@ export const withExpoPluginFirebaseNotification: ConfigPlugin = config => {
     };
 
     const application = config.modResults.manifest.application![0];
-    setFireBaseMessagingAndroidManifest(config, application);
+    setFireBaseMessagingAndroidManifest(config, application, props);
     return config;
   });
 };
 
-// Helper function to get notification icon and color from either config.notification or expo-notifications plugin
-const getNotificationConfig = (config: ExpoConfig) => {
-  // Check expo-notifications plugin
+// Helper function to get notification icon and color from plugin props, expo-notifications, or config.notification
+const getNotificationConfig = (config: ExpoConfig, props?: PluginConfigType) => {
+  // 1. Check props passed directly to @react-native-firebase/messaging plugin
+  if (props?.android?.notificationIcon || props?.android?.notificationColor) {
+    return {
+      icon: props.android.notificationIcon,
+      color: props.android.notificationColor,
+    };
+  }
+
+  // 2. Check expo-notifications plugin
   if (config.plugins) {
     const expoNotificationsPlugin = config.plugins.find(
       plugin => Array.isArray(plugin) && plugin[0] === 'expo-notifications',
@@ -66,8 +78,9 @@ const getNotificationConfig = (config: ExpoConfig) => {
 export function setFireBaseMessagingAndroidManifest(
   config: ExpoConfig,
   application: ManifestApplication,
+  props?: PluginConfigType,
 ) {
-  const { icon, color } = getNotificationConfig(config);
+  const { icon, color } = getNotificationConfig(config, props);
   if (!icon) {
     // This warning is important because the notification icon can only use pure white on Android. By default, the system uses the app icon as the notification icon, but the app icon is usually not pure white, so you need to set the notification icon
     // eslint-disable-next-line no-console

--- a/packages/messaging/plugin/src/index.ts
+++ b/packages/messaging/plugin/src/index.ts
@@ -1,17 +1,18 @@
 import { ConfigPlugin, withPlugins, createRunOncePlugin } from '@expo/config-plugins';
 import { withExpoPluginFirebaseNotification } from './android';
+import { PluginConfigType } from './pluginConfig';
 
 /**
- * A config plugin for configuring `@react-native-firebase/app`
+ * A config plugin for configuring `@react-native-firebase/messaging`
  */
-const withRnFirebaseApp: ConfigPlugin = config => {
+const withRnFirebaseMessaging: ConfigPlugin<PluginConfigType | undefined> = (config, props) => {
   return withPlugins(config, [
     // iOS
 
     // Android
-    withExpoPluginFirebaseNotification,
+    [withExpoPluginFirebaseNotification, props],
   ]);
 };
 
 const pak = require('@react-native-firebase/messaging/package.json');
-export default createRunOncePlugin(withRnFirebaseApp, pak.name, pak.version);
+export default createRunOncePlugin(withRnFirebaseMessaging, pak.name, pak.version);

--- a/packages/messaging/plugin/src/pluginConfig.ts
+++ b/packages/messaging/plugin/src/pluginConfig.ts
@@ -1,0 +1,8 @@
+export interface PluginConfigType {
+  android?: PluginConfigTypeAndroid;
+}
+
+export interface PluginConfigTypeAndroid {
+  notificationIcon?: string;
+  notificationColor?: string;
+}


### PR DESCRIPTION
## Summary

- Adds configurable props to the `@react-native-firebase/messaging` Expo config plugin, allowing users to pass `notificationIcon` and `notificationColor` directly without needing `expo-notifications` or the deprecated `config.notification` field (removed in Expo SDK 55)
- Priority order: plugin props > `expo-notifications` config > `config.notification` (deprecated fallback)
- Follows the same `PluginConfigType` pattern used by `@react-native-firebase/auth` and `@react-native-firebase/analytics` plugins

### Usage

```json
[
  "@react-native-firebase/messaging",
  {
    "android": {
      "notificationIcon": "./assets/notification-icon.png",
      "notificationColor": "#ffffff"
    }
  }
]
```

Closes #8840

## Test plan

- [x] 10 unit tests pass (`npx jest packages/messaging/plugin/__tests__/androidPlugin.test.ts`)
- [x] Tests cover: icon + color from props, icon-only, color-only fallback to expo-notifications, priority over expo-notifications
- [x] Plugin builds successfully (`tsc --build plugin`)
- [ ] No device testing needed — this is a build-time config plugin that modifies AndroidManifest.xml