### PR TITLE
fix(crashlytics, ios): restore dSYM upload script phase

### DIFF
--- a/packages/crashlytics/__tests__/reactNativeConfig.test.ts
+++ b/packages/crashlytics/__tests__/reactNativeConfig.test.ts
@@ -1,0 +1,26 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+
+import { describe, expect, it } from '@jest/globals';
+
+const config = require('../react-native.config.js');
+
+describe('Crashlytics react-native.config.js', function () {
+  it('declares the iOS script phase that uploads dSYMs', function () {
+    // Without this entry `pod install` silently drops the
+    // `[RNFB] Crashlytics Configuration` build phase from the Xcode project,
+    // so dSYMs are never uploaded and iOS crash reports stay unsymbolicated.
+    const scriptPhases = config.dependency.platforms.ios.scriptPhases;
+
+    expect(scriptPhases).toHaveLength(1);
+    expect(scriptPhases[0].name).toBe('[RNFB] Crashlytics Configuration');
+    expect(scriptPhases[0].path).toBe('./ios_config.sh');
+    expect(scriptPhases[0].execution_position).toBe('after_compile');
+  });
+
+  it('points the script phase at a script that exists', function () {
+    const scriptPath = join(__dirname, '..', config.dependency.platforms.ios.scriptPhases[0].path);
+
+    expect(existsSync(scriptPath)).toBe(true);
+  });
+});

--- a/packages/crashlytics/react-native.config.js
+++ b/packages/crashlytics/react-native.config.js
@@ -5,6 +5,19 @@ module.exports = {
         cmakeListsPath:
           './src/main/java/io/invertase/firebase/crashlytics/generated/jni/CMakeLists.txt',
       },
+      ios: {
+        scriptPhases: [
+          {
+            name: '[RNFB] Crashlytics Configuration',
+            path: './ios_config.sh',
+            execution_position: 'after_compile',
+            input_files: [
+              '${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}',
+              '$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)',
+            ],
+          },
+        ],
+      },
     },
   },
 };


### PR DESCRIPTION
### Description

`packages/crashlytics/react-native.config.js` lost its `ios.scriptPhases` entry in v26.0.0, so `pod install` no longer installs the `[RNFB] Crashlytics Configuration` build phase. dSYMs are never uploaded and iOS crash reports stay unsymbolicated.

The removal looks accidental rather than deliberate. The TurboModule migration (122295e) rewrote this file to add `android.cmakeListsPath` and the `ios` block went with it, while `ios_config.sh` stayed in the package and was actively extended in v26.1.0 (44a7a9a) with an SPM `upload-symbols` lookup. The script being invoked is still maintained; only the wiring that invokes it is gone. `packages/app/react-native.config.js` kept its equivalent `[RNFB] Core Configuration` phase, so crashlytics is the only affected package.

This PR restores the `ios` block verbatim from v25.1.0 and adds a jest regression guard, since nothing about this failure is loud — the app still builds and crashes are still collected, so the only symptom is unsymbolicated stack traces in the Firebase console.

### Related issues

Fixes #9168

### Release Summary

Restore the iOS dSYM upload build phase for `@react-native-firebase/crashlytics`, which was dropped in v26.0.0.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

`yarn jest packages/crashlytics` on this branch:

```
Test Suites: 4 passed, 4 total
Tests:       17 passed, 17 total
Snapshots:   2 passed, 2 total
```

Reverting only `react-native.config.js` and re-running the new test fails as expected, since `config.dependency.platforms.ios` is `undefined` without it:

```
● Crashlytics react-native.config.js › declares the iOS script phase that uploads dSYMs

  TypeError: Cannot read properties of undefined (reading 'scriptPhases')
```

Verified against a real app (RN 0.85.3, new architecture, CocoaPods with `$RNFirebaseDisableSPM = true`, firebase-ios-sdk 12.17.0). Before the fix, upgrading 23.8.6 to 26.1.0 and running `pod install` deletes the phase:

```diff
 				DF4DD20734CE8FDF8BE651AE /* [CP-User] [RNFB] Core Configuration */,
-				26804AC9E4CC4745C34B6608 /* [CP-User] [RNFB] Crashlytics Configuration */,
 			);
```

With this change applied via patch-package, `pod install` reinstates the phase and the Xcode build log shows it running:

```
info: Exec FirebaseCrashlytics Run from Pods
```
