### PR TITLE
build(deps): dependency updates 20260809

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/actions/stale/releases
-      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           operations-per-run: 1000
           stale-issue-message: |

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -272,7 +272,7 @@ jobs:
 
       - name: Detox Tests
         # https://github.com/reactivecircus/android-emulator-runner/releases
-        uses: reactivecircus/android-emulator-runner@0a638108440efd5c7f980e6ba145dbcdd8f32009 # v2.37.0
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         timeout-minutes: 45
         env:
           ANDROID_AVD_HOME: /mnt/avd
@@ -287,7 +287,7 @@ jobs:
 
       # https://github.com/codecov/codecov-action/releases
       - name: Upload Codecov e2e TS (Android)
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
           files: coverage/lcov.info
@@ -297,7 +297,7 @@ jobs:
 
       # Merged unit (*.exec) + e2e (*.ec) from jacocoTestReport (post-e2e-coverage).
       - name: Upload Codecov Android native
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
           files: tests/android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -512,7 +512,7 @@ jobs:
 
       # https://github.com/codecov/codecov-action/releases
       - name: Upload Codecov e2e TS (iOS)
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: contains(matrix.buildmode, 'debug')
         continue-on-error: true
         with:
@@ -522,7 +522,7 @@ jobs:
           verbose: true
 
       - name: Upload Codecov iOS native
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: contains(matrix.buildmode, 'debug')
         continue-on-error: true
         with:
@@ -532,7 +532,7 @@ jobs:
           verbose: true
 
       - name: Upload Codecov iOS Ruby
-        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: matrix.buildmode == 'debug' && matrix.dep-resolution == 'spm'
         continue-on-error: true
         with:
@@ -635,7 +635,7 @@ jobs:
           fetch-depth: 50
 
       - name: Yarn Cache Restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: yarn-cache
         continue-on-error: true
         with:
@@ -673,7 +673,7 @@ jobs:
           command: gem update cocoapods xcodeproj
 
       - name: Pods Cache Restore
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: pods-cache
         continue-on-error: true
         with:
@@ -719,7 +719,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Yarn Cache Save
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: "${{ github.ref == 'refs/heads/main' }}"
         continue-on-error: true
         with:
@@ -727,7 +727,7 @@ jobs:
           key: ${{ steps.yarn-cache.outputs.cache-primary-key }}
 
       - name: Pods Cache Save
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         if: "${{ github.ref == 'refs/heads/main' }}"
         continue-on-error: true
         with:

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -95,6 +95,10 @@ jobs:
       NX_NO_CLOUD: true
       NX_CACHE_DIRECTORY: .nx/cache
       NX_WORKSPACE_DATA_DIRECTORY: .nx/workspace-data
+      # Xcode 26+ MetalToolchain cryptex omits swiftCompatibility* libs; pin default
+      # toolchain so SharedAsyncStorage (async-storage 3.x) links on Other CI.
+      # https://github.com/actions/runner-images/issues/13135
+      TOOLCHAINS: com.apple.dt.toolchain.XcodeDefault
       CCACHE_SLOPPINESS: clang_index_store,file_stat_matches,include_file_ctime,include_file_mtime,ivfsoverlay,pch_defines,modules,system_headers,time_macros
       CCACHE_FILECLONE: true
       CCACHE_DEPEND: true
@@ -290,7 +294,7 @@ jobs:
         run: yarn tests:macos:test-cover
 
       # https://github.com/codecov/codecov-action/releases
-      - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
           files: coverage/lcov.info

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Jest
         run: yarn tests:jest-coverage
       # https://github.com/codecov/codecov-action/releases
-      - uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage/lcov.info
           flags: jest

