### PR TITLE
fix(remote-config): apply queued settings before fetch

### DIFF
--- a/packages/remote-config/__tests__/remote-config.test.ts
+++ b/packages/remote-config/__tests__/remote-config.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
 
 import { getApp } from '@react-native-firebase/app';
 import {
@@ -178,6 +178,81 @@ describe('remoteConfig()', function () {
             1337 as unknown as string,
           );
         }).toThrow('must be a string value');
+      });
+    });
+
+    describe('queued native mutations before fetch', function () {
+      const emptyConstants = {
+        lastFetchTime: Date.now(),
+        lastFetchStatus: 'success' as const,
+        values: {},
+      };
+
+      function mockNative() {
+        const resolved = { result: undefined, constants: emptyConstants };
+        return {
+          setConfigSettings: jest.fn(() => Promise.resolve(resolved)),
+          setDefaults: jest.fn(() => Promise.resolve({ result: null, constants: emptyConstants })),
+          fetch: jest.fn(() => Promise.resolve(resolved)),
+          fetchAndActivate: jest.fn(() =>
+            Promise.resolve({ result: true, constants: emptyConstants }),
+          ),
+          activate: jest.fn(() => Promise.resolve({ result: true, constants: emptyConstants })),
+          ensureInitialized: jest.fn(() => Promise.resolve(resolved)),
+        };
+      }
+
+      afterEach(function () {
+        jest.restoreAllMocks();
+      });
+
+      it('calls setConfigSettings before fetchAndActivate after settings assignment', async function () {
+        const native = mockNative();
+        const remoteConfig = getRemoteConfig() as RemoteConfigInternal & {
+          _nativeModule: typeof native;
+        };
+        remoteConfig._nativeModule = native;
+
+        remoteConfig.settings = { minimumFetchIntervalMillis: 0 } as typeof remoteConfig.settings;
+        const pending = fetchAndActivate(remoteConfig);
+
+        // Fetch must not start on this turn; the settings write is still queued.
+        expect(native.fetchAndActivate.mock.calls.length).toBe(0);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await pending;
+
+        expect(native.setConfigSettings.mock.calls.length).toBeGreaterThan(0);
+        expect(native.fetchAndActivate.mock.calls.length).toBeGreaterThan(0);
+        expect(native.setConfigSettings.mock.invocationCallOrder[0]).toBeLessThan(
+          native.fetchAndActivate.mock.invocationCallOrder[0] as number,
+        );
+      });
+
+      it('calls setDefaults before fetch after defaultConfig assignment', async function () {
+        const native = mockNative();
+        const remoteConfig = getRemoteConfig() as RemoteConfigInternal & {
+          _nativeModule: typeof native;
+        };
+        remoteConfig._nativeModule = native;
+
+        remoteConfig.defaultConfig = { queued_default: 'value' };
+        const pending = remoteConfig.fetch();
+
+        expect(native.fetch.mock.calls.length).toBe(0);
+
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await pending;
+
+        expect(native.setDefaults.mock.calls.length).toBeGreaterThan(0);
+        expect(native.fetch.mock.calls.length).toBeGreaterThan(0);
+        expect(native.setDefaults.mock.invocationCallOrder[0]).toBeLessThan(
+          native.fetch.mock.invocationCallOrder[0] as number,
+        );
       });
     });
 

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -78,6 +78,47 @@ describe('remoteConfig()', function () {
         should.equal(remoteConfig.fetchTimeMillis > fetchTimeBefore, true);
       });
 
