### PR TITLE
fix(app, sdks): adopt native SDK ios 12.18.0, android 34.18.0, js 12.17.1

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -34,8 +34,8 @@ npmPreapprovedPackages:
   - '@firebase/auth-types@0.13.1'
   - '@firebase/auth@1.13.4'
   - '@firebase/component@0.7.4'
-  - '@firebase/data-connect@0.7.2'
-  - '@firebase/database-compat@2.1.5'
+  - '@firebase/data-connect@0.7.3'
+  - '@firebase/database-compat@2.1.6'
   - '@firebase/database-types@1.0.21'
   - '@firebase/database@1.1.4'
   - '@firebase/firestore-compat@0.4.12'
@@ -63,4 +63,4 @@ npmPreapprovedPackages:
   - '@firebase/util@1.15.2'
   - '@firebase/webchannel-wrapper@1.0.6'
   - '@react-native-firebase/*'
-  - 'firebase@12.17.0' # If adopting recent firebase-js-sdk, specify directly here
+  - 'firebase@12.17.1' # If adopting recent firebase-js-sdk, specify directly here

--- a/docs/crashlytics/android-setup.mdx
+++ b/docs/crashlytics/android-setup.mdx
@@ -40,7 +40,7 @@ buildscript {
   // ..
   dependencies {
     // ..
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.7'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.8'
   }
   // ..
 }

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -379,7 +379,7 @@ project.ext {
       // Overriding Library SDK Versions if desired
       firebase: [
         // Override Firebase SDK Version
-        bom           : "34.16.0"
+        bom           : "34.18.0"
       ],
     ],
   ])
@@ -394,12 +394,12 @@ Open your projects `/ios/Podfile` and add any of the globals shown below to the 
 
 ```ruby
 # Override Firebase SDK Version if desired
-$FirebaseSDKVersion = '12.17.0'
+$FirebaseSDKVersion = '12.18.0'
 ```
 
 Once changed, reinstall your projects pods via pod install and rebuild your project with `npx react-native run-ios`.
 
-Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=12.17.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=12.17.0 yarn expo prebuild --clean`
+Alternatively, if you cannot edit the Podfile easily (as when using Expo), you may add the environment variable `FIREBASE_SDK_VERSION=12.18.0` (or whatever version you need) to the command line that installs pods. For example `FIREBASE_SDK_VERSION=12.18.0 yarn expo prebuild --clean`
 
 ### Android Performance
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "eslint-plugin-mocha": "^11.2.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
-    "firebase": "^12.17.0",
+    "firebase": "^12.17.1",
     "firebase-tools": "^15.22.4",
     "genversion": "^3.2.0",
     "google-java-format": "^2.3.0",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -112,7 +112,7 @@
     "react-native": "*"
   },
   "dependencies": {
-    "firebase": "12.17.0"
+    "firebase": "12.17.1"
   },
   "devDependencies": {
     "expo": "^55.0.18",
@@ -129,7 +129,7 @@
   },
   "sdkVersions": {
     "ios": {
-      "firebase": "12.17.0",
+      "firebase": "12.18.0",
       "firebaseSpmUrl": "https://github.com/firebase/firebase-ios-sdk.git",
       "iosTarget": "15.0",
       "macosTarget": "10.15",
@@ -139,8 +139,8 @@
       "minSdk": 23,
       "targetSdk": 34,
       "compileSdk": 34,
-      "firebase": "34.16.0",
-      "firebaseCrashlyticsGradle": "3.0.7",
+      "firebase": "34.18.0",
+      "firebaseCrashlyticsGradle": "3.0.8",
       "firebasePerfGradle": "2.0.2",
       "gmsGoogleServicesGradle": "4.5.0",
       "playServicesAuth": "21.5.0",

--- a/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
+++ b/packages/crashlytics/plugin/__tests__/__snapshots__/androidPlugin.test.ts.snap
@@ -15,7 +15,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.7'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.8'
         classpath("com.android.tools.build:gradle:4.1.0")
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/scripts/update-firebase-sdk-versions.sh
+++ b/scripts/update-firebase-sdk-versions.sh
@@ -17,10 +17,10 @@
 #       for freezing a release-notes snapshot in CI artifacts).
 #   ./scripts/update-firebase-sdk-versions.sh --apply [same fetch options as above]
 #       Phase 1: extract versions (printed as sorted KEY=value lines).
-#       Phase 2: write them into packages/app/package.json, root/tests
-#       package.json, .yarnrc.yml (firebase + transitive @firebase/* age-gate preapprovals),
-#       docs (.mdx), Gradle files, and Jest plugin snapshots; run yarn; run
-#       yarn tests:ios:pod:install.
+#       Phase 2: write them into packages/app/package.json, root/tests/
+#       tests-macos/package.json, .yarnrc.yml (firebase + transitive @firebase/*
+#       age-gate preapprovals), docs (.mdx), Gradle files, and Jest plugin
+#       snapshots; run yarn; run yarn tests:ios:pod:install when iOS SDK changed.
 #       If the JS or any native SDK / Android plugin / App Distribution API
 #       version changed, run yarn compare:types and yarn test:full (expects full
 #       Xcode/Android/macOS toolchains; exits 1 on failure).
@@ -268,7 +268,7 @@ app.sdkVersions.android.firebaseAppDistributionGradle =
   e.FIREBASE_ANDROID_APPDISTRIBUTION_GRADLE;
 fs.writeFileSync('packages/app/package.json', JSON.stringify(app, null, 2) + '\n');
 
-for (const path of ['package.json', 'tests/package.json']) {
+for (const path of ['package.json', 'tests/package.json', 'tests-macos/package.json']) {
   patchPackageJson(path);
 }
 NODE
@@ -458,8 +458,12 @@ rm -f "$tmp_snap_p"
 echo "update-firebase-sdk-versions: running yarn (refresh yarn.lock, workspace prepare)" >&2
 yarn
 
-echo "update-firebase-sdk-versions: running yarn tests:ios:pod:install" >&2
-yarn tests:ios:pod:install
+if [[ "$OLD_IOS" != "$FIREBASE_IOS_SDK" ]]; then
+  echo "update-firebase-sdk-versions: running yarn tests:ios:pod:install" >&2
+  yarn tests:ios:pod:install
+else
+  echo "update-firebase-sdk-versions: iOS SDK unchanged (${FIREBASE_IOS_SDK}); skipping yarn tests:ios:pod:install" >&2
+fi
 
 sdk_changed=false
 [[ "$js_changed" == true || "$native_changed" == true ]] && sdk_changed=true

--- a/tests-macos/package.json
+++ b/tests-macos/package.json
@@ -45,7 +45,7 @@
     "axios": "^1.15.2",
     "babel-plugin-istanbul": "^7.0.1",
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
-    "firebase": "^12.17.0",
+    "firebase": "^12.17.1",
     "jet": "patch:jet@npm%3A0.9.0-dev.13#~/.yarn/patches/jet-npm-0.9.0-dev.13-3321aeea6e.patch",
     "mocha": "^11.7.5",
     "nyc": "^18.0.0",

--- a/tests/android/build.gradle
+++ b/tests/android/build.gradle
@@ -37,7 +37,7 @@ buildscript {
     classpath("com.facebook.react:react-native-gradle-plugin")
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     classpath 'com.google.firebase:perf-plugin:2.0.2'
-    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.7'
+    classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.8'
     classpath 'com.google.firebase:firebase-appdistribution-gradle:5.3.0'
   }
 }

--- a/tests/ios/Podfile.lock
+++ b/tests/ios/Podfile.lock
@@ -3308,106 +3308,106 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AsyncStorage: 277e08206dc403ac228ffc74bd87e178cc016816
+  AsyncStorage: d7dcc63ec84ccd43e489b5dcdbd4bf93d12f04eb
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: d153c0a7ab3a2c865dd311cb3a5418cd66b658e6
   fmt: 530618a01105dae0fa3a2f27c81ae11fa8f67eac
   glog: 9c7bd858f1402a8e680d1637276210773c093b76
-  hermes-engine: 0d272856801a0d5da3d091c1a0a930df2cb67146
-  RCT-Folly: 957659fd132051eccf60310f242798220177d26e
+  hermes-engine: 8f3f876705e200bd22156b3040f8fdf180e4b4ee
+  RCT-Folly: 36c4f904fb6cd0219dcb76b94e9502d2a72fab0b
   RCTDeprecation: debcd5d989dc39edd50d61566b56e96da1c167b0
   RCTRequired: f06ef156c6b0244ac76aa51ef2e830a1a13004c8
   RCTSwiftUI: 04eac825e818fb067564bed44b20308916085563
-  RCTSwiftUIWrapper: 1ee57e921a7b0558d614bfeeedb3c4c47d3d8dd5
+  RCTSwiftUIWrapper: 2327c6c7121ace091456d14f52db03e9ed1d0587
   RCTTypeSafety: 99d2fd77cba14c82353eeb1ddfa92a9abf9c2258
   React: 4b2532a459d15e1adf6c22d3e399e5c85a94220f
   React-callinvoker: 4ce5eaeaed7ab9253fab8012c85490dced85419b
-  React-Core: d1cb2a723441ed72a53e82d3d87bb3942a5bf217
-  React-CoreModules: cc0cd6723f8040b46f316dd1786fa15bb50f7edc
-  React-cxxreact: be96b390688b4bdb933d2378f9df3ff0ec799105
+  React-Core: b977d0855fdc84aaa06ebb93ce1f7bf87e06f02d
+  React-CoreModules: 8348f6ba83c43d253e9bc9e3d0665367ecffd363
+  React-cxxreact: 97b011b9e4f4de8dd4f47113c0bc26fd29bee4b7
   React-debug: 39dc6b436ace8b801136718272f59ac9f1965881
-  React-defaultsnativemodule: 2a7a61870216d63d5fee4aa7ea4a370ec0ca7b6a
-  React-domnativemodule: 289253ca883749310da89c60e27e8bf993860eca
-  React-Fabric: 9078ca12ff2c69e7bc6de27aafd13314c0bd6adf
-  React-FabricComponents: e0f7b14a94210e102c7bd142b0b7cafd60809e14
-  React-FabricImage: 65cfee2f9a039dd5d5067e4dcfe80a1f0e82298f
-  React-featureflags: bbf7e33013fe56d2c36587d10afb5038b218b6d4
-  React-featureflagsnativemodule: 458d5318660f013dcf88deceb5ce8ba58227f63b
-  React-graphics: 9038189c3d67c34bf01bcd0c0264b1c8bdd8f76f
-  React-hermes: c0c09efefc2db29d55f5b1cc37ba364c5492a710
-  React-idlecallbacksnativemodule: 362769f0b65e6c758142703140239948586da667
-  React-ImageManager: 88b8c97dd63b520ab6d8d3e99ff90e02827cca8d
-  React-intersectionobservernativemodule: 9920dcc6867c145e6f8fa957069b1f5aedde8adf
-  React-jserrorhandler: 3b86549c3edcef53133537313fa12dd7dc40e663
-  React-jsi: 36a402669f13514f759a3ab088516b1b2ff3c328
-  React-jsiexecutor: 3a4efa9256c3817b4ab41c3b782e68bb71235e88
-  React-jsinspector: 7be50f917154a5fdc4172f38fdfc5705654b37e0
-  React-jsinspectorcdp: b337f0dbb7260cfa176f36ee21617d34b729cebc
-  React-jsinspectornetwork: 86cd96770cfc3087ab8f42621f66d53cc7c3f47e
-  React-jsinspectortracing: 6fe84b6c2a759749dffe3e8cc206a09543cb8c8d
-  React-jsitooling: 4e322aac272dc975b9bc27e561d889edca3f5e2d
-  React-jsitracing: 57431cab3d268f168fe06e940919a74de99d3086
-  React-logger: 4d5e869edd921f6ba1e2445a590ea3b20732cef1
-  React-Mapbuffer: 52354180dc2795d4f0d420a1eeae410d9fde51c5
-  React-microtasksnativemodule: c728251513acebdd0e48fcb71588c6cfd6c723a4
-  React-mutationobservernativemodule: 0d909c6027325d6df193914b657aedd56a46f92b
-  React-NativeModulesApple: d9a28e8f83636f1f3dbbf57caf480045b943505b
-  React-networking: 43ebb10b646d3215b4ba54c1bbfebf120a9cbcdd
+  React-defaultsnativemodule: df1b651352f64b9840fa8f91bbbf07fd2b116f7e
+  React-domnativemodule: 472aae83f34953cccfc8bba5c0c51bae9ef81990
+  React-Fabric: f1e5d8f2a5f23388e78db5a64b73c755f44e6427
+  React-FabricComponents: e6378c5a412bfd71bbf09300ab9d236142484661
+  React-FabricImage: addc7aeb8a110331a9cfb11d22c5d35662030ed8
+  React-featureflags: 7710df4d3542d1f065c0f7a03a86e757ed8f6986
+  React-featureflagsnativemodule: c0f7587f59a8fa2834a9cd4cfe4e6ec19421401d
+  React-graphics: ca88583f5755a57bb77c94562566fa78e3c2edcc
+  React-hermes: e6ee3eaf5fb1323e05a5e5e6a8ef4032c43e3aa0
+  React-idlecallbacksnativemodule: 1260bc1716df4159f0ca122fc8b1a91ad71cd22f
+  React-ImageManager: a2bca6f529dbbee46678ad178e8cb4e9faa8dc9a
+  React-intersectionobservernativemodule: df39ac12dbb711647aa7d07d0c7744bcc49e5266
+  React-jserrorhandler: 83230a36b65591bffdbf3675d7d398db64c86cc8
+  React-jsi: 3a086cab2daa7aed173f5868da9863a2dc66ed10
+  React-jsiexecutor: dc613df3545424791292da8912724523b547b602
+  React-jsinspector: fa5bc90ecebd9064e2a460d6b19e0ebfe746f9c7
+  React-jsinspectorcdp: 74f56e83c7e5962f422433850abc5fe81f2fcced
+  React-jsinspectornetwork: d152b6167b36d5d34bcb6467a5874463ae15251d
+  React-jsinspectortracing: 5b20199ac92dfa8be4d7a7c01e7e5b8b51c20fa4
+  React-jsitooling: 5ffef1f13119af3afc2cf60562d73c07a9837ddb
+  React-jsitracing: 52f60cfdd89ba1a44d2957c41598ec27ceafa63c
+  React-logger: ff68b92f4ed87c8140e55376715df214e4a5b44e
+  React-Mapbuffer: cf87509c42a709a0d54e4bb68141aa46da7c24d9
+  React-microtasksnativemodule: d49a73e18b9bed6d96f2840e9850f9371aa3c315
+  React-mutationobservernativemodule: 971a7f2bd87f425980181eacb4e7e3d46ca352da
+  React-NativeModulesApple: 52064379dd05d6c8e5af9b55e03f97b341670ceb
+  React-networking: 4ccf424ae6402e7ea5a54d2ddc107478d60e6620
   React-oscompat: 49e93f3b7500698c80920fdebd5771e532bab0bd
-  React-perflogger: 28f23b96a6ede947f670a0048a795bc9ce46dced
-  React-performancecdpmetrics: 84b77c4f929c4f5e3e7017670bbb4ce9ab42f1d0
-  React-performancetimeline: f2e0c177411c1b18bebf1bd5f85d68b0560b7e7b
+  React-perflogger: 1de94052792db307c5072234f9aae82a923f4ff6
+  React-performancecdpmetrics: 6d3f6d5f386e7e675ea48a098cc0e9e274051c2e
+  React-performancetimeline: a2bb9ad5e48d9155bf7bd6f0749170b7fb3d4d10
   React-RCTActionSheet: a063bc8d6ccfdb01d8e881e2d4880ac95fbe2ce9
-  React-RCTAnimation: 4275bab2d563a68fad7279b0549ad6a9d8aa254a
-  React-RCTAppDelegate: e0fdc1f16e9f2c1340e93743057a590987d466ab
-  React-RCTBlob: 6db50e74a24c04f558f2ccac92bee4f2b71518ae
-  React-RCTFabric: 3497141b1f9e22993b0fded8232cdf6d5e2e76a3
-  React-RCTFBReactNativeSpec: cf6834970b9e895e3cfd195c1a308f5192392865
-  React-RCTImage: cf57180d5e3ec959105769237be937a5884b2f89
-  React-RCTLinking: 304a945107e8e93d4973cdd028812fe2ea76640a
-  React-RCTNetwork: 2e81fe49b61ae910cb1cecbf0efea8b2a8b6aa02
-  React-RCTRuntime: 179ba1d7126e2479672db1189da666179dd5f823
-  React-RCTSettings: 14f0c930baa1ba0e153de914c989f93fbc3167e5
-  React-RCTText: a127a299290d2770bb98d71d6ed805fcb6fa3dbe
-  React-RCTVibration: 0a1c312c40bb1154dd5444eea8e2692b1da8c12d
+  React-RCTAnimation: 7e13837656a99bce9fc0438c44f14bbb397b81e4
+  React-RCTAppDelegate: 21a4dd4025c71ac088a699215874451b2113bfe9
+  React-RCTBlob: fac73aaff7670156407c1e5c35c7b99d3800488e
+  React-RCTFabric: 5cc95c3baf40c2b78ae1e5aa2d0ef6b9089bbd11
+  React-RCTFBReactNativeSpec: abf6aff475f1ba66fe5f69dcd30d316e7fadf26c
+  React-RCTImage: 3f7d929bec415ced8ece533ff067ceba8d6856f4
+  React-RCTLinking: 7f2b230527a5af0ec458eabc18b7d1a4a6b9d3e2
+  React-RCTNetwork: cff0b31d56eda251d2c173d8cbf1bd3d69769f50
+  React-RCTRuntime: 472469f7bace59d7ff0fa5c9168877111ed1fd58
+  React-RCTSettings: dd7519903c62ac3ec1952aecd1beef39f4054cd9
+  React-RCTText: 2bb166fb973f3a9f0f34f9a3049706e0d8049a60
+  React-RCTVibration: cd568037cd71cb662a6c8f3e616ba193409f4b38
   React-rendererconsistency: 31d27acc365fd0544575fc2a6842003e3c9e5c44
-  React-renderercss: 61a51d39c0e4166284eb644f25621cc74ebc3a2c
-  React-rendererdebug: 7a7dc7e42d2f39b7b2ca80f9633b0be9a837730e
-  React-RuntimeApple: 13eeb11a9b6a3f9935c6fe144882380577a6e1c4
-  React-RuntimeCore: 2d24cbe34ad63f8ad9e54df87b84d41e1452af11
-  React-runtimeexecutor: 351e1b2d9daa21e4b5f80d395fe567d0ca523e5e
-  React-RuntimeHermes: ba85b1f2cabe27610d11cc23be2a052013f5977d
-  React-runtimescheduler: 00e6fb126aeb3ff95af7d14339ad00234b4ce739
-  React-timing: 0e2715ad2e129cc8aaca4fa2b8d8cb2c6692c602
-  React-utils: 1cf0850e56602c28f491e5386c0541575e9f07ec
-  React-viewtransitionnativemodule: f3e58e8bc29d5587a69410db8f762084ccf13830
-  React-webperformancenativemodule: 44e6e7a84d642510099a96a67d69cc1eed022fe3
-  ReactAppDependencyProvider: 082ef199e27011a4314f499b6b2e2ac29e141267
-  ReactCodegen: 731f53966cbbd6173724a48dba7f0f3e16809e95
-  ReactCommon: 078ca6376aebd2e66df3f24ed3538c9168d7b591
-  RNAppleAuthentication: d6fe579e5f43cf8db54bdc48518bccea61c592a4
-  RNDeviceInfo: d79872e11c8e9c4de0d65b0ee6e0cee719f37fea
-  RNFBAnalytics: bd43e63788771c8ecd56cb784a2051ae7027a3b4
-  RNFBApp: d97baf5ec172e8e878de89f83d6feb6842acc0b4
-  RNFBAppCheck: 4a0b0e8078919d57ea51037cb3e31c8e0653efaa
-  RNFBAppDistribution: 3b9cfa97253f37fcf8cdf66c17ed498a7f13df50
-  RNFBAuth: 359e60815c8dc2b6f71c033114502d28904675d1
-  RNFBCrashlytics: 1e6d65e4999feb8cd9d442b4bcf64dcc6ed527ed
-  RNFBDatabase: ee6f9ac81fb920e4be3b00b84117c04cd76da745
-  RNFBFirestore: bae44f394815b628ee055bccab9bfe95ba48bfef
-  RNFBFunctions: a65a549d485cdaf9135610e3e2b58d8b8a4b648f
-  RNFBInAppMessaging: 0ce8db9980c2064eccef8e0d4c235c0bef220f82
-  RNFBInstallations: 084abccf56cce816f9cfad0b343c0cbf1c8cbdca
-  RNFBMessaging: 1a705a1fb8e818012595d923d62bb70e1f16c837
-  RNFBML: 879e237287131c343bfda605f64673423034bc5f
-  RNFBPerf: 2c2344de7d1d5559bfac7274691956f94b0034ae
-  RNFBRemoteConfig: 469892e6e7f3baee3c09cbd44ecdb5e4f02af50c
-  RNFBStorage: b09b4f859d144e41bdb16d1b16c35f42b8d81217
+  React-renderercss: ca9c9fa5010de6b6b253ff320e6a0717b4a813f2
+  React-rendererdebug: 1050a11de230fa1c1c929ffd6aeff0ed58adba86
+  React-RuntimeApple: 8edfa3ce587f62f1a056e9fcf930eeacb0867a93
+  React-RuntimeCore: c480d892f3246d48b9714bec8a6943e64f6cdcee
+  React-runtimeexecutor: 903ca65b2b6539dd8ceaf0eb4abba4ac2c312388
+  React-RuntimeHermes: 9847b16a4517f6d81104cefa799709278f7c1147
+  React-runtimescheduler: 6d46b9611b35c421830540e9a489f52001b2b7e3
+  React-timing: f8b93255a530a5bf9db86a2c0e17c9988ae80b4d
+  React-utils: dc4b01e8c31ae99a854ed6ac7a0653a2c86ab104
+  React-viewtransitionnativemodule: 01530fbfcfb561a8c40258e11ef320d25f951113
+  React-webperformancenativemodule: 03d2d86c1605a0b1ecbfb9fb6fb5b15826f27354
+  ReactAppDependencyProvider: 0e13d430eadac8a2ef18515a860d5c59df05b475
+  ReactCodegen: 3df238732b558dd01320d47ed87e653945dd0fc6
+  ReactCommon: 00ae3f3b9351312ee73cc8439d8204148084547a
+  RNAppleAuthentication: a89c9804592b38ed4ab11f0aee68d05ba12ad432
+  RNDeviceInfo: 4c852998208b60dc192ae3529e5867817719ad1e
+  RNFBAnalytics: 89257443fb35835eb5b3928df6b8c96a878cd45d
+  RNFBApp: c0988656691e2e94adc0d7921ab576e51d41192e
+  RNFBAppCheck: 0cee6d2f69f57b05c1c1372448b427dc4723a2e0
+  RNFBAppDistribution: 98d21283eb8243b862b4f64554af26e1edc7b9bf
+  RNFBAuth: 4a2cfe7966500d783385240f23fadefe207d0d3b
+  RNFBCrashlytics: f61444c4fc40d98b22a23f754e53e1af7b946bbe
+  RNFBDatabase: c021f088abbe8290c51a5532e82214e58c19dd04
+  RNFBFirestore: ec940987bfb1032ab3b5b420df1c485b78c1fac4
+  RNFBFunctions: 0d7eda36188c070b2e1b9cb08ef6dc1e58da4a5d
+  RNFBInAppMessaging: 7176132e58d57240225da797fc987bb474d4c87c
+  RNFBInstallations: 3487e492155a5237c6a94810791eb67e5f1a4aae
+  RNFBMessaging: c9b9f8ff37fc9e1e768274de49ad891a9881b2a1
+  RNFBML: 94ae16944523a252ec29a1ad124d5816315859f7
+  RNFBPerf: 22ed72d79dcec3315f030e4528cce85e005b2a1e
+  RNFBRemoteConfig: d774d6e97adc9efb5d4af007bd9dbe7bf0a48c9d
+  RNFBStorage: 053a14f69858e9368143a45309be90ced736a8c8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 24af75960dc03eceead31961827e7cecf3ea22a0
 
 PODFILE CHECKSUM: cdd7dbed1e67cfac55f6f21e0f791a1429f0e36b
 
-COCOAPODS: 1.17.0
+COCOAPODS: 1.16.2

--- a/tests/package.json
+++ b/tests/package.json
@@ -50,7 +50,7 @@
     "babel-plugin-transform-inline-environment-variables": "^0.4.4",
     "cpy-cli": "^7.0.0",
     "detox": "patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch",
-    "firebase": "^12.17.0",
+    "firebase": "^12.17.1",
     "firebase-tools": "^15.22.4",
     "jest-circus": "^30.3.0",
     "jest-environment-node": "^30.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3123,9 +3123,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@firebase/data-connect@npm:0.7.2":
-  version: 0.7.2
-  resolution: "@firebase/data-connect@npm:0.7.2"
+"@firebase/data-connect@npm:0.7.3":
+  version: 0.7.3
+  resolution: "@firebase/data-connect@npm:0.7.3"
   dependencies:
     "@firebase/auth-interop-types": "npm:0.2.5"
     "@firebase/component": "npm:0.7.4"
@@ -3134,13 +3134,13 @@ __metadata:
     tslib: "npm:^2.1.0"
   peerDependencies:
     "@firebase/app": 0.x
-  checksum: 10/83af22df79be71be3ad33697d9419165da47c8728938fb6af7460cecc4572ffaaa63a232f00be8c5644423690d1ddce31328d3bc15ae1ac78bc0ac6afe009452
+  checksum: 10/8d98d81e4d6c0337c61305496ce817bc38e3724ebdefb3f1afb13dc44109027e8f9f5beb9b79845b2e02884743ca1d4f452983bb4528275509c29c62edddd3e1
   languageName: node
   linkType: hard
 
-"@firebase/database-compat@npm:2.1.5":
-  version: 2.1.5
-  resolution: "@firebase/database-compat@npm:2.1.5"
+"@firebase/database-compat@npm:2.1.6":
+  version: 2.1.6
+  resolution: "@firebase/database-compat@npm:2.1.6"
   dependencies:
     "@firebase/component": "npm:0.7.4"
     "@firebase/database": "npm:1.1.4"
@@ -3156,7 +3156,7 @@ __metadata:
       optional: true
     "@firebase/app-compat":
       optional: true
-  checksum: 10/02de92b397b0f4bc01f43482c1fff25da4394857e75bcfd649dfe9dd99372af4aa8843ded6a361aee9d230fc1c933f6a28dddbd3744908516d6fccd353c9c6ca
+  checksum: 10/6a77cac8fc259d3b5e648603a0ac652ebb8047047c562ee580ab94248d11a2609062e1a9f33ef4d51897976226c64615171b8287e0b14994dc0b823b95311787
   languageName: node
   linkType: hard
 
@@ -6076,7 +6076,7 @@ __metadata:
   resolution: "@react-native-firebase/app@workspace:packages/app"
   dependencies:
     expo: "npm:^55.0.18"
-    firebase: "npm:12.17.0"
+    firebase: "npm:12.17.1"
     react-native-builder-bob: "npm:^0.41.0"
   peerDependencies:
     expo: ">=47.0.0"
@@ -13168,9 +13168,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"firebase@npm:12.17.0, firebase@npm:^12.17.0":
-  version: 12.17.0
-  resolution: "firebase@npm:12.17.0"
+"firebase@npm:12.17.1, firebase@npm:^12.17.1":
+  version: 12.17.1
+  resolution: "firebase@npm:12.17.1"
   dependencies:
     "@firebase/ai": "npm:2.14.0"
     "@firebase/analytics": "npm:0.10.23"
@@ -13182,9 +13182,9 @@ __metadata:
     "@firebase/app-types": "npm:0.9.5"
     "@firebase/auth": "npm:1.13.4"
     "@firebase/auth-compat": "npm:0.6.9"
-    "@firebase/data-connect": "npm:0.7.2"
+    "@firebase/data-connect": "npm:0.7.3"
     "@firebase/database": "npm:1.1.4"
-    "@firebase/database-compat": "npm:2.1.5"
+    "@firebase/database-compat": "npm:2.1.6"
     "@firebase/firestore": "npm:4.17.0"
     "@firebase/firestore-compat": "npm:0.4.12"
     "@firebase/functions": "npm:0.13.6"
@@ -13200,7 +13200,7 @@ __metadata:
     "@firebase/storage": "npm:0.14.4"
     "@firebase/storage-compat": "npm:0.4.4"
     "@firebase/util": "npm:1.15.2"
-  checksum: 10/54122bfd9cad0eded11096cb4573a1858b98ba6b18fea8c5ae7f1bb0921334a6d29a4c70cac9584204fffb9e4b3da453d19104ee4c89f1173b8a63d66a0cac1f
+  checksum: 10/5b598e6c524b0fb049e6adbba6e2fe576b622e9851db49d07757ef4e7aa076e9c4beb2d92cac6ef664cd91e3ad5294dbeaf882317275f138e09fd076168ece2f
   languageName: node
   linkType: hard
 
@@ -22362,7 +22362,7 @@ __metadata:
     axios: "npm:^1.15.2"
     babel-plugin-istanbul: "npm:^7.0.1"
     babel-plugin-transform-inline-environment-variables: "npm:^0.4.4"
-    firebase: "npm:^12.17.0"
+    firebase: "npm:^12.17.1"
     jet: "patch:jet@npm%3A0.9.0-dev.13#~/.yarn/patches/jet-npm-0.9.0-dev.13-3321aeea6e.patch"
     mocha: "npm:^11.7.5"
     nyc: "npm:^18.0.0"
@@ -22418,7 +22418,7 @@ __metadata:
     babel-plugin-transform-inline-environment-variables: "npm:^0.4.4"
     cpy-cli: "npm:^7.0.0"
     detox: "patch:detox@npm%3A20.51.0#~/.yarn/patches/detox-npm-20.51.0-3e13b6e309.patch"
-    firebase: "npm:^12.17.0"
+    firebase: "npm:^12.17.1"
     firebase-tools: "npm:^15.22.4"
     jest-circus: "npm:^30.3.0"
     jest-environment-node: "npm:^30.3.0"
@@ -22472,7 +22472,7 @@ __metadata:
     eslint-plugin-mocha: "npm:^11.2.0"
     eslint-plugin-prettier: "npm:^5.5.5"
     eslint-plugin-react: "npm:^7.37.5"
-    firebase: "npm:^12.17.0"
+    firebase: "npm:^12.17.1"
     firebase-tools: "npm:^15.22.4"
     genversion: "npm:^3.2.0"
     google-java-format: "npm:^2.3.0"


### PR DESCRIPTION
## Summary
- Bump Firebase iOS SDK to **12.18.0**, Android BOM to **34.18.0**, Crashlytics Gradle to **3.0.8**, and firebase-js-sdk to **12.17.1** via `scripts/update-firebase-sdk-versions.sh`.
- Apply script now also patches `tests-macos/package.json` and runs `yarn tests:ios:pod:install` when the iOS pin changes (keeps `tests/ios/Podfile.lock` with the bump).
- Docs, yarnrc preapprovals, yarn.lock, and crashlytics plugin snapshot updated to match.

## Test plan
- [x] Unit-focused + area-focused e2e (app harness): iOS 39, Android 39, macOS 33 — all exit 0
- [x] `yarn compare:types`, `yarn lint`, docs lint/spellcheck, crashlytics androidPlugin Jest
- [ ] CI green on this PR