### PR TITLE
fix(ios): link FirebaseCore into app target under SPM

### DIFF
--- a/okf-bundle/ios-spm-native-imports.md
+++ b/okf-bundle/ios-spm-native-imports.md
@@ -3,7 +3,7 @@ type: Reference
 title: iOS SPM native integration decisions
 description: Why RNFB uses dual imports, Objective-C helpers for Swift Firebase products, and an app framework-embedding phase.
 tags: [ios, spm, cocoapods, imports, firebase, cxx-modules]
-timestamp: 2026-08-05T11:48:00Z
+timestamp: 2026-08-06T16:00:00Z
 ---
 
 # iOS SPM native integration decisions
@@ -213,6 +213,46 @@ Do **not** reintroduce comments or docs that claim firebase-ios-sdk products
 use `.library(type: .dynamic)`. That claim is false and misled debugging of
 the multi-pod sharing failure.
 
+## App target FirebaseCore link: package dependency alone is not enough
+
+`rnfirebase_add_spm_core_to_app_target` exists for the case in the table above
+where the app's own native code (not just a pod) calls `FIRApp`/`FIROptions`
+APIs directly, most commonly Expo's config plugin injecting
+`[FIRApp configure];` into the generated `AppDelegate`. Declaring the
+`FirebaseCore` product on `target.package_product_dependencies` is necessary
+but not sufficient: Xcode only actually links a Swift package product into a
+target's binary if a matching `PBXBuildFile` (with `product_ref` pointing at
+that dependency) also exists on the target's `PBXFrameworksBuildPhase`. A
+dependency declared without that build file compiles (the app target can see
+the product's headers/module) but fails at the link step:
+
+```text
+Undefined symbols for architecture arm64: "_OBJC_CLASS_$_FIRApp"
+```
+
+This shipped for a period without the `PBXBuildFile` step, so every dynamic
+SPM app whose own target called Firebase APIs directly hit this at link time,
+while apps that only reached Firebase through a pod (no direct `FIRApp` call
+in app code) never noticed, since a pod target's `PBXFrameworksBuildPhase`
+already gets a matching build file via SPM's own attach path. Tracked from
+GitHub [#9158](https://github.com/invertase/react-native-firebase/issues/9158)
+/ Linear CPRN-301.
+
+### Idempotency guard must distinguish "declared" from "linked"
+
+`rnfirebase_add_spm_core_to_app_target` runs on every `pod install`, so its
+early-exit guard must be re-entrant. A guard that only checks
+"does `package_product_dependencies` already contain `FirebaseCore`" is not
+enough once the fix adds a second, independent artifact (the `PBXBuildFile`):
+a project built by a pre-fix RNFB version already has the dependency declared
+but never the build file, and a naive existence-only guard would treat that
+broken state as done and skip forever, silently never healing an existing
+consumer's checked-in `.pbxproj`. The guard must check both artifacts and,
+when the dependency exists but the build file doesn't, reuse the existing
+dependency object (do not create a second `package_product_dependencies`
+entry, and do not create a second `package_references` entry either) and add
+only the missing build file.
+
 ## Runtime framework embedding
 
 React Native's `spm_dependency` integration attaches SPM products to pod
@@ -355,6 +395,12 @@ invariants:
 - no private/transitive Firebase target added as if it were a public product;
 - SPM mode still adds exactly one app framework-embedding phase and CocoaPods
   mode does not require it;
+- `rnfirebase_add_spm_core_to_app_target`'s guard still checks for a matching
+  `PBXBuildFile`/`product_ref` on the Frameworks build phase, not just a
+  `package_product_dependencies` entry, so it self-heals a pre-fix
+  consumer's checked-in `.pbxproj` instead of treating a declared-but-unlinked
+  dependency as already done; and `rnfirebase_remove_spm_core_from_app_target`
+  removes both artifacts symmetrically;
 - `embed_frameworks_from`'s Archive `UninstalledProducts` path still skips
   frameworks whose internal binary is missing or not `dynamically linked`
   (`file -b`), so static CocoaPods products are never copied into the app

--- a/packages/app/__tests__/firebase_spm_shape_test.rb
+++ b/packages/app/__tests__/firebase_spm_shape_test.rb
@@ -200,6 +200,44 @@ if RNFIREBASE_SPM_SHAPE_CHECK_GEMS_AVAILABLE
       refute Xcodeproj::Project::Object::PBXLegacyTarget.method_defined?(:package_product_dependencies)
     end
 
+    # ── Xcodeproj::Project::Object::PBXBuildFile / PBXNativeTarget#frameworks_build_phase
+    #    (the exact API rnfirebase_add_spm_core_to_app_target relies on to
+    #    actually *link* a package product dependency, not just declare one --
+    #    see MockFrameworksBuildPhase/PBXBuildFile-under-Xcodeproj in
+    #    firebase_spm_test.rb, and this bug class's own regression test there) ──
+
+    def test_native_target_responds_to_frameworks_build_phase
+      assert Xcodeproj::Project::Object::PBXNativeTarget.method_defined?(:frameworks_build_phase),
+             'Xcodeproj::Project::Object::PBXNativeTarget#frameworks_build_phase no longer exists -- ' \
+             'rnfirebase_add_spm_core_to_app_target relies on this to find-or-create the target\'s ' \
+             'PBXFrameworksBuildPhase and actually link FirebaseCore, not just declare it as a dependency.'
+    end
+
+    def test_build_file_responds_to_product_ref
+      assert Xcodeproj::Project::Object::PBXBuildFile.method_defined?(:product_ref),
+             'Xcodeproj::Project::Object::PBXBuildFile#product_ref no longer exists -- ' \
+             'rnfirebase_add_spm_core_to_app_target sets this (not file_ref, which is for plain file ' \
+             'references) to link a Swift Package product dependency into the Frameworks build phase.'
+    end
+
+    def test_build_file_added_to_frameworks_build_phase_links_product_ref
+      project = new_scratch_project
+      target = project.new(Xcodeproj::Project::Object::PBXNativeTarget)
+      pkg = project.new(Xcodeproj::Project::Object::XCRemoteSwiftPackageReference)
+      pkg.repositoryURL = 'https://github.com/firebase/firebase-ios-sdk.git'
+      ref = project.new(Xcodeproj::Project::Object::XCSwiftPackageProductDependency)
+      ref.product_name = 'FirebaseCore'
+      ref.package = pkg
+      target.package_product_dependencies << ref
+
+      build_file = project.new(Xcodeproj::Project::Object::PBXBuildFile)
+      build_file.product_ref = ref
+      target.frameworks_build_phase.files << build_file
+
+      assert_includes target.frameworks_build_phase.files, build_file
+      assert_same ref, target.frameworks_build_phase.files.first.product_ref
+    end
+
     # ── Xcodeproj::Project::Object::XCBuildConfiguration (the element type of
     #    AbstractTarget#build_configurations -- MockBuildConfig's real
     #    counterpart in firebase_spm_test.rb) ──

--- a/packages/app/__tests__/firebase_spm_test.rb
+++ b/packages/app/__tests__/firebase_spm_test.rb
@@ -55,6 +55,28 @@ class MockTarget
     config = @build_configurations.find { |c| c.name == config_name }
     config.build_settings
   end
+
+  # Mirrors `PBXNativeTarget#frameworks_build_phase` (singular) → finds or
+  # creates the target's one `PBXFrameworksBuildPhase`. Defaults to an empty
+  # phase so every pre-existing test that never calls this keeps passing
+  # unmodified -- this method, and the `files` collection it exposes, did not
+  # exist on this mock before the fix for the missing `PBXBuildFile` link.
+  def frameworks_build_phase
+    @frameworks_build_phase ||= MockFrameworksBuildPhase.new
+  end
+end
+
+# Mirrors `Xcodeproj::Project::Object::PBXFrameworksBuildPhase`'s
+# `has_many :files, PBXBuildFile` -- the real collection
+# `rnfirebase_add_spm_core_to_app_target` must append a `PBXBuildFile` to in
+# order for Xcode to actually link a package product dependency, not just
+# declare it (see `MockTarget#frameworks_build_phase` above).
+class MockFrameworksBuildPhase
+  attr_accessor :files
+
+  def initialize
+    @files = []
+  end
 end
 
 class MockUserProject
@@ -137,6 +159,18 @@ module Xcodeproj
         def remove_from_project
           @package&.remove_referrer(self)
         end
+      end
+
+      # Mirrors `Xcodeproj::Project::Object::PBXBuildFile` -- specifically its
+      # `has_one :product_ref, XCSwiftPackageProductDependency` attribute, the
+      # real one `rnfirebase_add_spm_core_to_app_target` must set (not
+      # `file_ref`, which is for plain file references) so a package product
+      # dependency actually gets linked into the target's Frameworks build
+      # phase, rather than merely declared on
+      # `target.package_product_dependencies`. `file_ref` is modeled too, for
+      # completeness, but unused by production code here.
+      class PBXBuildFile
+        attr_accessor :product_ref, :file_ref
       end
     end
   end
@@ -653,6 +687,30 @@ class FirebaseSpmTest < Minitest::Test
     assert_equal 1, user_project.save_count
   end
 
+  # Regression test for the missing-link bug (#9158): declaring a
+  # `package_product_dependencies` entry alone tells Xcode the target
+  # *depends* on the package product, but never actually links it -- that
+  # requires a matching `PBXBuildFile` (with its `product_ref` pointed at the
+  # same dependency) in the target's `PBXFrameworksBuildPhase`. Without it,
+  # native code calling FIRApp/FIROptions directly (as Expo's generated
+  # AppDelegate does) fails at the link step with "Undefined symbols ...
+  # _OBJC_CLASS_$_FIRApp", even though `pod install` appears to succeed.
+  def test_add_core_links_build_file_into_frameworks_build_phase
+    load_firebase_spm
+    RNFirebaseSPM.activate!('12.10.0')
+
+    target = MockTarget.new(['[CP] Embed Pods Frameworks'])
+    user_project = MockUserProject.new([target])
+    installer = MockInstaller.new([MockAggregateTarget.new(user_project)])
+
+    rnfirebase_add_spm_core_to_app_target(installer)
+
+    ref = target.package_product_dependencies[0]
+    build_files = target.frameworks_build_phase.files
+    assert_equal 1, build_files.length
+    assert_same ref, build_files[0].product_ref
+  end
+
   def test_add_core_is_idempotent_across_repeated_pod_installs
     load_firebase_spm
     RNFirebaseSPM.activate!('12.10.0')
@@ -665,6 +723,13 @@ class FirebaseSpmTest < Minitest::Test
     rnfirebase_add_spm_core_to_app_target(installer)
 
     assert_equal 1, target.package_product_dependencies.length
+    # The early-exit guard (`target.package_product_dependencies.any? { ... }`)
+    # must also stop a second `pod install` from double-linking the build
+    # file it added on the first call.
+    assert_equal 1, target.frameworks_build_phase.files.length
+    # The second, redundant call must not re-save the pbxproj: nothing about
+    # the target actually changed on the second pass.
+    assert_equal 1, user_project.save_count
   end
 
   def test_add_core_handles_swift_include_paths_already_set_as_a_string
@@ -714,6 +779,63 @@ class FirebaseSpmTest < Minitest::Test
     assert_equal 1, target.package_product_dependencies.length
     assert_same existing_pkg, target.package_product_dependencies[0].package
     assert_equal 1, user_project.save_count
+
+    # No pre-existing product *dependency* on the target for this scenario --
+    # only a pre-existing package *reference* -- so the build-file-linking
+    # code path must still run and link the freshly-created dependency.
+    build_files = target.frameworks_build_phase.files
+    assert_equal 1, build_files.length
+    assert_same target.package_product_dependencies[0], build_files[0].product_ref
+  end
+
+  # Regression test for the "already-affected consumer" self-heal gap
+  # (#9158 follow-up): a project that already went through a *pre-fix*
+  # RNFB version has a `FirebaseCore` product dependency declared on the
+  # target, but no matching `PBXBuildFile` -- the exact broken state the
+  # fix above is meant to repair. The plain
+  # `target.package_product_dependencies.any? { dep.product_name == ... }`
+  # guard can't tell that state apart from the fully-healthy
+  # already-linked one, so it was bailing out before ever adding the
+  # missing build file -- meaning upgrading and running `pod install`
+  # alone could never self-heal an already-affected project.
+  def test_add_core_heals_existing_dependency_missing_build_file
+    load_firebase_spm
+    RNFirebaseSPM.activate!('12.10.0')
+
+    existing_pkg = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference.new
+    existing_pkg.repositoryURL = RNFirebaseSPM.url
+    existing_pkg.requirement = { kind: 'upToNextMajorVersion', minimumVersion: '12.0.0' }
+
+    existing_ref = Xcodeproj::Project::Object::XCSwiftPackageProductDependency.new
+    existing_ref.package = existing_pkg
+    existing_ref.product_name = 'FirebaseCore'
+
+    # Stale pre-fix state: dependency already declared on the target, but
+    # never linked -- `frameworks_build_phase.files` (via the default empty
+    # `MockFrameworksBuildPhase`) has no matching `PBXBuildFile` for it.
+    target = MockTarget.new(['[CP] Embed Pods Frameworks'], package_product_dependencies: [existing_ref])
+    user_project = MockUserProject.new([target], package_references: [existing_pkg])
+    installer = MockInstaller.new([MockAggregateTarget.new(user_project)])
+
+    rnfirebase_add_spm_core_to_app_target(installer)
+
+    # Healed: exactly one build file added, linking the *same* pre-existing
+    # dependency object -- not a fresh/duplicate one.
+    build_files = target.frameworks_build_phase.files
+    assert_equal 1, build_files.length
+    assert_same existing_ref, build_files[0].product_ref
+
+    # No duplicate dependency or package reference created in the process.
+    assert_equal 1, target.package_product_dependencies.length
+    assert_same existing_ref, target.package_product_dependencies[0]
+    assert_equal 1, user_project.root_object.package_references.length
+    assert_same existing_pkg, user_project.root_object.package_references[0]
+    assert_equal 1, user_project.save_count
+
+    search_path = '${SYMROOT}/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/'
+    target.build_configurations.each do |config|
+      assert_includes target.build_settings(config.name)['SWIFT_INCLUDE_PATHS'], search_path
+    end
   end
 
   # ── rnfirebase_apply_spm_build_settings ──
@@ -837,6 +959,33 @@ class FirebaseSpmTest < Minitest::Test
     assert_empty target.package_product_dependencies
     assert_empty user_project.root_object.package_references
     assert_equal 1, user_project.save_count
+  end
+
+  # Regression test for the dangling-PBXBuildFile bug found in review of #9158:
+  # `rnfirebase_add_spm_core_to_app_target` links FirebaseCore by appending both
+  # a package product dependency AND a matching PBXBuildFile to the target's
+  # Frameworks build phase. Undoing that (this function) must remove both --
+  # `ref.remove_from_project` alone only nils out the build file's product_ref,
+  # it doesn't delete the now-useless PBXBuildFile itself.
+  def test_remove_core_removes_orphaned_build_file_from_frameworks_build_phase
+    load_firebase_spm
+    RNFirebaseSPM.activate!('12.10.0')
+
+    target = MockTarget.new(['[CP] Embed Pods Frameworks'])
+    user_project = MockUserProject.new([target])
+    installer = MockInstaller.new([MockAggregateTarget.new(user_project)])
+
+    # First, SPM-enable: this is the real add path, and it's the only thing
+    # that creates the PBXBuildFile this test is checking gets cleaned up.
+    rnfirebase_add_spm_core_to_app_target(installer)
+    assert_equal 1, target.frameworks_build_phase.files.length
+
+    # Then, SPM-disable (e.g. `$RNFirebaseDisableSPM = true` on a later `pod install`).
+    RNFirebaseSPM.reset!
+    rnfirebase_remove_spm_core_from_app_target(installer)
+
+    assert_empty target.package_product_dependencies
+    assert_empty target.frameworks_build_phase.files
   end
 
   def test_remove_core_leaves_package_reference_when_still_used_by_another_target

--- a/packages/app/firebase_spm.rb
+++ b/packages/app/firebase_spm.rb
@@ -726,28 +726,67 @@ def rnfirebase_add_spm_core_to_app_target(installer)
       next unless target.respond_to?(:package_product_dependencies)
       next unless target.respond_to?(:shell_script_build_phases)
       next unless target.shell_script_build_phases.any? { |phase| phase.name == '[CP] Embed Pods Frameworks' }
-      next if target.package_product_dependencies.any? { |dep| dep.product_name == 'FirebaseCore' }
 
-      pkg = project.root_object.package_references.find do |candidate|
-        candidate.instance_of?(pkg_class) && candidate.repositoryURL == RNFirebaseSPM.url
-      end
-      unless pkg
-        pkg = project.new(pkg_class)
-        pkg.repositoryURL = RNFirebaseSPM.url
-        pkg.requirement = { kind: 'upToNextMajorVersion', minimumVersion: RNFirebaseSPM.version }
-        project.root_object.package_references << pkg
+      # A `FirebaseCore` product dependency already being declared on the
+      # target does *not* by itself mean this target is a genuine no-op:
+      # a pre-fix RNFB version could have committed that dependency into
+      # the consumer's `.pbxproj` without ever linking it (see the
+      # PBXBuildFile comment below) -- that's the exact broken state #9158
+      # reports, and it's already sitting in every affected consumer's
+      # project today. So checking `package_product_dependencies` alone
+      # can't tell that already-affected state apart from a healthy,
+      # already-linked one -- it has to check the build phase itself.
+      existing_ref = target.package_product_dependencies.find { |dep| dep.product_name == 'FirebaseCore' }
+      if existing_ref
+        next if target.frameworks_build_phase.files.any? { |bf| bf.product_ref == existing_ref }
+
+        # Healing path: reuse the dependency (and its package reference)
+        # that's already declared -- only the link (PBXBuildFile) is
+        # missing, so don't create a duplicate dependency/package reference.
+        ref = existing_ref
+      else
+        pkg = project.root_object.package_references.find do |candidate|
+          candidate.instance_of?(pkg_class) && candidate.repositoryURL == RNFirebaseSPM.url
+        end
+        unless pkg
+          pkg = project.new(pkg_class)
+          pkg.repositoryURL = RNFirebaseSPM.url
+          pkg.requirement = { kind: 'upToNextMajorVersion', minimumVersion: RNFirebaseSPM.version }
+          project.root_object.package_references << pkg
+        end
+
+        ref = project.new(ref_class)
+        ref.package = pkg
+        ref.product_name = 'FirebaseCore'
+        target.package_product_dependencies << ref
       end
 
       if defined?(Pod::UI)
-        Pod::UI.puts "[react-native-firebase] #{target.name}: ".yellow +
-                     'Linking FirebaseCore directly into the app target (SPM) so native code that calls ' \
-                     'FIRApp/FIROptions APIs directly can resolve those symbols.'
+        message = if existing_ref
+                    'Repairing FirebaseCore SPM link on the app target (dependency was already declared but ' \
+                      'never linked) so native code that calls FIRApp/FIROptions APIs directly can resolve ' \
+                      'those symbols.'
+                  else
+                    'Linking FirebaseCore directly into the app target (SPM) so native code that calls ' \
+                      'FIRApp/FIROptions APIs directly can resolve those symbols.'
+                  end
+        Pod::UI.puts "[react-native-firebase] #{target.name}: ".yellow + message
       end
 
-      ref = project.new(ref_class)
-      ref.package = pkg
-      ref.product_name = 'FirebaseCore'
-      target.package_product_dependencies << ref
+      # Declaring the product dependency (above, or in a prior install for
+      # the healing path) only tells Xcode the target *depends* on it -- it
+      # doesn't actually link it. Linking a package product (same as
+      # CocoaPods pod dependencies, and the same as adding
+      # one via Xcode's own "Frameworks, Libraries, and Embedded Content" UI)
+      # requires a matching PBXBuildFile, with its product_ref pointed at
+      # this same dependency, in the target's Frameworks build phase. Without
+      # this, the app fails at the link step with "Undefined symbols ...
+      # _OBJC_CLASS_$_FIRApp" for any native code that calls FIRApp/FIROptions
+      # directly (e.g. Expo's generated AppDelegate) -- even though `pod
+      # install` itself appears to succeed.
+      build_file = project.new(Xcodeproj::Project::Object::PBXBuildFile)
+      build_file.product_ref = ref
+      target.frameworks_build_phase.files << build_file
 
       target.build_configurations.each do |config|
         build_settings = target.build_settings(config.name)
@@ -820,6 +859,11 @@ def rnfirebase_remove_spm_core_from_app_target(installer)
 
       stale_refs.each do |ref|
         target.package_product_dependencies.delete(ref)
+        # `ref.remove_from_project` below only nils out the matching PBXBuildFile's
+        # product_ref -- it doesn't remove the now-empty PBXBuildFile itself from the
+        # Frameworks build phase -- so look it up first, while product_ref is still set.
+        stale_build_file = target.frameworks_build_phase.files.find { |file| file.product_ref == ref }
+        target.frameworks_build_phase.files.delete(stale_build_file) if stale_build_file
         ref.remove_from_project
       end
       project_modified = true


### PR DESCRIPTION
Fixes #9161.

`rnfirebase_add_spm_core_to_app_target` declared the `FirebaseCore` package product dependency on the app target but never added a matching `PBXBuildFile` to its Frameworks build phase, so apps whose own code calls `FIRApp`/`FIROptions` directly (e.g. Expo's injected AppDelegate hookup) failed at link time with an undefined `FIRApp` symbol under dynamic SPM linking.

- Adds the missing `PBXBuildFile`, removes it symmetrically when SPM is disabled
- Heals the idempotency guard so a project built by a prior RNFB version (dependency declared but never linked) gets repaired on the next `pod install` instead of being skipped as already done

## Test Plan

- [x] `yarn lint:ruby` (RuboCop over `firebase_spm.rb`, `firebase_json.rb`, `__tests__`) — 8 files inspected, no offenses
- [x] `yarn tests:ios:ruby` — `packages/app/__tests__/firebase_json_test.rb` (7 runs, 22 assertions)
- [x] `yarn tests:ios:ruby` — `packages/app/__tests__/firebase_spm_embed_script_test.rb` (4 runs, 29 assertions)
- [x] `yarn tests:ios:ruby` — `packages/app/__tests__/firebase_spm_shape_test.rb` (14 runs, 51 assertions), including new `frameworks_build_phase`/`PBXBuildFile#product_ref` shape checks
- [x] `yarn tests:ios:ruby` — `packages/app/__tests__/firebase_spm_test.rb` (74 runs, 269 assertions), including new `test_add_core_heals_existing_dependency_missing_build_file` and `test_remove_core_removes_orphaned_build_file_from_frameworks_build_phase` regression tests
- [x] Line coverage 301/301 (100%) on `packages/app/*.rb`