### PR TITLE
fix(auth, ios): match signInWithCustomToken selector to generated TurboModule spec

### DIFF
--- a/packages/app/__tests__/specNativeParityHelper.ts
+++ b/packages/app/__tests__/specNativeParityHelper.ts
@@ -161,6 +161,53 @@ export function extractIosTurboMethods(headerContent: string, moduleName: string
   return sortUnique(methods);
 }
 
+/**
+ * Full ObjC selectors from codegen `@selector(...)` invocations in *-generated.mm.
+ * Catches argument-label mismatches (e.g. token: vs customToken:) that method-name
+ * parity alone cannot detect — see #9145 / PR #9146.
+ */
+export function extractIosGeneratedSelectors(generatedMmContent: string): string[] {
+  const selectors: string[] = [];
+  const selectorRegex = /@selector\(([^)]+)\)/g;
+  let match = selectorRegex.exec(generatedMmContent);
+  while (match) {
+    const selector = match[1];
+    const methodName = selector.split(':')[0];
+    if (!EXCLUDED_METHODS.has(methodName)) {
+      selectors.push(selector);
+    }
+    match = selectorRegex.exec(generatedMmContent);
+  }
+  return sortUnique(selectors);
+}
+
+/**
+ * Full ObjC instance-method selectors from a TurboModule shell .mm implementation.
+ * Parses `- (ReturnType)name:…` declarations (including multi-line), not message sends.
+ */
+export function extractIosImplementedSelectors(implMmContent: string): string[] {
+  const withoutComments = implMmContent.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+  // RN / ObjC runtime hooks that are not TurboModule codegen selectors.
+  const NON_TURBO_METHODS = new Set(['dealloc', 'invalidate', 'getTurboModule']);
+
+  const selectors: string[] = [];
+  // Multi-line declarations: `- (ReturnType)name:… {` — stop at the method body's `{`.
+  const methodRegex = /^[ \t]*- \([^)]+\)([\s\S]*?)\{/gm;
+  let match = methodRegex.exec(withoutComments);
+  while (match) {
+    // Flatten whitespace then strip typed params: "foo:(NSString *)a bar:(id)b" → "foo:bar:"
+    const flattened = match[1].replace(/\s+/g, ' ').trim();
+    const selector = flattened.replace(/:\s*\([^)]*\)\s*\w+/g, ':').replace(/\s+/g, '');
+    const methodName = selector.split(':')[0];
+    if (selector && !EXCLUDED_METHODS.has(methodName) && !NON_TURBO_METHODS.has(methodName)) {
+      selectors.push(selector);
+    }
+    match = methodRegex.exec(withoutComments);
+  }
+  return sortUnique(selectors);
+}
+
 function sortUnique(values: string[]): string[] {
   return [...new Set(values)].sort();
 }

--- a/packages/auth/__tests__/iosTurboSelectorParity.test.ts
+++ b/packages/auth/__tests__/iosTurboSelectorParity.test.ts
@@ -1,0 +1,52 @@
+/**
+ * iOS New Architecture TurboModule selector parity for auth.
+ *
+ * Method-name parity (NewArch-AD-17.2) does not catch ObjC argument-label
+ * mismatches. Codegen emits @selector(signInWithCustomToken:token:resolve:reject:)
+ * while a mislabeled implementation (customToken:) is a different selector and
+ * crashes at runtime with unrecognized selector (#9145).
+ */
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+import {
+  diffSets,
+  extractIosGeneratedSelectors,
+  extractIosImplementedSelectors,
+  formatSetDiff,
+} from '../../app/__tests__/specNativeParityHelper';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const GENERATED_MM = path.join(
+  REPO_ROOT,
+  'packages/auth/ios/generated/RNFBAuthTurboModules/RNFBAuthTurboModules-generated.mm',
+);
+const IMPL_MM = path.join(REPO_ROOT, 'packages/auth/ios/RNFBAuth/RNFBAuthModule.mm');
+
+describe('auth iOS TurboModule selector parity (#9145)', function () {
+  it('implements every codegen @selector including argument labels', function () {
+    const generated = extractIosGeneratedSelectors(fs.readFileSync(GENERATED_MM, 'utf8'));
+    const implemented = extractIosImplementedSelectors(fs.readFileSync(IMPL_MM, 'utf8'));
+
+    const diff = diffSets(generated, implemented);
+    if (diff.missing.length || diff.extra.length) {
+      throw new Error(
+        [
+          'auth iOS TurboModule selector mismatch (codegen vs RNFBAuthModule.mm)',
+          formatSetDiff('codegen selectors vs implementation', diff),
+          'Argument labels are part of the ObjC selector — renaming a param label',
+          'without matching the TurboModule spec causes unrecognized-selector crashes.',
+        ].join('\n'),
+      );
+    }
+
+    expect(diff).toEqual({ missing: [], extra: [] });
+    expect(implemented).toEqual(expect.arrayContaining(generated));
+  });
+
+  it('uses signInWithCustomToken:token: (not customToken:) per NativeRNFBTurboAuth', function () {
+    const implemented = extractIosImplementedSelectors(fs.readFileSync(IMPL_MM, 'utf8'));
+    expect(implemented).toContain('signInWithCustomToken:token:resolve:reject:');
+    expect(implemented).not.toContain('signInWithCustomToken:customToken:resolve:reject:');
+  });
+});

