### PR TITLE
fix(app, android): discard tasks posted to shut-down transactional executors

### DIFF
--- a/packages/app/__tests__/e2eHelpers.test.js
+++ b/packages/app/__tests__/e2eHelpers.test.js
@@ -24,7 +24,11 @@ import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
 // correct, independent of how `process.env` is populated at runtime.
 const helpers = require('../e2e/helpers');
 
+// Every literal process.env key read by packages/app/e2e/helpers.js — incomplete
+// lists leak slotted ambient env (export-slot-env) into "default when nothing is set"
+// cases. Keep in sync with helpers.js staticEmulatorPort / staticMetroPort / staticJetPort.
 const ENV_KEYS = [
+  'RNFB_E2E_DEBUG',
   'RNFB_ANDROID_METRO_PORT',
   'RNFB_IOS_METRO_PORT',
   'RNFB_MACOS_METRO_PORT',
@@ -32,8 +36,20 @@ const ENV_KEYS = [
   'RNFB_IOS_JET_PORT',
   'RNFB_MACOS_JET_PORT',
   'RNFB_ANDROID_EMULATOR_FIRESTORE_PORT',
+  'RNFB_ANDROID_EMULATOR_AUTH_PORT',
+  'RNFB_ANDROID_EMULATOR_DATABASE_PORT',
+  'RNFB_ANDROID_EMULATOR_FUNCTIONS_PORT',
+  'RNFB_ANDROID_EMULATOR_STORAGE_PORT',
   'RNFB_IOS_EMULATOR_FIRESTORE_PORT',
+  'RNFB_IOS_EMULATOR_AUTH_PORT',
+  'RNFB_IOS_EMULATOR_DATABASE_PORT',
+  'RNFB_IOS_EMULATOR_FUNCTIONS_PORT',
+  'RNFB_IOS_EMULATOR_STORAGE_PORT',
   'RNFB_MACOS_EMULATOR_FIRESTORE_PORT',
+  'RNFB_MACOS_EMULATOR_AUTH_PORT',
+  'RNFB_MACOS_EMULATOR_DATABASE_PORT',
+  'RNFB_MACOS_EMULATOR_FUNCTIONS_PORT',
+  'RNFB_MACOS_EMULATOR_STORAGE_PORT',
   'JET_REMOTE_PORT',
   'JET_METRO_PORT',
   'RCT_METRO_PORT',

--- a/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
+++ b/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
@@ -22,7 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -73,7 +74,16 @@ public class TaskExecutorService {
 
   private ExecutorService getNewExecutor(boolean isTransactional) {
     if (isTransactional) {
-      return Executors.newSingleThreadExecutor();
+      // A bare Executors.newSingleThreadExecutor() has no rejection handler, so a
+      // play-services Task completing after shutdown() (module invalidation racing
+      // in-flight work, e.g. App Check attestation or Auth network calls finishing
+      // while the React instance is torn down) posts to the dead executor and
+      // crashes the process with an uncaught RejectedExecutionException. Use an
+      // equivalent single-thread pool that discards work arriving after shutdown.
+      ThreadPoolExecutor transactionalExecutor =
+          new ThreadPoolExecutor(1, 1, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+      transactionalExecutor.setRejectedExecutionHandler(discardAfterShutdown);
+      return transactionalExecutor;
     } else {
       ThreadPoolExecutor threadPoolExecutor =
           new ThreadPoolExecutor(
@@ -82,6 +92,16 @@ public class TaskExecutorService {
       return threadPoolExecutor;
     }
   }
+
+  private static final RejectedExecutionHandler discardAfterShutdown =
+      (r, executor) -> {
+        if (executor.isShutdown() || executor.isTerminated() || executor.isTerminating()) {
+          return;
+        }
+        // Unreachable with an unbounded queue, but preserve AbortPolicy semantics
+        // for any rejection that is not caused by shutdown.
+        throw new RejectedExecutionException("Task " + r + " rejected from " + executor);
+      };
 
   private final RejectedExecutionHandler executeInFallback =
       (r, executor) -> {

--- a/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
+++ b/packages/app/android/src/main/java/io/invertase/firebase/common/TaskExecutorService.java
@@ -95,7 +95,9 @@ public class TaskExecutorService {
 
   private static final RejectedExecutionHandler discardAfterShutdown =
       (r, executor) -> {
-        if (executor.isShutdown() || executor.isTerminated() || executor.isTerminating()) {
+        // isShutdown() remains true through the terminating and terminated states,
+        // so it is the only check needed to detect work arriving after shutdown.
+        if (executor.isShutdown()) {
           return;
         }
         // Unreachable with an unbounded queue, but preserve AbortPolicy semantics
@@ -105,7 +107,9 @@ public class TaskExecutorService {
 
   private final RejectedExecutionHandler executeInFallback =
       (r, executor) -> {
-        if (executor.isShutdown() || executor.isTerminated() || executor.isTerminating()) {
+        // isShutdown() remains true through the terminating and terminated states,
+        // so it is the only check needed to detect work arriving after shutdown.
+        if (executor.isShutdown()) {
           return;
         }
         ExecutorService fallbackExecutor = getTransactionalExecutor();

--- a/packages/app/android/src/test/java/io/invertase/firebase/common/TaskExecutorServiceTest.java
+++ b/packages/app/android/src/test/java/io/invertase/firebase/common/TaskExecutorServiceTest.java
@@ -19,17 +19,42 @@ package io.invertase.firebase.common;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
+import org.mockito.MockedStatic;
 
-@RunWith(RobolectricTestRunner.class)
+/**
+ * Plain JUnit4 + Mockito (AndroidTest-AD-1). Constructor reads pool sizing from {@link
+ * ReactNativeFirebaseJSON}; stub that away so we never touch Android's unmocked {@code
+ * org.json.JSONObject}.
+ */
 public class TaskExecutorServiceTest {
+
+  private MockedStatic<ReactNativeFirebaseJSON> jsonStatic;
+
+  @Before
+  public void setUp() {
+    ReactNativeFirebaseJSON json = mock(ReactNativeFirebaseJSON.class);
+    when(json.getIntValue(anyString(), anyInt())).thenAnswer(inv -> inv.getArgument(1));
+    jsonStatic = mockStatic(ReactNativeFirebaseJSON.class);
+    jsonStatic.when(ReactNativeFirebaseJSON::getSharedInstance).thenReturn(json);
+  }
+
+  @After
+  public void tearDown() {
+    jsonStatic.close();
+  }
 
   @Test
   public void transactionalExecutorRunsSubmittedWork() throws Exception {
@@ -62,8 +87,11 @@ public class TaskExecutorServiceTest {
     TaskExecutorService service = new TaskExecutorService("TestPooledShutdown");
     ExecutorService executor = service.getExecutor(false, "");
     service.shutdown();
+    AtomicBoolean ran = new AtomicBoolean(false);
 
     // Exercises the executeInFallback handler's shutdown guard.
-    executor.execute(() -> {});
+    executor.execute(() -> ran.set(true));
+
+    assertFalse("work submitted after shutdown is discarded", ran.get());
   }
 }

--- a/packages/app/android/src/test/java/io/invertase/firebase/common/TaskExecutorServiceTest.java
+++ b/packages/app/android/src/test/java/io/invertase/firebase/common/TaskExecutorServiceTest.java
@@ -1,0 +1,69 @@
+package io.invertase.firebase.common;
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class TaskExecutorServiceTest {
+
+  @Test
+  public void transactionalExecutorRunsSubmittedWork() throws Exception {
+    TaskExecutorService service = new TaskExecutorService("TestTransactionalRuns");
+    ExecutorService executor = service.getTransactionalExecutor();
+    CountDownLatch latch = new CountDownLatch(1);
+
+    executor.execute(latch::countDown);
+
+    assertTrue("work submitted before shutdown runs", latch.await(5, TimeUnit.SECONDS));
+    service.shutdown();
+  }
+
+  @Test
+  public void transactionalExecutorDiscardsWorkSubmittedAfterShutdown() {
+    TaskExecutorService service = new TaskExecutorService("TestTransactionalShutdown");
+    ExecutorService executor = service.getTransactionalExecutor();
+    service.shutdown();
+    AtomicBoolean ran = new AtomicBoolean(false);
+
+    // Must not throw RejectedExecutionException - this is the crash path hit when a
+    // play-services Task completes after module invalidation has shut the executor down.
+    executor.execute(() -> ran.set(true));
+
+    assertFalse("work submitted after shutdown is discarded", ran.get());
+  }
+
+  @Test
+  public void pooledExecutorDiscardsWorkSubmittedAfterShutdown() {
+    TaskExecutorService service = new TaskExecutorService("TestPooledShutdown");
+    ExecutorService executor = service.getExecutor(false, "");
+    service.shutdown();
+
+    // Exercises the executeInFallback handler's shutdown guard.
+    executor.execute(() -> {});
+  }
+}


### PR DESCRIPTION
### Description

`TaskExecutorService.getNewExecutor()` returns a bare `Executors.newSingleThreadExecutor()` for transactional executors. When `ReactNativeFirebaseModule.invalidate()` runs `shutdownNow()` while a play-services `Task` is still in flight — an App Check Play Integrity attestation, an Auth network call, or a Functions `httpsCallable` racing React instance teardown (app swiped away, headless task ending, reload) — the Task's completion listener posts its continuation to the now-dead executor. The default `AbortPolicy` throws an uncaught `RejectedExecutionException` on a gms pool thread and crashes the process:

```
Exception java.util.concurrent.RejectedExecutionException:
  at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution (ThreadPoolExecutor.java:2050)
  at java.util.concurrent.ThreadPoolExecutor.reject (ThreadPoolExecutor.java:797)
  at java.util.concurrent.ThreadPoolExecutor.execute (ThreadPoolExecutor.java:1338)
  at java.util.concurrent.Executors$DelegatedExecutorService.execute (Executors.java:643)
  at com.google.android.gms.tasks.zzj.zza (play-services-tasks@@18.4.0)
  at com.google.android.gms.tasks.zzr.zzb
  at com.google.android.gms.tasks.zzw.zzc
  at com.google.android.gms.tasks.zzx.run
```

d70520d ("catch RejectedExecutionException on executor-backed Tasks") guarded the database/firestore call sites, but the generic path through any module's transactional executor is still exposed — we see this in production via app-check/auth, and via Functions during in-process reload (#9276), where no `Tasks.call` wrapper exists to catch it (the throw happens inside play-services internals, not in RNFB code).

This PR replaces the bare single-thread executor with an equivalent `ThreadPoolExecutor(1, 1, 0ms, LinkedBlockingQueue)` carrying a `RejectedExecutionHandler` that silently discards work arriving after shutdown — the same treatment `executeInFallback` already gives the pooled executor. FIFO single-thread semantics are unchanged; a rejection on a live executor (unreachable with an unbounded queue) still throws to preserve `AbortPolicy` behaviour. Discarded continuations belong to a React instance that no longer exists, so nothing awaits them.

### Related issues

- Fixes #9276
- Related to #4047
- Related to #4118

Follow-up to d70520d39c16c6a414affe4585de6f65ec9ab345. Unblocked after #9093.

### Release Summary

fix(app, android): discard tasks posted to shut-down transactional executors instead of crashing with RejectedExecutionException

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [x] No

### Test Plan

We hit this crash in production (Google Play Console, Android vitals) in an app using only `app`, `app-check` (Play Integrity provider) and `auth` — reproduced by killing the app immediately after launch while an App Check attestation is in flight. #9276 reports the same crash class from Functions when an in-process React reload overlaps an active `httpsCallable`. No automated test is included: the race needs a live play-services Task completing after `invalidate()`, which isn't reachable from jest, and e2e teardown timing is nondeterministic. The change is semantically equivalent to the existing pooled-executor rejection handling. We're shipping this same change as a local patch via patch-package/bun patch and will report back with before/after crash-rate data from Play Console.
