### PR TITLE
build: restore tokenless npm OIDC publishing / use Node.js 24

### DIFF
--- a/.github/workflows/create_test_patches.yml
+++ b/.github/workflows/create_test_patches.yml
@@ -41,7 +41,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
 
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/deploy-api-reference.yml
+++ b/.github/workflows/deploy-api-reference.yml
@@ -25,7 +25,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: lts/*
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
       - name: Install latest NPM
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Yarn Cache Restore

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -34,7 +34,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -116,7 +116,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Yarn Cache Restore
@@ -174,7 +174,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Yarn Cache Restore
@@ -220,7 +220,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Yarn Cache Restore
@@ -282,7 +282,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Yarn Cache Restore

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -20,7 +20,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/amannn/action-semantic-pull-request/releases
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: lts/*
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
       - name: Install latest NPM
         # OIDC publishing requires a very up to date npm version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
       - name: Install latest NPM
         # OIDC publishing requires a very up to date npm version
         run: |
@@ -58,12 +59,7 @@ jobs:
           echo "Syncing unpublished versions with package registry..."
           yarn lerna publish from-package --yes --loglevel trace
         env:
-          # No NPM token needed, all of the packages have been configured
-          # on npmjs.com with this workflow file as an OIDC "Trusted Publisher"
-          # As of 20251208 tokenless OIDC Trusted Publish is not working.
-          # Unable to conclusively fix, using token for now. Expires 20250308
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          #
+          # Packages are configured on npmjs.com as OIDC Trusted Publisher for this workflow.
           # org admin Github Token required for the changelog/tag commit+push
           # to work via an exception to branch protection rules
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/rnfb-js-sdk-comparison.yml
+++ b/.github/workflows/rnfb-js-sdk-comparison.yml
@@ -42,7 +42,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Yarn Cache Restore

--- a/.github/workflows/scripts/functions/package.json
+++ b/.github/workflows/scripts/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "22"
+    "node": "24"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/.github/workflows/tests_e2e_android.yml
+++ b/.github/workflows/tests_e2e_android.yml
@@ -149,7 +149,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases

--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -147,7 +147,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases
@@ -624,7 +624,7 @@ jobs:
     steps:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
 
       - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:

--- a/.github/workflows/tests_e2e_other.yml
+++ b/.github/workflows/tests_e2e_other.yml
@@ -127,7 +127,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Configure JDK
         # https://github.com/actions/setup-java/releases

--- a/.github/workflows/tests_jest.yml
+++ b/.github/workflows/tests_jest.yml
@@ -45,7 +45,7 @@ jobs:
       # https://github.com/actions/setup-node/releases
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       # https://github.com/actions/cache/releases
       - uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         name: Yarn Cache Restore

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/ai"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/ai"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -32,7 +32,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/analytics"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/analytics"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -32,7 +32,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/app-check"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/app-check"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/app-distribution/package.json
+++ b/packages/app-distribution/package.json
@@ -32,7 +32,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/app-distribution"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/app-distribution"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -34,7 +34,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/app"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/app"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -32,7 +32,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/auth"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/auth"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -32,7 +32,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/crashlytics"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/crashlytics"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -34,7 +34,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/database"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/database"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/firestore"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/firestore"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/functions"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/functions"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/in-app-messaging/package.json
+++ b/packages/in-app-messaging/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/in-app-messaging"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/in-app-messaging"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/installations"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/installations"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -32,7 +32,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/messaging"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/messaging"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/ml/package.json
+++ b/packages/ml/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/ml"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/ml"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -32,7 +32,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/perf"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/perf"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/phone-number-verification/package.json
+++ b/packages/phone-number-verification/package.json
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/phone-number-verification"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/phone-number-verification"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/remote-config"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/remote-config"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -30,7 +30,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/storage"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/storage"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/packages/vertexai/package.json
+++ b/packages/vertexai/package.json
@@ -13,7 +13,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/vertexai"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/vertexai"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/_TEMPLATE_/package.json
+++ b/scripts/_TEMPLATE_/package.json
@@ -12,7 +12,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/invertase/react-native-firebase/tree/main/packages/_template_"
+    "url": "https://github.com/invertase/react-native-firebase",
+    "directory": "packages/_template_"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/tart/manifests/golden-expected.json
+++ b/scripts/tart/manifests/golden-expected.json
@@ -2,7 +2,7 @@
   "description": "Expected toolchain pins for rnfb-ios-e2e-golden. Update when CI macos-26 / tests_e2e_ios.yml changes.",
   "tart_seed_image": "ghcr.io/cirruslabs/macos-tahoe-xcode:26.5",
   "xcode_version": "26.5",
-  "node_major": 22,
+  "node_major": 24,
   "java_distribution": "temurin",
   "java_version": "21",
   "ruby_version": 3,


### PR DESCRIPTION
## Summary
- Pin GitHub Actions (and related engines/Tart expected) to Node.js 24 LTS so CI and publish run on the same runtime.
- Restore tokenless npm Trusted Publisher (OIDC): drop NODE_AUTH_TOKEN, keep id-token write plus npm@latest, disable setup-node package-manager cache.
- Rewrite published package repository fields to clone URL plus directory so provenance/Trusted Publisher matching succeeds (npm RFC 0010). tree/main package URLs do not match the GitHub repo.

Stacked layer 1 of 2. Merge this PR only. Do not merge a later pod-lockfile layer until a real tokenless Publish on main succeeds.

Fixes CPRN-331

### Related issues

Fixes CPRN-331

### Release Summary

Restore tokenless npm OIDC trusted publishing and fix monorepo repository metadata for provenance.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [x] `Other` (CI / npm publish)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- [x] Local Node v24.13.0: yarn, yarn lerna:prepare, yarn tsc:compile, yarn tsc:compile:consumer, yarn lint, yarn tests:jest --watchman=false (89 suites / 1337 tests) on both commits frozen trees
- [x] Grep: no leftover setup-node 22 / lts/*; no NODE_AUTH_TOKEN / NPM_TOKEN in publish.yml; no /tree/main repository URLs on the 19 packages plus template
- [ ] After merge: npmjs.com Trusted Publisher row for all 19 packages, then Actions → Publish on main (only real OIDC test)
