### PR TITLE
docs(ios): correct SPM product linkage and document FirebaseCore sharing limits

### DIFF
--- a/docs/ios-spm.mdx
+++ b/docs/ios-spm.mdx
@@ -177,11 +177,11 @@ links. Another pod's copy stays unconfigured, so `FirebaseApp.app()` can
 return `nil` there (and Auth can silently look signed-out even when RNFB JS
 Auth has a user).
 
-| RNFB | Other native dependency | Shared FirebaseCore? |
-| --- | --- | --- |
-| SPM | SPM (`spm_dependency`) | No: each dynamic pod embeds its own copy |
-| SPM | CocoaPods Firebase pods | No: dual resolution (SPM + CocoaPods Firebase) |
-| CocoaPods (`$RNFirebaseDisableSPM = true`) | CocoaPods Firebase pods | Yes: one CocoaPods `FirebaseCore` |
+| RNFB                                       | Other native dependency | Shared FirebaseCore?                           |
+| ------------------------------------------ | ----------------------- | ---------------------------------------------- |
+| SPM                                        | SPM (`spm_dependency`)  | No: each dynamic pod embeds its own copy       |
+| SPM                                        | CocoaPods Firebase pods | No: dual resolution (SPM + CocoaPods Firebase) |
+| CocoaPods (`$RNFirebaseDisableSPM = true`) | CocoaPods Firebase pods | Yes: one CocoaPods `FirebaseCore`              |
 
 If a third-party native module must share the same configured `FirebaseApp`
 with RNFB, opt out of SPM and resolve Firebase through CocoaPods for every

--- a/docs/ios-spm.mdx
+++ b/docs/ios-spm.mdx
@@ -90,7 +90,7 @@ The install output identifies the selected mode:
 ```
 
 RNFB also adds an `[RNFB] Embed Firebase SPM Frameworks` build phase to the app
-target. This phase embeds SPM-built Firebase frameworks that React Native's
+target. This phase embeds Firebase frameworks built by SPM that React Native's
 pod-level SPM integration does not otherwise copy into the app bundle.
 
 ### Release build and module-resolution settings
@@ -173,7 +173,7 @@ React Native attaches SPM products to each pod target via `spm_dependency`.
 Because firebase-ios-sdk products are automatic libraries, each dynamic pod
 framework that depends on Firebase embeds its own copy of `FirebaseCore`.
 `FirebaseApp.configure()` in the app configures only the copy that target
-links. Another pod's copy stays unconfigured, so `FirebaseApp.app()` can
+links. Another pod's copy is never configured, so `FirebaseApp.app()` can
 return `nil` there (and Auth can silently look signed-out even when RNFB JS
 Auth has a user).
 

--- a/docs/ios-spm.mdx
+++ b/docs/ios-spm.mdx
@@ -25,11 +25,14 @@ SPM requires dynamic framework linkage:
 use_frameworks! :linkage => :dynamic
 ```
 
