### PR TITLE
fix(app): align iOS constants with generated spec

### DIFF
--- a/packages/app/__tests__/iosConstantsReturnTypeParity.test.ts
+++ b/packages/app/__tests__/iosConstantsReturnTypeParity.test.ts
@@ -1,0 +1,55 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+
+const APP_ROOT = path.resolve(__dirname, '..');
+const GENERATED_HEADER = path.join(
+  APP_ROOT,
+  'ios/generated/RNFBAppTurboModules/RNFBAppTurboModules.h',
+);
+
+function extractReturnType(content: string, methodName: string): string {
+  const match = content.match(
+    new RegExp(`-\\s*\\((facebook::react::ModuleConstants<[^)]+>)\\)\\s*${methodName}\\b`),
+  );
+  if (!match) {
+    throw new Error(`Could not find return type for ${methodName}`);
+  }
+  return match[1].replace(/\s+/g, '');
+}
+
+function extractGeneratedProtocol(header: string, moduleName: string): string {
+  const start = header.indexOf(`@protocol ${moduleName}Spec`);
+  const end = header.indexOf('\n@end', start);
+  if (start === -1 || end === -1) {
+    throw new Error(`Could not find generated protocol for ${moduleName}`);
+  }
+  return header.slice(start, end);
+}
+
+describe('iOS TurboModule constants return types', () => {
+  const generatedHeader = fs.readFileSync(GENERATED_HEADER, 'utf8');
+  const modules = [
+    {
+      moduleName: 'NativeRNFBTurboApp',
+      implementation: 'ios/RNFBApp/RNFBAppModule.mm',
+    },
+    {
+      moduleName: 'NativeRNFBTurboUtils',
+      implementation: 'ios/RNFBApp/RNFBUtilsModule.mm',
+    },
+  ];
+
+  for (const { moduleName, implementation } of modules) {
+    it(`${moduleName} matches its generated constants protocol`, () => {
+      const protocol = extractGeneratedProtocol(generatedHeader, moduleName);
+      const implementationSource = fs.readFileSync(path.join(APP_ROOT, implementation), 'utf8');
+
+      for (const methodName of ['constantsToExport', 'getConstants']) {
+        expect(extractReturnType(implementationSource, methodName)).toBe(
+          extractReturnType(protocol, methodName),
+        );
+      }
+    });
+  }
+});

--- a/packages/app/ios/RNFBApp/RNFBAppModule.mm
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.mm
@@ -102,11 +102,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboApp)
   return constants;
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants::Builder>)constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self appConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/app/ios/RNFBApp/RNFBUtilsModule.mm
+++ b/packages/app/ios/RNFBApp/RNFBUtilsModule.mm
@@ -69,12 +69,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboUtils)
   return [constants copy];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants::Builder>)
-    constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self utilsConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants>)getConstants {
   return [self constantsToExport];
 }
 


### PR DESCRIPTION
### Description

The generated New Architecture protocols declare `constantsToExport` and `getConstants` as `ModuleConstants<...::Constants>`, while `RNFBAppModule` and `RNFBUtilsModule` still implemented `ModuleConstants<...::Constants::Builder>`. Objective-C++ therefore sees incompatible method return types against the generated spec.

This aligns the four implementation signatures with the generated header without changing the constants dictionaries or runtime behavior. A Jest parity test now compares both implementations against their generated protocols so future codegen changes cannot silently drift.

### Related issues

Fixes #9212

### Release Summary

Fix iOS New Architecture build errors caused by mismatched TurboModule constants return types.

### Checklist

- I read the Contributor Guide and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [x] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- RED: the new parity test reported `Constants::Builder` from both implementations versus `Constants` from both generated protocols.
- `yarn tests:jest packages/app/__tests__ --runInBand` — 9 suites, 95 tests passed.
- `yarn tsc:compile`
- `yarn workspace @react-native-firebase/app compile`
- `yarn eslint packages/app/__tests__/iosConstantsReturnTypeParity.test.ts --max-warnings=0`
- `yarn prettier --check packages/app/__tests__/iosConstantsReturnTypeParity.test.ts`
- `yarn lint:ios:check`
- `yarn codegen:verify` — regenerated all configured Android/iOS artifacts with no drift.

:fire: