### PR TITLE
test(security): batch of security improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for critical paths. GitHub requests review from these people when
+# a PR touches a matching file. Owners must have write access on this repo.
+#
+# Org team @invertase/react-native already has maintain here, but it is a
+# *secret* team — GitHub ignores secret teams in CODEOWNERS. Visible team
+# @invertase/invertase is not granted on this repository. Use the maintainers
+# who actually merge (recent history) plus the project owner in CONTRIBUTING.md.
+#
+# Intentionally no catch-all `*` — docs typos and other non-critical files do
+# not require a code-owner review unless they live under a path below.
+
+# Protect this file so owners cannot be swapped without a maintainer review.
+/.github/CODEOWNERS @mikehardy @Ehesp @russellwheatley
+
+# CI, tests, docs deploy, and release/publish workflows.
+/.github/workflows/ @mikehardy @Ehesp @russellwheatley
+
+# Published packages (JS, native, and package metadata).
+/packages/ @mikehardy @Ehesp @russellwheatley

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/invertase/react-native-firebase/security/policy
+    about: Do not file a public issue. Use private reporting or email as described in SECURITY.md.
   - name: Feature Request
     url: https://github.com/invertase/react-native-firebase/discussions/new?category_id=24212123
     about: Share ideas for new features.

--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -1,0 +1,18 @@
+---
+name: "Security vulnerability (do not file publicly)"
+about: Do not report vulnerabilities here. Use private reporting — see SECURITY.md.
+title: "[SECURITY] Do not file publicly — see SECURITY.md"
+labels: ''
+assignees: ''
+
+---
+
+**Do not file this issue.**
+
+Public GitHub issues are not the place to report security vulnerabilities, leaked secrets, or similar sensitive findings. Please close this form and report privately instead.
+
+1. Read **[SECURITY.md](https://github.com/invertase/react-native-firebase/blob/main/SECURITY.md)**.
+2. Prefer **GitHub private vulnerability reporting**: [open a private advisory](https://github.com/invertase/react-native-firebase/security/advisories/new) (once enabled on this repository).
+3. Or email `oss@invertase.io`.
+
+If you were going to report a **non-security** bug, use the Bug/Issue report template instead.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,14 @@ updates:
       semver-patch-days: 7
     labels:
       - 'dependencies'
+    # Batch noisy minor/patch bumps; keep majors as individual PRs for review.
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
 
   - package-ecosystem: 'github-actions'
     # Workflow files stored in the
@@ -27,6 +35,11 @@ updates:
       default-days: 7
     labels:
       - 'dependencies'
+    # Actions bumps are high-volume and usually compatible; one PR per interval.
+    groups:
+      github-actions:
+        patterns:
+          - '*'
 
   # iOS Ruby SimpleCov gems (packages/app/__tests__/Gemfile + Gemfile.lock)
   - package-ecosystem: 'bundler'
@@ -40,3 +53,11 @@ updates:
       semver-patch-days: 7
     labels:
       - 'dependencies'
+    # Test-only Gemfile; batch minor/patch, leave majors ungrouped.
+    groups:
+      bundler-minor-and-patch:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
+      - release-v*
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # javascript-typescript only. java-kotlin is omitted: packages/*/android are
+        # RN library modules, not a standalone Gradle app, so CodeQL autobuild is
+        # unreliable here. Do not add a custom Gradle build for this workflow.
+        language: [javascript-typescript]
+    steps:
+      # https://github.com/actions/checkout/releases
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      # https://github.com/github/codeql-action/releases
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      # https://github.com/github/codeql-action/releases
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -67,6 +67,18 @@ jobs:
           retry_wait_seconds: 30
           max_attempts: 3
           command: yarn
+      # Yarn 4 workspace audit. Recursive/full (`-R`) currently fails on known
+      # transitive advisories in lockfile (dev/test tooling). `--severity critical`
+      # is a real gate: the job fails if any workspace has a critical finding on
+      # a direct dependency (`--all` covers every workspace).
+      - name: Yarn npm audit
+        # https://github.com/nick-fields/retry/releases
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 5
+          retry_wait_seconds: 10
+          max_attempts: 3
+          command: yarn npm audit --all --severity critical
       - name: Lint
         # https://github.com/nick-fields/retry/releases
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+name: Scorecard
+
+on:
+  # Branch-Protection check (default branch only).
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  schedule:
+    # Weekly: keep the Maintained check current.
+    - cron: '30 1 * * 6'
+  push:
+    branches:
+      - main
+
+# Least privilege at workflow scope. Publish-results forbids workflow-level write.
+# Do not add top-level env or defaults (scorecard-action publish_results restriction).
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # SARIF upload to GitHub code scanning
+      security-events: write
+      # OIDC for publish_results (public API / badge)
+      id-token: write
+    steps:
+      # https://github.com/actions/checkout/releases
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # https://github.com/ossf/scorecard-action/releases
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Public repo: publish to OpenSSF API (also required for the badge).
+          # pull_request is experimental in scorecard-action and is omitted.
+          publish_results: true
+
+      # https://github.com/actions/upload-artifact/releases
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # https://github.com/github/codeql-action/releases
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,51 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - main
+      - release-v*
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      GITLEAKS_VERSION: '8.30.1'
+      # GitHub release asset digest for gitleaks_8.30.1_linux_x64.tar.gz
+      # https://github.com/gitleaks/gitleaks/releases/tag/v8.30.1
+      GITLEAKS_TARBALL_SHA256: '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb'
+    steps:
+      # https://github.com/actions/checkout/releases
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL -o "${archive}" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}"
+          echo "${GITLEAKS_TARBALL_SHA256}  ${archive}" | sha256sum -c -
+          mkdir -p "${HOME}/.local/bin"
+          tar -xzf "${archive}" -C "${HOME}/.local/bin" gitleaks
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+      - name: Run gitleaks
+        run: >
+          gitleaks detect
+          --source .
+          --no-git
+          --redact
+          --verbose
+          --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,32 @@
+# Extend default rules. Allowlists are limited to known public fixtures /
+# documentation examples so the CI gate still fails on new secrets.
+title = "react-native-firebase"
+
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Public Firebase demo and docs-example GCP API keys (not production secrets)"
+regexes = [
+  '''AIzaSyAHAsf51D0A407EklG1bs-5wA7EbyfNFg0''',
+  '''AIzaSyCuu4tbv9CwwTudNOweMNstzZHIDBhgJxA''',
+  '''AIzaSyDdVgKwhZl0sTTTLZ7iTmt1r3N2cJLnaDk''',
+]
+
+[[allowlists]]
+description = "High-entropy binary media fixtures for Vertex AI local tests"
+paths = [
+  '''tests/local-tests/vertexai/base-64-media\.(js|ts)$''',
+]
+
+[[allowlists]]
+description = "CocoaPods SPEC CHECKSUMS (pod-name: sha1) look like generic-api-key"
+paths = [
+  '''(^|/)Podfile\.lock$''',
+]
+
+[[allowlists]]
+description = "Public docs.page agent site key in docs.json (not a production secret)"
+regexes = [
+  '''6e277cd7-0065-4ade-a14a-3ecfa3f369a4''',
+]

--- a/.spellcheck.dict.txt
+++ b/.spellcheck.dict.txt
@@ -43,6 +43,7 @@ callables
 CarPlay
 CDN
 Changelog
+CHANGELOG
 changelogs
 checkForUpdate
 CLI

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+Thank you for helping keep React Native Firebase and its users safe.
+
+Please **do not** report security vulnerabilities, leaked secrets, or similar sensitive issues in public GitHub issues, discussions, or pull requests. Public reports can put users at risk before a fix is available.
+
+## Reporting a vulnerability
+
+Report privately using **either** of the following:
+
+1. **GitHub private vulnerability reporting** — open a private advisory from this repository’s [Security](https://github.com/invertase/react-native-firebase/security) tab ([privately report a vulnerability](https://github.com/invertase/react-native-firebase/security/advisories/new)). This is the preferred path once private vulnerability reporting is enabled on the repository.
+2. **Email** — send details to `oss@invertase.io` (the same Invertase OSS contact listed in [CONTRIBUTING.md](CONTRIBUTING.md) as `oss[at]invertase.io`).
+
+Include enough information for maintainers to reproduce and assess the issue (affected versions, environment, and steps or a proof of concept). Do not attach production secrets or personal data that are not required to demonstrate the vulnerability.
+
+## What to expect
+
+Maintainers will acknowledge private reports and work with you on a fix and coordinated disclosure where appropriate. Please do not disclose the issue publicly until we have confirmed a release or other mitigation.
+
+## Supported versions
+
+Security fixes are applied to the current major version published on npm. Older majors are not guaranteed to receive backports.
+
+## Scope
+
+This policy covers the React Native Firebase repository (`invertase/react-native-firebase`) and its published packages. Issues in upstream Firebase SDKs or other dependencies should be reported to those projects according to their own security policies.

--- a/docs/releases/index.mdx
+++ b/docs/releases/index.mdx
@@ -3,13 +3,21 @@ title: Release notes
 description: View the latest release notes for React Native Firebase
 ---
 
-Starting from version `10.0.0`, React Native Firebase packages share a single common version, with aggregated release notes available:
+## Current release — v26.3.1
 
-![hide:badge](https://img.shields.io/npm/v/@react-native-firebase/app.svg?style=for-the-badge&logo=npm) [View Release Notes &raquo;](https://github.com/invertase/react-native-firebase/tree/main/CHANGELOG.md)
+React Native Firebase packages share a single common version from `10.0.0` onward. The current published version is **`26.3.1`** (`@react-native-firebase/app`).
+
+Aggregated notes from version 10.0.0 onward (including current **v26**) are in the repository CHANGELOG — this site does not duplicate them as per-version MDX:
+
+![hide:badge](https://img.shields.io/npm/v/@react-native-firebase/app.svg?style=for-the-badge&logo=npm) [View CHANGELOG.md &raquo;](https://github.com/invertase/react-native-firebase/tree/main/CHANGELOG.md)
+
+A short current-version page is also available at [v26.3.1](/releases/v26.3.1).
 
 ---
 
-From version `v6.5.0` until `10.0.0`; all React Native Firebase packages were independently versioned with individually generated release notes:
+## Independently versioned packages (historical, v6.5.0 until 10.0.0)
+
+From version `v6.5.0` until `10.0.0`, React Native Firebase packages were independently versioned with individually generated release notes. Package changelogs on `main` remain available:
 
 | Package                |                                                                                                                      |                                                                                                                                   |
 | ---------------------- | :------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------: |
@@ -32,7 +40,9 @@ From version `v6.5.0` until `10.0.0`; all React Native Firebase packages were in
 
 ---
 
-To view release notes for versions prior to `v6.5.0` see the table below.
+## Pre-v6.5.0 MDX notes (historical)
+
+The table below is **historical** only (`v6.0.0`–`v6.4.0`). These pages are kept so existing links stay valid; they are not current releases.
 
 | Version |                                                |
 | ------- | :--------------------------------------------: |

--- a/docs/releases/v26.3.1.mdx
+++ b/docs/releases/v26.3.1.mdx
@@ -1,0 +1,14 @@
+---
+title: v26.3.1
+description: Current React Native Firebase release notes live in CHANGELOG.md.
+---
+
+# v26.3.1
+
+The current published version of `@react-native-firebase/app` (and the other aligned packages) is **`26.3.1`**.
+
+From version `10.0.0` onward, packages share a single common version. Full notes are in the repository CHANGELOG rather than duplicated here:
+
+[View CHANGELOG.md &raquo;](https://github.com/invertase/react-native-firebase/tree/main/CHANGELOG.md)
+
+For older independently versioned packages and pages from versions before `v6.5.0`, see [Release notes](/releases).


### PR DESCRIPTION
## Summary
- Closes repo-fixable OSS health dashboard gaps: SECURITY.md + disclosure template, CODEOWNERS, Dependabot grouping, yarn npm audit (critical), gitleaks, CodeQL (JS/TS), OpenSSF Scorecard Action, and current `docs/releases` stub for v26.3.1.
- Does **not** enable Dependabot security updates (OH3, GitHub UI) or required reviewers on Production environments (OH11). Org 2FA / default repo permission remain deferred (org admin).
- Re-run OSS health (OHV) after this lands on `main`; dashboard checks that need analyses on the default branch (CodeQL, Scorecard) will not turn green from the YAML alone until then.

## Test plan
- [ ] Confirm new workflows YAML-parse and SHA pins match tagged actions
- [ ] After merge: CodeQL + Scorecard + gitleaks jobs run on `main`
- [ ] Enable Dependabot security updates at repo Security settings (OH3)
- [ ] Optional: required reviewers on Production environments (OH11)
- [ ] Re-run OSS health pipeline and attach before/after (OHV)