--- a/okf-bundle/ci-workflows/other.md
+++ b/okf-bundle/ci-workflows/other.md
@@ -12,6 +12,26 @@ Local macOS e2e: [running e2e § Rules](../testing/running-e2e.md#rules) only. C
 4. **Pre-fetch JS bundle**; URL must match app request
 5. `tests:macos:test-cover` — internal `before` hook prefetches, then `open` app
 
+### CI failure: `swiftCompatibility56` / SharedAsyncStorage undefined symbols
+
+**Symptom** — `yarn tests:macos:build` / `** BUILD FAILED **` with:
+
+```
+Undefined symbols for architecture arm64
+  "__swift_FORCE_LOAD_$_swiftCompatibility56_$_SharedAsyncStorage"
+  "__swift_FORCE_LOAD_$_swiftCompatibilityConcurrency_$_SharedAsyncStorage"
+```
+
+**Cause** — async-storage 3.x vendors `SharedAsyncStorage.xcframework` (Swift). On Xcode 26 GitHub runners, the MetalToolchain cryptex is preferred for linker search paths and does not ship Swift compatibility static libs ([actions/runner-images#13135](https://github.com/actions/runner-images/issues/13135)).
+
+**Mitigations in this repo**
+
+| Change | Location |
+|--------|----------|
+| `TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault` job env | `.github/workflows/tests_e2e_other.yml` |
+| Same default in `build:macos` | `tests/package.json` |
+| App-target `OTHER_LDFLAGS` explicit `-lswiftCompatibility56` / `Concurrency` / `Packs` via `DT_TOOLCHAIN_DIR` | `tests/macos/Podfile` `post_install` |
+
 ### CI failure: bundle load hang / `Could not connect to development server`
 
 **Symptom** — `[💻] macOS app started` but no `[🟩] Jet client connected`; `syslog` shows:

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -115,7 +115,7 @@
     "firebase": "12.17.0"
   },
   "devDependencies": {
-    "@react-native-async-storage/async-storage": "^2.0.2",
+    "@react-native-async-storage/async-storage": "^3.1.1",
     "expo": "^55.0.18",
     "react-native-builder-bob": "^0.41.0"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,7 +42,7 @@
     "auth"
   ],
   "dependencies": {
-    "plist": "^3.1.1"
+    "@expo/plist": "^0.5.2"
   },
   "peerDependencies": {
     "@react-native-firebase/app": "26.1.0",
@@ -50,7 +50,6 @@
   },
   "devDependencies": {
     "@react-native-firebase/app": "26.1.0",
-    "@types/plist": "^3.0.5",
     "expo": "^55.0.18",
     "react-native-builder-bob": "^0.40.13"
   },

--- a/packages/auth/plugin/src/ios/urlTypes.ts
+++ b/packages/auth/plugin/src/ios/urlTypes.ts
@@ -6,7 +6,7 @@ import {
 } from '@expo/config-plugins';
 import fs from 'fs';
 import path from 'path';
-import plist from 'plist';
+import plist from '@expo/plist';
 import { PluginConfigType } from '../pluginConfig';
 
 // does this for you: https://firebase.google.com/docs/auth/ios/phone-auth#enable-phone-number-sign-in-for-your-firebase-project

--- a/packages/auth/plugin/tsconfig.json
+++ b/packages/auth/plugin/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "build",
     "rootDir": "src",
-    "declaration": true
+    "declaration": true,
+    "types": ["node"]
   },
   "include": ["./src"]
 }

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -6,7 +6,8 @@ buildscript {
 
  ext.ndkVersion = "27.1.12297006"
 
-  ext.kotlinVersion = '2.1.21' // https://kotlinlang.org/releases.html
+  // async-storage 3.x ships shared-storage / kotlin-stdlib with metadata 2.2.0 — compiler must be ≥ 2.2
+  ext.kotlinVersion = '2.2.10' // https://kotlinlang.org/releases.html
   ext.supportLibVersion = '1.17.0' // this maps to androidx.core https://developer.android.com/jetpack/androidx/releases/core
   ext.appCompatVersion = '1.7.1' // this maps to androidx.appcompat https://developer.android.com/jetpack/androidx/releases/appcompat
   ext.supportVersion = ext.supportLibVersion
@@ -34,7 +35,7 @@ buildscript {
     classpath 'com.google.gms:google-services:4.5.0' // https://developers.google.com/android/guides/google-services-plugin
     classpath 'com.android.tools.build:gradle:8.13.1' // https://mvnrepository.com/artifact/com.android.tools.build/gradle?repo=google
     classpath("com.facebook.react:react-native-gradle-plugin")
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     classpath 'com.google.firebase:perf-plugin:2.0.2'
     classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.7'
     classpath 'com.google.firebase:firebase-appdistribution-gradle:5.3.0'

--- a/tests/macos/Podfile
+++ b/tests/macos/Podfile
@@ -10,7 +10,8 @@ prepare_react_native_project!
 ENV['RCT_NEW_ARCH_ENABLED'] = '0'
 
 target 'io.invertase.testing-macOS' do
-  platform :macos, '11.0'
+  # async-storage 3.x AsyncStorage.podspec requires :osx => "12.0"
+  platform :macos, '12.0'
   # use_native_modules!
 
   # Flags change depending on the env values.
@@ -24,9 +25,37 @@ target 'io.invertase.testing-macOS' do
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
 
-  pod 'RNCAsyncStorage', :path => '../node_modules/@react-native-async-storage/async-storage'
+  # async-storage 3.x renamed the CocoaPods target RNCAsyncStorage → AsyncStorage
+  pod 'AsyncStorage', :path => '../node_modules/@react-native-async-storage/async-storage'
 
   post_install do |installer|
     react_native_post_install(installer)
+
+    # async-storage 3.x vendors SharedAsyncStorage.xcframework (Swift). On Xcode 26 CI
+    # (MetalToolchain cryptex), auto-link misses swiftCompatibility56/Concurrency —
+    # same class of failure as iOS Firebase Swift pods. Explicit app-target ldflags
+    # via DT_TOOLCHAIN_DIR (not TOOLCHAIN_DIR) resolve on CI workspaces.
+    # See: actions/runner-images#13135, tests/ios/Podfile coverage ldflags.
+    installer.aggregate_targets.each do |aggregate_target|
+      aggregate_target.user_project.native_targets.each do |target|
+        next unless target.name == 'io.invertase.testing-macOS'
+
+        target.build_configurations.each do |config|
+          ldflags = Array(config.build_settings['OTHER_LDFLAGS']).flatten
+          ldflags = ['$(inherited)'] if ldflags.empty?
+          extras = [
+            '-L$(DT_TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)',
+            '-L$(SDKROOT)/usr/lib/swift',
+            '-lswiftCompatibility56',
+            '-lswiftCompatibilityConcurrency',
+            '-lswiftCompatibilityPacks',
+          ]
+          extras.each { |flag| ldflags << flag unless ldflags.include?(flag) }
+          config.build_settings['OTHER_LDFLAGS'] = ldflags
+          # ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES already YES via Pods xcconfig
+        end
+      end
+      aggregate_target.user_project.save
+    end
   end
 end

--- a/tests/macos/Podfile.lock
+++ b/tests/macos/Podfile.lock
@@ -1,4 +1,25 @@
 PODS:
+  - AsyncStorage (3.1.1):
+    - DoubleConversion
+    - glog
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
@@ -1480,12 +1501,11 @@ PODS:
     - React-logger (= 0.78.6)
     - React-perflogger (= 0.78.6)
     - React-utils (= 0.78.6)
-  - RNCAsyncStorage (2.2.0):
-    - React-Core
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
+  - "AsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - boost (from `../node_modules/react-native-macos/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../node_modules/react-native-macos/third-party-podspecs/DoubleConversion.podspec`)
   - fast_float (from `../node_modules/react-native-macos/third-party-podspecs/fast_float.podspec`)
@@ -1551,11 +1571,12 @@ DEPENDENCIES:
   - ReactAppDependencyProvider (from `build/generated/ios`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native-macos/ReactCommon`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - SocketRocket (from `../node_modules/react-native-macos/third-party-podspecs/SocketRocket.podspec`)
   - Yoga (from `../node_modules/react-native-macos/ReactCommon/yoga`)
 
 EXTERNAL SOURCES:
+  AsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   boost:
     :podspec: "../node_modules/react-native-macos/third-party-podspecs/boost.podspec"
   DoubleConversion:
@@ -1682,14 +1703,13 @@ EXTERNAL SOURCES:
     :path: build/generated/ios
   ReactCommon:
     :path: "../node_modules/react-native-macos/ReactCommon"
-  RNCAsyncStorage:
-    :path: "../node_modules/@react-native-async-storage/async-storage"
   SocketRocket:
     :podspec: "../node_modules/react-native-macos/third-party-podspecs/SocketRocket.podspec"
   Yoga:
     :path: "../node_modules/react-native-macos/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  AsyncStorage: edfca36e0bfbccdac3710ce7a6d084dd568848f9
   boost: 7d49a506d1ac47358fea28558d184dd6431170ca
   DoubleConversion: 10f51d3e1238973c033faac2d84c0ea114942f53
   fast_float: 44983b3bddb2d2ed3021a98be86f60ec8abc9ffd
@@ -1753,10 +1773,9 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 78d1aa823d2f280f83372f9abb50502cee4d0424
   ReactCodegen: cfbf6d5eabb2335c65a821c9fd8e1883e87c1ef7
   ReactCommon: 6bb5e1ee21c4b0e6e203cece50d86cc3f7a5af1b
-  RNCAsyncStorage: b44e8a4e798c3e1f56bffccd0f591f674fb9198f
   SocketRocket: 03f7111df1a343b162bf5b06ead333be808e1e0a
   Yoga: 187db0b2a37012c01dac36afb886a29b92bfd943
 
-PODFILE CHECKSUM: 787ee60864ef7264ea1a666923a1119b7db1a281
+PODFILE CHECKSUM: c98b3e7eb87c56935afe83066024eb35ad189f3b
 
 COCOAPODS: 1.16.2

--- a/tests/macos/io.invertase.testing.xcodeproj/project.pbxproj
+++ b/tests/macos/io.invertase.testing.xcodeproj/project.pbxproj
@@ -180,8 +180,8 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-io.invertase.testing-macOS/Pods-io.invertase.testing-macOS-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/AsyncStorage/AsyncStorage_resources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
-				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
@@ -189,8 +189,8 @@
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AsyncStorage_resources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
@@ -260,11 +260,16 @@
 				ENABLE_DEBUG_DYLIB = NO;
 				INFOPLIST_FILE = "io.invertase.testing-macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
+					"-L$(DT_TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
+					"-L$(SDKROOT)/usr/lib/swift",
+					"-lswiftCompatibility56",
+					"-lswiftCompatibilityConcurrency",
+					"-lswiftCompatibilityPacks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = io.invertase.testing;
@@ -283,11 +288,16 @@
 				CURRENT_PROJECT_VERSION = 1;
 				INFOPLIST_FILE = "io.invertase.testing-macOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
 					"-lc++",
+					"-L$(DT_TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
+					"-L$(SDKROOT)/usr/lib/swift",
+					"-lswiftCompatibility56",
+					"-lswiftCompatibilityConcurrency",
+					"-lswiftCompatibilityPacks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = io.invertase.testing;

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "scripts": {
     "build:clean": "rimraf dist && rimraf android/build && rimraf android/app/build && rimraf android/.gradle && rimraf ios/build && rimraf macos/build",
-    "build:macos": "bash -c 'set -o pipefail && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace macos/io.invertase.testing.xcworkspace -scheme io.invertase.testing-macOS -configuration Debug -derivedDataPath macos/build | xcbeautify'",
+    "build:macos": "bash -c 'set -o pipefail && export TOOLCHAINS=\"${TOOLCHAINS:-com.apple.dt.toolchain.XcodeDefault}\" && xcodebuild CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ -workspace macos/io.invertase.testing.xcworkspace -scheme io.invertase.testing-macOS -configuration Debug -derivedDataPath macos/build | xcbeautify'",
     "prepare": "patch-package"
   },
   "dependencies": {
     "@invertase/react-native-apple-authentication": "^2.5.1",
-    "@react-native-async-storage/async-storage": "^2.0.2",
+    "@react-native-async-storage/async-storage": "^3.1.1",
     "@react-native-community/cli": "15.1.3",
     "@react-native-community/cli-platform-android": "15.1.3",
     "@react-native-community/cli-platform-ios": "15.1.3",

--- a/tests/patches/@react-native+gradle-plugin+0.78.3.patch
+++ b/tests/patches/@react-native+gradle-plugin+0.78.3.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt b/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+--- a/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
++++ b/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+@@ -13,14 +13,18 @@ import com.facebook.react.utils.PropertyUtils.INTERNAL_DISABLE_JAVA_VERSION_ALIG
+ import org.gradle.api.Action
+ import org.gradle.api.JavaVersion
+ import org.gradle.api.Project
+ import org.gradle.api.plugins.AppliedPlugin
+-import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
++import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+ 
+ internal object JdkConfiguratorUtils {
+   /**
+    * Function that takes care of configuring the JDK toolchain for all the projects projects. As we
+    * do decide the JDK version based on the AGP version that RNGP brings over, here we can safely
+    * configure the toolchain to 17.
++   *
++   * Uses kotlinExtension (not deprecated KotlinTopLevelExtension) so Kotlin Gradle Plugin ≥ 2.1/2.2
++   * works — required for @react-native-async-storage/async-storage 3.x shared-storage metadata 2.2.0.
++   * See facebook/react-native#48274.
+    */
+   fun configureJavaToolChains(input: Project) {
+     // Check at the app level if react.internal.disableJavaVersionAlignment is set.
+@@ -42,10 +46,10 @@ internal object JdkConfiguratorUtils {
+       project.pluginManager.withPlugin("com.android.application", action)
+       project.pluginManager.withPlugin("com.android.library", action)
+       project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
++        project.kotlinExtension.jvmToolchain(17)
+       }
+       project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
++        project.kotlinExtension.jvmToolchain(17)
+       }
+     }
+   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,14 +5594,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-async-storage/async-storage@npm:^2.0.2":
-  version: 2.2.0
-  resolution: "@react-native-async-storage/async-storage@npm:2.2.0"
+"@react-native-async-storage/async-storage@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@react-native-async-storage/async-storage@npm:3.1.1"
   dependencies:
-    merge-options: "npm:^3.0.4"
+    idb: "npm:8.0.3"
   peerDependencies:
-    react-native: ^0.0.0-0 || >=0.65 <1.0
-  checksum: 10/625e42134f0c487acfd4ba9b3ba182e6f6f29581485004cc658850ef024372cdb7381b7399393f4416fda39df2d822e3008427d7671d635a7363f9a65430a2dd
+    react: "*"
+    react-native: "*"
+  checksum: 10/60a6600af1edbd606bca7098f1a9ab9f69e5f6c0a388fb7dec28da513f5146b70f3f77aa954d955d42f7b0b3335513d7a8733ddcac8d77971785507348b1b3e6
   languageName: node
   linkType: hard
 
@@ -5874,7 +5875,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-native-firebase/app@workspace:packages/app"
   dependencies:
-    "@react-native-async-storage/async-storage": "npm:^2.0.2"
+    "@react-native-async-storage/async-storage": "npm:^3.1.1"
     expo: "npm:^55.0.18"
     firebase: "npm:12.17.0"
     react-native-builder-bob: "npm:^0.41.0"
@@ -5892,10 +5893,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-native-firebase/auth@workspace:packages/auth"
   dependencies:
+    "@expo/plist": "npm:^0.5.2"
     "@react-native-firebase/app": "npm:26.1.0"
-    "@types/plist": "npm:^3.0.5"
     expo: "npm:^55.0.18"
-    plist: "npm:^3.1.1"
     react-native-builder-bob: "npm:^0.40.13"
   peerDependencies:
     "@react-native-firebase/app": 26.1.0
@@ -6932,16 +6932,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/plist@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "@types/plist@npm:3.0.5"
-  dependencies:
-    "@types/node": "npm:*"
-    xmlbuilder: "npm:>=11.0.1"
-  checksum: 10/71417189c9bc0d0cb4595106cea7c7a8a7274f64d2e9c4dd558efd7993bcfdada58be6917189e3be7c455fe4e5557004658fd13bd12254eafed8c56e0868b59e
-  languageName: node
-  linkType: hard
-
 "@types/react-native@npm:^0.73.0":
   version: 0.73.0
   resolution: "@types/react-native@npm:0.73.0"
@@ -7418,13 +7408,6 @@ __metadata:
   version: 0.8.11
   resolution: "@xmldom/xmldom@npm:0.8.11"
   checksum: 10/f6d6ffdf71cf19d9b3c10e978fad40d2f85453bf5b2aa05be8aa0c5ad13f84690c3153316729213cc652d06ec12c605ddb0aa03886f1d73d51b974b4105d31e3
-  languageName: node
-  linkType: hard
-
-"@xmldom/xmldom@npm:^0.9.10":
-  version: 0.9.10
-  resolution: "@xmldom/xmldom@npm:0.9.10"
-  checksum: 10/8d39ed498baf33dc8bbc82ec575e7448ddf08a0d6874bcc30a70c001b7519e6df6564f98d13c03836fa8be099c6d74cbc4078cfcfcbcf005681d4e67f1363412
   languageName: node
   linkType: hard
 
@@ -14298,6 +14281,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"idb@npm:8.0.3":
+  version: 8.0.3
+  resolution: "idb@npm:8.0.3"
+  checksum: 10/e2beccb0be7c6af562a5e92b209363358571a770aecdc68e891d1141d994d8f1e8f34b79dafa309ed7467d0f4df2b7b4c15f67cfd0611100282bfc3d85f9c73c
+  languageName: node
+  linkType: hard
+
 "ieee754@npm:1.2.1, ieee754@npm:^1.1.13, ieee754@npm:^1.2.1":
   version: 1.2.1
   resolution: "ieee754@npm:1.2.1"
@@ -17608,15 +17598,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-options@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "merge-options@npm:3.0.4"
-  dependencies:
-    is-plain-obj: "npm:^2.1.0"
-  checksum: 10/d86ddb3dd6e85d558dbf25dc944f3527b6bacb944db3fdda6e84a3f59c4e4b85231095f58b835758b9a57708342dee0f8de0dffa352974a48221487fe9f4584f
-  languageName: node
-  linkType: hard
-
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -20884,17 +20865,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"plist@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "plist@npm:3.1.1"
-  dependencies:
-    "@xmldom/xmldom": "npm:^0.9.10"
-    base64-js: "npm:^1.5.1"
-    xmlbuilder: "npm:^15.1.1"
-  checksum: 10/dffa39e82c42292de4985312584e5963e60413cf6ed5f32193a8b2d3b55afadcec824da740bf437c99f8db3195c359181d17e1f41eb01afa4793da6c369f2087
-  languageName: node
-  linkType: hard
-
 "pngjs@npm:^3.3.0":
   version: 3.4.0
   resolution: "pngjs@npm:3.4.0"
@@ -21598,7 +21568,7 @@ __metadata:
   dependencies:
     "@firebase/rules-unit-testing": "npm:^5.0.0"
     "@invertase/react-native-apple-authentication": "npm:^2.5.1"
-    "@react-native-async-storage/async-storage": "npm:^2.0.2"
+    "@react-native-async-storage/async-storage": "npm:^3.1.1"
     "@react-native-community/cli": "npm:15.1.3"
     "@react-native-community/cli-platform-android": "npm:15.1.3"
     "@react-native-community/cli-platform-ios": "npm:15.1.3"
@@ -26060,7 +26030,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xmlbuilder@npm:>=11.0.1, xmlbuilder@npm:^15.1.1":
+"xmlbuilder@npm:^15.1.1":
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
   checksum: 10/e6f4bab2504afdd5f80491bda948894d2146756532521dbe7db33ae0931cd3000e3b4da19b3f5b3f51bedbd9ee06582144d28136d68bd1df96579ecf4d4404a2


### PR DESCRIPTION
## Summary

Combines several open Dependabot `build(deps)` PRs onto one branch, with fixes where the tips alone would not green CI.

**Included**
- GHA pin bumps: `actions/stale`, `actions/cache` (iOS archive restore+save), `codecov/codecov-action`, `reactivecircus/android-emulator-runner`
- Auth Expo config plugin: replace direct `plist` with `@expo/plist`
- Test app / app package: `@react-native-async-storage/async-storage` 2.x → 3.1.1, with Kotlin/Gradle + macOS CocoaPods + Xcode 26 Swift link alignment

**Intentionally skipped**
- #9160 (`react` / `@types/react`) — cannot upgrade React in this tree right now

### plist (#9142)

Dependabot proposed `plist` 3.1.1 → **5.0.0**. That package is ESM-only (`"type": "module"`) and its `exports` map only defines `import` / `browser` — no `require` condition.

That breaks our Expo auth config plugin path:
- **Jest:** `Cannot find module 'plist'` from `packages/auth/plugin/src/ios/urlTypes.ts`
- **`yarn attw:check` Expo plugin smoke:** `ERR_PACKAGE_PATH_NOT_EXPORTED: No "exports" main defined in …/plist/package.json`

`plist@4` is also ESM, so a mid-major pin would not help. We only use `plist.parse` for `GoogleService-Info.plist` in Expo plugin code, and `@expo/plist` is already present via the Expo stack and works under CJS config-plugin / Jest.

**Fix:** depend on `@expo/plist`, switch the import, drop `@types/plist`, and set plugin `tsconfig` `"types": ["node"]`.

### async-storage + Kotlin / Gradle / macOS (#9125)

Dependabot proposed async-storage **3.1.1**. Breakages beyond the tip:

**Android:** `:react-native-async-storage_async-storage:compileDebugKotlin` failed with Kotlin metadata **2.2.0** (shared-storage-api + kotlin-stdlib) vs compiler expecting **2.0.0**.

**Fix (tests Android):** bump `ext.kotlinVersion` to **2.2.10**, pin `kotlin-gradle-plugin:$kotlinVersion`, and add `tests/patches/@react-native+gradle-plugin+0.78.3.patch` so RNGP’s JDK toolchain helper uses `kotlinExtension` (facebook/react-native#48274) until upstream / RN bump.

**macOS (Other CI) — pod name / deployment target:** `pod install` failed with `No podspec found for RNCAsyncStorage` — async-storage 3.x renamed the pod to **`AsyncStorage`** and requires macOS **12.0+**.

**Fix:** Podfile `RNCAsyncStorage` → `AsyncStorage`, bump platform / `MACOSX_DEPLOYMENT_TARGET` to 12.0, refresh Podfile.lock + resource-bundle paths.

**macOS (Other CI) — Xcode 26 Swift link:** build then failed linking vendored `SharedAsyncStorage.xcframework` with undefined `__swift_FORCE_LOAD_$_swiftCompatibility56` / `Concurrency` (MetalToolchain cryptex omits those libs — [actions/runner-images#13135](https://github.com/actions/runner-images/issues/13135)).

**Fix:** pin `TOOLCHAINS=com.apple.dt.toolchain.XcodeDefault` on the Other job and in `tests` `build:macos`, and add app-target `OTHER_LDFLAGS` `-lswiftCompatibility56/Concurrency/Packs` via macos Podfile `post_install` (documented in `okf-bundle/ci-workflows/other.md`). Local `yarn tests:macos:test-cover` **33 passing** including the async-storage persistence check.

## Obsoletes

- Obsoletes: #9159
- Obsoletes: #9150
- Obsoletes: #9148
- Obsoletes: #9142
- Obsoletes: #9141
- Obsoletes: #9125

## Test plan

- [ ] CI matrix green on this PR (Jest, Lint, Android, iOS, **Other**, attw)
- [ ] Confirm Dependabot PRs listed under Obsoletes can be closed once this merges
- [ ] Spot-check auth Expo plugin still injects URL types from a sample GoogleService-Info.plist (covered by `iosPlugin_urlTypes` Jest)
- [ ] Confirm tests Android still builds with async-storage 3.x (CI Android job)
- [ ] Confirm macOS Other job pods + build + e2e with `AsyncStorage` 3.x / Swift compatibility link