### PR TITLE
fix(remote-config, ios): apply pending settings writes before fetching

### DIFF
--- a/packages/remote-config/__tests__/nativeCallOrdering.test.ts
+++ b/packages/remote-config/__tests__/nativeCallOrdering.test.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { TurboModuleRegistry } from 'react-native';
+
+import {
+  activate,
+  ensureInitialized,
+  fetchAndActivate,
+  fetchConfig,
+  getRemoteConfig,
+} from '../lib';
+
+// The native module is exposed through a Proxy that refuses `set`, so `jest.spyOn` cannot be used
+// here. The jest setup already installs `jest.fn()`s for every method, so ordering is read straight
+// off `mock.invocationCallOrder`, which is a process-wide monotonic counter shared by all mocks.
+const native = TurboModuleRegistry.get('NativeRNFBTurboConfig') as any;
+
+const MOCKED_METHODS = [
+  'setConfigSettings',
+  'setDefaults',
+  'activate',
+  'fetch',
+  'fetchAndActivate',
+  'ensureInitialized',
+];
+
+function firstCallOrderOf(method: string): number {
+  const calls: number[] = native[method].mock.invocationCallOrder;
+  if (calls.length === 0) {
+    throw new Error(`expected the native \`${method}\` to have been called, but it never was`);
+  }
+  return calls[0];
+}
+
+/** Resolves after every pending microtask has run. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
+const CONSTANTS = {
+  lastFetchTime: Date.now(),
+  lastFetchStatus: 'success',
+  fetchTimeout: 60,
+  minimumFetchInterval: 43200,
+  values: {},
+};
+
+describe('remoteConfig() native call ordering', function () {
+  let config: any;
+
+  beforeEach(async function () {
+    config = getRemoteConfig();
+    // `getRemoteConfig()` is a singleton, so drain any mutation left queued by a previous test
+    // before clearing the recorded call order.
+    await flushMicrotasks();
+    MOCKED_METHODS.forEach(method => native[method].mockClear());
+  });
+
+  describe('deferring reads behind queued property writes', function () {
+    // The `settings` and `defaultConfig` setters cannot return a promise, so they hand the native
+    // write to a microtask queue. Reads used to call native synchronously and therefore overtook
+    // that queued write. On iOS, `setConfigSettings:` landing mid-fetch tears down and recreates
+    // the SDK's URL session, cancelling the in-flight request with NSURLErrorCancelled (-999).
+    // https://github.com/invertase/react-native-firebase/issues/9194
+
+    it('sends a queued `settings` write before `fetchAndActivate`', async function () {
+      config.settings = { minimumFetchIntervalMillis: 0, fetchTimeoutMillis: 60000 };
+      await fetchAndActivate(config);
+
+      expect(native.setConfigSettings).toHaveBeenCalledTimes(1);
+      expect(native.fetchAndActivate).toHaveBeenCalledTimes(1);
+      expect(firstCallOrderOf('setConfigSettings')).toBeLessThan(
+        firstCallOrderOf('fetchAndActivate'),
+      );
+    });
+
+    it('sends a queued `defaultConfig` write before `fetchAndActivate`', async function () {
+      config.defaultConfig = { some_flag: true };
+      await fetchAndActivate(config);
+
+      expect(native.setDefaults).toHaveBeenCalledTimes(1);
+      expect(native.fetchAndActivate).toHaveBeenCalledTimes(1);
+      expect(firstCallOrderOf('setDefaults')).toBeLessThan(firstCallOrderOf('fetchAndActivate'));
+    });
+
+    it('sends a queued `settings` write before `fetch`', async function () {
+      config.settings = { minimumFetchIntervalMillis: 0 };
+      await fetchConfig(config);
+
+      expect(firstCallOrderOf('setConfigSettings')).toBeLessThan(firstCallOrderOf('fetch'));
+    });
+
+    it('sends a queued `settings` write before `activate`', async function () {
+      config.settings = { minimumFetchIntervalMillis: 0 };
+      await activate(config);
+
+      expect(firstCallOrderOf('setConfigSettings')).toBeLessThan(firstCallOrderOf('activate'));
+    });
+
+    it('sends a queued `settings` write before `ensureInitialized`', async function () {
+      config.settings = { minimumFetchIntervalMillis: 0 };
+      await ensureInitialized(config);
+
+      expect(firstCallOrderOf('setConfigSettings')).toBeLessThan(
+        firstCallOrderOf('ensureInitialized'),
+      );
+    });
+
+    it('keeps the writes in order when both setters run before a fetch', async function () {
+      config.defaultConfig = { some_flag: true };
+      config.settings = { minimumFetchIntervalMillis: 0 };
+      await fetchAndActivate(config);
+
+      expect(firstCallOrderOf('setDefaults')).toBeLessThan(firstCallOrderOf('setConfigSettings'));
+      expect(firstCallOrderOf('setConfigSettings')).toBeLessThan(
+        firstCallOrderOf('fetchAndActivate'),
+      );
+    });
+  });
+
+  describe('reads with nothing queued', function () {
+    it('still reaches native and resolves with the native result', async function () {
+      await expect(fetchAndActivate(config)).resolves.toBe(true);
+      await expect(activate(config)).resolves.toBe(true);
+      await expect(ensureInitialized(config)).resolves.toBe(true);
+      await expect(fetchConfig(config)).resolves.toBe(true);
+
+      expect(native.fetchAndActivate).toHaveBeenCalledTimes(1);
+      expect(native.activate).toHaveBeenCalledTimes(1);
+      expect(native.ensureInitialized).toHaveBeenCalledTimes(1);
+      expect(native.fetch).toHaveBeenCalledTimes(1);
+      expect(native.setConfigSettings).not.toHaveBeenCalled();
+      expect(native.setDefaults).not.toHaveBeenCalled();
+    });
+
+    it('keeps validating `fetch` arguments synchronously', function () {
+      expect(() => config.fetch('not a number')).toThrow(
+        "firebase.remoteConfig().fetch(): 'expirationDurationSeconds' must be a number value.",
+      );
+      expect(native.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reads do not hold up later writes', function () {
+    it('lets a `settings` write through while a fetch is still in flight', async function () {
+      // A fetch may run for up to `fetchTimeoutMillis`. Reads wait for the queue but must not join
+      // it, otherwise every later property write would be stuck behind an in-flight fetch.
+      let releaseFetch: () => void = () => {};
+      native.fetchAndActivate.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            releaseFetch = () => resolve({ result: true, constants: CONSTANTS });
+          }),
+      );
+
+      const pendingFetch = fetchAndActivate(config);
+      config.settings = { minimumFetchIntervalMillis: 0 };
+
+      await flushMicrotasks();
+      expect(native.fetchAndActivate).toHaveBeenCalledTimes(1);
+      expect(native.setConfigSettings).toHaveBeenCalledTimes(1);
+
+      releaseFetch();
+      await expect(pendingFetch).resolves.toBe(true);
+    });
+  });
+});

--- a/packages/remote-config/lib/index.ts
+++ b/packages/remote-config/lib/index.ts
@@ -317,7 +317,9 @@ class FirebaseConfigModule extends FirebaseModule<typeof nativeModuleName> {
    * @returns {Promise<boolean>}
    */
   activate(): Promise<boolean> {
-    return this._promiseWithConstants(this.native.activate());
+    return this._afterPendingNativeMutations(() =>
+      this._promiseWithConstants(this.native.activate()),
+    );
   }
 
   /**
@@ -333,17 +335,23 @@ class FirebaseConfigModule extends FirebaseModule<typeof nativeModuleName> {
       );
     }
 
-    return this._promiseWithConstants(
-      this.native.fetch(expirationDurationSeconds !== undefined ? expirationDurationSeconds : -1),
+    return this._afterPendingNativeMutations(() =>
+      this._promiseWithConstants(
+        this.native.fetch(expirationDurationSeconds !== undefined ? expirationDurationSeconds : -1),
+      ),
     );
   }
 
   fetchAndActivate(): Promise<boolean> {
-    return this._promiseWithConstants(this.native.fetchAndActivate());
+    return this._afterPendingNativeMutations(() =>
+      this._promiseWithConstants(this.native.fetchAndActivate()),
+    );
   }
 
   ensureInitialized(): Promise<void> {
-    return this._promiseWithConstants(this.native.ensureInitialized());
+    return this._afterPendingNativeMutations(() =>
+      this._promiseWithConstants(this.native.ensureInitialized()),
+    );
   }
 
   /**
@@ -518,6 +526,21 @@ class FirebaseConfigModule extends FirebaseModule<typeof nativeModuleName> {
       () => undefined,
     );
     return next;
+  }
+
+  private _afterPendingNativeMutations<T>(task: () => Promise<T>): Promise<T> {
+    // The `settings` and `defaultConfig` setters cannot be awaited, so they hand their native write
+    // to `_enqueueNativeMutation`, which only reaches native on a later microtask. Reads have to
+    // wait for that write, otherwise native sees the read first and the write lands mid-flight — on
+    // iOS `setConfigSettings:` then recreates the SDK's URL session and cancels the running fetch
+    // with NSURLErrorCancelled (-999). See #9194.
+    //
+    // `_enqueueNativeMutation` reassigns `_nativeMutationQueue` synchronously, so by the time a read
+    // runs the queue already covers every write issued before it — no timing assumption needed.
+    //
+    // Reads wait for the queue rather than joining it: a fetch can run for `fetchTimeoutMillis`, and
+    // must not hold up property writes made while it is still in flight.
+    return this._nativeMutationQueue.then(task, task);
   }
 }
 


### PR DESCRIPTION
### Description

Assigning `remoteConfig.settings` and then immediately awaiting `fetchAndActivate()` cancels the fetch on iOS with `NSURLErrorCancelled (-999)`.

**Why.** The `settings` and `defaultConfig` setters cannot return a promise, so they hand their native write to `_enqueueNativeMutation`, which only reaches native on a later microtask. The reads — `activate()`, `fetch()`, `fetchAndActivate()`, `ensureInitialized()` — called native synchronously:

```ts
fetchAndActivate(): Promise<boolean> {
  return this._promiseWithConstants(this.native.fetchAndActivate());
}
```

So native received the read **first**, and the queued `setConfigSettings` write landed while the fetch was already in flight. On iOS, firebase-ios-sdk's `setConfigSettings:` recreates the SDK's URL session via `invalidateAndCancel`, which cancels that in-flight request. The result is that the documented pattern below fails on its first call:

```js
const remoteConfig = getRemoteConfig();
remoteConfig.settings = { minimumFetchIntervalMillis: 0, fetchTimeoutMillis: 60000 };
await fetchAndActivate(remoteConfig); // rejects: NSURLErrorCancelled (-999)
```

**Fix.** Route those four reads through a new `_afterPendingNativeMutations`, which waits for the mutation queue before touching native.

Two properties make this safe:

- `_enqueueNativeMutation` reassigns `_nativeMutationQueue` **synchronously** (only the `.then` callback is deferred), so by the time a read runs the queue already covers every write issued before it. There is no timing assumption and no added delay when nothing is queued.
- Reads **wait for** the queue rather than **joining** it — they do not reassign `_nativeMutationQueue`. A fetch can run for `fetchTimeoutMillis`, and must not hold up property writes made while it is still in flight. There is a test covering exactly this.

Argument validation in `fetch()` remains synchronous.

This removes the need for the "yield once before fetching" workaround.

**Known remaining piece (deliberately not in this PR).** There is a second, native-side contributor on iOS: the constants payload in `RNFBConfigHelper.m` reads `configSettings`, so the session can be recreated on calls that were not meant to mutate settings. That is a separate change in native code with a different risk profile, so this PR is scoped to the JS ordering bug only.

### Related issues

Fixes #9194

### Release Summary

Fixed `fetchAndActivate()` / `fetch()` / `activate()` / `ensureInitialized()` being cancelled on iOS with `NSURLErrorCancelled (-999)` when called right after assigning `settings` or `defaultConfig`.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [x] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

The fix is in shared JS, so all platforms get the correct ordering; the crash it resolves is iOS-specific.

No new e2e tests: `packages/remote-config/e2e/config.e2e.js` already exercises this exact sequence (`remoteConfig.settings = { minimumFetchIntervalMillis: 0 }` immediately followed by `await fetchAndActivate(...)`) at lines 71, 85 and 103, so the existing suite covers the path against a real device.

No public type changed — `_afterPendingNativeMutations` is private and the four method signatures are unchanged.

### Test Plan

New jest suite: `packages/remote-config/__tests__/nativeCallOrdering.test.ts` (9 tests). The native module is exposed through a `Proxy` that refuses `set`, so `jest.spyOn` cannot be used; ordering is read off `mock.invocationCallOrder` on the `jest.fn()`s that `jest.setup.ts` already installs.

Coverage:

- a queued `settings` write reaches native before each of `fetchAndActivate`, `fetch`, `activate`, `ensureInitialized`
- a queued `defaultConfig` write reaches native before `fetchAndActivate`
- two queued writes stay in order relative to each other and to the fetch
- **non-vacuity:** with nothing queued, all four reads still reach native exactly once and resolve with the native result
- `fetch()` still validates its argument synchronously
- a `settings` write still reaches native while a fetch is in flight (guards the wait-for vs. join-the-queue choice)

Counterfactual — with the source change reverted and the new tests kept:

```
Test Suites: 1 failed, 2 passed, 3 total
Tests:       6 failed, 29 passed, 35 total
```

Failing with, for example, `Expected: < 9, Received: 10` — native received `fetchAndActivate` one call ahead of `setConfigSettings`.

With the fix applied:

```
Test Suites: 3 passed, 3 total
Tests:       35 passed, 35 total
```

Baseline before this PR was 26/26 in 2 suites, so all 26 pre-existing tests still pass and 9 are added. `tsc --noEmit`, `eslint` and `prettier --check` are clean on both changed files.