+      // Coverage for iOS fetch reject userInfo: nativeErrorCode / nativeErrorMessage
+      // (https://github.com/invertase/react-native-firebase/pull/9196). Interval 0
+      // forces a real fetch; 1ms timeout makes firebase-ios-sdk fail so both
+      // fetch: and fetchAndActivate: reject paths run. Public code/message stay
+      // the canned failure strings; native* carry the NSError.
+      it('attaches nativeErrorCode and nativeErrorMessage when iOS fetch rejects', async function () {
+        if (!Platform.ios) {
+          return;
+        }
+
+        const { getRemoteConfig, fetchConfig, fetchAndActivate } = remoteConfigModular;
+        const remoteConfig = getRemoteConfig();
+        const previousSettings = { ...remoteConfig.settings };
+
+        const assertNativeFetchError = async promise => {
+          try {
+            await promise;
+            throw new Error('Did not reject');
+          } catch (error) {
+            if (error.message === 'Did not reject') {
+              throw error;
+            }
+            error.code.should.equal('remoteConfig/failure');
+            should(error.nativeErrorCode).be.a.Number();
+            should(error.nativeErrorMessage).be.a.String();
+            error.nativeErrorMessage.length.should.be.greaterThan(0);
+          }
+        };
+
+        try {
+          remoteConfig.settings = {
+            minimumFetchIntervalMillis: 0,
+            fetchTimeoutMillis: 1,
+          };
+          await assertNativeFetchError(fetchConfig(remoteConfig));
+          await assertNativeFetchError(fetchAndActivate(remoteConfig));
+        } finally {
+          remoteConfig.settings = previousSettings;
+        }
+      });
+
       // Regression test for https://github.com/invertase/react-native-firebase/issues/7779
       // On iOS, fetchAndActivate() used to always resolve `true` whenever the underlying fetch
       // succeeded, even when the fetched values were identical to what was already active

--- a/packages/remote-config/e2e/config.e2e.js
+++ b/packages/remote-config/e2e/config.e2e.js
@@ -60,6 +60,24 @@ describe('remoteConfig()', function () {
         (await fetchAndActivate(getRemoteConfig())).should.be.a.Boolean();
       });
 
+      // Regression for https://github.com/invertase/react-native-firebase/issues/9194
+      // Assigning settings then calling fetchAndActivate in the next statement used to
+      // start the fetch before native setConfigSettings, so iOS cancelled the request
+      // (NSURLErrorCancelled / -999). A 12h cache hit with stale native settings must
+      // not satisfy this: interval 0 forces a real fetch.
+      it('applies settings assigned in the previous statement before fetchAndActivate', async function () {
+        const { getRemoteConfig, fetchAndActivate } = remoteConfigModular;
+        const remoteConfig = getRemoteConfig();
+        // Snapshot before the settings write. A 12h cache hit (stale native interval)
+        // leaves fetchTimeMillis unchanged; interval 0 must force a real fetch.
+        const fetchTimeBefore = remoteConfig.fetchTimeMillis;
+        remoteConfig.settings = { minimumFetchIntervalMillis: 0 };
+        const activated = await fetchAndActivate(remoteConfig);
+        activated.should.be.a.Boolean();
+        remoteConfig.lastFetchStatus.should.not.equal('failure');
+        should.equal(remoteConfig.fetchTimeMillis > fetchTimeBefore, true);
+      });
+
       // Regression test for https://github.com/invertase/react-native-firebase/issues/7779
       // On iOS, fetchAndActivate() used to always resolve `true` whenever the underlying fetch
       // succeeded, even when the fetched values were identical to what was already active

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigHelper.m
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigHelper.m
@@ -109,9 +109,6 @@ static FIRApp *firebaseAppForName(NSString *appName) {
   NSDate *lastFetchTime = remoteConfig.lastFetchTime;
   NSString *lastFetchStatus =
       convertFIRRemoteConfigFetchStatusToNSString(remoteConfig.lastFetchStatus);
-  double minimumFetchInterval =
-      [RCTConvert double:@([remoteConfig configSettings].minimumFetchInterval)];
-  double fetchTimeout = [RCTConvert double:@([remoteConfig configSettings].fetchTimeout)];
 
   NSMutableDictionary *values = [NSMutableDictionary new];
   NSSet *keys = [[FIRRemoteConfig remoteConfigWithApp:firebaseApp] keysWithPrefix:nil];
@@ -130,12 +127,12 @@ static FIRApp *firebaseAppForName(NSString *appName) {
     }
   }
 