-Do not use RNFB's SPM mode with `use_frameworks! :linkage => :static`. Firebase's
-SPM products are dynamic, and static linkage makes multiple RNFB pods link
-duplicate copies of them. `pod install` fails fast with this error if it
-detects the combination, rather than letting it surface later as a confusing
-duplicate-symbol linker error.
+Do not use RNFB's SPM mode with `use_frameworks! :linkage => :static`.
+firebase-ios-sdk SPM products are automatic libraries (plain `.library(...)`,
+not `type: .dynamic`), so each pod that depends on them embeds its own copy.
+With static pod linkage those copies collide at link time as duplicate-symbol
+errors. `pod install` fails fast for that combination instead of surfacing the
+linker failure later. Dynamic linkage is required for SPM mode to build and
+run; see [Sharing FirebaseCore with other native pods](#sharing-firebasecore-with-other-native-pods)
+for what dynamic linkage does and does not give you.
 
 CocoaPods mode supports either static or dynamic linkage, subject to the
 requirements of the other dependencies in your app.
@@ -87,7 +90,7 @@ The install output identifies the selected mode:
 ```
 
 RNFB also adds an `[RNFB] Embed Firebase SPM Frameworks` build phase to the app
-target. This phase embeds dynamic Firebase frameworks that React Native's
+target. This phase embeds SPM-built Firebase frameworks that React Native's
 pod-level SPM integration does not otherwise copy into the app bundle.
 
 ### Release build and module-resolution settings
@@ -164,12 +167,48 @@ other value -- `false`, `nil`, or leaving it unset -- uses SPM (React Native
 always emit the variable, e.g. `$RNFirebaseDisableSPM = false`: that still
 uses SPM, it does not fall back to CocoaPods.
 
+## Sharing FirebaseCore with other native pods
+
+React Native attaches SPM products to each pod target via `spm_dependency`.
+Because firebase-ios-sdk products are automatic libraries, each dynamic pod
+framework that depends on Firebase embeds its own copy of `FirebaseCore`.
+`FirebaseApp.configure()` in the app configures only the copy that target
+links. Another pod's copy stays unconfigured, so `FirebaseApp.app()` can
+return `nil` there (and Auth can silently look signed-out even when RNFB JS
+Auth has a user).
+
+| RNFB | Other native dependency | Shared FirebaseCore? |
+| --- | --- | --- |
+| SPM | SPM (`spm_dependency`) | No: each dynamic pod embeds its own copy |
+| SPM | CocoaPods Firebase pods | No: dual resolution (SPM + CocoaPods Firebase) |
+| CocoaPods (`$RNFirebaseDisableSPM = true`) | CocoaPods Firebase pods | Yes: one CocoaPods `FirebaseCore` |
+
+If a third-party native module must share the same configured `FirebaseApp`
+with RNFB, opt out of SPM and resolve Firebase through CocoaPods for every
+native consumer:
+
+```ruby
+$RNFirebaseDisableSPM = true
+```
+
+Do not mix RNFB SPM with a third-party pod that pulls Firebase via CocoaPods
+pods. That is dual resolution and does not produce one shared runtime.
+
+Static pod linkage is not a sharing workaround under SPM: it fails at link
+time with duplicate symbols (and `pod install` rejects the combination).
+
 ## Troubleshooting
 
 - **`pod install` fails with "SPM + static linkage is not supported":** Do not
   combine RNFB SPM mode with static linkage. Use dynamic linkage
   (`use_frameworks! :linkage => :dynamic`) or set
   `$RNFirebaseDisableSPM = true`.
+- **`FirebaseApp.app()` is `nil` / Auth looks signed-out inside another native
+  pod, or runtime logs duplicate `FIRApp` classes:** SPM mode cannot share one
+  `FirebaseCore` across dynamic pod frameworks. Set
+  `$RNFirebaseDisableSPM = true` and resolve Firebase via CocoaPods for RNFB
+  and that dependency. See
+  [Sharing FirebaseCore with other native pods](#sharing-firebasecore-with-other-native-pods).
 - **`FirebaseCoreInternal`/`FirebaseSharedSwift` cannot be resolved, or a
   Release/Archive build crashes at launch with a missing Firebase symbol:**
   RNFB applies `-ObjC`, `SWIFT_ENABLE_EXPLICIT_MODULES = 'NO'`, and

--- a/okf-bundle/ios-spm-native-imports.md
+++ b/okf-bundle/ios-spm-native-imports.md
@@ -176,6 +176,43 @@ root and calls that binary directly (`chmod +x` first if the checkout didn't
 preserve the executable bit). If none of the three paths resolve, the script
 warns and lists every path it checked rather than failing silently.
 
+## Automatic SPM products and multi-pod FirebaseCore sharing
+
+firebase-ios-sdk `Package.swift` declares products as plain `.library(...)`
+with no `type: .dynamic` (confirmed on current tags, including 12.17.0).
+Automatic SPM libraries are linked statically into each consumer.
+
+React Native's `spm_dependency` attaches those products to **each pod target**.
+With `use_frameworks! :linkage => :dynamic` (required for RNFB SPM mode):
+
+- each dynamic pod framework embeds a private FirebaseCore (and related)
+  copy;
+- the app target may also get a `PackageFrameworks/*_PackageProduct.framework`
+  via `rnfirebase_add_spm_core_to_app_target`;
+- runtime can log duplicate `FIRApp` / related classes;
+- `FirebaseApp.configure()` in the app does not configure another pod's copy.
+
+| RNFB | Other native dependency | Shared FirebaseCore? |
+| --- | --- | --- |
+| SPM | SPM (`spm_dependency`) | No |
+| SPM | CocoaPods Firebase pods | No (dual resolution) |
+| CocoaPods (`$RNFirebaseDisableSPM = true`) | CocoaPods Firebase pods | Yes |
+
+SPM + static pods is rejected by `rnfirebase_fail_if_spm_static_linkage!`:
+per-pod copies collide at link time (`duplicate symbol`). Static linkage is
+not a sharing path under SPM.
+
+This is a packaging limitation of automatic SPM libraries + per-pod
+attachment, not a Data Connect-specific bug. Consumer-facing guidance:
+[`docs/ios-spm.mdx`](../docs/ios-spm.mdx#sharing-firebasecore-with-other-native-pods).
+Tracked from GitHub
+[#9140](https://github.com/invertase/react-native-firebase/issues/9140) /
+Linear CPRN-292.
+
+Do **not** reintroduce comments or docs that claim firebase-ios-sdk products
+use `.library(type: .dynamic)`. That claim is false and misled debugging of
+the multi-pod sharing failure.
+
 ## Runtime framework embedding
 
 React Native's `spm_dependency` integration attaches SPM products to pod
@@ -286,6 +323,10 @@ invariants:
 - no private/transitive Firebase target added as if it were a public product;
 - SPM mode still adds exactly one app framework-embedding phase and CocoaPods
   mode does not require it;
+- docs/comments must not claim firebase-ios-sdk SPM products use
+  `.library(type: .dynamic)`; products are automatic libraries, and multi-pod
+  FirebaseCore sharing under SPM is unsupported (CocoaPods mode is the
+  supported path when another native pod must share `FirebaseApp`);
 - if a Firebase/Google SPM package adds a new `.binaryTarget` xcframework to
   the resolved graph (e.g. a firebase-ios-sdk version bump),
   `RNFIREBASE_SPM_SIGNATURE_FIX_ARTIFACT_NAMES` is re-checked against a clean

--- a/okf-bundle/ios-spm-native-imports.md
+++ b/okf-bundle/ios-spm-native-imports.md
@@ -192,11 +192,11 @@ With `use_frameworks! :linkage => :dynamic` (required for RNFB SPM mode):
 - runtime can log duplicate `FIRApp` / related classes;
 - `FirebaseApp.configure()` in the app does not configure another pod's copy.
 
-| RNFB | Other native dependency | Shared FirebaseCore? |
-| --- | --- | --- |
-| SPM | SPM (`spm_dependency`) | No |
-| SPM | CocoaPods Firebase pods | No (dual resolution) |
-| CocoaPods (`$RNFirebaseDisableSPM = true`) | CocoaPods Firebase pods | Yes |
+| RNFB                                       | Other native dependency | Shared FirebaseCore? |
+| ------------------------------------------ | ----------------------- | -------------------- |
+| SPM                                        | SPM (`spm_dependency`)  | No                   |
+| SPM                                        | CocoaPods Firebase pods | No (dual resolution) |
+| CocoaPods (`$RNFirebaseDisableSPM = true`) | CocoaPods Firebase pods | Yes                  |
 
 SPM + static pods is rejected by `rnfirebase_fail_if_spm_static_linkage!`:
 per-pod copies collide at link time (`duplicate symbol`). Static linkage is

--- a/packages/app/firebase_spm.rb
+++ b/packages/app/firebase_spm.rb
@@ -149,10 +149,15 @@ end
 # because static frameworks cause each pod to embed Firebase SPM products,
 # resulting in duplicate symbol linker errors.
 #
-# firebase-ios-sdk SPM requires dynamic linkage. There is no upstream statement
-# from Google that SPM+static is supported. See:
+# firebase-ios-sdk SPM products are plain `.library(...)` (automatic linkage),
+# not `.library(type: .dynamic)`. See:
 # https://github.com/firebase/firebase-ios-sdk/blob/main/Package.swift
-# (all products use .library(type: .dynamic))
+# Automatic products are linked statically into each consumer. RNFB SPM mode
+# therefore requires `use_frameworks! :linkage => :dynamic` so the app can
+# build and run; static pod linkage collides those per-pod copies at link time.
+# Dynamic pods avoid the link failure but still embed a private copy per pod,
+# so third-party pods cannot share one FirebaseCore/FirebaseApp with RNFB
+# under SPM (use `$RNFirebaseDisableSPM = true` + CocoaPods for that).
 #
 # Returns true only when `$RNFirebaseDisableSPM` has been explicitly set to `true`.
 #
@@ -366,14 +371,16 @@ end
 # architecture ..." linker error later, at Xcode build time, with no obvious
 # link back to the Podfile setting that caused it.
 #
-# firebase-ios-sdk's SPM package only ships dynamic library products -- see
-# https://github.com/firebase/firebase-ios-sdk/blob/main/Package.swift (every
-# product uses `.library(type: .dynamic)`) -- so under static linkage, every
-# RNFB pod that resolves Firebase via SPM ends up statically embedding its
-# own private copy of the same Firebase SPM products, and the app target
-# links duplicate symbols for each one. There is no supported combination of
-# RNFB's SPM mode with static linkage to fall back to; the fix is always to
-# either switch to dynamic linkage or opt out of SPM entirely.
+# firebase-ios-sdk's SPM products are automatic libraries (plain `.library(...)`,
+# not `type: .dynamic`) -- see
+# https://github.com/firebase/firebase-ios-sdk/blob/main/Package.swift -- so
+# each pod that resolves Firebase via SPM statically embeds its own copy.
+# Under static pod linkage those copies collide when the app links
+# (`duplicate symbol`). Under dynamic pod linkage the app builds, but each
+# dynamic framework still keeps a private copy (runtime class duplication /
+# split FirebaseApp registries). There is no supported combination of RNFB's
+# SPM mode with static linkage; the fix is always to switch to dynamic
+# linkage or opt out of SPM entirely.
 #
 # Raises `Pod::Informative` -- CocoaPods' own user-facing error class, which
 # `pod install` prints as a plain, readable message with no Ruby backtrace --
@@ -404,7 +411,7 @@ def rnfirebase_fail_if_spm_static_linkage!(installer)
   raise Pod::Informative, <<~MESSAGE
     [react-native-firebase] SPM + static linkage is not supported (target(s): #{target_names}).
 
-    firebase-ios-sdk's Swift Package only ships dynamic library products, so `use_frameworks! :linkage => :static` causes every react-native-firebase pod that resolves Firebase via SPM to embed its own copy of the same Firebase frameworks -- this produces duplicate-symbol linker errors at build time instead of a clear error here.
+    firebase-ios-sdk's Swift Package products are automatic libraries (not `type: .dynamic`), so each react-native-firebase pod that resolves Firebase via SPM embeds its own copy. With `use_frameworks! :linkage => :static` those copies collide at link time as duplicate-symbol errors.
 
     Fix one of the following in your Podfile, then run `pod install` again:
       - Use dynamic linkage: `use_frameworks! :linkage => :dynamic`


### PR DESCRIPTION
Documents the SPM multi-pod FirebaseCore sharing limit from #9140.

- Correct the false claim that firebase-ios-sdk SPM products use `.library(type: .dynamic)`
- Document when FirebaseCore can be shared, and the `$RNFirebaseDisableSPM` workaround
- Align `firebase_spm.rb` comments and the static-linkage fail message with that model

Closes #9140