### PR TITLE
fix(auth, app): fix web auth initialization crash and missing methods

### DIFF
--- a/packages/app/__tests__/webAppModule.test.ts
+++ b/packages/app/__tests__/webAppModule.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+jest.mock('react-native', () => ({
+  DeviceEventEmitter: {
+    emit: jest.fn(),
+  },
+}));
+
+jest.mock('../lib/internal/web/firebaseApp', () => ({
+  initializeApp: jest.fn(),
+  setLogLevel: jest.fn(),
+  getApp: jest.fn(),
+  getApps: jest.fn(() => []),
+  deleteApp: jest.fn(),
+}));
+
+const appModule = require('../lib/internal/web/RNFBAppModule.ts').default;
+
+describe('RNFBAppModule setImmediate guards', () => {
+  describe('with setImmediate available', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('eventsSendEvent uses setImmediate when available', () => {
+      const spy = jest.spyOn(globalThis, 'setImmediate');
+      appModule.eventsAddListener('test_event');
+      appModule.eventsNotifyReady(true);
+      appModule.eventsPing('test_event', { data: 1 });
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('eventsNotifyReady uses setImmediate when available', () => {
+      const spy = jest.spyOn(globalThis, 'setImmediate');
+      appModule.eventsNotifyReady(true);
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('eventsAddListener uses setImmediate when available', () => {
+      const spy = jest.spyOn(globalThis, 'setImmediate');
+      appModule.eventsAddListener('another_event');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  describe('without setImmediate (browser environment)', () => {
+    let savedSetImmediate: typeof setImmediate;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      savedSetImmediate = globalThis.setImmediate;
+      // @ts-expect-error — simulating browser where setImmediate is absent
+      delete globalThis.setImmediate;
+    });
+
+    afterEach(() => {
+      globalThis.setImmediate = savedSetImmediate;
+      jest.useRealTimers();
+    });
+
+    it('eventsSendEvent falls back to setTimeout', () => {
+      const spy = jest.spyOn(globalThis, 'setTimeout');
+      appModule.eventsAddListener('browser_event');
+      appModule.eventsNotifyReady(true);
+      appModule.eventsPing('browser_event', { data: 2 });
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('eventsNotifyReady falls back to setTimeout', () => {
+      const spy = jest.spyOn(globalThis, 'setTimeout');
+      appModule.eventsNotifyReady(true);
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('eventsAddListener falls back to setTimeout', () => {
+      const spy = jest.spyOn(globalThis, 'setTimeout');
+      appModule.eventsAddListener('browser_event_2');
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+});

--- a/packages/app/__tests__/webUtils.test.ts
+++ b/packages/app/__tests__/webUtils.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+jest.mock('react-native', () => ({
+  DeviceEventEmitter: {
+    emit: jest.fn(),
+  },
+}));
+
+import { DeviceEventEmitter } from 'react-native';
+import { emitEvent } from '../lib/internal/web/utils';
+
+describe('web/utils', () => {
+  describe('emitEvent', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.mocked(DeviceEventEmitter.emit).mockClear();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('emits event with rnfb_ prefix asynchronously', async () => {
+      const payload = { appName: '[DEFAULT]', user: null };
+      emitEvent('auth_state_changed', payload);
+
+      expect(DeviceEventEmitter.emit).not.toHaveBeenCalled();
+      jest.runAllTimers();
+      await Promise.resolve();
+      expect(DeviceEventEmitter.emit).toHaveBeenCalledWith('rnfb_auth_state_changed', payload);
+    });
+
+    it('falls back to setTimeout when setImmediate is not available', () => {
+      const original = globalThis.setImmediate;
+      // @ts-expect-error — removing global to simulate browser environment
+      delete globalThis.setImmediate;
+
+      try {
+        const payload = { appName: '[DEFAULT]', user: null };
+        emitEvent('auth_id_token_changed', payload);
+
+        expect(DeviceEventEmitter.emit).not.toHaveBeenCalled();
+        jest.runAllTimers();
+        expect(DeviceEventEmitter.emit).toHaveBeenCalledWith('rnfb_auth_id_token_changed', payload);
+      } finally {
+        globalThis.setImmediate = original;
+      }
+    });
+  });
+});

--- a/packages/app/lib/internal/web/RNFBAppModule.ts
+++ b/packages/app/lib/internal/web/RNFBAppModule.ts
@@ -71,7 +71,12 @@ function eventsSendEvent(eventName: string, eventBody: any): void {
     queuedEvents.push(event);
     return;
   }
-  setImmediate(() => DeviceEventEmitter.emit('rnfb_' + eventName, eventBody));
+  const emit = () => DeviceEventEmitter.emit('rnfb_' + eventName, eventBody);
+  if (typeof setImmediate === 'function') {
+    setImmediate(emit);
+  } else {
+    setTimeout(emit, 0);
+  }
 }
 
 function eventsSendQueuedEvents(): void {
@@ -251,7 +256,11 @@ export default {
   eventsNotifyReady(ready: boolean): void {
     jsReady = ready;
     if (jsReady) {
-      setImmediate(() => eventsSendQueuedEvents());
+      if (typeof setImmediate === 'function') {
+        setImmediate(() => eventsSendQueuedEvents());
+      } else {
+        setTimeout(() => eventsSendQueuedEvents(), 0);
+      }
     }
   },
 
@@ -289,7 +298,11 @@ export default {
         jsListeners[eventName]++;
       }
     }
-    setImmediate(() => eventsSendQueuedEvents());
+    if (typeof setImmediate === 'function') {
+      setImmediate(() => eventsSendQueuedEvents());
+    } else {
+      setTimeout(() => eventsSendQueuedEvents(), 0);
+    }
   },
 
   /**

--- a/packages/app/lib/internal/web/utils.ts
+++ b/packages/app/lib/internal/web/utils.ts
@@ -53,5 +53,10 @@ export function getWebError(error: Error & { code?: string }): {
 }
 
 export function emitEvent(eventName: string, event: unknown): void {
-  setImmediate(() => DeviceEventEmitter.emit('rnfb_' + eventName, event));
+  const emit = () => DeviceEventEmitter.emit('rnfb_' + eventName, event);
+  if (typeof setImmediate === 'function') {
+    setImmediate(emit);
+  } else {
+    setTimeout(emit, 0);
+  }
 }

--- a/packages/auth/__tests__/webAuthIntegration.test.ts
+++ b/packages/auth/__tests__/webAuthIntegration.test.ts
@@ -29,12 +29,10 @@ jest.mock('react-native', () => ({
   },
 }));
 
-const mockOnAuthStateChanged = jest.fn(
-  (_auth: unknown, callback: (user: null) => void) => {
-    setTimeout(() => callback(null), 0);
-    return jest.fn();
-  },
-);
+const mockOnAuthStateChanged = jest.fn((_auth: unknown, callback: (user: null) => void) => {
+  setTimeout(() => callback(null), 0);
+  return jest.fn();
+});
 
 jest.mock('@react-native-firebase/app/dist/module/internal/web/firebaseAuth', () => ({
   getApp: jest.fn(() => ({ name: '[DEFAULT]' })),
@@ -102,7 +100,6 @@ jest.mock('@react-native-firebase/app/dist/module/internal/asyncStorage', () => 
 }));
 
 // Import with explicit .ts extension to bypass Jest's iOS platform resolution
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const webModule = require('../lib/web/RNFBAuthModule.ts');
 const mod = webModule.default as Record<string, (...args: unknown[]) => unknown>;
 

--- a/packages/auth/__tests__/webAuthIntegration.test.ts
+++ b/packages/auth/__tests__/webAuthIntegration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Integration-style tests that simulate the web runtime environment
+ * and verify the auth module initializes and operates without crashing.
+ *
+ * These reproduce the exact failures from issue #7921:
+ * 1. ReferenceError: setImmediate is not defined
+ * 2. NativeFirebaseError: [auth/unknown] "" is not a function (missing methods)
+ * 3. Misleading AsyncStorage warning on web
+ */
+import { describe, expect, it, jest, beforeAll, afterAll } from '@jest/globals';
+
+let originalSetImmediate: typeof setImmediate;
+
+beforeAll(() => {
+  originalSetImmediate = globalThis.setImmediate;
+  // @ts-expect-error — simulating browser where setImmediate is absent
+  delete globalThis.setImmediate;
+});
+
+afterAll(() => {
+  globalThis.setImmediate = originalSetImmediate;
+});
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'web' },
+  DeviceEventEmitter: {
+    emit: jest.fn(),
+    addListener: jest.fn(() => ({ remove: jest.fn() })),
+  },
+}));
+
+const mockOnAuthStateChanged = jest.fn(
+  (_auth: unknown, callback: (user: null) => void) => {
+    setTimeout(() => callback(null), 0);
+    return jest.fn();
+  },
+);
+
+jest.mock('@react-native-firebase/app/dist/module/internal/web/firebaseAuth', () => ({
+  getApp: jest.fn(() => ({ name: '[DEFAULT]' })),
+  initializeAuth: jest.fn(() => ({
+    currentUser: null,
+    languageCode: 'en',
+    tenantId: null,
+    signOut: jest.fn(),
+  })),
+  onAuthStateChanged: mockOnAuthStateChanged,
+  onIdTokenChanged: jest.fn((_auth: unknown, callback: (user: null) => void) => {
+    setTimeout(() => callback(null), 0);
+    return jest.fn();
+  }),
+  isSignInWithEmailLink: jest.fn(() => false),
+  signOut: jest.fn(() => Promise.resolve()),
+  signInAnonymously: jest.fn(),
+  sendSignInLinkToEmail: jest.fn(),
+  getAdditionalUserInfo: jest.fn(),
+  multiFactor: jest.fn(),
+  getMultiFactorResolver: jest.fn(),
+  TotpMultiFactorGenerator: {
+    assertionForSignIn: jest.fn(),
+    assertionForEnrollment: jest.fn(),
+    generateSecret: jest.fn(),
+  },
+  createUserWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+  signInWithEmailLink: jest.fn(),
+  signInWithCustomToken: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+  useDeviceLanguage: jest.fn(),
+  verifyPasswordResetCode: jest.fn(),
+  connectAuthEmulator: jest.fn(),
+  fetchSignInMethodsForEmail: jest.fn(),
+  sendEmailVerification: jest.fn(),
+  verifyBeforeUpdateEmail: jest.fn(),
+  confirmPasswordReset: jest.fn(),
+  updateEmail: jest.fn(),
+  updatePassword: jest.fn(),
+  updateProfile: jest.fn(),
+  updatePhoneNumber: jest.fn(),
+  signInWithCredential: jest.fn(),
+  unlink: jest.fn(),
+  linkWithCredential: jest.fn(),
+  reauthenticateWithCredential: jest.fn(),
+  getIdToken: jest.fn(),
+  getIdTokenResult: jest.fn(),
+  applyActionCode: jest.fn(),
+  checkActionCode: jest.fn(),
+  EmailAuthProvider: { credential: jest.fn() },
+  FacebookAuthProvider: { credential: jest.fn() },
+  GoogleAuthProvider: { credential: jest.fn() },
+  TwitterAuthProvider: { credential: jest.fn() },
+  GithubAuthProvider: { credential: jest.fn() },
+  PhoneAuthProvider: { credential: jest.fn() },
+  OAuthProvider: jest.fn(),
+  deleteUser: jest.fn(),
+  reload: jest.fn(),
+}));
+
+jest.mock('@react-native-firebase/app/dist/module/internal/asyncStorage', () => ({
+  getReactNativeAsyncStorageInternal: jest.fn(() => ({})),
+  isMemoryStorage: jest.fn(() => true),
+}));
+
+// Import with explicit .ts extension to bypass Jest's iOS platform resolution
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const webModule = require('../lib/web/RNFBAuthModule.ts');
+const mod = webModule.default as Record<string, (...args: unknown[]) => unknown>;
+
+describe('Web auth integration (simulated browser — no setImmediate)', () => {
+  it('setImmediate is confirmed absent (simulating browser)', () => {
+    expect(typeof globalThis.setImmediate).toBe('undefined');
+  });
+
+  it('addAuthStateListener does not crash (was: "" is not a function)', () => {
+    // Issue #7921: this.native.addAuthStateListener() threw
+    // NativeFirebaseError: [auth/unknown] "" is not a function
+    expect(() => mod.addAuthStateListener('[DEFAULT]')).not.toThrow();
+    expect(mockOnAuthStateChanged).toHaveBeenCalled();
+  });
+
+  it('addIdTokenListener does not crash (was: "" is not a function)', () => {
+    // Issue #7921: this.native.addIdTokenListener() threw the same error
+    expect(() => mod.addIdTokenListener('[DEFAULT]')).not.toThrow();
+  });
+
+  it('signInWithCustomToken is a callable function (was: "" is not a function)', () => {
+    // Issue #7921: this.native.signInWithCustomToken() threw the same error
+    expect(typeof mod.signInWithCustomToken).toBe('function');
+  });
+
+  it('configureAuthDomain rejects gracefully instead of crashing', async () => {
+    // Issue #7921: this.native.configureAuthDomain() threw
+    // NativeFirebaseError: [auth/unsupported] This operation is not supported
+    // Now guarded in index.ts with `if (!isOther)`, but the web module also
+    // rejects cleanly if called directly.
+    await expect(mod.configureAuthDomain('[DEFAULT]')).rejects.toBeDefined();
+  });
+
+  it('does not warn about AsyncStorage on web (persistence uses IndexedDB)', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Force a new auth instance creation
+    mod.setLanguageCode('[DEFAULT]', 'fr');
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('Firebase Auth persistence is disabled'),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('verifyPhoneNumberWithMultiFactorInfo exists and rejects (was: crash)', () => {
+    // This method was completely missing from the web module,
+    // causing runtime crash when called via this.native
+    expect(typeof mod.verifyPhoneNumberWithMultiFactorInfo).toBe('function');
+    return expect(mod.verifyPhoneNumberWithMultiFactorInfo()).rejects.toBeDefined();
+  });
+
+  it('resolveTotpSignIn exists and rejects (was: crash)', () => {
+    // This method was completely missing from the web module
+    expect(typeof mod.resolveTotpSignIn).toBe('function');
+    return expect(mod.resolveTotpSignIn()).rejects.toBeDefined();
+  });
+});

--- a/packages/auth/__tests__/webAuthModule.test.ts
+++ b/packages/auth/__tests__/webAuthModule.test.ts
@@ -76,7 +76,6 @@ jest.mock('@react-native-firebase/app/dist/module/internal/asyncStorage', () => 
 
 // Import the base .ts file directly — Jest's React Native preset resolves to
 // .ios.ts (empty stub) by default, so we must bypass platform resolution.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const webModule = require('../lib/web/RNFBAuthModule.ts');
 const mod = (webModule.default ?? webModule) as Record<string, (...args: unknown[]) => unknown>;
 
@@ -101,7 +100,7 @@ describe('RNFBAuthModule (web)', () => {
       'reauthenticateWithProvider',
     ];
 
-    it.each(unsupportedMethods)('%s rejects with unsupported', async (method) => {
+    it.each(unsupportedMethods)('%s rejects with unsupported', async method => {
       expect(typeof mod[method]).toBe('function');
       await expect(mod[method]()).rejects.toEqual(
         expect.objectContaining({
@@ -176,7 +175,7 @@ describe('RNFBAuthModule (web)', () => {
       'useEmulator',
     ];
 
-    it.each(specMethods)('%s is defined as a function', (method) => {
+    it.each(specMethods)('%s is defined as a function', method => {
       expect(typeof mod[method]).toBe('function');
     });
   });

--- a/packages/auth/__tests__/webAuthModule.test.ts
+++ b/packages/auth/__tests__/webAuthModule.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'web' },
+  DeviceEventEmitter: {
+    emit: jest.fn(),
+  },
+}));
+
+jest.mock('@react-native-firebase/app/dist/module/internal/web/firebaseAuth', () => ({
+  getApp: jest.fn(),
+  initializeAuth: jest.fn(() => ({
+    currentUser: null,
+    languageCode: null,
+    tenantId: null,
+  })),
+  onAuthStateChanged: jest.fn(),
+  onIdTokenChanged: jest.fn(),
+  signInAnonymously: jest.fn(),
+  sendSignInLinkToEmail: jest.fn(),
+  getAdditionalUserInfo: jest.fn(),
+  multiFactor: jest.fn(),
+  getMultiFactorResolver: jest.fn(),
+  TotpMultiFactorGenerator: {
+    assertionForSignIn: jest.fn(),
+    assertionForEnrollment: jest.fn(),
+    generateSecret: jest.fn(),
+  },
+  createUserWithEmailAndPassword: jest.fn(),
+  signInWithEmailAndPassword: jest.fn(),
+  isSignInWithEmailLink: jest.fn(() => false),
+  signInWithEmailLink: jest.fn(),
+  signInWithCustomToken: jest.fn(),
+  sendPasswordResetEmail: jest.fn(),
+  useDeviceLanguage: jest.fn(),
+  verifyPasswordResetCode: jest.fn(),
+  connectAuthEmulator: jest.fn(),
+  fetchSignInMethodsForEmail: jest.fn(),
+  sendEmailVerification: jest.fn(),
+  verifyBeforeUpdateEmail: jest.fn(),
+  confirmPasswordReset: jest.fn(),
+  updateEmail: jest.fn(),
+  updatePassword: jest.fn(),
+  updateProfile: jest.fn(),
+  updatePhoneNumber: jest.fn(),
+  signInWithCredential: jest.fn(),
+  unlink: jest.fn(),
+  linkWithCredential: jest.fn(),
+  reauthenticateWithCredential: jest.fn(),
+  getIdToken: jest.fn(),
+  getIdTokenResult: jest.fn(),
+  applyActionCode: jest.fn(),
+  checkActionCode: jest.fn(),
+  EmailAuthProvider: { credential: jest.fn() },
+  FacebookAuthProvider: { credential: jest.fn() },
+  GoogleAuthProvider: { credential: jest.fn() },
+  TwitterAuthProvider: { credential: jest.fn() },
+  GithubAuthProvider: { credential: jest.fn() },
+  PhoneAuthProvider: { credential: jest.fn() },
+  OAuthProvider: jest.fn(),
+  signOut: jest.fn(),
+  deleteUser: jest.fn(),
+  reload: jest.fn(),
+}));
+
+jest.mock('@react-native-firebase/app/dist/module/internal/web/utils', () => ({
+  guard: jest.fn(<T>(fn: () => Promise<T>) => fn()),
+  getWebError: jest.fn((e: Error) => e),
+  emitEvent: jest.fn(),
+}));
+
+jest.mock('@react-native-firebase/app/dist/module/internal/asyncStorage', () => ({
+  getReactNativeAsyncStorageInternal: jest.fn(() => ({})),
+  isMemoryStorage: jest.fn(() => false),
+}));
+
+// Import the base .ts file directly — Jest's React Native preset resolves to
+// .ios.ts (empty stub) by default, so we must bypass platform resolution.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const webModule = require('../lib/web/RNFBAuthModule.ts');
+const mod = (webModule.default ?? webModule) as Record<string, (...args: unknown[]) => unknown>;
+
+describe('RNFBAuthModule (web)', () => {
+  describe('unsupported method stubs reject with auth/unsupported', () => {
+    const unsupportedMethods = [
+      'configureAuthDomain',
+      'getCustomAuthDomain',
+      'forceRecaptchaFlowForTesting',
+      'setAutoRetrievedSmsCodeForPhoneNumber',
+      'setAppVerificationDisabledForTesting',
+      'signInWithProvider',
+      'signInWithPhoneNumber',
+      'verifyPhoneNumberWithMultiFactorInfo',
+      'verifyPhoneNumberForMultiFactor',
+      'resolveMultiFactorSignIn',
+      'resolveTotpSignIn',
+      'finalizeMultiFactorEnrollment',
+      'confirmationResultConfirm',
+      'verifyPhoneNumber',
+      'linkWithProvider',
+      'reauthenticateWithProvider',
+    ];
+
+    it.each(unsupportedMethods)('%s rejects with unsupported', async (method) => {
+      expect(typeof mod[method]).toBe('function');
+      await expect(mod[method]()).rejects.toEqual(
+        expect.objectContaining({
+          code: 'auth/unsupported',
+          message: 'This operation is not supported in this environment.',
+        }),
+      );
+    });
+  });
+
+  describe('all TurboModule spec methods exist on the web module', () => {
+    const specMethods = [
+      'configureAuthDomain',
+      'getCustomAuthDomain',
+      'addAuthStateListener',
+      'removeAuthStateListener',
+      'addIdTokenListener',
+      'removeIdTokenListener',
+      'forceRecaptchaFlowForTesting',
+      'setAutoRetrievedSmsCodeForPhoneNumber',
+      'setAppVerificationDisabledForTesting',
+      'useUserAccessGroup',
+      'signOut',
+      'signInAnonymously',
+      'createUserWithEmailAndPassword',
+      'isSignInWithEmailLink',
+      'signInWithEmailAndPassword',
+      'signInWithEmailLink',
+      'signInWithCustomToken',
+      'revokeToken',
+      'sendPasswordResetEmail',
+      'sendSignInLinkToEmail',
+      'deleteUser',
+      'reload',
+      'sendEmailVerification',
+      'verifyBeforeUpdateEmail',
+      'updateEmail',
+      'updatePassword',
+      'updatePhoneNumber',
+      'updateProfile',
+      'getIdToken',
+      'getIdTokenResult',
+      'signInWithCredential',
+      'signInWithProvider',
+      'signInWithPhoneNumber',
+      'verifyPhoneNumberWithMultiFactorInfo',
+      'verifyPhoneNumberForMultiFactor',
+      'resolveMultiFactorSignIn',
+      'resolveTotpSignIn',
+      'generateTotpSecret',
+      'generateQrCodeUrl',
+      'openInOtpApp',
+      'getSession',
+      'unenrollMultiFactor',
+      'finalizeMultiFactorEnrollment',
+      'finalizeTotpEnrollment',
+      'confirmationResultConfirm',
+      'verifyPhoneNumber',
+      'confirmPasswordReset',
+      'applyActionCode',
+      'checkActionCode',
+      'linkWithCredential',
+      'linkWithProvider',
+      'unlink',
+      'reauthenticateWithCredential',
+      'reauthenticateWithProvider',
+      'fetchSignInMethodsForEmail',
+      'setLanguageCode',
+      'setTenantId',
+      'useDeviceLanguage',
+      'verifyPasswordResetCode',
+      'useEmulator',
+    ];
+
+    it.each(specMethods)('%s is defined as a function', (method) => {
+      expect(typeof mod[method]).toBe('function');
+    });
+  });
+});

--- a/packages/auth/lib/web/RNFBAuthModule.ts
+++ b/packages/auth/lib/web/RNFBAuthModule.ts
@@ -327,33 +327,31 @@ const sessionMap = new Map<string, MultiFactorSession>();
 const totpSecretMap = new Map<string, WebTotpSecret>();
 let sessionId = 0;
 
-// Returns a cached Firestore instance.
 function getCachedAuthInstance(appName: string): Auth {
   if (!instances[appName]) {
-    if (isMemoryStorage()) {
-      // Warn auth persistence is is disabled unless Async Storage implementation is provided.
-      // eslint-disable-next-line no-console
-      console.warn(
-        'Firebase Auth persistence is disabled. To enable persistence, provide an Async Storage implementation.\n' +
-          '\n' +
-          'For example, to use React Native Async Storage:\n' +
-          '\n' +
-          "  import AsyncStorage from '@react-native-async-storage/async-storage';\n" +
-          '\n' +
-          '  // Before initializing Firebase set the Async Storage implementation\n' +
-          '  // that will be used to persist user sessions.\n' +
-          '  firebase.setReactNativeAsyncStorage(AsyncStorage);\n' +
-          '\n' +
-          '  // Then initialize Firebase as normal.\n' +
-          '  await firebase.initializeApp({ ... });\n',
-      );
-    }
-
     const authOptions: { persistence?: unknown } = {};
-    if (Platform.OS !== 'web') {
-      // Non-web platforms pull the react-native export from package.json and
-      // get a bundle that defines `getReactNativePersistence` etc, but web platforms
-      // do *not* have that method defined. So we only call it for non-web platforms
+
+    if (Platform.OS === 'web') {
+      // Web uses the Firebase JS SDK's default persistence (IndexedDB).
+      // No AsyncStorage needed — skip the warning and persistence setup.
+    } else {
+      if (isMemoryStorage()) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'Firebase Auth persistence is disabled. To enable persistence, provide an Async Storage implementation.\n' +
+            '\n' +
+            'For example, to use React Native Async Storage:\n' +
+            '\n' +
+            "  import AsyncStorage from '@react-native-async-storage/async-storage';\n" +
+            '\n' +
+            '  // Before initializing Firebase set the Async Storage implementation\n' +
+            '  // that will be used to persist user sessions.\n' +
+            '  firebase.setReactNativeAsyncStorage(AsyncStorage);\n' +
+            '\n' +
+            '  // Then initialize Firebase as normal.\n' +
+            '  await firebase.initializeApp({ ... });\n',
+        );
+      }
       authOptions.persistence = getReactNativePersistence(getReactNativeAsyncStorageInternal());
     }
 
@@ -918,6 +916,13 @@ export default {
     });
   },
 
+  verifyPhoneNumberWithMultiFactorInfo() {
+    return rejectPromiseWithCodeAndMessage(
+      'unsupported',
+      'This operation is not supported in this environment.',
+    );
+  },
+
   verifyPhoneNumberForMultiFactor() {
     return rejectPromiseWithCodeAndMessage(
       'unsupported',
@@ -933,6 +938,13 @@ export default {
   },
 
   resolveMultiFactorSignIn() {
+    return rejectPromiseWithCodeAndMessage(
+      'unsupported',
+      'This operation is not supported in this environment.',
+    );
+  },
+
+  resolveTotpSignIn() {
     return rejectPromiseWithCodeAndMessage(
       'unsupported',
       'This operation is not supported in this environment.',

--- a/packages/auth/lib/web/RNFBAuthModule.ts
+++ b/packages/auth/lib/web/RNFBAuthModule.ts
@@ -331,10 +331,7 @@ function getCachedAuthInstance(appName: string): Auth {
   if (!instances[appName]) {
     const authOptions: { persistence?: unknown } = {};
 
-    if (Platform.OS === 'web') {
-      // Web uses the Firebase JS SDK's default persistence (IndexedDB).
-      // No AsyncStorage needed — skip the warning and persistence setup.
-    } else {
+    if (Platform.OS !== 'web') {
       if (isMemoryStorage()) {
         // eslint-disable-next-line no-console
         console.warn(


### PR DESCRIPTION
## Summary

Fixes #7921 — Web (Other Platforms) auth was completely broken due to three root causes:

- **`setImmediate` crash**: `setImmediate` is a Node.js/React Native global, not available in browsers. It was used unguarded in `emitEvent()` (utils.ts) and 3 event functions in `RNFBAppModule.ts`, causing `ReferenceError: Can't find variable: setImmediate` on any auth initialization.
- **Missing method stubs**: `verifyPhoneNumberWithMultiFactorInfo` and `resolveTotpSignIn` were absent from the web auth module, causing `"" is not a function` runtime crashes.
- **Misleading AsyncStorage warning**: `getCachedAuthInstance` tried to use `getReactNativePersistence(AsyncStorage)` on web, where IndexedDB is the correct persistence mechanism.

## Changes

- Guard all `setImmediate` calls with `typeof` check, falling back to `setTimeout(fn, 0)` in browsers
- Add `verifyPhoneNumberWithMultiFactorInfo` and `resolveTotpSignIn` stubs that reject with `auth/unsupported`
- Restructure `getCachedAuthInstance` to skip AsyncStorage/persistence setup when `Platform.OS === 'web'`

## Test plan

- [x] 86 new tests (unit + integration), all passing
- [x] Browser-tested via Expo web app: `initializeApp`, `getAuth`, `onAuthStateChanged`, `signInAnonymously` all work
- [x] Verified `setImmediate` fallback fires correctly in browser environment
- [x] Verified no AsyncStorage warning on web
- [x] Existing tests unaffected

Linear: CPRN-282