### PR TITLE
chore: add Cursor and Claude agent commit gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Shell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/agent-hooks/gate-commit.js\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Shell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/agent-hooks/record-validation.js\""
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PROJECT_DIR}/scripts/agent-hooks/handoff-nudge.js\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "node scripts/agent-hooks/gate-commit.js"
+      }
+    ],
+    "afterShellExecution": [
+      {
+        "command": "node scripts/agent-hooks/record-validation.js"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "node scripts/agent-hooks/handoff-nudge.js"
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -607,6 +607,9 @@ vertexai-sdk-test-data*
 mocks-lookup.ts
 
 .nx/
-.claude/
+# Share project Claude hooks; keep local overrides private.
+.claude/*
+!.claude/settings.json
+.claude/settings.local.json
 .codex/
 Package.Resolved

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Follow `okf-bundle/documentation-policy.md`: durable knowledge in reference docs; ephemeral state only in explicit work queues; commits are documentation; single-commit PR titles must match the commit subject exactly.
 - Testing entry points: `okf-bundle/testing/index.md`; validation requirements: `okf-bundle/testing/validation-checklist.md`.
 - Match validation to the **work type** and **validation tier** in OKF ([change authoring workflow](okf-bundle/testing/change-authoring-workflow.md); term ids in [iteration vocabulary](okf-bundle/testing/iteration-vocabulary.md)).
+- **Agent hooks (Cursor + Claude):** [scripts/agent-hooks/README.md](scripts/agent-hooks/README.md) — commit gate + validation evidence + compaction handoff.
 
 ## PR instructions
 

--- a/okf-bundle/documentation-policy.md
+++ b/okf-bundle/documentation-policy.md
@@ -60,3 +60,51 @@ Work queues record **gates**, **`next_work_type`**, **`validation_tier`**, and *
 Record **`commit_subject`** (the planned Conventional Commit subject line) **before** `git commit`, in the same staged changeset as the item being memorialized. Do not record SHAs — they are unstable under history rewrite. After commit, the subject in git and in the queue must match character-for-character ([PR title rule](#pull-requests) for single-commit PRs).
 
 New work queues link here in frontmatter/opening section; do not copy policy inline.
+
+### When to create a work queue
+
+Create a new work-queue markdown file when **all** of these are true:
+
+1. The work is a **multi-item backlog** that will span multiple sessions (migration, API removal, coverage drain, compare-types parity, etc.).
+2. Gate state (`implementation` / `review` / `commit`), `next_work_type`, and `validation_tier` must survive chat compaction and fresh sessions.
+3. Linear alone is not enough (too many parallel gated items to track cleanly in one issue description).
+
+Do **not** create a queue file for:
+
+- A single PR / contained fix (use the Linear issue Step 10 structure instead — see [Cross Platform Issue Authoring Guide](https://linear.app/invertase/document/cross-platform-issue-authoring-and-agent-workflow-guide-2b429e4aace0)).
+- Truly one-shot work that finishes in one session (chat is enough).
+
+Orchestrator role split (implement / review / commit) can still run without a queue file.
+
+### Where a work queue lives
+
+| Scale | Persistence |
+| ----- | ----------- |
+| Multi-item backlog | Tracked markdown under `okf-bundle/` (e.g. `okf-bundle/<area>/work-queue.md` or `okf-bundle/testing/<name>-work-queue.md`), updated after every subagent return, **committed with the product change** |
+| Single PR / contained fix spanning chats | Linear issue only (Step 10 + dated comments) |
+| One-shot | Chat alone |
+
+**Default for new RNFB queues:** tracked + committed with the product change. That matches existing queues (`okf-bundle/monorepo-tooling/work-queue.md`, `okf-bundle/testing/compare-types-work-queue.md`, and similar). A gitignored-on-disk option was considered and is **not** the default — ephemeral means the *content* is disposable session state, not that the file is untracked.
+
+### Bootstrap template (minimum shape)
+
+Copy structure from an existing queue rather than inventing a new format. Minimum:
+
+1. YAML frontmatter (`type: Reference`, `title`, `description`, `tags` including `work-queue`, `timestamp`).
+2. Status banner blockquote (`IN PROGRESS` / `COMPLETE`, next pickup, goal).
+3. Links to canonical OKF docs (this policy, [iteration vocabulary](testing/iteration-vocabulary.md), [change authoring](testing/change-authoring-workflow.md), package workflow if any) — **link, do not restate**.
+4. Resume checklist (host/prepare/validation pointers).
+5. Item table with columns using vocabulary field ids: `commit_subject`, `implementation_gate`, `review_gate`, `commit_gate`, `next_work_type`, `validation_tier`, notes.
+6. Footer: current snapshot / current gates.
+
+Private orchestrator skill (`work-queue-orchestrator`) owns how agents dispatch against the queue; this policy owns when/where/what the file contains.
+
+### Defining the queue (before orchestrating)
+
+Do not invent queue rows cold and immediately start the orchestrator. For a new multi-item backlog:
+
+1. **Grill the plan** from current state → stated goal using [grill-me](https://github.com/mattpocock/skills/tree/main/skills/productivity/grill-me) / [grilling](https://github.com/mattpocock/skills/tree/main/skills/productivity/grilling). Capture hard-to-reverse decisions with [domain-modeling](https://github.com/mattpocock/skills/tree/main/skills/engineering/domain-modeling) / [ADR format](https://github.com/mattpocock/skills/blob/main/skills/engineering/domain-modeling/ADR-FORMAT.md) when they meet the ADR bar.
+2. **Developer comprehension gate:** run [comprehension-gate](https://github.com/tomasmihalyi/living-spec-skill/blob/main/agents/comprehension-gate.md) so the human can prove they understand the plan (trade-offs, assumptions, failure modes) before Planning → Building. Do not write the queue or start implementation until that gate passes. (Prefer [grill-with-docs](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs) when ADRs/glossary should be written during the interview.)
+3. **Gap analysis → queue:** after the gate passes, draft the work-queue markdown (often starting with a `gap-analysis` / scope item), then hand off to `work-queue-orchestrator`.
+
+Canonical kickoff wording and Cross Platform-facing summary: [How the Work Queue Orchestrator Works](https://linear.app/invertase/document/how-the-work-queue-orchestrator-works-ad928da78c5a) § Defining the queue before orchestrating.

--- a/scripts/agent-hooks/README.md
+++ b/scripts/agent-hooks/README.md
@@ -1,0 +1,46 @@
+# Agent hooks (Cursor + Claude Code)
+
+Shared commit / validation / compaction hooks for React Native Firebase agent sessions.
+
+## What they do
+
+1. **`gate-commit.js`** (before shell / PreToolUse)
+   - Deny `git commit --no-verify`
+   - Deny staged `.only(`, `tests/harness.overrides.js`, or `RNFBDebug: true`
+   - Deny committing staged `packages/**` or `tests/**` without fresh OKF validation evidence
+2. **`record-validation.js`** (after shell / PostToolUse)
+   - On allowlisted OKF validation commands, write `.git/rnfb-validation-evidence.json`
+3. **`handoff-nudge.js`** (preCompact / PreCompact)
+   - Remind to update Linear before context compaction
+
+Evidence is intentionally not forge-resistant. It blocks agent product commits until an allowlisted validation run is recorded; it does not prove honesty. (`ask` was dropped after Cursor agent Shell continued without a human prompt.)
+
+## Wiring (keep both in sync)
+
+| Tool | Config | Events |
+|------|--------|--------|
+| Claude Code | `.claude/settings.json` | `PreToolUse` / `PostToolUse` / `PreCompact` |
+| Cursor | `.cursor/hooks.json` | `beforeShellExecution` / `afterShellExecution` / `preCompact` |
+
+Both call the same scripts under `scripts/agent-hooks/`.
+
+For local dogfooding before merge, you can also point `~/.cursor/hooks.json` at absolute paths to these scripts. Cursor runs those with cwd `~/.cursor` and an empty `cwd` field; the scripts resolve the real checkout via payload `workspace_roots` (then `git rev-parse`). They no-op outside RNFB checkouts (`okf-bundle/` or `package.json` name `react-native-firebase`). Keep this branch checked out at that path (or copy the scripts elsewhere); use a git worktree for other RNFB work.
+
+Evidence is written under `git rev-parse --git-dir` (worktree-safe), not `repo/.git/file`.
+
+## Allowlisted validation (mint evidence)
+
+Examples: `yarn tests:jest`, `yarn lint:js`, `yarn tsc:compile`, `yarn compare:types`, `yarn tests:ios:test-cover`, and other commands listed in `lib.js` `VALIDATION_PATTERNS` (aligned with `okf-bundle/testing/validation-checklist.md`).
+
+## Manual smoke
+
+```bash
+# Never-stage deny (requires something staged — use a throwaway index in a test clone)
+echo '{"command":"git commit -m test --no-verify"}' | node scripts/agent-hooks/gate-commit.js; echo exit:$?
+
+# Simulate Cursor user-hook cwd (~/.cursor) with workspace_roots pointing at a worktree
+echo '{"command":"git commit -m test","workspace_roots":["/path/to/rnfb-worktree"]}' | node scripts/agent-hooks/gate-commit.js
+
+# Record a jest run
+echo '{"command":"yarn tests:jest","output":"Test Suites: 1 passed"}' | node scripts/agent-hooks/record-validation.js
+```

--- a/scripts/agent-hooks/gate-commit.js
+++ b/scripts/agent-hooks/gate-commit.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Pre-commit gate for agent shells (Cursor beforeShellExecution / Claude PreToolUse).
+ *
+ * Hard deny:
+ *   - git commit --no-verify
+ *   - staged .only(, tests/harness.overrides.js, RNFBDebug true
+ *   - staged packages/** / tests/** / tests-web/** without fresh OKF validation evidence
+ *
+ * Non-commit shell commands are always allowed.
+ *
+ * Missing-evidence used to return `ask`, but Cursor agent Shell auto-continues on ask,
+ * so that path had no friction. Deny forces validation (or a human terminal commit).
+ */
+
+const {
+  readStdin,
+  parseHookInput,
+  normalizeInput,
+  findRepoRoot,
+  isRnfbRepo,
+  isGitCommitCommand,
+  hasNoVerify,
+  stagedNameOnly,
+  stagedRequiresEvidence,
+  maxStagedProductMtimeMs,
+  hasFreshEvidence,
+  neverStageViolations,
+  readEvidence,
+  emitDecision,
+  emitAllow,
+} = require('./lib');
+
+function main() {
+  const input = normalizeInput(parseHookInput(readStdin()));
+  const command = input.command;
+
+  if (!command || !isGitCommitCommand(command)) {
+    emitAllow();
+    return;
+  }
+
+  const repoRoot = findRepoRoot(input);
+  if (!isRnfbRepo(repoRoot)) {
+    emitAllow();
+    return;
+  }
+
+  if (hasNoVerify(command)) {
+    emitDecision({
+      permission: 'deny',
+      reason:
+        'Blocked: git commit --no-verify / -n is not allowed. Run validation, then commit with hooks enabled.',
+    });
+    return;
+  }
+  const violations = neverStageViolations(repoRoot);
+  if (violations.length > 0) {
+    emitDecision({
+      permission: 'deny',
+      reason: `Blocked commit (never-stage rules):\n- ${violations.join('\n- ')}\nUnstage those changes and retry.`,
+    });
+    return;
+  }
+
+  const staged = stagedNameOnly(repoRoot);
+  if (!stagedRequiresEvidence(staged)) {
+    emitAllow();
+    return;
+  }
+
+  const sinceMs = maxStagedProductMtimeMs(repoRoot, staged);
+  const evidence = readEvidence(repoRoot);
+  if (hasFreshEvidence(evidence, sinceMs)) {
+    emitAllow();
+    return;
+  }
+
+  emitDecision({
+    permission: 'deny',
+    reason: [
+      'Blocked: no fresh OKF validation evidence for staged product changes.',
+      'Run allowlisted validation (e.g. yarn tests:jest, yarn lint:js, yarn tsc:compile, yarn tests:<platform>:test-cover)',
+      'so scripts/agent-hooks can record evidence, then retry the commit.',
+      'See okf-bundle/testing/change-authoring-workflow.md#validation-evidence-blocking',
+    ].join(' '),
+  });
+}
+
+main();

--- a/scripts/agent-hooks/handoff-nudge.js
+++ b/scripts/agent-hooks/handoff-nudge.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Compaction handoff nudge (Cursor preCompact / Claude PreCompact).
+ *
+ * Cursor: primarily human-visible (user_message).
+ * Claude: can surface to the agent (agent_message / systemMessage / additionalContext).
+ *
+ * When loaded from ~/.cursor (global), only nudge inside RNFB checkouts.
+ */
+
+const { readStdin, parseHookInput, normalizeInput, findRepoRoot, isRnfbRepo } = require('./lib');
+
+const MESSAGE = [
+  'Context compaction is about to run.',
+  'Before continuing in a fresh/degraded context: update the active Linear issue',
+  '(dated comment + live Decisions / Discovery / Work Completed / Work To Be Completed)',
+  'so a new session can pick up cold. See Cross Platform Issue Authoring & Agent Workflow Guide.',
+].join(' ');
+
+function main() {
+  const input = normalizeInput(parseHookInput(readStdin()));
+  if (!isRnfbRepo(findRepoRoot(input))) {
+    process.stdout.write(`${JSON.stringify({ continue: true })}\n`);
+    return;
+  }
+
+  const body = {
+    user_message: MESSAGE,
+    agent_message: MESSAGE,
+    systemMessage: MESSAGE,
+    additionalContext: MESSAGE,
+    continue: true,
+  };
+  process.stdout.write(`${JSON.stringify(body)}\n`);
+}
+
+main();

--- a/scripts/agent-hooks/lib.js
+++ b/scripts/agent-hooks/lib.js
@@ -1,0 +1,465 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const EVIDENCE_FILENAME = 'rnfb-validation-evidence.json';
+const EVIDENCE_VERSION = 1;
+const MAX_RUNS = 50;
+
+/** OKF allowlisted validation commands that mint commit evidence. */
+const VALIDATION_PATTERNS = [
+  /\byarn\s+tests:jest\b/,
+  /\byarn\s+tests:jest-coverage\b/,
+  /\byarn\s+lint:js\b/,
+  /\byarn\s+lint:android\b/,
+  /\byarn\s+lint:markdown\b/,
+  /\byarn\s+lint:spellcheck\b/,
+  /\byarn\s+lint:deps\b/,
+  /\byarn\s+lint:ruby\b/,
+  /\byarn\s+lint\b(?!:)/,
+  /\byarn\s+tsc:compile\b/,
+  /\byarn\s+tsc:compile:consumer\b/,
+  /\byarn\s+compare:types\b/,
+  /\byarn\s+reference:api\b/,
+  /\byarn\s+tests:macos:test-cover\b/,
+  /\byarn\s+tests:ios:test-cover\b/,
+  /\byarn\s+tests:android:test-cover\b/,
+  /\byarn\s+tests:ios:ruby\b/,
+  /\byarn\s+tests:android:unit\b/,
+  /\byarn\s+tests:android:post-e2e-coverage\b/,
+];
+
+const FAILURE_PATTERNS = [
+  /\bELIFECYCLE\b/,
+  /error Command failed/i,
+  /Command failed with exit code [1-9]/i,
+  /Test Suites:.*failed/,
+  /\bFAIL\b/,
+  /\bFAILED\b/,
+  /([1-9]\d*)\s+failing\b/i,
+  /Process exited with code [^0]/i,
+  /exit code [^0]/i,
+];
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function parseHookInput(raw) {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) {
+    return {};
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return { _raw: trimmed };
+  }
+}
+
+/**
+ * Normalize Cursor / Claude Code hook payloads into a shared shape.
+ */
+function normalizeInput(payload) {
+  const toolInput =
+    payload.tool_input && typeof payload.tool_input === 'object'
+      ? payload.tool_input
+      : typeof payload.tool_input === 'string'
+        ? safeJson(payload.tool_input)
+        : {};
+
+  const command =
+    payload.command ||
+    toolInput.command ||
+    payload.tool_input?.command ||
+    (typeof payload.toolInput === 'object' ? payload.toolInput.command : undefined) ||
+    '';
+
+  const output =
+    payload.output ||
+    payload.tool_response ||
+    payload.tool_result ||
+    payload.response ||
+    (typeof payload.toolResponse === 'string' ? payload.toolResponse : '') ||
+    '';
+
+  const exitCode =
+    payload.exit_code ??
+    payload.exitCode ??
+    toolInput.exit_code ??
+    extractExitCode(payload) ??
+    null;
+
+  const cwd =
+    (typeof payload.cwd === 'string' && payload.cwd) ||
+    (typeof toolInput.cwd === 'string' && toolInput.cwd) ||
+    '';
+
+  const workspaceRoots = collectWorkspaceRoots(payload, toolInput);
+
+  return {
+    command: String(command || ''),
+    output: typeof output === 'string' ? output : JSON.stringify(output),
+    exitCode,
+    cwd,
+    workspaceRoots,
+    payload,
+  };
+}
+
+function collectWorkspaceRoots(payload, toolInput) {
+  const pools = [
+    payload.workspace_roots,
+    payload.workspaceRoots,
+    toolInput.workspace_roots,
+    toolInput.workspaceRoots,
+  ];
+  const roots = [];
+  for (const pool of pools) {
+    if (!Array.isArray(pool)) {
+      continue;
+    }
+    for (const entry of pool) {
+      if (typeof entry === 'string' && entry.trim()) {
+        roots.push(entry.trim());
+      }
+    }
+  }
+  return roots;
+}
+
+function safeJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return {};
+  }
+}
+
+function extractExitCode(payload) {
+  if (payload.tool_response && typeof payload.tool_response === 'object') {
+    if (typeof payload.tool_response.exit_code === 'number') {
+      return payload.tool_response.exit_code;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the RNFB repo root for hook execution.
+ *
+ * Cursor user hooks (~/.cursor/hooks.json) run with cwd ~/.cursor and often an
+ * empty payload.cwd, but they do include workspace_roots. Prefer those before
+ * falling back to git from process.cwd().
+ *
+ * @param {{ cwd?: string, workspaceRoots?: string[] } | string} [hint]
+ */
+function findRepoRoot(hint) {
+  const options =
+    typeof hint === 'string'
+      ? { cwd: hint, workspaceRoots: [] }
+      : hint && typeof hint === 'object'
+        ? hint
+        : {};
+
+  const candidates = [];
+  if (typeof options.cwd === 'string' && options.cwd.trim()) {
+    candidates.push(options.cwd.trim());
+  }
+  if (Array.isArray(options.workspaceRoots)) {
+    for (const root of options.workspaceRoots) {
+      if (typeof root === 'string' && root.trim()) {
+        candidates.push(root.trim());
+      }
+    }
+  }
+  candidates.push(process.cwd());
+
+  const seen = new Set();
+  for (const candidate of candidates) {
+    if (seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    const toplevel = gitShowToplevel(candidate);
+    if (toplevel) {
+      return toplevel;
+    }
+    // Non-git path that already looks like an RNFB checkout (rare).
+    if (isRnfbRepo(candidate)) {
+      return candidate;
+    }
+  }
+
+  return process.cwd();
+}
+
+function gitShowToplevel(cwd) {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function gitDir(repoRoot) {
+  try {
+    const dir = execFileSync('git', ['rev-parse', '--git-dir'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return path.isAbsolute(dir) ? dir : path.join(repoRoot, dir);
+  } catch {
+    return path.join(repoRoot, '.git');
+  }
+}
+
+/**
+ * Global (~/.cursor) hooks run in every workspace. Only enforce in RNFB checkouts
+ * (including git worktrees of this repo).
+ */
+function isRnfbRepo(repoRoot) {
+  try {
+    if (fs.existsSync(path.join(repoRoot, 'okf-bundle'))) {
+      return true;
+    }
+    const pkgPath = path.join(repoRoot, 'package.json');
+    if (!fs.existsSync(pkgPath)) {
+      return false;
+    }
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    return pkg.name === 'react-native-firebase';
+  } catch {
+    return false;
+  }
+}
+
+function evidencePath(repoRoot) {
+  // Worktrees have a .git *file*; write into the real git dir instead.
+  return path.join(gitDir(repoRoot), EVIDENCE_FILENAME);
+}
+
+function readEvidence(repoRoot) {
+  const file = evidencePath(repoRoot);
+  try {
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!data || data.version !== EVIDENCE_VERSION || !Array.isArray(data.runs)) {
+      return { version: EVIDENCE_VERSION, updatedAt: null, runs: [] };
+    }
+    return data;
+  } catch {
+    return { version: EVIDENCE_VERSION, updatedAt: null, runs: [] };
+  }
+}
+
+function writeEvidence(repoRoot, evidence) {
+  const file = evidencePath(repoRoot);
+  fs.writeFileSync(file, `${JSON.stringify(evidence, null, 2)}\n`, 'utf8');
+}
+
+function isValidationCommand(command) {
+  return VALIDATION_PATTERNS.some(re => re.test(command));
+}
+
+function looksFailed(output, exitCode) {
+  if (typeof exitCode === 'number' && exitCode !== 0) {
+    return true;
+  }
+  if (!output) {
+    return false;
+  }
+  return FAILURE_PATTERNS.some(re => re.test(output));
+}
+
+function isGitCommitCommand(command) {
+  // Match `git commit`, `git commit -m`, etc. Avoid `git commit-tree`.
+  return /(?:^|[;&|]\s*|&&\s*|^\s*env\s+[^=]+=\S+\s+)*git(?:\s+-C\s+\S+)?\s+commit\b/.test(command);
+}
+
+function hasNoVerify(command) {
+  // Strip quoted args so commit messages containing "-n" do not false-positive.
+  const stripped = String(command).replace(/'[^']*'|"[^"]*"/g, '""');
+  return /--no-verify\b|(?:^|\s)-n(?:\s|$)/.test(stripped);
+}
+
+function stagedNameOnly(repoRoot) {
+  try {
+    const out = execFileSync('git', ['diff', '--cached', '--name-only', '-z'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    return out.split('\0').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function stagedPatch(repoRoot) {
+  try {
+    return execFileSync('git', ['diff', '--cached', '--unified=0'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 20 * 1024 * 1024,
+    });
+  } catch {
+    return '';
+  }
+}
+
+function isProductPath(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  if (
+    normalized === 'tests/harness.overrides.example.js' ||
+    normalized === 'tests/harness.overrides.stub.js'
+  ) {
+    return false;
+  }
+  return (
+    normalized.startsWith('packages/') ||
+    normalized.startsWith('tests/') ||
+    normalized.startsWith('tests-web/')
+  );
+}
+
+function isHooksOnlyPath(filePath) {
+  const normalized = filePath.replace(/\\/g, '/');
+  return (
+    normalized.startsWith('scripts/agent-hooks/') ||
+    normalized.startsWith('.claude/') ||
+    normalized.startsWith('.cursor/') ||
+    normalized.startsWith('.codex/')
+  );
+}
+
+function stagedRequiresEvidence(files) {
+  const product = files.filter(isProductPath);
+  if (product.length === 0) {
+    return false;
+  }
+  // Pure hook/config commits that also touch nothing else product-related already filtered.
+  return true;
+}
+
+function maxStagedProductMtimeMs(repoRoot, files) {
+  let max = 0;
+  for (const file of files.filter(isProductPath)) {
+    const abs = path.join(repoRoot, file);
+    try {
+      const stat = fs.statSync(abs);
+      if (stat.mtimeMs > max) {
+        max = stat.mtimeMs;
+      }
+    } catch {
+      // Deleted or only-in-index: treat as needing evidence recorded "now or later".
+      max = Math.max(max, Date.now());
+    }
+  }
+  return max;
+}
+
+function hasFreshEvidence(evidence, sinceMs) {
+  return (evidence.runs || []).some(run => {
+    if (!run || run.ok !== true || !run.recordedAt) {
+      return false;
+    }
+    const t = Date.parse(run.recordedAt);
+    return Number.isFinite(t) && t >= sinceMs;
+  });
+}
+
+function neverStageViolations(repoRoot) {
+  const files = stagedNameOnly(repoRoot);
+  const violations = [];
+
+  if (files.includes('tests/harness.overrides.js')) {
+    violations.push('staged tests/harness.overrides.js (never commit local harness overrides)');
+  }
+
+  const patch = stagedPatch(repoRoot);
+  const addedLines = patch
+    .split('\n')
+    .filter(line => line.startsWith('+') && !line.startsWith('+++'));
+
+  const addedText = addedLines.join('\n');
+  if (/\.only\s*\(/.test(addedText)) {
+    violations.push('staged `.only(` (never commit suite narrowing)');
+  }
+  if (/RNFBDebug\s*:\s*true/.test(addedText) || /RNFBDebug\s*=\s*true/.test(addedText)) {
+    violations.push('staged `RNFBDebug: true` / `RNFBDebug = true` (never commit debug fail-fast)');
+  }
+
+  return violations;
+}
+
+function emitDecision({ permission, reason, eventName = 'PreToolUse' }) {
+  const message = reason || '';
+  const body = {
+    permission,
+    user_message: message,
+    agent_message: message,
+    // Claude Code nested format (also accepted by Cursor third-party hooks).
+    hookSpecificOutput: {
+      hookEventName: eventName,
+      permissionDecision: permission,
+      permissionDecisionReason: message,
+    },
+  };
+  process.stdout.write(`${JSON.stringify(body)}\n`);
+  if (permission === 'deny') {
+    process.exitCode = 2;
+  }
+}
+
+function emitAllow() {
+  emitDecision({ permission: 'allow', reason: '' });
+}
+
+function appendValidationRun(repoRoot, { command, ok }) {
+  const evidence = readEvidence(repoRoot);
+  const recordedAt = new Date().toISOString();
+  evidence.runs = [
+    { command: command.slice(0, 500), ok, recordedAt },
+    ...(evidence.runs || []),
+  ].slice(0, MAX_RUNS);
+  evidence.updatedAt = recordedAt;
+  evidence.version = EVIDENCE_VERSION;
+  writeEvidence(repoRoot, evidence);
+  return evidence;
+}
+
+module.exports = {
+  VALIDATION_PATTERNS,
+  readStdin,
+  parseHookInput,
+  normalizeInput,
+  findRepoRoot,
+  evidencePath,
+  readEvidence,
+  writeEvidence,
+  isValidationCommand,
+  looksFailed,
+  isGitCommitCommand,
+  hasNoVerify,
+  stagedNameOnly,
+  stagedRequiresEvidence,
+  maxStagedProductMtimeMs,
+  hasFreshEvidence,
+  neverStageViolations,
+  emitDecision,
+  emitAllow,
+  appendValidationRun,
+  isProductPath,
+  isHooksOnlyPath,
+  isRnfbRepo,
+};

--- a/scripts/agent-hooks/record-validation.js
+++ b/scripts/agent-hooks/record-validation.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Record OKF validation runs after shell tools finish
+ * (Cursor afterShellExecution / Claude PostToolUse).
+ *
+ * Writes .git/rnfb-validation-evidence.json (never committed).
+ * Not forge-resistant by design — friction only.
+ */
+
+const {
+  readStdin,
+  parseHookInput,
+  normalizeInput,
+  findRepoRoot,
+  isRnfbRepo,
+  isValidationCommand,
+  looksFailed,
+  appendValidationRun,
+} = require('./lib');
+
+function main() {
+  const input = normalizeInput(parseHookInput(readStdin()));
+  const command = input.command;
+  const repoRoot = findRepoRoot(input);
+
+  if (!isRnfbRepo(repoRoot) || !command || !isValidationCommand(command)) {
+    // Always exit 0; recording hooks must not disrupt the session.
+    process.stdout.write(`${JSON.stringify({ continue: true })}\n`);
+    return;
+  }
+
+  const ok = !looksFailed(input.output, input.exitCode);
+  appendValidationRun(repoRoot, { command, ok });
+
+  process.stdout.write(
+    `${JSON.stringify({
+      continue: true,
+      // Harmless ack for debugging in Hooks output channels.
+      user_message: ok
+        ? `Recorded OKF validation evidence for: ${command.slice(0, 120)}`
+        : `Validation looked failed; not counting as commit evidence: ${command.slice(0, 120)}`,
+    })}\n`,
+  );
+}
+
+main();

--- a/scripts/agent-hooks/smoke-test.js
+++ b/scripts/agent-hooks/smoke-test.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '../..');
+const gate = path.join(root, 'scripts/agent-hooks/gate-commit.js');
+const record = path.join(root, 'scripts/agent-hooks/record-validation.js');
+const handoff = path.join(root, 'scripts/agent-hooks/handoff-nudge.js');
+
+function run(script, payload) {
+  const result = spawnSync(process.execPath, [script], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    cwd: root,
+  });
+  return {
+    status: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+const bypassFlag = ['--', 'no', '-verify'].join('');
+const cases = [];
+
+cases.push(['allow non-commit', run(gate, { command: 'ls' })]);
+cases.push(['deny bypass flag', run(gate, { command: `git commit -m test ${bypassFlag}` })]);
+cases.push(['allow -n inside message', run(gate, { command: 'git commit -m "fix -n bug"' })]);
+cases.push([
+  'deny bypass via workspace_roots from foreign cwd',
+  (() => {
+    const result = spawnSync(process.execPath, [gate], {
+      input: JSON.stringify({
+        command: `git commit -m test ${bypassFlag}`,
+        cwd: '',
+        workspace_roots: [root],
+      }),
+      encoding: 'utf8',
+      cwd: path.join(require('os').homedir(), '.cursor'),
+    });
+    return {
+      status: result.status,
+      stdout: (result.stdout || '').trim(),
+      stderr: (result.stderr || '').trim(),
+    };
+  })(),
+]);
+cases.push([
+  'deny missing evidence via workspace_roots (worktree or staged product)',
+  (() => {
+    // Use a temp clone with a staged packages file and no evidence.
+    const tmp = fs.mkdtempSync(path.join(require('os').tmpdir(), 'rnfb-gate-'));
+    const resultInit = spawnSync('git', ['init', '-q', tmp], { encoding: 'utf8' });
+    if (resultInit.status !== 0) {
+      return { status: 1, stdout: '', stderr: resultInit.stderr || 'git init failed' };
+    }
+    spawnSync('git', ['-C', tmp, 'config', 'user.email', 't@t.com'], { encoding: 'utf8' });
+    spawnSync('git', ['-C', tmp, 'config', 'user.name', 't'], { encoding: 'utf8' });
+    fs.mkdirSync(path.join(tmp, 'packages/app'), { recursive: true });
+    fs.mkdirSync(path.join(tmp, 'okf-bundle'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'react-native-firebase' }),
+    );
+    fs.writeFileSync(path.join(tmp, 'packages/app/x.js'), 'module.exports = 1;\n');
+    spawnSync('git', ['-C', tmp, 'add', 'packages/app/x.js', 'package.json'], { encoding: 'utf8' });
+    const result = spawnSync(process.execPath, [gate], {
+      input: JSON.stringify({
+        command: 'git commit -m missing-evidence',
+        cwd: '',
+        workspace_roots: [tmp],
+      }),
+      encoding: 'utf8',
+      cwd: path.join(require('os').homedir(), '.cursor'),
+    });
+    return {
+      status: result.status,
+      stdout: (result.stdout || '').trim(),
+      stderr: (result.stderr || '').trim(),
+    };
+  })(),
+]);
+cases.push([
+  'record pass',
+  run(record, {
+    command: 'yarn tests:jest',
+    output: 'Test Suites: 1 passed, 1 total',
+  }),
+]);
+cases.push([
+  'record fail',
+  run(record, {
+    command: 'yarn tests:jest',
+    output: 'Test Suites: 1 failed\nFAIL packages/foo',
+  }),
+]);
+cases.push(['handoff', run(handoff, { workspace_roots: [root] })]);
+
+let failed = false;
+for (const [name, result] of cases) {
+  console.log(`\n=== ${name} ===`);
+  console.log(`status=${result.status}`);
+  console.log(result.stdout.slice(0, 400));
+  if (result.stderr) {
+    console.log('stderr:', result.stderr.slice(0, 200));
+  }
+  if (
+    name === 'deny bypass via workspace_roots from foreign cwd' ||
+    name === 'deny missing evidence via workspace_roots (worktree or staged product)'
+  ) {
+    if (result.status !== 2 || !/"permission":"deny"/.test(result.stdout)) {
+      console.log(`ASSERT FAIL: expected deny for ${name}`);
+      failed = true;
+    }
+  }
+}
+
+const { evidencePath } = require('./lib');
+const evidenceFile = evidencePath(root);
+console.log('\n=== evidence file ===');
+console.log(fs.readFileSync(evidenceFile, 'utf8'));
+
+if (failed) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Adds shared Cursor + Claude agent hooks.

- Deny agent `git commit` when staged `packages/**` / `tests/**` lack fresh OKF validation evidence (Cursor `ask` continued without a prompt, so this is hard deny)
- Deny never-stage patterns and commit-hook bypass
- Record allowlisted validation runs under the real git dir (worktree-safe)
- Resolve repo root from Cursor `workspace_roots` so user-level `~/.cursor` hooks work on worktrees
- Compaction handoff nudge, update Linear or durable work queue.
- Document work-queue bootstrap in `okf-bundle/documentation-policy.md`

Dogfooded from a worktree with `~/.cursor/hooks.json` pointed at these scripts. After merge, drop that user override and rely on project `.cursor/hooks.json`.
