### PR TITLE
fix(app-check, ios): do not install debug provider before configure

### DIFF
--- a/docs/app-check/usage/index.mdx
+++ b/docs/app-check/usage/index.mdx
@@ -93,9 +93,9 @@ For instructions on how to generate required keys and register an app for the de
 
 ## Initialize
 
-> If you're using Expo Managed Workflow, you can load the `@react-native-firebase/app-check` config plugin to skip the Initialize setup step.
+> If you're using Expo Managed Workflow, you can load the `@react-native-firebase/app-check` config plugin to skip the native setup step below. The plugin only registers the native module before `FirebaseApp.configure()` (Firebase requires this order regardless of which provider you use); you still need to call `initializeAppCheck` from JavaScript.
 
-You must initialize the AppCheck module prior to calling any Firebase backend services for App Check to function.
+You must call `initializeAppCheck` prior to calling any Firebase backend services for App Check to function. Until `initializeAppCheck` (or the deprecated `activate`) configures a provider, App Check is pending: any `getToken` / `getLimitedUseToken` call fails immediately with `appCheck/provider-not-ready` instead of fetching a real token.
 
 #### All react-native >= 0.77 with AppDelegate.swift
 
@@ -309,6 +309,14 @@ If unset, the "tokenAutoRefreshEnabled" setting will defer to the app's "automat
 ## Using App Check tokens for non-firebase services
 
 The [official documentation](https://firebase.google.com/docs/app-check/web/custom-resource) shows how to use `getToken` to access the current App Check token and then verify it in external services.
+
+## Troubleshooting
+
+### `appCheck/provider-not-ready`
+
+If `getToken` / `getLimitedUseToken` rejects with `appCheck/provider-not-ready`, App Check has not been configured yet for that app. Call `initializeAppCheck` (or the deprecated `activate`) before requesting tokens or calling any App Check-protected Firebase service.
+
+This error replaces an older iOS behavior where App Check could install the debug provider before `initializeAppCheck` ran, including in release builds. That could exchange a debug token with Firebase's backend outside of development, showing up as unexplained `exchangeDebugToken` 403/429 responses in your logs. If you saw those errors before upgrading, look for a code path that requests a token before `initializeAppCheck` completes and move it after.
 
 ## Manually Setting Up App Check Debug Token for Testing Environments / CI
 

--- a/okf-bundle/index.md
+++ b/okf-bundle/index.md
@@ -35,6 +35,7 @@ okf_version: '0.1'
 # Packages
 
 - [AI](/packages/ai/index.md) — Agent Platform / Vertex backend naming, compare-types, generative models
+- [App Check](/packages/app-check/index.md) — iOS provider-factory init (pending + fail-closed), ADRs + work queue for #9116
 - [Auth](/packages/auth/index.md) — modular API type parity, platform matrix, `compare:types`
 - [Firestore](/packages/firestore/index.md) — Pipelines architecture, parity, e2e coverage
 - [Messaging](/packages/messaging/index.md) — iOS `UNUserNotificationCenter` delegate forwarding, `completionHandler` contract

--- a/okf-bundle/packages/app-check/architecture-decisions.md
+++ b/okf-bundle/packages/app-check/architecture-decisions.md
@@ -1,0 +1,117 @@
+---
+type: Reference
+title: App Check decisions (ADR)
+description: Canonical owner of durable architectural decisions for @react-native-firebase/app-check — provider factory timing, pending state, and related init behavior.
+tags: [app-check, ios, provider, architecture, decisions, adr]
+timestamp: 2026-08-04T00:00:00Z
+---
+
+# App Check decisions (ADR)
+
+**Canonical owner of durable architectural decisions** for `@react-native-firebase/app-check`. Procedure and ephemeral gate state live in the [iOS provider init work queue](ios-provider-init-work-queue.md). That queue **links here** for the "why" — it does not restate decisions.
+
+**Policy:** [OKF documentation and commit policy](../../documentation-policy.md).
+
+**Upstream:** [GitHub #9116](https://github.com/invertase/react-native-firebase/issues/9116), contributor PR [#9117](https://github.com/invertase/react-native-firebase/pull/9117) (temporary `#if DEBUG` default; not the durable design), discussion [#7518](https://github.com/invertase/react-native-firebase/discussions/7518).
+
+## Decision ID convention
+
+Use the **`AppCheck-AD-<n>`** prefix when citing these decisions in code or docs.
+
+## Status legend
+
+| Status       | Meaning                                                                                                                              |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **Accepted** | Decided; implement to this.                                                                                                          |
+| **Proposed** | Recommended, awaiting sign-off in `gap-analysis`; safe to plan around.                                                               |
+| **Open**     | Under analysis; do not lock in code until resolved.                                                                                  |
+| **Deferred** | Direction noted; needs a dedicated follow-up before implementation; not on the critical path for the iOS debug-provider footgun fix. |
+
+---
+
+## AppCheck-AD-1 — Pending provider before configure; fail-closed token APIs — **Accepted**
+
+When `RNFBAppCheckProviderFactory` `createProviderWithApp:` runs before any `configure` / `configureProvider` for that app, install the RNFB provider **facade only** with **no** real delegate (`debug`, App Attest, DeviceCheck, etc.).
+
+While pending, `getToken` / limited-use token completion handlers must **fail closed**: invoke the completion with an error immediately and **must not** call Google APIs (`exchangeDebugToken` or attestation).
+
+**Why:** Firebase requires the App Check provider factory to be registered before `FirebaseApp.configure()`. Eager `FIRAppCheckInterop` creation during `configure()` then calls `createProviderWithApp:` while JS has not yet configured a provider. The historical default installed `FIRAppCheckDebugProvider`, which produced release-build `exchangeDebugToken` 403/429 traffic ([#9116](https://github.com/invertase/react-native-firebase/issues/9116)). Android already refuses to invent a provider (`create` throws if not configured). iOS cannot throw during eager create without risking launch failure, so a pending facade + fail-closed tokens is the iOS-safe equivalent.
+
+**Rejected:**
+
+- **Default to `appAttestWithDeviceCheckFallback` outside `#if DEBUG`** ([#9117](https://github.com/invertase/react-native-firebase/pull/9117)) — acceptable local patch, not durable: wrong provider for many apps, `#if DEBUG` ≠ prod intent, CocoaPods macro skew, still creates a real provider too early.
+- **Reverse AppDelegate so `FirebaseApp.configure()` runs before factory registration** — conflicts with Firebase’s factory-before-configure contract.
+- **Block/wait or queue token requests until configure** — hang risk if JS never configures.
+
+---
+
+## AppCheck-AD-2 — Same pending path for DEBUG and release — **Accepted**
+
+Do **not** special-case `#if DEBUG` to install the debug provider before `configureProvider`. DEBUG and release share the pending + fail-closed path until JS/native configure runs.
+
+**Why:** Early debug tokens before `initializeAppCheck` were accidental. Normal RNFB usage configures `provider: 'debug'` from JS in development. A DEBUG-only native default recreates the footgun class (#9117 path).
+
+**Follow-up (not this fix):** explicit native opt-in for pre-JS providers is [AppCheck-AD-5](#appcheck-ad-5--pre-js-native-provider-via-firebasejson--deferred).
+
+---
+
+## AppCheck-AD-3 — Expo / AppDelegate: keep factory before `FirebaseApp.configure()` — **Accepted**
+
+The Expo config plugin (and bare AppDelegate guidance) must keep `RNFBAppCheckModule.sharedInstance()` **before** `FirebaseApp.configure()`. Fix misleading comments/docs that imply Firebase should be initialized before App Check. Do **not** change emitted call order as the bug fix.
+
+**Why:** Factory-before-configure is required by Firebase. The defect is the factory’s debug default, not the registration order. Reordering every consumer AppDelegate has high blast radius for no architectural gain once AD-1 lands.
+
+---
+
+## AppCheck-AD-4 — `initializeAppCheck`: configure provider before enabling auto-refresh — **Accepted**
+
+In JS `initializeAppCheck`, call native `configureProvider` **before** `setTokenAutoRefreshEnabled`.
+
+**Why:** Today auto-refresh can be enabled while the provider is still pending (or previously defaulted to debug). After AD-1, early refresh only errors, but reordering removes useless failed refresh attempts during the pending window and matches the intended init sequence.
+
+---
+
+## AppCheck-AD-5 — Pre-JS native provider via firebase.json — **Deferred**
+
+A firebase.json / Info.plist (or similar) knob to install a real provider before JS runs is **out of scope** for the #9116 fix. Record the need here; design and implement in a follow-up after pending + fail-closed ships.
+
+**Why:** Keeps the bug fix focused. Apps that need tokens before JS can call `initializeAppCheck` earlier today; a native default is a feature, not required to stop debug exchanges in release.
+
+---
+
+## AppCheck-AD-6 — Native regression coverage preferred; no new iOS XCTest platform in this fix — **Accepted**
+
+Prefer a small iOS unit/host test or injectable seam proving pre-configure `createProviderWithApp:` does not install debug and fail-closed token paths do not hit the network. If that requires standing up full package XCTest + CI wiring beyond this bugfix, use a cheap in-package seam first; if still intractable, ship with Jest (JS reorder) + plugin snapshot + area-focused app-check e2e and record an evidence-backed intractable limitation (user-accepted) in this ADR / coverage notes.
+
+**Why:** The monorepo has Android JVM unit tests ([AndroidTest-AD-*](../../testing/android-architecture-decisions.md)) but no package-level iOS XCTest harness. Introducing that platform is a separate decision, not a blocker for #9116.
+
+---
+
+## AppCheck-AD-7 — Soft-break release framing — **Accepted**
+
+Treat the behavior change as a **bug fix** with an explicit release note and troubleshooting docs (early token fetch before `initializeAppCheck` now errors; release builds must not exchange debug tokens). Do **not** hold for a coordinated semver major solely for this.
+
+**Why:** The old behavior was unsupported footgun behavior, not a documented API. Callers still need a clear “configure before use” story ([docs work in the queue](ios-provider-init-work-queue.md)).
+
+---
+
+## AppCheck-AD-8 — Fail-closed error identity — **Accepted**
+
+While pending, token completions must use an **actionable** error that mentions configuring / `initializeAppCheck`.
+
+**Locked shape (AC0 gap-analysis):**
+
+| Layer | Value |
+| ----- | ----- |
+| Provider `NSError` domain | `RNFBErrorDomain` (same as `RNFBSharedUtils`) |
+| Provider `NSError` code | `666` (RNFB promise-error convention) |
+| `userInfo[@"code"]` | `provider-not-ready` |
+| Message | `App Check provider is not ready. Call initializeAppCheck before requesting tokens.` |
+| JS / TurboModule reject `code` | `provider-not-ready` |
+| Full `NativeFirebaseError` | `appCheck/provider-not-ready` |
+
+Map pending in `RNFBAppCheckModule` (`getToken` / `getLimitedUseToken`) so provider errors do not collapse to generic `token-error`. Detect via `userInfo[@"code"] == provider-not-ready` or nil `delegateProvider` before calling the SDK.
+
+**Rejected:** Reusing `FIRAppCheckErrorCodeInvalidConfiguration` (or other `FIRAppCheckErrorDomain` codes) for pending — those mean SDK invalid-config / network / keychain, not “JS has not configured yet,” and would still surface as today’s generic `token-error` path without an explicit module map.
+
+**Why:** Fail-closed without a clear message produces another support loop. Stable codes help tests and app-level handling. Fits existing RNFB reject / `NativeFirebaseError` prefixing (`appCheck/<code>`).

--- a/okf-bundle/packages/app-check/index.md
+++ b/okf-bundle/packages/app-check/index.md
@@ -1,0 +1,17 @@
+# @react-native-firebase/app-check
+
+Knowledge for App Check native/JS initialization, especially iOS provider-factory timing relative to `FirebaseApp.configure()`.
+
+## Documents
+
+* [Architecture decisions (ADR)](architecture-decisions.md) — `AppCheck-AD-*` (pending provider, fail-closed tokens, plugin order, deferred firebase.json pre-JS provider)
+* [iOS provider init work queue](ios-provider-init-work-queue.md) — ephemeral gates for [#9116](https://github.com/invertase/react-native-firebase/issues/9116) (pending + fail-closed fix)
+
+## Related repository files
+
+* [`packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.m`](../../../packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.m) — pre-configure provider creation
+* [`packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m`](../../../packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m) — delegate provider facade / token proxy
+* [`packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.mm`](../../../packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.mm) — `sharedInstance` factory registration, `configureProvider`
+* [`packages/app-check/lib/index.ts`](../../../packages/app-check/lib/index.ts) — `initializeAppCheck`
+* [`packages/app-check/plugin/src/ios/appDelegate.ts`](../../../packages/app-check/plugin/src/ios/appDelegate.ts) — Expo AppDelegate injection
+* [`docs/app-check/usage/index.mdx`](../../../docs/app-check/usage/index.mdx) — user-facing App Check docs

--- a/okf-bundle/packages/app-check/ios-provider-init-work-queue.md
+++ b/okf-bundle/packages/app-check/ios-provider-init-work-queue.md
@@ -1,0 +1,230 @@
+---
+type: Reference
+title: App Check iOS provider init work queue
+description: Ephemeral tracker for fixing iOS App Check installing the debug provider before JS configure (GitHub #9116).
+tags: [app-check, ios, provider, work-queue]
+timestamp: 2026-08-04T00:00:00Z
+---
+
+# App Check iOS provider init — work queue
+
+> **DONE:** All gates closed 2026-08-07. Commit subject: `fix(app-check, ios): do not install debug provider before configure`. No further pickup for this item.
+> **Goal:** Stop release (and DEBUG) builds from installing `FIRAppCheckDebugProvider` during eager `FirebaseApp.configure()`; pending facade + fail-closed tokens until `configureProvider`; JS configure-before-auto-refresh; plugin comment/docs honesty; soft-break troubleshooting docs.
+> **Upstream:** [#9116](https://github.com/invertase/react-native-firebase/issues/9116). Contributor [#9117](https://github.com/invertase/react-native-firebase/pull/9117) left open as temporary patch; close manually when the durable PR is up (do not merge #9117 as the long-term design).
+
+Ephemeral tracker; see [OKF policy](../../documentation-policy.md). Work types / tiers / gate field ids: [iteration vocabulary](../../testing/iteration-vocabulary.md). **Loop, gates, host rule, harness:** [change authoring workflow](../../testing/change-authoring-workflow.md) — not restated. **Agent commands:** [agent command policy](../../testing/agent-command-policy.md) only.
+
+Durable decisions: **[architecture-decisions.md](architecture-decisions.md)**. Package index: **[index.md](index.md)**.
+
+---
+
+## Locked decisions (index)
+
+| ADR | Decision |
+| --- | -------- |
+| [AppCheck-AD-1](architecture-decisions.md#appcheck-ad-1--pending-provider-before-configure-fail-closed-token-apis--accepted) | Pending provider + fail-closed tokens |
+| [AppCheck-AD-2](architecture-decisions.md#appcheck-ad-2--same-pending-path-for-debug-and-release--accepted) | Same path for DEBUG and release |
+| [AppCheck-AD-3](architecture-decisions.md#appcheck-ad-3--expo--appdelegate-keep-factory-before-firebaseappconfigure--accepted) | Keep factory before `configure()`; fix comments/docs only |
+| [AppCheck-AD-4](architecture-decisions.md#appcheck-ad-4--initializeappcheck-configure-provider-before-enabling-auto-refresh--accepted) | JS: configure provider before auto-refresh |
+| [AppCheck-AD-5](architecture-decisions.md#appcheck-ad-5--pre-js-native-provider-via-firebasejson--deferred) | firebase.json pre-JS provider — **Deferred** |
+| [AppCheck-AD-6](architecture-decisions.md#appcheck-ad-6--native-regression-coverage-preferred-no-new-ios-xctest-platform-in-this-fix--accepted) | Prefer native seam/test; fallback Jest/plugin/e2e |
+| [AppCheck-AD-7](architecture-decisions.md#appcheck-ad-7--soft-break-release-framing--accepted) | Soft-break bug fix + troubleshooting docs |
+| [AppCheck-AD-8](architecture-decisions.md#appcheck-ad-8--fail-closed-error-identity--accepted) | `appCheck/provider-not-ready` — **Accepted** (AC0) |
+
+---
+
+## Phase ordering
+
+| Phase | Focus | Why |
+| ----- | ----- | --- |
+| **AC0** | `gap-analysis` | Promote/confirm ADRs; lock AppCheck-AD-8; estimate diff size → keep one AC1 or split AC1a/b/c |
+| **AC1** | `implementation` | Pending factory + fail-closed + tests; JS reorder; plugin comment (single item if reasonably sized) |
+| **AC2** | `independent-review` | Frozen tree; area-focused; **iOS + Android + macOS** app-check e2e |
+| **AC3** | `documentation` | Site troubleshooting (`exchangeDebugToken` 403); usage “configure before use”; OKF durable moves; release-note wording |
+| **AC4** | `commit` | One focused Conventional Commit (or per-split subjects if AC0 re-slices) |
+
+**Re-slice rule (AC0):** Prefer one AC1 implementation if the diff stays reasonably sized. If AC0 estimates a large blast radius, split before coding into e.g. **AC1a** native pending/fail-closed + tests, **AC1b** JS reorder, **AC1c** plugin comment — each with its own gates/commit subjects as needed.
+
+---
+
+## Resume checklist
+
+Before any `:test-cover` ([host rule](../../testing/change-authoring-workflow.md#host-rule)):
+
+1. [Pre-flight](../../testing/running-e2e.md#pre-flight-is-the-host-clear-to-start): host-clear probes, services ready, harness matches validation tier; [harness narrowing gate](../../testing/running-e2e.md#harness-narrowing-gate-blocking); serial `:test-cover`; [frozen tree](../../testing/change-authoring-workflow.md#frozen-tree) for `independent-review`.
+2. **unit-focused (AC1):** iOS-speed loop (native `:build` when iOS native touched) + Jest + plugin tests; Android/macOS e2e optional unless needed for diagnosis.
+3. **area-focused (AC2):** full loaded app-check spec on **iOS, Android, and macOS**.
+
+---
+
+## Current snapshot
+
+**Label:** `app-check-ios-provider-init-queue-authored-2026-08-04`
+
+**Next pickup:** none — item complete.
+
+**Current gates:** AC0–AC4 all closed 2026-08-07. AC1/AC2 `review_gate` closed on a user-accepted exception for the delta re-review tier (see AC2 section below). `commit_gate` closes on the commit matching the subject above.
+
+---
+
+## Item arbiter
+
+| Item | Scope | `commit_subject` | `implementation_gate` | `review_gate` | `commit_gate` | `next_work_type` | `validation_tier` | `platform` | Notes |
+| ---- | ----- | ---------------- | ----------------------- | ------------- | ------------- | ---------------- | ------------------- | ---------- | ----- |
+| **AC0** | ADR lock + size / re-slice | — | closed | closed | closed | — (done) | `none` | — | Closed 2026-08-04. Single AC1 (~150–250 LOC). AppCheck-AD-8 Accepted as `appCheck/provider-not-ready`. Do not merge #9117. |
+| **AC1** | Native pending + fail-closed + tests; JS reorder; plugin comment | `fix(app-check, ios): do not install debug provider before configure` | closed | closed | closed | — (done) | `area-focused` | `ios`+`android`+`macos` | Exclude Podfile.lock. Nit remediation evidence below. |
+| **AC2** | Independent review of AC1 | `fix(app-check, ios): do not install debug provider before configure` | closed | closed | closed | — (done) | `area-focused` | `ios`+`android`+`macos` | Full re-review green with nits 2026-08-05. Delta closed 2026-08-07 on user-accepted exception (see below). |
+| **AC3** | User docs + durable OKF | `fix(app-check, ios): do not install debug provider before configure` | closed | closed | closed | — (done) | `none` | — | Docs done 2026-08-07. `lib/types/internal.ts` activate() docstring fixed; `docs/app-check/usage/index.mdx` Expo/configure-before-use note + new Troubleshooting section (`appCheck/provider-not-ready`, `exchangeDebugToken` soft-break). AD-8 durable docs re-verified accurate against code, no changes needed. |
+| **AC4** | Commit | `fix(app-check, ios): do not install debug provider before configure` | closed | closed | closed | — (done) | `none` | — | Stage product + docs + this queue together. Exclude `tests/*/Podfile.lock`. |
+
+---
+
+## AC0 — gap-analysis checklist
+
+Read-only. Closed 2026-08-04 (explore gap-analysis).
+
+- [x] Confirm factory-before-configure still required by current Firebase iOS App Check docs/SDK behavior
+- [x] Trace `createProviderWithApp:` → eager `FIRAppCheckInterop` → JS `configureProvider` on current `main`
+- [x] Choose fail-closed `NSError` / JS code — **Accepted:** `provider-not-ready` → `appCheck/provider-not-ready` ([AppCheck-AD-8](architecture-decisions.md#appcheck-ad-8--fail-closed-error-identity--accepted))
+- [x] Assess native test seam vs XCTest cost — nil `delegateProvider` seam; no new XCTest; Jest + plugin + AC2 e2e ([AppCheck-AD-6](architecture-decisions.md#appcheck-ad-6--native-regression-coverage-preferred-no-new-ios-xctest-platform-in-this-fix--accepted))
+- [x] Estimate AC1 diff size → **single AC1** (~150–250 LOC); no AC1a/b/c
+- [x] Note plugin snapshot tests — source-comment-only → **no** snapshot updates unless emitted AppDelegate text changes
+- [x] Note stale docs lines for AC3 — `packages/app-check/lib/types/internal.ts` “including the module”; `docs/app-check/usage/index.mdx` Expo/configure-before-use / missing `exchangeDebugToken` troubleshooting; plugin comment inverted
+
+**AC0 notes (evidence summary):**
+
+- Footgun: `RNFBAppCheckProviderFactory.m` `createProviderWithApp:` calls `configure:… providerName:@"debug"`.
+- JS AD-4 gap: `lib/index.ts` enables auto-refresh before `configureProvider`.
+- Module today maps all provider errors to `token-error`; AC1 must map pending → `provider-not-ready`.
+- Android already throws if `create` before configure; iOS uses pending facade instead (AD-1).
+
+---
+
+## AC1 — implementation acceptance (draft)
+
+- [x] Pre-configure `createProviderWithApp:` does not call `configure:… providerName:@"debug"`
+- [x] Pending token APIs fail closed (no network)
+- [x] `configureProvider` attaches real delegate; subsequent tokens use configured provider
+- [x] JS `initializeAppCheck` configures provider before auto-refresh
+- [x] Expo plugin comment corrected; emitted order unchanged
+- [x] Tests per AppCheck-AD-6; validation + coverage evidence recorded (unit-focused)
+
+**AC1 unit-focused validation evidence:**
+
+| Check | Exit | Result | Log |
+| --- | --- | --- | --- |
+| `yarn` + `yarn lerna:prepare` | 0 | green | (shell) |
+| Jest app-check + plugin | 0 | **25 passed**, 5 snapshots unchanged | `/tmp/rnfb-jest-app-check.log` |
+| `yarn lint` (js+deps+android+ios) | 0 | green | `/tmp/rnfb-lint.log` |
+| `yarn tests:ios:pod:install` | 0 | pods installed | `/tmp/rnfb-ios-pod-install.log` |
+| `yarn tests:ios:build` | 0 | Build Succeeded | `/tmp/rnfb-ios-build.log` |
+| `yarn tests:ios:test-cover` | 0 | **42 passing**, 0 failing | `/tmp/rnfb-e2e-ios.log` |
+| `yarn tests:ios:test:process-coverage` | 0 | `coverage/ios-native/lcov.info` | `/tmp/rnfb-ios-native-coverage.log` |
+
+Harness: narrowed to `app`+`appCheck` during run; overrides removed after. Coverage: factory/configure/JS AD-4 hit; pending fail-closed **0% e2e** — gap disposition AppCheck-AD-6 nil-delegate seam (ADR-accepted). Residual: optional e2e negative case for AC2 judgment. Note: `tests/ios/Podfile.lock` dirty from pod install (review whether to include).
+
+---
+
+## AC2 — independent-review (failed 2026-08-05)
+
+**Verdict:** failed (critical). Area-focused e2e green: iOS 42 / Android 42 / macOS 35+2 pending. Jest 24. Harness narrowed `app`+`appCheck`, reverted after. **Exclude** `tests/ios/Podfile.lock` and `tests/macos/Podfile.lock` from commit.
+
+| Severity | Finding | Fix |
+| --- | --- | --- |
+| **critical** | AD-8 JS identity lost: `FIRAppCheck` wraps `RNFBErrorDomain` pending errors; module reads top-level `userInfo[@"code"]` only → JS gets `appCheck/token-error` not `appCheck/provider-not-ready`. Files: `RNFBAppCheckProvider.m` emit; `RNFBAppCheckModule.mm` mapper. | In module `getToken` / `getLimitedUseToken`, if factory provider for app has `delegateProvider == nil`, reject `provider-not-ready` **before** calling FIRAppCheck. Optionally also walk `NSUnderlyingErrorKey`. |
+| **nit** | Podfile.lock churn (AppCheckCore patch + macOS pod install) | Exclude from AC1 commit |
+
+**AC2 validation evidence:**
+
+| Check | Exit | Result | Log |
+| --- | --- | --- | --- |
+| Jest app-check + plugin | 0 | 24 passed | `/tmp/rnfb-jest-app-check.log` |
+| `yarn tests:ios:test-cover` | 0 | **42 passing** | `/tmp/rnfb-e2e-ios.log` |
+| `yarn tests:android:test-cover` | 0 | **42 passing** | `/tmp/rnfb-e2e-android.log` |
+| `yarn tests:macos:test-cover` | 0 | **35 passing**, 2 pending | `/tmp/rnfb-e2e-macos.log` |
+
+Coverage: factory pending/configure/JS AD-4 hit; module `provider-not-ready` mapper **0%** (broken by SDK wrap). AD-6 e2e gap on pending path not a separate finding; finding #1 is product/AD-8.
+
+---
+
+## AC2 — independent-review re-run (green with nits 2026-08-05)
+
+**Verdict:** green with nits. Prior AD-8 critical **resolved** (iOS e2e both pending cases assert `provider-not-ready`, not `token-error`). Acceptance 1–7 hold. Do not merge #9117.
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| **nit** | AD-8 message string duplicated | **Fixed** — `kRNFBAppCheckProviderNotReadyMessage` in Provider.h/.m; Module uses shared constant. Unit-focused iOS 44 green. |
+| **nit** | `tests/ios/Podfile.lock` + `tests/macos/Podfile.lock` dirty | **Exclude** from commit (not product) |
+
+**Nit remediation validation (unit-focused iOS):**
+
+| Check | Exit | Result | Log |
+| --- | --- | --- | --- |
+| `yarn tests:ios:build` | 0 | Build Succeeded | (shell) |
+| `yarn tests:ios:test-cover` | 0 | **44 passing** (both AD-8 cases) | `/tmp/rnfb-e2e-ios.log` |
+
+**AC2 validation evidence:**
+
+| Check | Exit | Result | Log |
+| --- | --- | --- | --- |
+| Jest app-check + plugin | 0 | **25 passed** | `/tmp/rnfb-jest-app-check.log` |
+| `yarn lint` / `yarn compare:types` | 0 | green | `/tmp/rnfb-lint.log`, `/tmp/rnfb-compare-types.log` |
+| `yarn tests:ios:test-cover` | 0 | **44 passing** | `/tmp/rnfb-e2e-ios.log` |
+| `yarn tests:android:test-cover` | 0 | **42 passing**, 2 pending | `/tmp/rnfb-e2e-android.log` |
+| `yarn tests:macos:test-cover` | 0 | **35 passing**, 4 pending | `/tmp/rnfb-e2e-macos.log` |
+
+Harness: `app`+`appCheck`, reverted. Coverage: pre-check FNDA:7; provider pending bodies FNDA:0 (shadowed by module pre-check, acceptable).
+
+**Delta re-review disposition (user-accepted exception, 2026-08-07):** The 2026-08-05 area-focused reviewer run above already covers the full AC1 diff pre-fix. The subsequent nit fix (shared `kRNFBAppCheckProviderNotReadyMessage` constant) touches only `RNFBAppCheckProvider.h/.m` and `RNFBAppCheckModule.mm` — a string-literal extraction, no logic change, no Android/macOS files touched. A fresh area-focused reviewer for this delta would re-run Android/macOS e2e that this diff cannot affect. User confirmed accepting the iOS-only unit-focused evidence (`yarn tests:ios:build` + `yarn tests:ios:test-cover`, 44 passing, both AD-8 pending cases) as sufficient to close `review_gate` for AC1/AC2, in lieu of relaunching the delta area-focused reviewer. `review_gate` closed 2026-08-07.
+
+---
+
+## AC1 remediation — AD-8 mapping (unit-focused green 2026-08-05)
+
+**Fix:** `RNFBAppCheckRejectIfProviderNotReady` in module before FIRAppCheck; `providerForApp:` on factory; `RejectCodeForError` walks `NSUnderlyingErrorKey`. E2e on `secondaryFromNative` asserts `provider-not-ready` (not `token-error`).
+
+| Check | Exit | Result | Log |
+| --- | --- | --- | --- |
+| Jest `appcheck.test.ts` | 0 | **15/15** | `/tmp/rnfb-jest-appcheck.log` |
+| `yarn tests:ios:build` | 0 | Build Succeeded | `/tmp/rnfb-ios-build.log` |
+| `yarn tests:ios:test-cover` | 0 | **44 passing**, 0 failing | `/tmp/rnfb-e2e-ios.log` |
+| `yarn tests:ios:test:process-coverage` | 0 | `coverage/ios-native/lcov.info` | (processed 2026-08-05) |
+
+Harness: `app`+`appCheck`, reverted after. Coverage: pre-check helper FNDA:7; AD-8 e2e both green. Exclude Podfile.lock.
+
+---
+
+## AC3 — documentation (closed 2026-08-07)
+
+**Scope:** `packages/app-check/lib/types/internal.ts` (stale `activate()` docstring), `docs/app-check/usage/index.mdx` (Expo/configure-before-use note, new Troubleshooting section), durable OKF re-verification (no changes needed — `AppCheck-AD-8` locked shape confirmed to match code exactly), OKF bundle consistency scan.
+
+**Validation evidence:**
+
+| Check | Exit | Result |
+| --- | --- | --- |
+| `yarn lerna:prepare` | 0 | 20 projects, app-check rebuilt clean |
+| `yarn tsc:compile` | 0 | no errors |
+| `yarn lint:js` | 0 | no errors |
+| `yarn lint:markdown` | 0 | Prettier-clean |
+| `yarn lint:spellcheck` | 0 | no failures |
+| `yarn format:js` | 0 | no reformat needed on target files (unrelated `packages/app/type-test.ts` drift reformatted then reverted, out of scope) |
+| `yarn compare:types` | 0 | app-check: 4 missing / 9 extra / 2 different — documented (pre-existing) |
+
+**OKF bundle consistency pass:** full `okf-bundle/` sweep, focused on `packages/app-check/**` and inbound links. No DRY violations or dangling anchors found in files touched by this item. One **pre-existing, unrelated** dangling anchor flagged (not fixed — out of scope): `documentation-policy.md`'s OKF update contract table links `testing/coverage-design.md#coverage-evidence-package`, actual heading slug is `#coverage-evidence-package-blocking`. Route to a separate cleanup.
+
+**Draft release-note wording** (repo has no CHANGELOG/changeset file; for PR body use):
+
+- Fixed: on iOS, App Check could install and use the debug provider before `initializeAppCheck` ran, including in release builds, sometimes producing unexpected `exchangeDebugToken` 403/429 traffic. The native provider now stays pending until `initializeAppCheck` (or the deprecated `activate`) is called.
+- Behavior change: requesting a token before `initializeAppCheck` now rejects immediately with `appCheck/provider-not-ready` instead of silently exchanging a debug token or falling through to another provider.
+
+---
+
+## Related product files (starting points)
+
+- `packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.m`
+- `packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m`
+- `packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.mm`
+- `packages/app-check/lib/index.ts` (`initializeAppCheck`)
+- `packages/app-check/plugin/src/ios/appDelegate.ts`
+- `packages/app-check/plugin/__tests__/`
+- `docs/app-check/usage/index.mdx`

--- a/packages/app-check/__tests__/appcheck.test.ts
+++ b/packages/app-check/__tests__/appcheck.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, afterEach } from '@jest/globals';
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
 import { Platform } from 'react-native';
 
 import {
@@ -25,6 +25,88 @@ describe('appCheck()', function () {
       expect(() => initializeAppCheck(undefined, undefined)).toThrow(
         'Invalid configuration: no options defined.',
       );
+    });
+
+    describe('initializeAppCheck native call order (AppCheck-AD-4)', function () {
+      it('calls configureProvider before setTokenAutoRefreshEnabled', async function () {
+        const provider = new ReactNativeFirebaseAppCheckProvider();
+        provider.configure({
+          android: { provider: 'debug' },
+        });
+
+        // Bootstrap the modular instance, then flush the fire-and-forget init.
+        const appCheck = initializeAppCheck(undefined, {
+          provider,
+          isTokenAutoRefreshEnabled: true,
+        }) as any;
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const callOrder: string[] = [];
+        const configureProvider = jest.fn((_provider?: string, _debugToken?: string) => {
+          callOrder.push('configureProvider');
+          return Promise.resolve();
+        });
+        const setTokenAutoRefreshEnabledNative = jest.fn((_enabled?: boolean) => {
+          callOrder.push('setTokenAutoRefreshEnabled');
+        });
+        appCheck._nativeModule = {
+          configureProvider,
+          setTokenAutoRefreshEnabled: setTokenAutoRefreshEnabledNative,
+        };
+
+        await appCheck.initializeAppCheck({
+          provider,
+          isTokenAutoRefreshEnabled: true,
+        });
+
+        expect(configureProvider).toHaveBeenCalledWith('debug', undefined);
+        expect(setTokenAutoRefreshEnabledNative).toHaveBeenCalledWith(true);
+        expect(callOrder).toEqual(['configureProvider', 'setTokenAutoRefreshEnabled']);
+      });
+
+      it('calls configureProvider before setTokenAutoRefreshEnabled on apple', async function () {
+        const originalOS = Platform.OS;
+        Platform.OS = 'ios' as typeof Platform.OS;
+
+        try {
+          const provider = new ReactNativeFirebaseAppCheckProvider();
+          provider.configure({
+            apple: { provider: 'debug' },
+          });
+
+          const appCheck = initializeAppCheck(undefined, {
+            provider,
+            isTokenAutoRefreshEnabled: false,
+          }) as any;
+          await Promise.resolve();
+          await Promise.resolve();
+
+          const callOrder: string[] = [];
+          const configureProvider = jest.fn((_provider?: string, _debugToken?: string) => {
+            callOrder.push('configureProvider');
+            return Promise.resolve();
+          });
+          const setTokenAutoRefreshEnabledNative = jest.fn((_enabled?: boolean) => {
+            callOrder.push('setTokenAutoRefreshEnabled');
+          });
+          appCheck._nativeModule = {
+            configureProvider,
+            setTokenAutoRefreshEnabled: setTokenAutoRefreshEnabledNative,
+          };
+
+          await appCheck.initializeAppCheck({
+            provider,
+            isTokenAutoRefreshEnabled: false,
+          });
+
+          expect(configureProvider).toHaveBeenCalledWith('debug', undefined);
+          expect(setTokenAutoRefreshEnabledNative).toHaveBeenCalledWith(false);
+          expect(callOrder).toEqual(['configureProvider', 'setTokenAutoRefreshEnabled']);
+        } finally {
+          Platform.OS = originalOS;
+        }
+      });
     });
 
     describe('provider name validation', function () {
@@ -101,6 +183,34 @@ describe('appCheck()', function () {
 
     it('`getLimitedUseToken` function is properly exposed to end user', function () {
       expect(getLimitedUseToken).toBeDefined();
+    });
+
+    // AppCheck-AD-8 locked JS reject identity (native pre-check / error map → NativeFirebaseError).
+    it('surfaces appCheck/provider-not-ready from native getToken reject (AppCheck-AD-8)', async function () {
+      const provider = new ReactNativeFirebaseAppCheckProvider();
+      provider.configure({
+        android: { provider: 'debug' },
+      });
+      const appCheck = initializeAppCheck(undefined, { provider }) as any;
+      await Promise.resolve();
+      await Promise.resolve();
+
+      const notReady = Object.assign(new Error('appCheck/provider-not-ready'), {
+        code: 'appCheck/provider-not-ready',
+        message:
+          '[appCheck/provider-not-ready] App Check provider is not ready. Call initializeAppCheck before requesting tokens.',
+      });
+      appCheck._nativeModule = {
+        getToken: jest.fn(() => Promise.reject(notReady)),
+        getLimitedUseToken: jest.fn(() => Promise.reject(notReady)),
+      };
+
+      await expect(getToken(appCheck, false)).rejects.toMatchObject({
+        code: 'appCheck/provider-not-ready',
+      });
+      await expect(getLimitedUseToken(appCheck)).rejects.toMatchObject({
+        code: 'appCheck/provider-not-ready',
+      });
     });
 
     it('`setTokenAutoRefreshEnabled` function is properly exposed to end user', function () {

--- a/packages/app-check/e2e/appcheck.e2e.js
+++ b/packages/app-check/e2e/appcheck.e2e.js
@@ -156,6 +156,23 @@ describe('appCheck()', function () {
     });
 
     describe('getToken()', function () {
+      // AppCheck-AD-8: pending facade must reject as provider-not-ready, not token-error.
+      // Uses secondaryFromNative (never initializeAppCheck'd) so delegateProvider stays nil.
+      // Direct TurboModule reject code is unprefixed; FirebaseModule wraps to appCheck/<code>.
+      it('pending provider rejects with provider-not-ready (AppCheck-AD-8)', async function () {
+        if (!Platform.ios) {
+          this.skip();
+        }
+        try {
+          await NativeModules.NativeRNFBTurboAppCheck.getToken('secondaryFromNative', false);
+          return Promise.reject(new Error('should have thrown provider-not-ready'));
+        } catch (e) {
+          (e.code || '').should.equal('provider-not-ready');
+          String(e.message || e).should.containEql('initializeAppCheck');
+          String(e.code || e.message || e).should.not.containEql('token-error');
+        }
+      });
+
       it('token fetch attempt with configured debug token should work', async function () {
         const { getToken } = appCheckModular;
 
@@ -259,6 +276,20 @@ describe('appCheck()', function () {
     });
 
     describe('getLimitedUseToken()', function () {
+      it('pending provider rejects limited-use with provider-not-ready (AppCheck-AD-8)', async function () {
+        if (!Platform.ios) {
+          this.skip();
+        }
+        try {
+          await NativeModules.NativeRNFBTurboAppCheck.getLimitedUseToken('secondaryFromNative');
+          return Promise.reject(new Error('should have thrown provider-not-ready'));
+        } catch (e) {
+          (e.code || '').should.equal('provider-not-ready');
+          String(e.message || e).should.containEql('initializeAppCheck');
+          String(e.code || e.message || e).should.not.containEql('token-error');
+        }
+      });
+
       it('limited use token fetch attempt with configured debug token should work', async function () {
         if (Platform.other) {
           this.skip();

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.mm
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckModule.mm
@@ -124,21 +124,62 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAppCheck)
   resolve([NSNumber numberWithBool:isTokenAutoRefreshEnabled]);
 }
 
+// AppCheck-AD-8: map pending fail-closed to provider-not-ready (not token-error).
+// Walk NSUnderlyingErrorKey because FIRAppCheck wraps non-SDK errors via
+// publicDomainErrorWithError: and drops top-level userInfo[@"code"].
+// Locked message: kRNFBAppCheckProviderNotReadyMessage (RNFBAppCheckProvider.h).
+static NSString *RNFBAppCheckRejectCodeForError(NSError *error) {
+  NSError *current = error;
+  while (current != nil) {
+    id code = current.userInfo[@"code"];
+    if ([code isKindOfClass:[NSString class]] && [code isEqualToString:@"provider-not-ready"]) {
+      return @"provider-not-ready";
+    }
+    current = current.userInfo[NSUnderlyingErrorKey];
+    if (![current isKindOfClass:[NSError class]]) {
+      break;
+    }
+  }
+  return @"token-error";
+}
+
+// AppCheck-AD-8 durable path: reject before FIRAppCheck token APIs when the
+// factory-held facade still has a nil delegateProvider (pending / not configured).
+static BOOL RNFBAppCheckRejectIfProviderNotReady(FIRApp *firebaseApp,
+                                                 RCTPromiseRejectBlock reject) {
+  RNFBAppCheckProviderFactory *factory = [RNFBAppCheckModule sharedInstance].providerFactory;
+  RNFBAppCheckProvider *provider = [factory providerForApp:firebaseApp];
+  if (provider != nil && provider.delegateProvider != nil) {
+    return NO;
+  }
+  DLog(@"RNFBAppCheck - provider not ready for app %@ (delegateProvider nil)", firebaseApp.name);
+  [RNFBSharedUtils rejectPromiseWithUserInfo:reject
+                                    userInfo:(NSMutableDictionary *)@{
+                                      @"code" : @"provider-not-ready",
+                                      @"message" : kRNFBAppCheckProviderNotReadyMessage,
+                                    }];
+  return YES;
+}
+
 - (void)getToken:(NSString *)appName
     forceRefresh:(BOOL)forceRefresh
          resolve:(RCTPromiseResolveBlock)resolve
           reject:(RCTPromiseRejectBlock)reject {
   FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
-  FIRAppCheck *appCheck = [FIRAppCheck appCheckWithApp:firebaseApp];
   DLog(@"appName %@", firebaseApp.name);
+  if (RNFBAppCheckRejectIfProviderNotReady(firebaseApp, reject)) {
+    return;
+  }
+  FIRAppCheck *appCheck = [FIRAppCheck appCheckWithApp:firebaseApp];
   [appCheck
       tokenForcingRefresh:forceRefresh
                completion:^(FIRAppCheckToken *_Nullable token, NSError *_Nullable error) {
                  if (error != nil) {
                    DLog(@"RNFBAppCheck - getToken - Unable to retrieve App Check token: %@", error);
+                   NSString *code = RNFBAppCheckRejectCodeForError(error);
                    [RNFBSharedUtils rejectPromiseWithUserInfo:reject
                                                      userInfo:(NSMutableDictionary *)@{
-                                                       @"code" : @"token-error",
+                                                       @"code" : code,
                                                        @"message" : [error localizedDescription],
                                                      }];
                    return;
@@ -163,15 +204,19 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAppCheck)
                    resolve:(RCTPromiseResolveBlock)resolve
                     reject:(RCTPromiseRejectBlock)reject {
   FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
-  FIRAppCheck *appCheck = [FIRAppCheck appCheckWithApp:firebaseApp];
   DLog(@"appName %@", firebaseApp.name);
+  if (RNFBAppCheckRejectIfProviderNotReady(firebaseApp, reject)) {
+    return;
+  }
+  FIRAppCheck *appCheck = [FIRAppCheck appCheckWithApp:firebaseApp];
   [appCheck limitedUseTokenWithCompletion:^(FIRAppCheckToken *_Nullable token,
                                             NSError *_Nullable error) {
     if (error != nil) {
       DLog(@"RNFBAppCheck - getLimitedUseToken - Unable to retrieve App Check token: %@", error);
+      NSString *code = RNFBAppCheckRejectCodeForError(error);
       [RNFBSharedUtils rejectPromiseWithUserInfo:reject
                                         userInfo:(NSMutableDictionary *)@{
-                                          @"code" : @"token-error",
+                                          @"code" : code,
                                           @"message" : [error localizedDescription],
                                         }];
       return;

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.h
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.h
@@ -25,6 +25,9 @@
 @import FirebaseAppCheck;
 #endif
 
+// AppCheck-AD-8 locked message (Provider pending error + Module early reject).
+FOUNDATION_EXPORT NSString *const kRNFBAppCheckProviderNotReadyMessage;
+
 @interface RNFBAppCheckProvider : NSObject <FIRAppCheckProvider>
 
 @property FIRApp *app;

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProvider.m
@@ -17,6 +17,9 @@
 #import "RNFBAppCheckProvider.h"
 #import "RNFBApp/RNFBSharedUtils.h"
 
+NSString *const kRNFBAppCheckProviderNotReadyMessage =
+    @"App Check provider is not ready. Call initializeAppCheck before requesting tokens.";
+
 @implementation RNFBAppCheckProvider
 
 - (id)initWithApp:app {
@@ -85,14 +88,35 @@
   }
 }
 
+// AppCheck-AD-8: fail closed while pending — no network / no exchangeDebugToken.
+static NSError *RNFBAppCheckProviderNotReadyError(void) {
+  return [NSError errorWithDomain:@"RNFBErrorDomain"
+                             code:666
+                         userInfo:@{
+                           @"code" : @"provider-not-ready",
+                           @"message" : kRNFBAppCheckProviderNotReadyMessage,
+                           NSLocalizedDescriptionKey : kRNFBAppCheckProviderNotReadyMessage,
+                         }];
+}
+
 - (void)getTokenWithCompletion:(nonnull void (^)(FIRAppCheckToken *_Nullable,
                                                  NSError *_Nullable))handler {
+  if (self.delegateProvider == nil) {
+    DLog(@"getTokenWithCompletion: provider not ready (nil delegateProvider)");
+    handler(nil, RNFBAppCheckProviderNotReadyError());
+    return;
+  }
   DLog(@"proxying getTokenWithCompletion to delegateProvider...");
   [self.delegateProvider getTokenWithCompletion:handler];
 }
 
 - (void)getLimitedUseTokenWithCompletion:(nonnull void (^)(FIRAppCheckToken *_Nullable,
                                                            NSError *_Nullable))handler {
+  if (self.delegateProvider == nil) {
+    DLog(@"getLimitedUseTokenWithCompletion: provider not ready (nil delegateProvider)");
+    handler(nil, RNFBAppCheckProviderNotReadyError());
+    return;
+  }
   DLog(@"proxying getLimitedUseTokenWithCompletion to delegateProvider...");
   [self.delegateProvider getLimitedUseTokenWithCompletion:handler];
 }

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.h
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.h
@@ -25,4 +25,7 @@
      providerName:(NSString *_Nonnull)providerName
        debugToken:(NSString *_Nullable)debugToken;
 
+/** Returns the factory-held facade for `app`, or nil if none exists yet. */
+- (RNFBAppCheckProvider *_Nullable)providerForApp:(FIRApp *_Nonnull)app;
+
 @end

--- a/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.m
+++ b/packages/app-check/ios/RNFBAppCheck/RNFBAppCheckProviderFactory.m
@@ -23,19 +23,18 @@
 - (nullable id<FIRAppCheckProvider>)createProviderWithApp:(FIRApp *)app {
   DLog(@"appName %@", app.name);
 
-  // The SDK may try to call this before we have been configured,
-  // so we will configure ourselves and set the provider up as a default to start
-  // pre-configure
+  // Firebase may call this during FirebaseApp.configure() before JS runs
+  // configureProvider. Install a pending facade only (AppCheck-AD-1).
   if (self.providers == nil) {
     DLog(@"providers dictionary initializing for app %@", app.name);
     self.providers = [NSMutableDictionary new];
   }
 
   if (self.providers[app.name] == nil) {
-    DLog(@"provider initializing (with default to debug) for app %@", app.name);
+    // AppCheck-AD-1 / AD-2: facade only until configureProvider; no real provider
+    // (debug/App Attest/etc.) before JS/native configure. Same path DEBUG and release.
+    DLog(@"provider initializing (pending, no delegate) for app %@", app.name);
     self.providers[app.name] = [RNFBAppCheckProvider new];
-    RNFBAppCheckProvider *provider = self.providers[app.name];
-    [provider configure:app providerName:@"debug" debugToken:nil];
   }
 
   return self.providers[app.name];
@@ -56,6 +55,13 @@
 
   RNFBAppCheckProvider *provider = self.providers[app.name];
   [provider configure:app providerName:providerName debugToken:debugToken];
+}
+
+- (RNFBAppCheckProvider *)providerForApp:(FIRApp *)app {
+  if (app == nil || self.providers == nil) {
+    return nil;
+  }
+  return self.providers[app.name];
 }
 
 @end

--- a/packages/app-check/lib/index.ts
+++ b/packages/app-check/lib/index.ts
@@ -152,35 +152,43 @@ class FirebaseAppCheckModule extends FirebaseModule<typeof nativeModuleName> {
     if (!isBoolean(options.isTokenAutoRefreshEnabled)) {
       options.isTokenAutoRefreshEnabled = true;
     }
-    this.native.setTokenAutoRefreshEnabled(options.isTokenAutoRefreshEnabled);
+    const isTokenAutoRefreshEnabled = options.isTokenAutoRefreshEnabled as boolean;
 
     if (!hasProviderOptions(options.provider)) {
       throw new Error('Invalid configuration: no provider or no provider options defined.');
     }
     const provider = options.provider;
+
+    // AppCheck-AD-4: attach the real provider before enabling auto-refresh so early
+    // refresh does not run while the native facade is still pending.
+    let configurePromise: Promise<void>;
     if (Platform.OS === 'android') {
       if (!isString(provider.providerOptions?.android?.provider)) {
         throw new Error(
           'Invalid configuration: no android provider configured while on android platform.',
         );
       }
-      return this.native.configureProvider(
+      configurePromise = this.native.configureProvider(
         provider.providerOptions.android.provider,
         provider.providerOptions.android.debugToken,
       );
-    }
-    if (Platform.OS === 'ios' || Platform.OS === 'macos') {
+    } else if (Platform.OS === 'ios' || Platform.OS === 'macos') {
       if (!isString(provider.providerOptions?.apple?.provider)) {
         throw new Error(
           'Invalid configuration: no apple provider configured while on apple platform.',
         );
       }
-      return this.native.configureProvider(
+      configurePromise = this.native.configureProvider(
         provider.providerOptions.apple.provider,
         provider.providerOptions.apple.debugToken,
       );
+    } else {
+      throw new Error('Unsupported platform: ' + Platform.OS);
     }
-    throw new Error('Unsupported platform: ' + Platform.OS);
+
+    return Promise.resolve(configurePromise).then(() => {
+      this.native.setTokenAutoRefreshEnabled(isTokenAutoRefreshEnabled);
+    });
   }
 
   activate(

--- a/packages/app-check/lib/types/internal.ts
+++ b/packages/app-check/lib/types/internal.ts
@@ -33,8 +33,10 @@ export type AppCheckInternal = AppCheck & {
 
   /**
    * Activate App Check
-   * On iOS App Check is activated with DeviceCheck provider simply by including the module, using the token auto refresh default or
-   * the specific value (if configured) in firebase.json, but calling this does no harm.
+   * On iOS calling this activates App Check with the DeviceCheck provider, using the token auto refresh default or
+   * the specific value (if configured) in firebase.json. Before `activate` or `initializeAppCheck` is called, the
+   * native App Check provider is pending and `getToken` / `getLimitedUseToken` fail closed with
+   * `appCheck/provider-not-ready`.
    * On Android if you call this it will install the PlayIntegrity provider in release builds, the Debug provider if debuggable.
    * On both platforms you may use this method to alter the token refresh setting after startup.
    * On iOS if you want to set a specific AppCheckProviderFactory (for instance to FIRAppCheckDebugProviderFactory or

--- a/packages/app-check/plugin/src/ios/appDelegate.ts
+++ b/packages/app-check/plugin/src/ios/appDelegate.ts
@@ -141,8 +141,9 @@ export function modifySwiftAppDelegate(contents: string): string {
     );
   }
 
-  // If Firebase initialization block not found, add both Firebase and App Check initialization
-  // This is to make sure Firebase is initialized before App Check
+  // If Firebase initialization block not found, register the App Check provider factory
+  // then call FirebaseApp.configure(). Firebase requires the factory before configure
+  // (AppCheck-AD-3); do not reverse this order.
   const methodInvocationBlock = `RNFBAppCheckModule.sharedInstance()
     FirebaseApp.configure()`;
 


### PR DESCRIPTION
### Description

Fixes iOS App Check installing the debug provider before JS calls `initializeAppCheck`. Firebase requires the provider factory to be registered before `FirebaseApp.configure()`, which runs before JS, so release builds could exchange debug tokens during that gap and hit `exchangeDebugToken` 403/429s (#9116).

The factory now installs a pending facade with no delegate until `configureProvider` runs, same path for DEBUG and release. While pending, `getToken` / `getLimitedUseToken` fail closed with `appCheck/provider-not-ready` instead of hitting the network. JS `initializeAppCheck` configures the provider before enabling auto-refresh.

Supersedes the temporary `#if DEBUG` mitigation in #9117 (not merged) with the durable fix.

### Related issues

Closes #9116.

### Release Summary

Fixes an iOS App Check bug where token requests before `initializeAppCheck` could silently exchange debug tokens, including in release builds. They now fail closed with `appCheck/provider-not-ready` until `initializeAppCheck` is called.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [x] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

---

Think `react-native-firebase` is great? Please consider supporting the project with any of the below:

- 👉 Star this repo on GitHub ⭐️
- 👉 Follow [`React Native Firebase`](https://twitter.com/rnfirebase) and [`Invertase`](https://twitter.com/invertaseio) on Twitter
