### PR TITLE
build(deps): dependency updates 20260811

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,7 +37,7 @@ jobs:
           node-version: 22
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -272,7 +272,7 @@ jobs:
 
       - name: Detox Tests
         # https://github.com/reactivecircus/android-emulator-runner/releases
-        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         timeout-minutes: 45
         env:
           ANDROID_AVD_HOME: /mnt/avd

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -128,7 +128,7 @@ jobs:
     steps:
       - name: Setup Environment for Screen Recording
         # https://github.com/guidepup/setup-action/releases
-        uses: guidepup/setup-action@5ab89fbb6641406f6f6c91057225f3fb397c2eea # v0.20.0
+        uses: guidepup/setup-action@5d19b1151e972898cae0f0cc44e239127953bd90 # v0.21.0
         continue-on-error: true
         if: env.RNFB_RECORD_SCREENS == '1'
         with:
@@ -151,7 +151,7 @@ jobs:
 
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -239,7 +239,7 @@ jobs:
 
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases
-        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 3
 
@@ -660,7 +660,7 @@ jobs:
           command: yarn
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 3
 

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -110,7 +110,7 @@ jobs:
     steps:
       - name: Setup Environment for Screen Recording
         # https://github.com/guidepup/setup-action/releases
-        uses: guidepup/setup-action@5ab89fbb6641406f6f6c91057225f3fb397c2eea # v0.20.0
+        uses: guidepup/setup-action@5d19b1151e972898cae0f0cc44e239127953bd90 # v0.21.0
         continue-on-error: true
         with:
           record: true
@@ -131,7 +131,7 @@ jobs:
 
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -192,7 +192,7 @@ jobs:
 
       - name: Setup Ruby
         # https://github.com/ruby/setup-ruby/releases
-        uses: ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 3
 

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -42,7 +42,7 @@
     "auth"
   ],
   "dependencies": {
-    "@expo/plist": "^0.5.2"
+    "@expo/plist": "^0.8.1"
   },
   "peerDependencies": {
     "@react-native-firebase/app": "26.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,6 +2792,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@expo/plist@npm:^0.8.1":
+  version: 0.8.1
+  resolution: "@expo/plist@npm:0.8.1"
+  dependencies:
+    "@xmldom/xmldom": "npm:^0.8.8"
+    base64-js: "npm:^1.5.1"
+    xmlbuilder: "npm:^15.1.1"
+  checksum: 10/0ce22d2f132d85b89b655b2b54596ba1bf9feac9ae3c0f84af171478002a9b9ba5609e11f958f31fda66547444720cfb6da1ef15197e5dcc22a2a84c4b4ecd48
+  languageName: node
+  linkType: hard
+
 "@expo/prebuild-config@npm:^55.0.16":
   version: 55.0.16
   resolution: "@expo/prebuild-config@npm:55.0.16"
@@ -5893,7 +5904,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@react-native-firebase/auth@workspace:packages/auth"
   dependencies:
-    "@expo/plist": "npm:^0.5.2"
+    "@expo/plist": "npm:^0.8.1"
     "@react-native-firebase/app": "npm:26.2.0"
     expo: "npm:^55.0.18"
     react-native-builder-bob: "npm:^0.40.13"


### PR DESCRIPTION
Combines open Dependabot `build(deps)` PRs onto one branch.

**Included**
- `actions/setup-java` 5.6.0 → 5.7.0
- `guidepup/setup-action` 0.20.0 → 0.21.0
- `reactivecircus/android-emulator-runner` 2.37.0 → 2.38.0
- `ruby/setup-ruby` 1.313.0 → 1.321.0
- `@expo/plist` 0.5.2 → 0.8.1 (auth Expo config plugin)

**Intentionally skipped**
- #9160 (`react` / `@types/react`) — cannot upgrade React in this tree right now

### Note on #9187

#9171 only SHA-pinned `android-emulator-runner` within **v2.37.0**. This PR takes Dependabot's follow-up bump to **v2.38.0** (build-tools 37). The red checks on #9187 were unrelated to that pin: conventional-commit title vs commit-subject mismatch, plus an iOS SPM flake on a GitHub TLS cert during checkout.

## Obsoletes

- Obsoletes: #9189
- Obsoletes: #9188
- Obsoletes: #9187
- Obsoletes: #9186
- Obsoletes: #9172