### PR TITLE
fix(app, ios): link Photos framework explicitly

### DIFF
--- a/packages/app/RNFBApp.podspec
+++ b/packages/app/RNFBApp.podspec
@@ -23,6 +23,9 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = firebase_tvos_target
   s.cocoapods_version   = '>= 1.12.0'
   s.source_files        = "ios/**/*.{h,m,mm,cpp}"
+  # Objective-C++ sources emit no clang autolink records, so PhotoKit must be
+  # linked explicitly: RNFBUtilsModule references PHAsset.
+  s.frameworks          = "Photos"
   s.private_header_files = "ios/**/*.h"
   s.exclude_files       = 'ios/generated/RCTThirdPartyComponentsProvider.*', 'ios/generated/RCTAppDependencyProvider.*', 'ios/generated/RCTModuleProviders.*', 'ios/generated/RCTModulesConformingToProtocolsProvider.*', 'ios/generated/RCTUnstableModulesRequiringMainQueueSetupProvider.*'
 


### PR DESCRIPTION
`RNFBUtilsModule` moved from `.m` to `.mm` in 26.0.0. Objective-C++ emits no clang autolink records, so `Photos.framework` stopped being linked and `PHAsset` is undefined at link time.

This declares the framework explicitly instead of relying on autolinking.

Fixes #9136

Verified red before / green after on React Native 0.86.2 and 0.88 nightly, with `use_frameworks! :linkage => :static`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
