### PR TITLE
docs(okf): add missing concept frontmatter

### DIFF
--- a/okf-bundle/ci-workflows/android.md
+++ b/okf-bundle/ci-workflows/android.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Android CI workflows
+description: Android CI job structure, coverage handling, Detox failure modes, mitigations, and troubleshooting guidance.
+tags: [ci, android, detox, e2e, coverage, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Android CI workflows
 
 ## E2E job shape (CI — mirrors workflow YAML; local: [running e2e](../testing/running-e2e.md))

--- a/okf-bundle/ci-workflows/detox-patches.md
+++ b/okf-bundle/ci-workflows/detox-patches.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Detox yarn patches
+description: Inventory, rationale, diagnosis, and update procedures for the repository's Detox and related Yarn patches.
+tags: [ci, detox, yarn, patches, e2e, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Detox yarn patches
 
 E2E runs on **Detox 20.51.0** (`tests/package.json`), applied via Yarn Berry patch:

--- a/okf-bundle/ci-workflows/ios.md
+++ b/okf-bundle/ci-workflows/ios.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: iOS CI workflows
+description: iOS CI simulator reliability, instrumentation, Detox orchestration, failure triage, and pinned tooling guidance.
+tags: [ci, ios, detox, simulator, e2e, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # iOS CI workflows
 
 **Testing E2E iOS** workflow (`.github/workflows/tests_e2e_ios.yml`) and `.github/workflows/scripts/`.

--- a/okf-bundle/ci-workflows/other.md
+++ b/okf-bundle/ci-workflows/other.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Other CI workflows
+description: macOS and shared CI pipeline behavior, known failure modes, mitigations, and troubleshooting guidance.
+tags: [ci, macos, e2e, metro, jet, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Other CI workflows
 
 ## macOS e2e (`tests_e2e_other.yml`)

--- a/okf-bundle/monorepo-tooling/index.md
+++ b/okf-bundle/monorepo-tooling/index.md
@@ -1,11 +1,3 @@
----
-type: Reference
-title: Monorepo tooling
-description: Durable decisions and design for React Native Firebase monorepo build tooling — Nx local cache, prepare graph, declaration maps, dependency cycle linting, dev watch, and the ephemeral rollout queue.
-tags: [monorepo, tooling, nx, lerna, bob, build, work-queue]
-timestamp: 2026-07-10T00:00:00Z
----
-
 # Monorepo tooling
 
 Build-tooling decisions and design for the React Native Firebase monorepo: task orchestration, caching, package build graph, declaration maps, dependency-cycle linting, and developer watch/TDD ergonomics.

--- a/okf-bundle/packages/auth/compare-types-triage.md
+++ b/okf-bundle/packages/auth/compare-types-triage.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Auth modular API compare:types triage
+description: Durable classification of modular Auth type and runtime differences from the Firebase JavaScript SDK.
+tags: [auth, modular-api, types, compare-types, firebase-js-sdk, parity]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Auth modular API — compare:types triage
 
 Known differences between `@react-native-firebase/auth` and firebase-js-sdk modular Auth.


### PR DESCRIPTION
Adds required OKF frontmatter to five concept files so parsers can index them.

- Removes frontmatter from the monorepo tooling directory index to match the reserved index convention
- Leaves document bodies unchanged

Closes #9222

---
Maintainer note: Fixes internal CPRN-378