### PR TITLE
feat(ai): send X-Firebase-AppVersion when data collection enabled

### DIFF
--- a/docs/app/utils.mdx
+++ b/docs/app/utils.mdx
@@ -45,6 +45,24 @@ async function bootstrap() {
 }
 ```
 
+# App Version
+
+`appVersion` returns the host app's marketing version string: Android `versionName` or iOS
+`CFBundleShortVersionString`. Use it when you need the installed app version without pulling in a
+separate package.
+
+> Be aware, `appVersion` is available on Android and iOS only. On web and other non-native platforms
+> it is `undefined` (including when the native value is empty).
+
+```js
+import { utils } from '@react-native-firebase/app';
+
+const version = utils().appVersion;
+if (version) {
+  console.log('App version:', version);
+}
+```
+
 # Android - Checking Play Services
 
 It is useful to know if the Android device has play services available, and what to do in response to certain use cases:

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -88,6 +88,7 @@ jest.doMock('react-native', () => {
         NativeRNFBTurboUtils: {
           getConstants: () => ({
             isRunningInTestLab: false,
+            appVersion: '1.0.0',
             MAIN_BUNDLE: '/',
             CACHES_DIRECTORY: '/cache',
             DOCUMENT_DIRECTORY: '/documents',
@@ -97,6 +98,7 @@ jest.doMock('react-native', () => {
             MOVIES_DIRECTORY: '/movies',
           }),
           isRunningInTestLab: false,
+          appVersion: '1.0.0',
           MAIN_BUNDLE: '/',
           CACHES_DIRECTORY: '/cache',
           DOCUMENT_DIRECTORY: '/documents',

--- a/packages/ai/__tests__/request.test.ts
+++ b/packages/ai/__tests__/request.test.ts
@@ -15,7 +15,15 @@
  * limitations under the License.
  */
 import { describe, expect, it, jest, afterEach } from '@jest/globals';
-import { RequestUrl, Task, getHeaders, makeRequest } from '../lib/requests/request';
+import {
+  RequestUrl,
+  Task,
+  TemplateRequestUrl,
+  ServerPromptTemplateTask,
+  getHeaders,
+  getTemplateHeaders,
+  makeRequest,
+} from '../lib/requests/request';
 import { ApiSettings } from '../lib/types/internal';
 import { DEFAULT_API_VERSION } from '../lib/constants';
 import { AIErrorCode } from '../lib/types';
@@ -281,6 +289,174 @@ describe('request methods', () => {
       );
       const headers = await getHeaders(fakeUrl);
       expect(headers.has('Authorization')).toBe(false);
+    });
+
+    it('adds X-Firebase-Appid and X-Firebase-AppVersion when collection enabled', async () => {
+      const fakeUrl = new RequestUrl(
+        'models/model-name',
+        Task.GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: true,
+          appVersion: '2.3.4',
+        },
+        true,
+        {},
+      );
+      const headers = await getHeaders(fakeUrl);
+      expect(headers.get('X-Firebase-Appid')).toBe('my-appid');
+      expect(headers.get('X-Firebase-AppVersion')).toBe('2.3.4');
+    });
+
+    it('omits AppId and AppVersion when collection disabled', async () => {
+      const fakeUrl = new RequestUrl(
+        'models/model-name',
+        Task.GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: false,
+          appVersion: '2.3.4',
+        },
+        true,
+        {},
+      );
+      const headers = await getHeaders(fakeUrl);
+      expect(headers.has('X-Firebase-Appid')).toBe(false);
+      expect(headers.has('X-Firebase-AppVersion')).toBe(false);
+    });
+
+    it('adds AppId but omits AppVersion when version missing', async () => {
+      const fakeUrl = new RequestUrl(
+        'models/model-name',
+        Task.GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: true,
+        },
+        true,
+        {},
+      );
+      const headers = await getHeaders(fakeUrl);
+      expect(headers.get('X-Firebase-Appid')).toBe('my-appid');
+      expect(headers.has('X-Firebase-AppVersion')).toBe(false);
+    });
+
+    it('omits AppVersion when version is empty string', async () => {
+      const fakeUrl = new RequestUrl(
+        'models/model-name',
+        Task.GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: true,
+          appVersion: '',
+        },
+        true,
+        {},
+      );
+      const headers = await getHeaders(fakeUrl);
+      expect(headers.get('X-Firebase-Appid')).toBe('my-appid');
+      expect(headers.has('X-Firebase-AppVersion')).toBe(false);
+    });
+  });
+
+  describe('getTemplateHeaders', () => {
+    it('adds X-Firebase-Appid and X-Firebase-AppVersion when collection enabled', async () => {
+      const fakeUrl = new TemplateRequestUrl(
+        'template-id',
+        ServerPromptTemplateTask.TEMPLATE_GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: true,
+          appVersion: '9.9.9',
+        },
+        false,
+        {},
+      );
+      const headers = await getTemplateHeaders(fakeUrl);
+      expect(headers.get('X-Firebase-Appid')).toBe('my-appid');
+      expect(headers.get('X-Firebase-AppVersion')).toBe('9.9.9');
+    });
+
+    it('omits AppId and AppVersion when collection disabled', async () => {
+      const fakeUrl = new TemplateRequestUrl(
+        'template-id',
+        ServerPromptTemplateTask.TEMPLATE_GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: false,
+          appVersion: '9.9.9',
+        },
+        false,
+        {},
+      );
+      const headers = await getTemplateHeaders(fakeUrl);
+      expect(headers.has('X-Firebase-Appid')).toBe(false);
+      expect(headers.has('X-Firebase-AppVersion')).toBe(false);
+    });
+
+    it('adds AppId but omits AppVersion when version missing', async () => {
+      const fakeUrl = new TemplateRequestUrl(
+        'template-id',
+        ServerPromptTemplateTask.TEMPLATE_GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: true,
+        },
+        false,
+        {},
+      );
+      const headers = await getTemplateHeaders(fakeUrl);
+      expect(headers.get('X-Firebase-Appid')).toBe('my-appid');
+      expect(headers.has('X-Firebase-AppVersion')).toBe(false);
+    });
+
+    it('omits AppVersion when version is empty string', async () => {
+      const fakeUrl = new TemplateRequestUrl(
+        'template-id',
+        ServerPromptTemplateTask.TEMPLATE_GENERATE_CONTENT,
+        {
+          apiKey: 'key',
+          project: 'myproject',
+          appId: 'my-appid',
+          location: 'moon',
+          backend: new VertexAIBackend(),
+          automaticDataCollectionEnabled: true,
+          appVersion: '',
+        },
+        false,
+        {},
+      );
+      const headers = await getTemplateHeaders(fakeUrl);
+      expect(headers.get('X-Firebase-Appid')).toBe('my-appid');
+      expect(headers.has('X-Firebase-AppVersion')).toBe(false);
     });
   });
 

--- a/packages/ai/__tests__/utils.test.ts
+++ b/packages/ai/__tests__/utils.test.ts
@@ -15,12 +15,22 @@
  * limitations under the License.
  */
 import { describe, expect, it, jest } from '@jest/globals';
-import { type ReactNativeFirebase } from '@react-native-firebase/app';
+import { getUtils, type ReactNativeFirebase } from '@react-native-firebase/app';
 import { AI, AIErrorCode } from '../lib/public-types';
 import { AIError } from '../lib/errors';
 import { VertexAIBackend } from '../lib/backend';
 import { AIService } from '../lib/service';
 import { initApiSettings } from '../lib/models/utils';
+
+jest.mock('@react-native-firebase/app', () => {
+  const actual = jest.requireActual<typeof import('@react-native-firebase/app')>(
+    '@react-native-firebase/app',
+  );
+  return {
+    ...actual,
+    getUtils: jest.fn((...args: Parameters<typeof actual.getUtils>) => actual.getUtils(...args)),
+  };
+});
 
 const fakeAI: AI = {
   app: {
@@ -158,5 +168,25 @@ describe('initApiSettings', function () {
     } catch (e) {
       expect((e as AIError).code).toBe(AIErrorCode.NO_APP_ID);
     }
+  });
+
+  it('populates appVersion from app utils when available', function () {
+    const apiSettings = initApiSettings(fakeAI);
+    expect(apiSettings.appVersion).toBe('1.0.0');
+  });
+
+  it('omits appVersion when getUtils throws', function () {
+    jest.mocked(getUtils).mockImplementationOnce(() => {
+      throw new Error('native utils unavailable');
+    });
+
+    const apiSettings = initApiSettings(fakeAI);
+    expect(apiSettings.appVersion).toBeUndefined();
+    expect(apiSettings.apiKey).toBe('key');
+    expect(apiSettings.project).toBe('my-project');
+    expect(apiSettings.appId).toBe('my-appid');
+    expect(apiSettings.location).toBe('us-central1');
+    expect(apiSettings.automaticDataCollectionEnabled).toBe(true);
+    expect(apiSettings.backend).toBe(fakeAI.backend);
   });
 });

--- a/packages/ai/lib/models/utils.ts
+++ b/packages/ai/lib/models/utils.ts
@@ -16,6 +16,7 @@
  */
 import type { AppCheck } from '@react-native-firebase/app-check';
 import { getLimitedUseToken, getToken } from '@react-native-firebase/app-check';
+import { getUtils } from '@react-native-firebase/app';
 import { AIError } from '../errors';
 import { AI, AIErrorCode } from '../public-types';
 import { AIService } from '../service';
@@ -52,6 +53,16 @@ export function initApiSettings(ai: AI): ApiSettings {
     location: ai.location,
     backend: ai.backend,
   };
+
+  try {
+    // Utils is single-app (hasMultiAppSupport: false); do not pass ai.app.
+    const appVersion = getUtils().appVersion;
+    if (appVersion) {
+      apiSettings.appVersion = appVersion;
+    }
+  } catch {
+    // Native utils unavailable (web / non-native) — omit appVersion.
+  }
 
   const appCheck = ai.appCheck as AppCheck;
   if (appCheck) {

--- a/packages/ai/lib/requests/request.ts
+++ b/packages/ai/lib/requests/request.ts
@@ -163,6 +163,9 @@ export async function getHeaders(url: RequestUrl): Promise<Headers> {
   headers.append('x-goog-api-key', url.apiSettings.apiKey);
   if (url.apiSettings.automaticDataCollectionEnabled) {
     headers.append('X-Firebase-Appid', url.apiSettings.appId);
+    if (url.apiSettings.appVersion) {
+      headers.append('X-Firebase-AppVersion', url.apiSettings.appVersion);
+    }
   }
   if (url.apiSettings.getAppCheckToken) {
     let appCheckToken;
@@ -194,6 +197,9 @@ export async function getTemplateHeaders(url: TemplateRequestUrl): Promise<Heade
   headers.append('x-goog-api-key', url.apiSettings.apiKey);
   if (url.apiSettings.automaticDataCollectionEnabled) {
     headers.append('X-Firebase-Appid', url.apiSettings.appId);
+    if (url.apiSettings.appVersion) {
+      headers.append('X-Firebase-AppVersion', url.apiSettings.appVersion);
+    }
   }
   if (url.apiSettings.getAppCheckToken) {
     let appCheckToken;

--- a/packages/ai/lib/types/internal.ts
+++ b/packages/ai/lib/types/internal.ts
@@ -26,6 +26,10 @@ export interface ApiSettings {
    */
   location: string;
   automaticDataCollectionEnabled?: boolean;
+  /**
+   * Host app marketing version when available (Android versionName / iOS CFBundleShortVersionString).
+   */
+  appVersion?: string;
   backend: Backend;
   getAuthToken?: () => Promise<string>;
   getAppCheckToken?: () => Promise<AppCheckTokenResult>;

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/app/generated/java/com/facebook/fbreact/specs/NativeRNFBTurboUtilsSpec.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/app/generated/java/com/facebook/fbreact/specs/NativeRNFBTurboUtilsSpec.java
@@ -59,7 +59,8 @@ public abstract class NativeRNFBTurboUtilsSpec extends ReactContextBaseJavaModul
           "EXTERNAL_DIRECTORY",
           "EXTERNAL_STORAGE_DIRECTORY",
           "FILE_TYPE_DIRECTORY",
-          "FILE_TYPE_REGULAR"
+          "FILE_TYPE_REGULAR",
+          "appVersion"
       ));
       Set<String> undeclaredConstants = new HashSet<>(constants.keySet());
       undeclaredConstants.removeAll(obligatoryFlowConstants);

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/NativeRNFBTurboUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/NativeRNFBTurboUtils.java
@@ -20,6 +20,7 @@ package io.invertase.firebase.utils;
 import android.app.Activity;
 import android.content.Context;
 import android.content.IntentSender;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.Settings;
@@ -135,6 +136,15 @@ public class NativeRNFBTurboUtils extends NativeRNFBTurboUtilsSpec {
     }
   }
 
+  private static String getAppVersionName(Context context) {
+    try {
+      return context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
+    } catch (PackageManager.NameNotFoundException error) {
+      Log.d(TAG, "getAppVersionName", error);
+      return null;
+    }
+  }
+
   private int isGooglePlayServicesAvailable() {
     GoogleApiAvailability gapi = GoogleApiAvailability.getInstance();
     return gapi.isGooglePlayServicesAvailable(getReactApplicationContext());
@@ -166,6 +176,11 @@ public class NativeRNFBTurboUtils extends NativeRNFBTurboUtilsSpec {
     constants.put("isRunningInTestLab", isRunningInTestLab());
 
     Context context = getReactApplicationContext();
+    String appVersion = getAppVersionName(context);
+    if (appVersion != null && !appVersion.isEmpty()) {
+      constants.put("appVersion", appVersion);
+    }
+
     constants.put(KEY_MAIN_BUNDLE, "");
     constants.put(KEY_LIBRARY_DIRECTORY, context.getFilesDir().getAbsolutePath());
     constants.put(KEY_TEMP_DIRECTORY, context.getCacheDir().getAbsolutePath());

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/NativeRNFBTurboUtils.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/utils/NativeRNFBTurboUtils.java
@@ -20,7 +20,6 @@ package io.invertase.firebase.utils;
 import android.app.Activity;
 import android.content.Context;
 import android.content.IntentSender;
-import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Environment;
 import android.provider.Settings;
@@ -139,7 +138,8 @@ public class NativeRNFBTurboUtils extends NativeRNFBTurboUtilsSpec {
   private static String getAppVersionName(Context context) {
     try {
       return context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
-    } catch (PackageManager.NameNotFoundException error) {
+    } catch (Exception error) {
+      // Optional metadata: prefer omit over crashing on null context / unexpected PM failures.
       Log.d(TAG, "getAppVersionName", error);
       return null;
     }

--- a/packages/app/android/src/test/java/io/invertase/firebase/utils/NativeRNFBTurboUtilsTest.java
+++ b/packages/app/android/src/test/java/io/invertase/firebase/utils/NativeRNFBTurboUtilsTest.java
@@ -1,0 +1,120 @@
+package io.invertase.firebase.utils;
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import com.facebook.react.bridge.ReactApplicationContext;
+import io.invertase.firebase.app.ReactNativeFirebaseApp;
+import java.lang.reflect.Method;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+/**
+ * JVM coverage for {@link NativeRNFBTurboUtils} appVersion constant export branches (null, empty,
+ * NameNotFoundException).
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class NativeRNFBTurboUtilsTest {
+
+  private ReactApplicationContext reactContext;
+  private PackageManager packageManager;
+  private String packageName;
+
+  @Before
+  public void setUp() {
+    android.app.Application application = RuntimeEnvironment.getApplication();
+    ReactNativeFirebaseApp.setApplicationContext(application);
+
+    packageName = application.getPackageName();
+    packageManager = mock(PackageManager.class);
+
+    reactContext = mock(ReactApplicationContext.class);
+    when(reactContext.getApplicationContext()).thenReturn(application);
+    when(reactContext.getPackageName()).thenReturn(packageName);
+    when(reactContext.getPackageManager()).thenReturn(packageManager);
+    when(reactContext.getFilesDir()).thenReturn(application.getFilesDir());
+    when(reactContext.getCacheDir()).thenReturn(application.getCacheDir());
+    when(reactContext.getExternalFilesDir(null)).thenReturn(application.getExternalFilesDir(null));
+  }
+
+  @Test
+  public void getTypedExportedConstants_includesAppVersionWhenPresent() throws Exception {
+    stubVersionName("4.5.6");
+
+    Map<String, Object> constants = invokeGetTypedExportedConstants();
+
+    assertEquals("4.5.6", constants.get("appVersion"));
+  }
+
+  @Test
+  public void getTypedExportedConstants_omitsAppVersionWhenNull() throws Exception {
+    stubVersionName(null);
+
+    Map<String, Object> constants = invokeGetTypedExportedConstants();
+
+    assertFalse(constants.containsKey("appVersion"));
+  }
+
+  @Test
+  public void getTypedExportedConstants_omitsAppVersionWhenEmpty() throws Exception {
+    stubVersionName("");
+
+    Map<String, Object> constants = invokeGetTypedExportedConstants();
+
+    assertFalse(constants.containsKey("appVersion"));
+  }
+
+  @Test
+  public void getTypedExportedConstants_omitsAppVersionOnNameNotFound() throws Exception {
+    when(packageManager.getPackageInfo(anyString(), anyInt()))
+        .thenThrow(new NameNotFoundException(packageName));
+
+    Map<String, Object> constants = invokeGetTypedExportedConstants();
+
+    assertFalse(constants.containsKey("appVersion"));
+  }
+
+  private void stubVersionName(String versionName) throws Exception {
+    PackageInfo packageInfo = new PackageInfo();
+    packageInfo.versionName = versionName;
+    when(packageManager.getPackageInfo(anyString(), anyInt())).thenReturn(packageInfo);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> invokeGetTypedExportedConstants() throws Exception {
+    NativeRNFBTurboUtils module = new NativeRNFBTurboUtils(reactContext);
+    Method method = NativeRNFBTurboUtils.class.getDeclaredMethod("getTypedExportedConstants");
+    method.setAccessible(true);
+    return (Map<String, Object>) method.invoke(module);
+  }
+}

--- a/packages/app/android/src/test/java/io/invertase/firebase/utils/NativeRNFBTurboUtilsTest.java
+++ b/packages/app/android/src/test/java/io/invertase/firebase/utils/NativeRNFBTurboUtilsTest.java
@@ -40,7 +40,7 @@ import org.robolectric.annotation.Config;
 
 /**
  * JVM coverage for {@link NativeRNFBTurboUtils} appVersion constant export branches (null, empty,
- * NameNotFoundException).
+ * package-manager failure).
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 34)

--- a/packages/app/e2e/utils.e2e.js
+++ b/packages/app/e2e/utils.e2e.js
@@ -31,6 +31,16 @@ describe('utils()', function () {
       });
     });
 
+    describe('appVersion', function () {
+      it('returns a non-empty marketing version string', function () {
+        const { getUtils } = modular;
+        const appVersion = getUtils().appVersion;
+        should.exist(appVersion);
+        should(appVersion).be.a.String();
+        should(appVersion.length).be.above(0);
+      });
+    });
+
     describe('playServicesAvailability', function () {
       it('returns isAvailable and Play Service status', async function () {
         const { getUtils } = modular;

--- a/packages/app/ios/RNFBApp/RNFBUtilsModule.mm
+++ b/packages/app/ios/RNFBApp/RNFBUtilsModule.mm
@@ -49,7 +49,7 @@ RCT_EXPORT_MODULE(NativeRNFBTurboUtils)
 }
 
 - (NSDictionary *)utilsConstantsDictionary {
-  return @{
+  NSMutableDictionary *constants = [@{
     @"isRunningInTestLab" : @NO,
     @"MAIN_BUNDLE" : [[NSBundle mainBundle] bundlePath],
     @"CACHES_DIRECTORY" : [self getPathForDirectory:NSCachesDirectory],
@@ -58,7 +58,15 @@ RCT_EXPORT_MODULE(NativeRNFBTurboUtils)
     @"MOVIES_DIRECTORY" : [self getPathForDirectory:NSMoviesDirectory],
     @"TEMP_DIRECTORY" : NSTemporaryDirectory(),
     @"LIBRARY_DIRECTORY" : [self getPathForDirectory:NSLibraryDirectory],
-  };
+  } mutableCopy];
+
+  NSString *appVersion =
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  if ([appVersion isKindOfClass:[NSString class]] && appVersion.length > 0) {
+    constants[@"appVersion"] = appVersion;
+  }
+
+  return [constants copy];
 }
 
 - (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants::Builder>)

--- a/packages/app/ios/generated/RNFBAppTurboModules/RNFBAppTurboModules.h
+++ b/packages/app/ios/generated/RNFBAppTurboModules/RNFBAppTurboModules.h
@@ -37,6 +37,9 @@ namespace JS {
     struct FirebaseAppConfig {
 
       struct Builder {
+        // Backwards compat for RCTTypedModuleConstants
+        using ResultT = FirebaseAppConfig;
+
         struct Input {
           RCTRequired<NSString *> name;
           std::optional<bool> automaticResourceManagement;
@@ -66,6 +69,9 @@ namespace JS {
     struct FirebaseAppOptions {
 
       struct Builder {
+        // Backwards compat for RCTTypedModuleConstants
+        using ResultT = FirebaseAppOptions;
+
         struct Input {
           RCTRequired<NSString *> apiKey;
           RCTRequired<NSString *> appId;
@@ -102,6 +108,9 @@ namespace JS {
     struct NativeFirebaseApp {
 
       struct Builder {
+        // Backwards compat for RCTTypedModuleConstants
+        using ResultT = NativeFirebaseApp;
+
         struct Input {
           RCTRequired<JS::NativeRNFBTurboApp::FirebaseAppConfig::Builder> appConfig;
           RCTRequired<JS::NativeRNFBTurboApp::FirebaseAppOptions::Builder> options;
@@ -130,6 +139,9 @@ namespace JS {
     struct Constants {
 
       struct Builder {
+        // Backwards compat for RCTTypedModuleConstants
+        using ResultT = Constants;
+
         struct Input {
           RCTRequired<std::vector<JS::NativeRNFBTurboApp::NativeFirebaseApp::Builder>> NATIVE_FIREBASE_APPS;
           RCTRequired<NSString *> FIREBASE_RAW_JSON;
@@ -221,6 +233,9 @@ namespace JS {
     struct Constants {
 
       struct Builder {
+        // Backwards compat for RCTTypedModuleConstants
+        using ResultT = Constants;
+
         struct Input {
           RCTRequired<bool> isRunningInTestLab;
           NSString *appVersion;

--- a/packages/app/ios/generated/RNFBAppTurboModules/RNFBAppTurboModules.h
+++ b/packages/app/ios/generated/RNFBAppTurboModules/RNFBAppTurboModules.h
@@ -37,9 +37,6 @@ namespace JS {
     struct FirebaseAppConfig {
 
       struct Builder {
-        // Backwards compat for RCTTypedModuleConstants
-        using ResultT = FirebaseAppConfig;
-
         struct Input {
           RCTRequired<NSString *> name;
           std::optional<bool> automaticResourceManagement;
@@ -69,9 +66,6 @@ namespace JS {
     struct FirebaseAppOptions {
 
       struct Builder {
-        // Backwards compat for RCTTypedModuleConstants
-        using ResultT = FirebaseAppOptions;
-
         struct Input {
           RCTRequired<NSString *> apiKey;
           RCTRequired<NSString *> appId;
@@ -108,9 +102,6 @@ namespace JS {
     struct NativeFirebaseApp {
 
       struct Builder {
-        // Backwards compat for RCTTypedModuleConstants
-        using ResultT = NativeFirebaseApp;
-
         struct Input {
           RCTRequired<JS::NativeRNFBTurboApp::FirebaseAppConfig::Builder> appConfig;
           RCTRequired<JS::NativeRNFBTurboApp::FirebaseAppOptions::Builder> options;
@@ -139,9 +130,6 @@ namespace JS {
     struct Constants {
 
       struct Builder {
-        // Backwards compat for RCTTypedModuleConstants
-        using ResultT = Constants;
-
         struct Input {
           RCTRequired<std::vector<JS::NativeRNFBTurboApp::NativeFirebaseApp::Builder>> NATIVE_FIREBASE_APPS;
           RCTRequired<NSString *> FIREBASE_RAW_JSON;
@@ -233,11 +221,9 @@ namespace JS {
     struct Constants {
 
       struct Builder {
-        // Backwards compat for RCTTypedModuleConstants
-        using ResultT = Constants;
-
         struct Input {
           RCTRequired<bool> isRunningInTestLab;
+          NSString *appVersion;
           RCTRequired<NSString *> MAIN_BUNDLE;
           RCTRequired<NSString *> CACHES_DIRECTORY;
           RCTRequired<NSString *> DOCUMENT_DIRECTORY;
@@ -368,6 +354,8 @@ inline JS::NativeRNFBTurboUtils::Constants::Builder::Builder(const Input i) : _f
   NSMutableDictionary *d = [NSMutableDictionary new];
   auto isRunningInTestLab = i.isRunningInTestLab.get();
   d[@"isRunningInTestLab"] = @(isRunningInTestLab);
+  auto appVersion = i.appVersion;
+  d[@"appVersion"] = appVersion;
   auto MAIN_BUNDLE = i.MAIN_BUNDLE.get();
   d[@"MAIN_BUNDLE"] = MAIN_BUNDLE;
   auto CACHES_DIRECTORY = i.CACHES_DIRECTORY.get();

--- a/packages/app/lib/internal/NativeModules.ts
+++ b/packages/app/lib/internal/NativeModules.ts
@@ -75,6 +75,8 @@ export interface RNFBAppModuleInterface {
 export interface RNFBUtilsModuleInterface {
   // Android-only properties and methods
   isRunningInTestLab: boolean;
+  /** Host app marketing version when available from native utils constants. */
+  appVersion?: string;
   androidPlayServices: {
     isAvailable: boolean;
     status: number;

--- a/packages/app/lib/types/app.ts
+++ b/packages/app/lib/types/app.ts
@@ -557,6 +557,11 @@ export namespace Utils {
      */
     abstract isRunningInTestLab: boolean;
     /**
+     * Host app marketing version string when available from native
+     * (Android `versionName` / iOS `CFBundleShortVersionString`), otherwise `undefined`.
+     */
+    abstract appVersion: string | undefined;
+    /**
      * Returns PlayServicesAvailability properties, always `{ isAvailable: true, status: 0 }` on iOS
      *
      * #### Example

--- a/packages/app/lib/utils/index.ts
+++ b/packages/app/lib/utils/index.ts
@@ -15,7 +15,7 @@
  *
  */
 
-import { isIOS } from '../common';
+import { isIOS, isOther } from '../common';
 import { FirebaseModule, getOrCreateModularInstance } from '../internal';
 import type { ModuleConfig } from '../internal';
 import type { ReactNativeFirebase, Utils } from '../types/app';
@@ -39,6 +39,18 @@ class FirebaseUtilsModule extends FirebaseModule<'RNFBUtilsModule'> {
       return false;
     }
     return this.native.isRunningInTestLab;
+  }
+
+  /**
+   * Host app marketing version (Android `versionName` / iOS `CFBundleShortVersionString`).
+   * Empty or unavailable on web / non-native platforms.
+   */
+  get appVersion(): string | undefined {
+    if (isOther) {
+      return undefined;
+    }
+    const version = this.native.appVersion;
+    return typeof version === 'string' && version.length > 0 ? version : undefined;
   }
 
   get playServicesAvailability(): Utils.PlayServicesAvailability {

--- a/packages/app/specs/NativeRNFBTurboUtils.ts
+++ b/packages/app/specs/NativeRNFBTurboUtils.ts
@@ -12,6 +12,8 @@ export type PlayServicesAvailability = {
 export interface Spec extends TurboModule {
   getConstants(): {
     isRunningInTestLab: boolean;
+    /** Host app marketing version (Android versionName / iOS CFBundleShortVersionString). */
+    appVersion?: string;
     MAIN_BUNDLE: string;
     CACHES_DIRECTORY: string;
     DOCUMENT_DIRECTORY: string;

--- a/packages/app/type-test.ts
+++ b/packages/app/type-test.ts
@@ -34,6 +34,7 @@ initializeApp({ apiKey: 'a', appId: 'b', projectId: 'c' }, 'foo');
 // utils instance API
 const modularUtils = getUtils();
 console.log(modularUtils.isRunningInTestLab);
+console.log(modularUtils.appVersion);
 console.log(modularUtils.playServicesAvailability);
 modularUtils.getPlayServicesStatus();
 modularUtils.promptForPlayServices();


### PR DESCRIPTION
Fixes Console "App version" showing unknown for Firebase AI Logic requests ([#8801](https://github.com/invertase/react-native-firebase/issues/8801)).

- Send `X-Firebase-AppVersion` alongside `X-Firebase-Appid` when `automaticDataCollectionEnabled` is true (header name matches Android/iOS, not the hyphenated form in the issue)
- Plumb host marketing version via a new optional `utils().appVersion` TurboModule constant (`versionName` / `CFBundleShortVersionString`)
- Omit the header when collection is off or the version is missing/empty
- Live/WebSocket left alone (no AppId header path yet)
- Follow-up commit restores iOS codegen `ResultT` aliases after regen (NewArch-AD-21)

closes #8801