+  // Never read `[remoteConfig configSettings]` (firebase-ios-sdk getter/setter both
+  // `recreateNetworkSession` / `invalidateAndCancel`). JS no-ops missing settings keys.
   return @{
     @"values" : values,
     @"lastFetchStatus" : lastFetchStatus,
     @"lastFetchTime" : @(round([lastFetchTime timeIntervalSince1970] * 1000.0)),
-    @"minimumFetchInterval" : @(minimumFetchInterval),
-    @"fetchTimeout" : @(fetchTimeout)
   };
 }
 
@@ -181,7 +178,9 @@ static FIRApp *firebaseAppForName(NSString *appName) {
                                userInfo:[@{
                                  @"code" : convertFIRRemoteConfigFetchStatusToNSString(status),
                                  @"message" :
-                                     convertFIRRemoteConfigFetchStatusToNSStringDescription(status)
+                                     convertFIRRemoteConfigFetchStatusToNSStringDescription(status),
+                                 @"nativeErrorCode" : @(error.code),
+                                 @"nativeErrorMessage" : error.localizedDescription ?: @""
                                } mutableCopy]];
         } else {
           resolve([self resultWithVoidConstantsForApp:firebaseApp]);
@@ -244,7 +243,9 @@ static FIRApp *firebaseAppForName(NSString *appName) {
                                userInfo:[@{
                                  @"code" : convertFIRRemoteConfigFetchStatusToNSString(status),
                                  @"message" :
-                                     convertFIRRemoteConfigFetchStatusToNSStringDescription(status)
+                                     convertFIRRemoteConfigFetchStatusToNSStringDescription(status),
+                                 @"nativeErrorCode" : @(error.code),
+                                 @"nativeErrorMessage" : error.localizedDescription ?: @""
                                } mutableCopy]];
           return;
         }

--- a/packages/remote-config/lib/index.ts
+++ b/packages/remote-config/lib/index.ts
@@ -317,7 +317,9 @@ class FirebaseConfigModule extends FirebaseModule<typeof nativeModuleName> {
    * @returns {Promise<boolean>}
    */
   activate(): Promise<boolean> {
-    return this._promiseWithConstants(this.native.activate());
+    // Wait for queued setters (settings / defaults) but do not serialize fetch-length
+    // work onto `_nativeMutationQueue`. A fetch can run up to fetchTimeoutMillis.
+    return this._nativeMutationQueue.then(() => this._promiseWithConstants(this.native.activate()));
   }
 
   /**
@@ -333,17 +335,23 @@ class FirebaseConfigModule extends FirebaseModule<typeof nativeModuleName> {
       );
     }
 
-    return this._promiseWithConstants(
-      this.native.fetch(expirationDurationSeconds !== undefined ? expirationDurationSeconds : -1),
+    return this._nativeMutationQueue.then(() =>
+      this._promiseWithConstants(
+        this.native.fetch(expirationDurationSeconds !== undefined ? expirationDurationSeconds : -1),
+      ),
     );
   }
 
   fetchAndActivate(): Promise<boolean> {
-    return this._promiseWithConstants(this.native.fetchAndActivate());
+    return this._nativeMutationQueue.then(() =>
+      this._promiseWithConstants(this.native.fetchAndActivate()),
+    );
   }
 
   ensureInitialized(): Promise<void> {
-    return this._promiseWithConstants(this.native.ensureInitialized());
+    return this._nativeMutationQueue.then(() =>
+      this._promiseWithConstants(this.native.ensureInitialized()),
+    );
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/invertase/react-native-firebase/issues/9194. Closes CPRN-308.

`remoteConfig.settings = …` then `fetchAndActivate()` was starting the iOS fetch before the native settings write, so firebase-ios-sdk tore down the session (`NSURLErrorCancelled` / -999) and fresh installs never received Remote Config.

- Wait for queued settings/defaults before fetch, activate, and `ensureInitialized` (do not put fetch on that queue)
- Stop reading iOS `configSettings` when building constants (getter recreates the network session)
- Add `nativeErrorCode` / `nativeErrorMessage` on iOS fetch reject paths; public `code` / `message` unchanged
- Jest ordering test plus e2e that requires `fetchTimeMillis` to advance so a stale 12h cache hit cannot pass