### PR TITLE
feat(app, ios): support disabling SPM via Expo config plugin

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -111,6 +111,19 @@ If you use `@react-native-firebase/analytics` with Expo, including EAS Build, an
 
 The `withoutAdIdSupport` option adds `$RNFirebaseAnalyticsWithoutAdIdSupport = true` to opt out of iOS Ad ID support. The `googleAppMeasurementOnDeviceConversion` option adds `$RNFirebaseAnalyticsGoogleAppMeasurementOnDeviceConversion = true` to include Google Analytics on-device conversion measurement support. You may omit either option if it is not needed.
 
+If you want to opt out of Swift Package Manager for the Firebase iOS SDK and use CocoaPods instead, pass the `disableSPM` option to the `@react-native-firebase/app` config plugin. It adds `$RNFirebaseDisableSPM = true` to the generated Podfile during prebuild - see [iOS SPM Support](/ios-spm) for details:
+
+```json
+[
+  "@react-native-firebase/app",
+  {
+    "ios": {
+      "disableSPM": true
+    }
+  }
+]
+```
+
 ### Local app compilation
 
 If you are compiling your app locally, run [`npx expo prebuild --clean`](https://docs.expo.dev/workflow/continuous-native-generation/) to generate the native project directories. Then, follow the local app compilation steps described in [Local app development](https://docs.expo.dev/guides/local-app-development/) guide in Expo docs. If you prefer using a build service, refer to [EAS Build](https://docs.expo.dev/build/setup/).

--- a/docs/ios-spm.mdx
+++ b/docs/ios-spm.mdx
@@ -59,9 +59,27 @@ Expo projects can select dynamic linkage with
 }
 ```
 
-To use CocoaPods mode in a generated project, a config plugin must add
-`$RNFirebaseDisableSPM = true` before the target blocks and configure the
-linkage your project requires.
+To use CocoaPods mode in a generated project, pass `disableSPM` to the
+`@react-native-firebase/app` config plugin -- it adds
+`$RNFirebaseDisableSPM = true` before the target blocks during prebuild --
+and configure the linkage your project requires:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@react-native-firebase/app",
+        {
+          "ios": {
+            "disableSPM": true
+          }
+        }
+      ]
+    ]
+  }
+}
+```
 
 The sections below (**Use SPM (React Native CLI)**, **Use CocoaPods (React
 Native CLI)**) describe editing `ios/Podfile` directly. Do not follow them in

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -51,6 +51,20 @@ To use CocoaPods instead, add this before any target block in your Podfile:
 $RNFirebaseDisableSPM = true
 ```
 
+Expo projects can set the same flag through the config plugin, which adds it
+to the generated Podfile during prebuild:
+
+```json
+[
+  "@react-native-firebase/app",
+  {
+    "ios": {
+      "disableSPM": true
+    }
+  }
+]
+```
+
 CocoaPods mode supports static or dynamic linkage. React Native versions older
 than 0.75 fall back to CocoaPods automatically.
 

--- a/packages/app/plugin/__tests__/__snapshots__/iosPodfile.test.ts.snap
+++ b/packages/app/plugin/__tests__/__snapshots__/iosPodfile.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`App Config Plugin iOS Podfile Tests adds the Podfile flag when disableSPM is enabled 1`] = `
+"platform :ios, '15.0'
+
+prepare_react_native_project!
+# @generated begin @react-native-firebase/app-disableSPM - expo prebuild (DO NOT MODIFY) sync-09f7df9a837716fd4f96713144d8f77224017d89
+$RNFirebaseDisableSPM = true
+# @generated end @react-native-firebase/app-disableSPM
+
+target 'ReactNativeFirebaseDemo' do
+end
+"
+`;

--- a/packages/app/plugin/__tests__/iosPodfile.test.ts
+++ b/packages/app/plugin/__tests__/iosPodfile.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { setAppPodfileDisableSPM } from '../src/ios/podfile';
+
+const podfileFixture = `platform :ios, '15.0'
+
+prepare_react_native_project!
+
+target 'ReactNativeFirebaseDemo' do
+end
+`;
+
+describe('App Config Plugin iOS Podfile Tests', function () {
+  it('adds the Podfile flag when disableSPM is enabled', function () {
+    const result = setAppPodfileDisableSPM(podfileFixture, true);
+    expect(result).toContain('$RNFirebaseDisableSPM = true');
+    expect(result).toMatchSnapshot();
+  });
+
+  it('places the flag before the target block', function () {
+    const result = setAppPodfileDisableSPM(podfileFixture, true);
+    expect(result.indexOf('$RNFirebaseDisableSPM = true')).toBeLessThan(
+      result.indexOf("target 'ReactNativeFirebaseDemo'"),
+    );
+  });
+
+  it('is idempotent when the Podfile flag is already present', function () {
+    const onceModified = setAppPodfileDisableSPM(podfileFixture, true);
+    const twiceModified = setAppPodfileDisableSPM(onceModified, true);
+
+    expect(twiceModified).toEqual(onceModified);
+  });
+
+  it('removes the generated Podfile flag when disableSPM is disabled', function () {
+    const onceModified = setAppPodfileDisableSPM(podfileFixture, true);
+    const restored = setAppPodfileDisableSPM(onceModified, false);
+
+    expect(restored).toEqual(podfileFixture);
+  });
+
+  it('leaves the Podfile untouched when disableSPM was never enabled', function () {
+    expect(setAppPodfileDisableSPM(podfileFixture, false)).toEqual(podfileFixture);
+    expect(setAppPodfileDisableSPM(podfileFixture)).toEqual(podfileFixture);
+  });
+});

--- a/packages/app/plugin/src/index.ts
+++ b/packages/app/plugin/src/index.ts
@@ -5,16 +5,18 @@ import {
   withBuildscriptDependency,
   withCopyAndroidGoogleServices,
 } from './android';
-import { withFirebaseAppDelegate, withIosGoogleServicesFile } from './ios';
+import { withFirebaseAppDelegate, withIosGoogleServicesFile, withIosDisableSPM } from './ios';
+import { PluginConfigType } from './pluginConfig';
 
 /**
  * A config plugin for configuring `@react-native-firebase/app`
  */
-const withRnFirebaseApp: ConfigPlugin = config => {
+const withRnFirebaseApp: ConfigPlugin<PluginConfigType> = (config, props) => {
   return withPlugins(config, [
     // iOS
     withFirebaseAppDelegate,
     withIosGoogleServicesFile,
+    [withIosDisableSPM, props],
 
     // Android
     withBuildscriptDependency,

--- a/packages/app/plugin/src/ios/index.ts
+++ b/packages/app/plugin/src/ios/index.ts
@@ -1,4 +1,5 @@
 import { withFirebaseAppDelegate } from './appDelegate';
 import { withIosGoogleServicesFile } from './googleServicesPlist';
+import { withIosDisableSPM } from './podfile';
 
-export { withIosGoogleServicesFile, withFirebaseAppDelegate };
+export { withIosGoogleServicesFile, withFirebaseAppDelegate, withIosDisableSPM };

--- a/packages/app/plugin/src/ios/podfile.ts
+++ b/packages/app/plugin/src/ios/podfile.ts
@@ -1,0 +1,40 @@
+import { ConfigPlugin, withPodfile } from '@expo/config-plugins';
+import {
+  mergeContents,
+  removeGeneratedContents,
+} from '@expo/config-plugins/build/utils/generateCode';
+
+import { PluginConfigType } from '../pluginConfig';
+
+const TAG = '@react-native-firebase/app-disableSPM';
+const ANCHOR = /prepare_react_native_project!/;
+const FLAG = '$RNFirebaseDisableSPM = true';
+
+// The flag must be defined before any target block so firebase_spm.rb sees it
+// when pods are declared - anchoring just after `prepare_react_native_project!`
+// guarantees that in the Podfile Expo generates.
+export function setAppPodfileDisableSPM(src: string, enabled: boolean = false): string {
+  if (!enabled) {
+    return removeGeneratedContents(src, TAG) ?? src;
+  }
+
+  return mergeContents({
+    src,
+    newSrc: FLAG,
+    tag: TAG,
+    anchor: ANCHOR,
+    offset: 1,
+    comment: '#',
+  }).contents;
+}
+
+export const withIosDisableSPM: ConfigPlugin<PluginConfigType> = (config, props) => {
+  return withPodfile(config, config => {
+    config.modResults.contents = setAppPodfileDisableSPM(
+      config.modResults.contents,
+      props?.ios?.disableSPM === true,
+    );
+
+    return config;
+  });
+};

--- a/packages/app/plugin/src/pluginConfig.ts
+++ b/packages/app/plugin/src/pluginConfig.ts
@@ -1,0 +1,13 @@
+export interface PluginConfigType {
+  ios?: PluginConfigTypeIos;
+}
+
+export interface PluginConfigTypeIos {
+  /**
+   * Sets `$RNFirebaseDisableSPM = true` in the Podfile, forcing Firebase
+   * dependencies to be installed with CocoaPods instead of Swift Package Manager.
+   *
+   * @platform ios iOS
+   */
+  disableSPM?: boolean;
+}


### PR DESCRIPTION
### Description

React Native 0.75+ resolves Firebase iOS SDK dependencies through SPM by default, and opting out requires setting `$RNFirebaseDisableSPM = true` before any target block in the Podfile. In Expo projects the Podfile is regenerated on every prebuild, so today the only way to opt out is maintaining a custom config plugin.

This PR adds an `ios.disableSPM` prop to the `@react-native-firebase/app` config plugin:

```json
["@react-native-firebase/app", { "ios": { "disableSPM": true } }]
```

When enabled, the plugin injects `$RNFirebaseDisableSPM = true` into the generated Podfile right after `prepare_react_native_project!` (before any target block, as required by `firebase_spm.rb`), using `mergeContents` with a tagged block. When the prop is `false` or omitted the generated block is removed, and the flag is never emitted as `= false` (which would still select SPM and is a documented pitfall).

The implementation mirrors the existing `@react-native-firebase/analytics` config plugin, which manages its own Podfile flags the same way.

Docs updated: `docs/index.mdx`, `docs/ios-spm.mdx` (Expo section), and `packages/app/README.md`.

### Related issues

### Release Summary

feat(app, ios): add `ios.disableSPM` option to the Expo config plugin to opt out of SPM (`$RNFirebaseDisableSPM = true`) in generated Podfiles

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [x] `jest` tests added or updated in `packages/\*\*/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- `yarn jest packages/app/plugin` — 15 tests pass (flag insertion, placement before target blocks, idempotency, removal, default no-op)
- `tsc --build plugin` and `eslint plugin/src/*` pass
- The injected line and placement match what is already validated in production Expo apps via hand-written config plugins setting the same flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)