--- a/packages/auth/e2e/auth.e2e.js
+++ b/packages/auth/e2e/auth.e2e.js
@@ -21,7 +21,13 @@ const TEST_PASS = 'test1234';
 const DISABLED_EMAIL = 'disabled@example.com';
 const DISABLED_PASS = 'test1234';
 
-const { clearAllUsers, disableUser, getLastOob, resetPassword } = require('./helpers');
+const {
+  clearAllUsers,
+  createEmulatorCustomToken,
+  disableUser,
+  getLastOob,
+  resetPassword,
+} = require('./helpers');
 
 describe('auth() modular', function () {
   describe('modular', function () {
@@ -154,8 +160,24 @@ describe('auth() modular', function () {
     });
 
     describe('signInWithCustomToken()', function () {
-      // Needs a different setup when running against the emulator
-      xit('signs in with an admin SDK created custom auth token', async function () {
+      // Regression for #9145: on iOS New Arch, a TurboModule selector mismatch
+      // (customToken: vs token:) crashes with unrecognized selector before Auth runs.
+      it('rejects an invalid custom token without crashing the TurboModule bridge', async function () {
+        const { getApp } = modular;
+        const { signInWithCustomToken, getAuth } = authModular;
+        const defaultAuth = getAuth(getApp());
+
+        let didError = false;
+        try {
+          await signInWithCustomToken(defaultAuth, 'not-a-valid-custom-token');
+        } catch (e) {
+          didError = true;
+          e.code.should.equal('auth/invalid-custom-token');
+        }
+        didError.should.equal(true);
+      });
+
+      it('signs in with an Auth-emulator custom token', async function () {
         const { getApp } = modular;
         const { signInWithEmailAndPassword, signOut, signInWithCustomToken, getAuth } = authModular;
         const defaultAuth = getAuth(getApp());
@@ -181,12 +203,11 @@ describe('auth() modular', function () {
           successCb,
         );
 
-        const IdToken = await defaultAuth.currentUser.getIdToken();
-
         await signOut(defaultAuth);
         await Utils.sleep(50);
 
-        const token = await new TestAdminApi(IdToken).auth().createCustomToken(user.uid, {});
+        // Emulator accepts unsigned hand-crafted JWTs (no Admin SDK / remote TestAdminApi).
+        const token = createEmulatorCustomToken(user.uid, {});
 
         await signInWithCustomToken(defaultAuth, token);
 

--- a/packages/auth/e2e/helpers.js
+++ b/packages/auth/e2e/helpers.js
@@ -21,6 +21,42 @@ function getRandomPhoneNumber() {
 }
 exports.getRandomPhoneNumber = getRandomPhoneNumber;
 
+/**
+ * Mint a Firebase Auth custom token accepted by the Auth emulator.
+ *
+ * The emulator does not validate JWT signature or expiry, so a hand-crafted
+ * unsigned token is enough for e2e (no Admin SDK / api.rnfirebase.io).
+ * @see https://firebase.google.com/docs/emulator-suite/connect_auth#custom_token_authentication
+ */
+function base64UrlEncodeJson(value) {
+  const json = JSON.stringify(value);
+  const base64 =
+    typeof globalThis.btoa === 'function'
+      ? globalThis.btoa(json)
+      : Buffer.from(json, 'utf8').toString('base64');
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+exports.createEmulatorCustomToken = function createEmulatorCustomToken(uid, claims) {
+  if (!uid || typeof uid !== 'string') {
+    throw new Error('createEmulatorCustomToken: uid is required');
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const serviceAccount = `firebase-adminsdk@${getE2eTestProject()}.iam.gserviceaccount.com`;
+  const payload = {
+    uid,
+    iat: now,
+    exp: now + 3600,
+    aud: 'https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit',
+    iss: serviceAccount,
+    sub: serviceAccount,
+  };
+  if (claims && typeof claims === 'object' && Object.keys(claims).length > 0) {
+    payload.claims = claims;
+  }
+  return `${base64UrlEncodeJson({ alg: 'none', typ: 'JWT' })}.${base64UrlEncodeJson(payload)}.`;
+};
+
 exports.clearAllUsers = async function clearAllUsers() {
   // console.error('auth::helpers::clearAllUsers');
   try {

--- a/packages/auth/e2e/helpers.js
+++ b/packages/auth/e2e/helpers.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
 const { getE2eTestProject, getE2eEmulatorHost } = require('../../app/e2e/helpers');
+// Shared Latin1 btoa — do not use Node Buffer / globalThis.btoa (Other/HermesVM).
+// Same import path as app-check & installations e2e.
+const { Base64 } = require('@react-native-firebase/app/dist/module/common');
 
 // Call HTTP REST API URL and return JSON response parsed into object
 const callRestApi = async function callRestAPI(url, returnRedirectUrl = false) {
@@ -27,36 +30,12 @@ exports.getRandomPhoneNumber = getRandomPhoneNumber;
  * The emulator does not validate JWT signature or expiry, so a hand-crafted
  * unsigned token is enough for e2e (no Admin SDK / api.rnfirebase.io).
  * @see https://firebase.google.com/docs/emulator-suite/connect_auth#custom_token_authentication
- *
- * Encoding must not use Node `Buffer` or rely on `globalThis.btoa`: Other/HermesVM
- * has neither (RN web API shims are incomplete there). Same Latin1 encoder as
- * `packages/app/lib/common/Base64.ts` / app-check & installations e2e.
  */
-function latin1Btoa(input) {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-  let block = 0;
-  let i = 0;
-  let map = chars;
-  let output = '';
-
-  for (
-    block = 0, i = 0, map = chars;
-    input.charAt(i | 0) || ((map = '='), i % 1);
-    output += map.charAt(63 & (block >> (8 - (i % 1) * 8)))
-  ) {
-    const charCode = input.charCodeAt((i += 3 / 4));
-    if (charCode > 0xff) {
-      throw new Error('latin1Btoa: input contains characters outside Latin1');
-    }
-    block = (block << 8) | charCode;
-  }
-
-  return output;
-}
-
 function base64UrlEncodeJson(value) {
-  const json = JSON.stringify(value);
-  return latin1Btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  return Base64.btoa(JSON.stringify(value))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
 }
 
 exports.createEmulatorCustomToken = function createEmulatorCustomToken(uid, claims) {

--- a/packages/auth/e2e/helpers.js
+++ b/packages/auth/e2e/helpers.js
@@ -27,14 +27,36 @@ exports.getRandomPhoneNumber = getRandomPhoneNumber;
  * The emulator does not validate JWT signature or expiry, so a hand-crafted
  * unsigned token is enough for e2e (no Admin SDK / api.rnfirebase.io).
  * @see https://firebase.google.com/docs/emulator-suite/connect_auth#custom_token_authentication
+ *
+ * Encoding must not use Node `Buffer` or rely on `globalThis.btoa`: Other/HermesVM
+ * has neither (RN web API shims are incomplete there). Same Latin1 encoder as
+ * `packages/app/lib/common/Base64.ts` / app-check & installations e2e.
  */
+function latin1Btoa(input) {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+  let block = 0;
+  let i = 0;
+  let map = chars;
+  let output = '';
+
+  for (
+    block = 0, i = 0, map = chars;
+    input.charAt(i | 0) || ((map = '='), i % 1);
+    output += map.charAt(63 & (block >> (8 - (i % 1) * 8)))
+  ) {
+    const charCode = input.charCodeAt((i += 3 / 4));
+    if (charCode > 0xff) {
+      throw new Error('latin1Btoa: input contains characters outside Latin1');
+    }
+    block = (block << 8) | charCode;
+  }
+
+  return output;
+}
+
 function base64UrlEncodeJson(value) {
   const json = JSON.stringify(value);
-  const base64 =
-    typeof globalThis.btoa === 'function'
-      ? globalThis.btoa(json)
-      : Buffer.from(json, 'utf8').toString('base64');
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+  return latin1Btoa(json).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
 exports.createEmulatorCustomToken = function createEmulatorCustomToken(uid, claims) {

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.mm
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.mm
@@ -331,11 +331,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAuth);
 }
 
 - (void)signInWithCustomToken:(NSString *)appName
-                  customToken:(NSString *)customToken
+                        token:(NSString *)token
                       resolve:(RCTPromiseResolveBlock)resolve
                        reject:(RCTPromiseRejectBlock)reject {
   [RNFBAuthHelper signInWithCustomToken:appName
-                            customToken:customToken
+                            customToken:token
                                 resolve:resolve
                                  reject:reject];
 }

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.mm
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.mm
@@ -334,10 +334,7 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAuth);
                         token:(NSString *)token
                       resolve:(RCTPromiseResolveBlock)resolve
                        reject:(RCTPromiseRejectBlock)reject {
-  [RNFBAuthHelper signInWithCustomToken:appName
-                            customToken:token
-                                resolve:resolve
-                                 reject:reject];
+  [RNFBAuthHelper signInWithCustomToken:appName customToken:token resolve:resolve reject:reject];
 }
 
 #if TARGET_OS_IOS


### PR DESCRIPTION
### Description

Any call to `signInWithCustomToken()` on iOS with the New Architecture enabled crashes the app immediately:

```
NSInvalidArgumentException: -[RNFBAuthModule signInWithCustomToken:token:resolve:reject:]: unrecognized selector sent to instance
```

**Affected versions:** `@react-native-firebase/auth` 26.0.0 – 26.1.0 (still present on `main`).

**Root cause:** a selector mismatch between the shipped pre-generated TurboModule codegen and the Objective-C implementation.

- The codegen spec (`packages/auth/specs/NativeRNFBTurboAuth.ts`) declares `signInWithCustomToken(appName: string, token: string)`, so the generated protocol (`RNFBAuthTurboModules.h`) and the generated invocation (`RNFBAuthTurboModules-generated.mm`) both use the selector:
  `signInWithCustomToken:token:resolve:reject:`
- The implementation in `RNFBAuthModule.mm` used a different parameter label:
  `signInWithCustomToken:customToken:resolve:reject:`

Objective-C selectors include argument labels, so these are two different selectors. `RNFBAuthModule` therefore did not implement the method required by `NativeRNFBTurboAuthSpec`, and the generated TurboModule invocation throws `unrecognized selector` at runtime.

**Fix:** rename the second parameter label in `RNFBAuthModule.mm` from `customToken:` to `token:` so the implementation matches the generated spec protocol. The internal `RNFBAuthHelper` call is unchanged — the helper's own signature (`+ (void)signInWithCustomToken:appName customToken:...` in `RNFBAuthHelper.h`) legitimately uses `customToken:` and is not part of the codegen contract.

**Audit of the other methods:** I diffed every selector declared in the generated `NativeRNFBTurboAuthSpec` protocol against the implementations in `RNFBAuthModule.mm`. `signInWithCustomToken` was the only mismatch — all other methods conform. (`setEventEmitterCallback:` belongs to the generated `NativeRNFBTurboAuthSpecBase` class, implemented in the generated `.mm` itself, not to the module protocol.)

**Platforms:** Android is unaffected — the generated `NativeRNFBTurboAuth.java` binds arguments positionally, so the Java implementation's parameter name never mattered. macOS uses the same `ios/**` sources via `RNFBAuth.podspec`, so this one-file change covers it too.

**Minimal repro:** iOS app with New Architecture enabled, `@react-native-firebase/auth` ≥ 26.0.0, call `signInWithCustomToken()` with any token — the app crashes before the request is made.

**Note on e2e coverage:** an e2e test exists for this API (`packages/auth/e2e/auth.e2e.js`, `describe('signInWithCustomToken()')`) but it is currently skipped (`xit`) because it needs a different setup when running against the emulator — which is why this crash was not caught by CI.

### Related issues

Fixes #9145

### Release Summary

fix(auth, ios): `signInWithCustomToken()` crashed with `unrecognized selector` on the New Architecture — the Objective-C implementation's selector now matches the generated TurboModule spec.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] No

### Test Plan

The fix is a pure Objective-C selector rename with no behavior change. Verification: every selector required by the generated `NativeRNFBTurboAuthSpec` protocol is now implemented by `RNFBAuthModule` (scripted selector-by-selector diff of `RNFBAuthTurboModules.h` vs `RNFBAuthModule.mm`). Once the implementation conforms to the protocol, the generated invocation at `RNFBAuthTurboModules-generated.mm` resolves the selector correctly. The existing e2e test for this API is skipped on the emulator (see note above), so no automated test exercises this path.

🔥
