### PR TITLE
test(ci): unique-ify secondary app names in tests

### DIFF
--- a/.yarn/patches/jet-npm-0.9.0-dev.13-3321aeea6e.patch
+++ b/.yarn/patches/jet-npm-0.9.0-dev.13-3321aeea6e.patch
@@ -231,10 +231,71 @@ index 35c04da87c63a79bc26707aaffe3156fb98eca79..3ad2cea4c214e8c3c4f4698acacfff26
  //# sourceMappingURL=cli.js.map
 \ No newline at end of file
 diff --git a/lib/commonjs/index.js b/lib/commonjs/index.js
-index a72380ed2ace01b19b028bb8e6f9d29dc3affbcd..030475cff75349b2b7f820cf8a3556fb1d7bea45 100644
+index a72380ed2ace01b19b028bb8e6f9d29dc3affbcd..0f2065e94f1ad1b16951e072b2f1a1bb5e47f241 100644
 --- a/lib/commonjs/index.js
 +++ b/lib/commonjs/index.js
-@@ -63,15 +63,7 @@ function JetProvider(props) {
+@@ -52,9 +52,16 @@ function JetProvider(props) {
+       ...props,
+       title: props.title ?? `Jet tests on ${_reactNative.Platform.OS}`,
+       async transformFailure(_, err) {
+-        const stack = (0, _parseErrorStack.default)(err.stack);
+-        const symbolicated = await (0, _symbolicateStackTrace.default)(stack);
+-        err.stack = framesToStack(err, symbolicated.stack);
++        try {
++          const stack = (0, _parseErrorStack.default)(err.stack);
++          const symbolicated = await (0, _symbolicateStackTrace.default)(stack);
++          err.stack = framesToStack(err, symbolicated.stack);
++        } catch (cause) {
++          // Release / no Metro: symbolicateStackTrace throws ("Bundle was not loaded from Metro.").
++          // Returning a thrown transformFailure would mask the real test error in mocha-remote.
++          const msg = cause instanceof Error ? cause.message : String(cause);
++          console.warn(`[jet] symbolicateStackTrace unavailable; returning original error (${msg})`);
++        }
+         return err;
+       },
+       tests(_config) {
+@@ -63,15 +70,7 @@ function JetProvider(props) {
+         });
+         after(async () => {
+           if (_config.coverage) {
+-            const coverage = global.__coverage__ ?? {};
+-            const url = (props.url ?? 'ws://localhost:8090').replace('ws://', 'http://') + '/coverage';
+-            return fetch(url, {
+-              method: 'POST',
+-              headers: {
+-                'Content-Type': 'application/json'
+-              },
+-              body: JSON.stringify(coverage)
+-            });
++            return client.uploadCoverage();
+           }
+           return Promise.resolve();
+         });
+diff --git a/lib/module/index.js b/lib/module/index.js
+index 897b62288ae128e1ce071142fa3de136caa99239..ad8c11f4b1278f32ec5c5101b1d5b7d5fc3889b9 100644
+--- a/lib/module/index.js
++++ b/lib/module/index.js
+@@ -40,9 +40,16 @@ export function JetProvider(props) {
+       ...props,
+       title: props.title ?? `Jet tests on ${Platform.OS}`,
+       async transformFailure(_, err) {
+-        const stack = parseErrorStack(err.stack);
+-        const symbolicated = await symbolicateStackTrace(stack);
+-        err.stack = framesToStack(err, symbolicated.stack);
++        try {
++          const stack = parseErrorStack(err.stack);
++          const symbolicated = await symbolicateStackTrace(stack);
++          err.stack = framesToStack(err, symbolicated.stack);
++        } catch (cause) {
++          // Release / no Metro: symbolicateStackTrace throws ("Bundle was not loaded from Metro.").
++          // Returning a thrown transformFailure would mask the real test error in mocha-remote.
++          const msg = cause instanceof Error ? cause.message : String(cause);
++          console.warn(`[jet] symbolicateStackTrace unavailable; returning original error (${msg})`);
++        }
+         return err;
+       },
+       tests(_config) {
+@@ -51,15 +58,7 @@ export function JetProvider(props) {
          });
          after(async () => {
            if (_config.coverage) {
@@ -252,10 +313,32 @@ index a72380ed2ace01b19b028bb8e6f9d29dc3affbcd..030475cff75349b2b7f820cf8a3556fb
            return Promise.resolve();
          });
 diff --git a/src/index.tsx b/src/index.tsx
-index 1b28aca3fe817fee3e8701ac5096df6fc608bc39..17c631309f88a8017a9fd01e3420df2b4bab140e 100644
+index 1b28aca3fe817fee3e8701ac5096df6fc608bc39..10cf19c7dc1be39d07a3a9e7702ad67d2ef82508 100644
 --- a/src/index.tsx
 +++ b/src/index.tsx
-@@ -82,17 +82,7 @@ export function JetProvider(props: JetProviderProps): React.JSX.Element {
+@@ -71,9 +71,18 @@ export function JetProvider(props: JetProviderProps): React.JSX.Element {
+       ...props,
+       title: props.title ?? `Jet tests on ${Platform.OS}`,
+       async transformFailure(_, err) {
+-        const stack = parseErrorStack(err.stack as any);
+-        const symbolicated = (await symbolicateStackTrace(stack)) as any;
+-        err.stack = framesToStack(err, symbolicated.stack);
++        try {
++          const stack = parseErrorStack(err.stack as any);
++          const symbolicated = (await symbolicateStackTrace(stack)) as any;
++          err.stack = framesToStack(err, symbolicated.stack);
++        } catch (cause) {
++          // Release / no Metro: symbolicateStackTrace throws ("Bundle was not loaded from Metro.").
++          // Returning a thrown transformFailure would mask the real test error in mocha-remote.
++          const msg = cause instanceof Error ? cause.message : String(cause);
++          console.warn(
++            `[jet] symbolicateStackTrace unavailable; returning original error (${msg})`,
++          );
++        }
+         return err;
+       },
+       tests(_config) {
+@@ -82,17 +91,7 @@ export function JetProvider(props: JetProviderProps): React.JSX.Element {
          });
          after(async () => {
            if (_config.coverage) {

--- a/okf-bundle/ci-workflows/detox-patches.md
+++ b/okf-bundle/ci-workflows/detox-patches.md
@@ -17,7 +17,7 @@ Patches are in-repo. Prefer direct patch-file edits or headless workflow; `yarn 
 | Ignore missing adb reverse on teardown | `ADB.js` | Android | Jet WS 1006 triggers mid-run `reverse --remove` → adb exit 1 |
 | **2× device-registry lock stale** | `ExclusiveLockfile.js` | iOS, macOS, Android | `proper-lockfile` `ECOMPROMISED` before tests start |
 
-Related patches: `jet`, `mocha-remote-client`, `mocha-remote-server` — WS reconnect grace, coverage handshake, client keepalive, parse buffering, reconnect assignment order; **host control HTTP on `JET_REMOTE_PORT + 1` (default 8091)** for launch defer + orchestrate phase (`RNFB_JET_DEFER_RUN`); HTTP POST `/coverage` on 8090 removed. See [Jet host orchestration](../testing/running-e2e.md#jet-host-orchestration-ports-and-launch-gate), [coverage design](../testing/coverage-design.md), [iOS issues 6–8](ios.md#6-jet-websocket-disconnect-1006--1001).
+Related patches: `jet`, `mocha-remote-client`, `mocha-remote-server` — WS reconnect grace, coverage handshake, client keepalive, parse buffering, reconnect assignment order, `transformFailure` Metro symbolication soft-fail; **host control HTTP on `JET_REMOTE_PORT + 1` (default 8091)** for launch defer + orchestrate phase (`RNFB_JET_DEFER_RUN`); HTTP POST `/coverage` on 8090 removed. See [Jet host orchestration](../testing/running-e2e.md#jet-host-orchestration-ports-and-launch-gate), [coverage design](../testing/coverage-design.md), [iOS issues 6–8](ios.md#6-jet-websocket-disconnect-1006--1001) (incl. [6c](ios.md#6c-release-transformfailure-masks-real-errors-metro-symbolication)).
 
 ## Updating the jet patch (headless)
 
@@ -35,7 +35,7 @@ yarn patch-commit -s "$PATCH_DIR"
 
 3. `yarn install` from repo root — confirm updated `yarn.lock` patch hash and applied files in `tests/node_modules/jet/`.
 
-**Touch list:** `lib/commonjs/cli.js` (server: WS `coverage-data`, reconnect grace, **`startControlHttpServer` on port `JET_REMOTE_PORT + 1`**, defer `server.run()` until `POST /launch-ready` when `RNFB_JET_DEFER_RUN=1`; **no** control HTTP on the 8090 WebSocket stack), `lib/commonjs/index.js` + `src/index.tsx` (client: `client.uploadCoverage()`). Metro resolves Jet via `"react-native": "src/index"` — patching `lib/` alone does not fix macOS bundles.
+**Touch list:** `lib/commonjs/cli.js` (server: WS `coverage-data`, reconnect grace, **`startControlHttpServer` on port `JET_REMOTE_PORT + 1`**, defer `server.run()` until `POST /launch-ready` when `RNFB_JET_DEFER_RUN=1`; **no** control HTTP on the 8090 WebSocket stack), `lib/commonjs/index.js` + `src/index.tsx` (client: `client.uploadCoverage()`; `transformFailure` symbolication soft-fail — [iOS §6c](ios.md#6c-release-transformfailure-masks-real-errors-metro-symbolication)). Metro resolves Jet via `"react-native": "src/index"` — patching `lib/` alone does not fix macOS bundles.
 
 ## Device registry lock (`ECOMPROMISED`)
 

--- a/okf-bundle/ci-workflows/ios.md
+++ b/okf-bundle/ci-workflows/ios.md
@@ -373,6 +373,8 @@ rg 'disconnect_context|resource-monitor' detox-step.log resource-monitor.log
 | `[rnfb-e2e] Retrying after transient Jet WS` | Second Jet attempt starting (simulator reboot) |
 | `disconnect_context` with high loadavg / RSS | Correlate with `resource-monitor-*_log` snapshot at same UTC timestamp |
 | Release passes, debug fails with 1006 | Points at Metro/debug+coverage load, not test logic |
+| `reconnect_recovered` alone then ordinary product assertion (single `Jet tests on `) | **Not** Jet-retryable — bare reconnect must not mask deterministic product bugs. Tradeoff: avoids false retries; D1 (Release `transformFailure` mask) + D4 (secondary app-name collision) cover related flakes separately |
+| `reconnect_recovered` **and** desync signal (`Jet tests on ` ≥2 / suite re-entry, or `Unknown% ( 0/0 )`, or `[🟥] Stopped the server`) | Mid-suite reconnect left polluted JS / Firebase registry or lost coverage; Jet attempt 2 should trigger (`jetReconnectDesync` in `retry-eligibility`) |
 | `reconnect_recovered` then `Error: No client connected` or `send skipped action=pull-coverage` | Reconnect send race (issue 6b); Jet attempt 2 should trigger |
 
 #### 6b. Reconnect send race under extreme host load

--- a/okf-bundle/ci-workflows/ios.md
+++ b/okf-bundle/ci-workflows/ios.md
@@ -417,6 +417,29 @@ Correlate `disconnect_context loadavg=…` with `resource-monitor-*_log` — hig
 
 **Reference symptom** — grace can recover after a disconnect, then Jet may still crash on `No client connected`.
 
+#### 6c. Release `transformFailure` masks real errors (Metro symbolication)
+
+**Symptom** (Release builds, or Debug when Metro is not serving the app bundle — any failing assertion):
+
+```
+Failed to transform failure: Bundle was not loaded from Metro.
+```
+
+**Cause** — Jet `JetProvider.transformFailure` calls RN `symbolicateStackTrace`, which talks to Metro. Release embeds JS (no Metro); when symbolication throws, mocha-remote replaces the **original** test failure with `Failed to transform failure: …`, hiding the real assertion.
+
+**Mitigation in this repo**
+
+| Change | Location |
+|--------|----------|
+| Catch symbolication failure; `console.warn` one line; return original `err` | `.yarn/patches/jet-npm-0.9.0-dev.13-*.patch` → `src/index.tsx`, `lib/*/index.js` |
+
+**Sentinel patterns**
+
+| Pattern | Meaning |
+|---------|---------|
+| `[jet] symbolicateStackTrace unavailable; returning original error` | Soft-fail path hit; original test error preserved |
+| `Failed to transform failure: Bundle was not loaded from Metro.` | Pre-fix masking — patch missing or not applied after install |
+
 #### 7. FrontBoard / LaunchServices race after terminate+relaunch
 
 **Symptom** — Second `launchApp` attempt fails after a slow or failed first launch:

--- a/packages/functions/e2e/functions.e2e.js
+++ b/packages/functions/e2e/functions.e2e.js
@@ -112,19 +112,24 @@ describe('functions() modular', function () {
     });
 
     it('accepts passing in an FirebaseApp instance as first arg', async function () {
-      const { initializeApp } = modular;
+      const { initializeApp, deleteApp } = modular;
       const { getFunctions } = functionsModular;
-      const appName = `functionsApp${FirebaseHelpers.id}3`;
+      // Process-stable name `functionsApp${id}3` collided after Jet reconnect / suite re-entry.
+      const appName = `functionsApp${FirebaseHelpers.id}${Date.now()}`;
       const platformAppConfig = FirebaseHelpers.app.config();
       const app = await initializeApp(platformAppConfig, appName);
-      const functions = getFunctions(app);
+      try {
+        const functions = getFunctions(app);
 
-      functions.app.should.equal(app);
-      functions.app.name.should.equal(app.name);
+        functions.app.should.equal(app);
+        functions.app.name.should.equal(app.name);
 
-      // check from an app
-      getFunctions(app).app.should.equal(app);
-      getFunctions(app).app.name.should.equal(app.name);
+        // check from an app
+        getFunctions(app).app.should.equal(app);
+        getFunctions(app).app.name.should.equal(app.name);
+      } finally {
+        await deleteApp(app);
+      }
     });
 
     it('accepts passing in a region string as first arg to an app', async function () {

--- a/tests/e2e/firebase.test.js
+++ b/tests/e2e/firebase.test.js
@@ -19,7 +19,10 @@ const { execSync, spawn } = require('child_process');
 const net = require('net');
 const path = require('path');
 
-const { pullIosCoverage, pullAndroidCoverageWithRetry } = require('../scripts/pull-native-coverage');
+const {
+  pullIosCoverage,
+  pullAndroidCoverageWithRetry,
+} = require('../scripts/pull-native-coverage');
 const { recordE2eCloudMetricFromHost } = require('../../packages/app/e2e/cloud-metrics');
 
 const E2E_TEST_PROJECT = 'react-native-firebase-testing';
@@ -83,6 +86,8 @@ const JET_RETRYABLE_WS_RE = /\[jet-ws\] RETRYABLE_DISCONNECT code=(1006|1001)\b/
 const JET_RECONNECT_RECOVERED_RE = /\[jet-ws\] reconnect_recovered code=(1006|1001)\b/;
 const JET_SERVER_NOT_RUNNING_RE = /server wasn't running/i;
 const JET_COVERAGE_LOST_RE = /Coverage summary:[\s\S]*?Unknown% \( 0\/0 \)/;
+const JET_SERVER_STOPPED_RE = /\[🟥\] Stopped the server/i;
+const JET_SUITE_TITLE_FRAGMENT = 'Jet tests on ';
 const JET_COVERAGE_TEARDOWN_RE =
   /Failed to send 'coverage-ready' message: WebSocket is closed|coverage upload timed out waiting for coverage-ack/i;
 const JET_PROTOCOL_ERROR_RE = /\[🟥\] Unexpected end of JSON input/i;
@@ -128,7 +133,10 @@ function resolveAppBinaryPath() {
   }
 
   const fs = require('node:fs');
-  const debugIosApp = path.resolve(__dirname, '../ios/build/Build/Products/Debug-iphonesimulator/testing.app');
+  const debugIosApp = path.resolve(
+    __dirname,
+    '../ios/build/Build/Products/Debug-iphonesimulator/testing.app',
+  );
   if (fs.existsSync(debugIosApp)) {
     return debugIosApp;
   }
@@ -219,9 +227,7 @@ function logLaunchInstallState(label) {
         timeout: 30000,
       });
       const invertaseLine =
-        apps
-          .split('\n')
-          .find(line => line.includes('com.invertase.testing')) || '(not listed)';
+        apps.split('\n').find(line => line.includes('com.invertase.testing')) || '(not listed)';
       console.log(`[rnfb-e2e] install-state label=${label} listapps=${invertaseLine.trim()}`);
     } catch (err) {
       console.warn(
@@ -284,7 +290,9 @@ function resolveAdbPath() {
 function resolveEmulatorPath() {
   const sdkRoot = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
   if (!sdkRoot) {
-    throw new Error('ANDROID_HOME or ANDROID_SDK_ROOT is required to cold boot the Android emulator');
+    throw new Error(
+      'ANDROID_HOME or ANDROID_SDK_ROOT is required to cold boot the Android emulator',
+    );
   }
   return path.join(sdkRoot, 'emulator', 'emulator');
 }
@@ -339,7 +347,9 @@ function killTcpPortListener(port, label) {
       timeout: 5000,
     }).trim();
   } catch (err) {
-    console.warn(`[rnfb-e2e] ${label}: unable to inspect :${port} listener: ${err?.message || err}`);
+    console.warn(
+      `[rnfb-e2e] ${label}: unable to inspect :${port} listener: ${err?.message || err}`,
+    );
     return;
   }
 
@@ -715,6 +725,35 @@ function isRetryableJetDisconnect(output) {
   return JET_RETRYABLE_WS_RE.test(output);
 }
 
+function countJetSuiteTitles(output) {
+  const text = String(output);
+  let count = 0;
+  let from = 0;
+  while (from < text.length) {
+    const idx = text.indexOf(JET_SUITE_TITLE_FRAGMENT, from);
+    if (idx === -1) {
+      break;
+    }
+    count += 1;
+    from = idx + JET_SUITE_TITLE_FRAGMENT.length;
+  }
+  return count;
+}
+
+function hasJetReconnectDesyncSignal(output) {
+  // Suite re-entry after reconnect (preserving_runner restarted the mocha tree),
+  // or prior reconnect gates: lost coverage / server stopped mid-session.
+  return (
+    countJetSuiteTitles(output) >= 2 ||
+    JET_COVERAGE_LOST_RE.test(output) ||
+    JET_SERVER_STOPPED_RE.test(output)
+  );
+}
+
+function isJetReconnectDesyncFailure(output) {
+  return JET_RECONNECT_RECOVERED_RE.test(output) && hasJetReconnectDesyncSignal(output);
+}
+
 function isRetryableJetSessionFailure(output) {
   if (JET_SERVER_NOT_RUNNING_RE.test(output)) {
     return true;
@@ -732,11 +771,15 @@ function isRetryableJetSessionFailure(output) {
     return true;
   }
 
-  if (!JET_RECONNECT_RECOVERED_RE.test(output)) {
-    return false;
+  // Bare reconnect_recovered is not enough — product assertion failures after a
+  // benign reconnect must fail the attempt. Retry only when reconnect coincides
+  // with a desync / polluted-session signal (suite re-entry, coverage 0/0, or
+  // server stopped).
+  if (isJetReconnectDesyncFailure(output)) {
+    return true;
   }
 
-  return JET_COVERAGE_LOST_RE.test(output) || /\[🟥\] Stopped the server/i.test(output);
+  return false;
 }
 
 function isRetryableCloudQuotaFailure(jetOutput) {
@@ -773,6 +816,9 @@ function logRetryEligibility(err, attempt) {
   const checks = {
     jetDisconnect: isRetryableJetDisconnect(jetOutput),
     jetSession: isRetryableJetSessionFailure(jetOutput),
+    jetReconnectRecovered: JET_RECONNECT_RECOVERED_RE.test(jetOutput),
+    jetReconnectDesync: isJetReconnectDesyncFailure(jetOutput),
+    jetReconnectSuiteRestart: countJetSuiteTitles(jetOutput) >= 2,
     jetProtocol: JET_PROTOCOL_ERROR_RE.test(jetOutput),
     jetNoClient: JET_NO_CLIENT_CONNECTED_RE.test(jetOutput),
     coverageTeardown: JET_COVERAGE_TEARDOWN_RE.test(jetOutput),
@@ -827,7 +873,8 @@ async function terminateAppWithTiming(label) {
 }
 
 async function launchAppWithTimeout(launchArgs, { deleteApp = true, timeoutMs } = {}) {
-  const effectiveTimeout = timeoutMs ?? (usesLiveMetro() ? LAUNCH_APP_TIMEOUT_MS : LAUNCH_APP_RELEASE_TIMEOUT_MS);
+  const effectiveTimeout =
+    timeoutMs ?? (usesLiveMetro() ? LAUNCH_APP_TIMEOUT_MS : LAUNCH_APP_RELEASE_TIMEOUT_MS);
   console.log(
     `[rnfb-e2e] launchApp starting timeout=${effectiveTimeout}ms delete=${deleteApp} liveMetro=${usesLiveMetro()}`,
   );
@@ -1136,10 +1183,16 @@ describe('Jet Tests', function () {
             if (JET_PROTOCOL_ERROR_RE.test(lastOutput)) {
               console.warn('[rnfb-e2e] Retrying after Jet protocol error (JSON/WS desync)');
             } else if (JET_NO_CLIENT_CONNECTED_RE.test(lastOutput)) {
-              console.warn('[rnfb-e2e] Retrying after Jet reconnect send race (No client connected)');
+              console.warn(
+                '[rnfb-e2e] Retrying after Jet reconnect send race (No client connected)',
+              );
+            } else if (isJetReconnectDesyncFailure(lastOutput)) {
+              console.warn(
+                '[rnfb-e2e] Retrying after Jet reconnect desync (suite re-entry / coverage lost / server stopped)',
+              );
             } else {
               console.warn(
-                '[rnfb-e2e] Retrying after Jet session desync (reconnect recovered / coverage teardown / server not running)',
+                '[rnfb-e2e] Retrying after Jet session desync (coverage teardown / server not running)',
               );
             }
           } else if (isRetryableLaunchFailure(lastFailure)) {
@@ -1207,9 +1260,7 @@ describe('Jet Tests', function () {
         intervalMs: 1000,
       });
       if (!pulled) {
-        console.warn(
-          '[native-coverage] Android .ec not pulled on Jet close; post-e2e will retry',
-        );
+        console.warn('[native-coverage] Android .ec not pulled on Jet close; post-e2e will retry');
       }
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -16022,7 +16022,7 @@ __metadata:
 
 "jet@patch:jet@npm%3A0.9.0-dev.13#~/.yarn/patches/jet-npm-0.9.0-dev.13-3321aeea6e.patch":
   version: 0.9.0-dev.13
-  resolution: "jet@patch:jet@npm%3A0.9.0-dev.13#~/.yarn/patches/jet-npm-0.9.0-dev.13-3321aeea6e.patch::version=0.9.0-dev.13&hash=da22b8"
+  resolution: "jet@patch:jet@npm%3A0.9.0-dev.13#~/.yarn/patches/jet-npm-0.9.0-dev.13-3321aeea6e.patch::version=0.9.0-dev.13&hash=0d87d1"
   dependencies:
     "@types/mocha": "npm:^10.0.10"
     babel-plugin-istanbul: "npm:^7.0.0"
@@ -16039,7 +16039,7 @@ __metadata:
     react-native: "*"
   bin:
     jet: jet.js
-  checksum: 10/aa8a2bf53d96324b584f97d8c33bf4c655c8bd9b8191ca0067c8a42fd0bc2627b35894d927c6fbd477cdd5a51ceec46bdb9cf1735af4242a372c86b101b80680
+  checksum: 10/f999c7ec39f34c123517e06f797913599f3768456d8e3d391ea98c80d1d6e151777f957c7cf8404f2d62a5c24bacb508f1d60c71a6395222b1e18d086176a82e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Soft-fail Jet `transformFailure` when Metro symbolicate is unavailable so Release e2e keeps the original error (D1).
- Retry Jet only when `reconnect_recovered` coincides with a mid-suite desync signal (suite re-entry / coverage 0/0 / server stopped), not on bare reconnect (D2).
- Uniquify the functions modular secondary `initializeApp` app name with `Date.now()` and clean up via `deleteApp` so suite re-entry cannot collide (D4).

## Test plan
- [x] D1/D2/D4 area-focused `app`+`functions` e2e on iOS and Android (74 passing / 1 pending)
- [ ] CI e2e matrix on this PR