### PR TITLE
fix(ios): align TurboModule constants return type with generated spec

### DIFF
--- a/okf-bundle/ci-workflows/android.md
+++ b/okf-bundle/ci-workflows/android.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Android CI workflows
+description: Android CI job structure, coverage handling, Detox failure modes, mitigations, and troubleshooting guidance.
+tags: [ci, android, detox, e2e, coverage, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Android CI workflows
 
 ## E2E job shape (CI — mirrors workflow YAML; local: [running e2e](../testing/running-e2e.md))

--- a/okf-bundle/ci-workflows/detox-patches.md
+++ b/okf-bundle/ci-workflows/detox-patches.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Detox yarn patches
+description: Inventory, rationale, diagnosis, and update procedures for the repository's Detox and related Yarn patches.
+tags: [ci, detox, yarn, patches, e2e, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Detox yarn patches
 
 E2E runs on **Detox 20.51.0** (`tests/package.json`), applied via Yarn Berry patch:

--- a/okf-bundle/ci-workflows/ios.md
+++ b/okf-bundle/ci-workflows/ios.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: iOS CI workflows
+description: iOS CI simulator reliability, instrumentation, Detox orchestration, failure triage, and pinned tooling guidance.
+tags: [ci, ios, detox, simulator, e2e, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # iOS CI workflows
 
 **Testing E2E iOS** workflow (`.github/workflows/tests_e2e_ios.yml`) and `.github/workflows/scripts/`.

--- a/okf-bundle/ci-workflows/other.md
+++ b/okf-bundle/ci-workflows/other.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Other CI workflows
+description: macOS and shared CI pipeline behavior, known failure modes, mitigations, and troubleshooting guidance.
+tags: [ci, macos, e2e, metro, jet, troubleshooting]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Other CI workflows
 
 ## macOS e2e (`tests_e2e_other.yml`)

--- a/okf-bundle/monorepo-tooling/index.md
+++ b/okf-bundle/monorepo-tooling/index.md
@@ -1,11 +1,3 @@
----
-type: Reference
-title: Monorepo tooling
-description: Durable decisions and design for React Native Firebase monorepo build tooling — Nx local cache, prepare graph, declaration maps, dependency cycle linting, dev watch, and the ephemeral rollout queue.
-tags: [monorepo, tooling, nx, lerna, bob, build, work-queue]
-timestamp: 2026-07-10T00:00:00Z
----
-
 # Monorepo tooling
 
 Build-tooling decisions and design for the React Native Firebase monorepo: task orchestration, caching, package build graph, declaration maps, dependency-cycle linting, and developer watch/TDD ergonomics.

--- a/okf-bundle/packages/auth/compare-types-triage.md
+++ b/okf-bundle/packages/auth/compare-types-triage.md
@@ -1,3 +1,11 @@
+---
+type: Reference
+title: Auth modular API compare:types triage
+description: Durable classification of modular Auth type and runtime differences from the Firebase JavaScript SDK.
+tags: [auth, modular-api, types, compare-types, firebase-js-sdk, parity]
+timestamp: 2026-08-26T00:00:00Z
+---
+
 # Auth modular API — compare:types triage
 
 Known differences between `@react-native-firebase/auth` and firebase-js-sdk modular Auth.

--- a/packages/app/__tests__/iosTurboModuleConstantsReturnTypeParity.test.ts
+++ b/packages/app/__tests__/iosTurboModuleConstantsReturnTypeParity.test.ts
@@ -1,0 +1,128 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+
+// Guards against the class of bug in issue #9212: a package's committed codegen
+// output (`packages/*/ios/generated/**`, `includesGeneratedCode: true`) declares
+// `constantsToExport`/`getConstants` returning `ModuleConstants<Foo>`, but the
+// hand-written .mm implementation returns `ModuleConstants<Foo::Builder>` (or any
+// other stale return type) instead. Objective-C only warns on a return-type
+// mismatch against a conformed protocol (-Wmismatched-return-types) rather than
+// failing the build, so this drifts silently until something crashes or a user
+// hits a stricter compiler.
+//
+// This complements (does not replace) the `-Werror=mismatched-return-types` build
+// setting scoped to RNFB targets in tests/ios/Podfile, which is the durable,
+// build-level guardrail for this same failure mode across every current and
+// future TurboModule package. This test exists because it runs in the fast Jest
+// CI lane, with no Xcode build required, so drift is caught before a native build
+// is even attempted.
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+function extractReturnType(source: string, methodName: string): string {
+  const match = source.match(
+    new RegExp(`-\\s*\\((facebook::react::ModuleConstants<[^)]+>)\\)\\s*${methodName}\\b`),
+  );
+  if (!match) {
+    throw new Error(`Could not find a "${methodName}" return type in the given source`);
+  }
+  return match[1].replace(/\s+/g, '');
+}
+
+function extractGeneratedProtocol(header: string, moduleName: string): string {
+  const start = header.indexOf(`@protocol ${moduleName}Spec`);
+  const end = header.indexOf('\n@end', start);
+  if (start === -1 || end === -1) {
+    throw new Error(`Could not find the generated "${moduleName}Spec" protocol in the header`);
+  }
+  return header.slice(start, end);
+}
+
+// Every package whose iOS TurboModule implementation hand-writes
+// `constantsToExport`/`getConstants` against a committed, codegen-generated Spec
+// protocol. Add new entries here whenever a package gains a hand-written
+// constants-exporting TurboModule, do not assume codegen churn can't touch it.
+const constantsExportingModules = [
+  {
+    package: 'app',
+    moduleName: 'NativeRNFBTurboApp',
+    generatedHeader: 'app/ios/generated/RNFBAppTurboModules/RNFBAppTurboModules.h',
+    implementation: 'app/ios/RNFBApp/RNFBAppModule.mm',
+  },
+  {
+    package: 'app',
+    moduleName: 'NativeRNFBTurboUtils',
+    generatedHeader: 'app/ios/generated/RNFBAppTurboModules/RNFBAppTurboModules.h',
+    implementation: 'app/ios/RNFBApp/RNFBUtilsModule.mm',
+  },
+  {
+    package: 'auth',
+    moduleName: 'NativeRNFBTurboAuth',
+    generatedHeader: 'auth/ios/generated/RNFBAuthTurboModules/RNFBAuthTurboModules.h',
+    implementation: 'auth/ios/RNFBAuth/RNFBAuthModule.mm',
+  },
+  {
+    package: 'crashlytics',
+    moduleName: 'NativeRNFBTurboCrashlytics',
+    generatedHeader:
+      'crashlytics/ios/generated/RNFBCrashlyticsTurboModules/RNFBCrashlyticsTurboModules.h',
+    implementation: 'crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.mm',
+  },
+  {
+    package: 'in-app-messaging',
+    moduleName: 'NativeRNFBTurboFiam',
+    generatedHeader:
+      'in-app-messaging/ios/generated/RNFBInAppMessagingTurboModules/RNFBInAppMessagingTurboModules.h',
+    implementation: 'in-app-messaging/ios/RNFBFiam/RNFBFiamModule.mm',
+  },
+  {
+    package: 'messaging',
+    moduleName: 'NativeRNFBTurboMessaging',
+    generatedHeader:
+      'messaging/ios/generated/RNFBMessagingTurboModules/RNFBMessagingTurboModules.h',
+    implementation: 'messaging/ios/RNFBMessaging/RNFBMessagingModule.mm',
+  },
+  {
+    package: 'perf',
+    moduleName: 'NativeRNFBTurboPerf',
+    generatedHeader: 'perf/ios/generated/RNFBPerfTurboModules/RNFBPerfTurboModules.h',
+    implementation: 'perf/ios/RNFBPerf/RNFBPerfModule.mm',
+  },
+  {
+    package: 'remote-config',
+    moduleName: 'NativeRNFBTurboConfig',
+    generatedHeader:
+      'remote-config/ios/generated/RNFBRemoteConfigTurboModules/RNFBRemoteConfigTurboModules.h',
+    implementation: 'remote-config/ios/RNFBConfig/RNFBConfigModule.mm',
+  },
+  {
+    package: 'storage',
+    moduleName: 'NativeRNFBTurboStorage',
+    generatedHeader: 'storage/ios/generated/RNFBStorageTurboModules/RNFBStorageTurboModules.h',
+    implementation: 'storage/ios/RNFBStorage/RNFBStorageModule.mm',
+  },
+] as const;
+
+describe('iOS TurboModule constants return types match their generated Spec protocol', () => {
+  for (const {
+    package: pkg,
+    moduleName,
+    generatedHeader,
+    implementation,
+  } of constantsExportingModules) {
+    it(`${pkg}: ${moduleName} constantsToExport/getConstants match generated protocol`, () => {
+      const header = fs.readFileSync(path.join(REPO_ROOT, 'packages', generatedHeader), 'utf8');
+      const protocol = extractGeneratedProtocol(header, moduleName);
+      const implementationSource = fs.readFileSync(
+        path.join(REPO_ROOT, 'packages', implementation),
+        'utf8',
+      );
+
+      for (const methodName of ['constantsToExport', 'getConstants']) {
+        expect(extractReturnType(implementationSource, methodName)).toBe(
+          extractReturnType(protocol, methodName),
+        );
+      }
+    });
+  }
+});

--- a/packages/app/ios/RNFBApp/RNFBAppModule.mm
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.mm
@@ -102,11 +102,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboApp)
   return constants;
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants::Builder>)constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self appConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboApp::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/app/ios/RNFBApp/RNFBUtilsModule.mm
+++ b/packages/app/ios/RNFBApp/RNFBUtilsModule.mm
@@ -69,12 +69,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboUtils)
   return [constants copy];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants::Builder>)
-    constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self utilsConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboUtils::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/auth/ios/RNFBAuth/RNFBAuthModule.mm
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthModule.mm
@@ -577,12 +577,12 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAuth);
 #pragma mark -
 #pragma mark Constants
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboAuth::Constants::Builder>)constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboAuth::Constants>)constantsToExport {
   return
       [_RCTTypedModuleConstants newWithUnsafeDictionary:[RNFBAuthHelper authConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboAuth::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboAuth::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.mm
+++ b/packages/crashlytics/ios/RNFBCrashlytics/RNFBCrashlyticsModule.mm
@@ -65,13 +65,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboCrashlytics)
   return constants;
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboCrashlytics::Constants::Builder>)
-    constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboCrashlytics::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self crashlyticsConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboCrashlytics::Constants::Builder>)
-    getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboCrashlytics::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.mm
+++ b/packages/in-app-messaging/ios/RNFBFiam/RNFBFiamModule.mm
@@ -38,11 +38,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboFiam)
   return constants;
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboFiam::Constants::Builder>)constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboFiam::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self fiamConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboFiam::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboFiam::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
@@ -83,12 +83,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboMessaging)
   return constants;
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboMessaging::Constants::Builder>)
-    constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboMessaging::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self messagingConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboMessaging::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboMessaging::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/perf/ios/RNFBPerf/RNFBPerfModule.mm
+++ b/packages/perf/ios/RNFBPerf/RNFBPerfModule.mm
@@ -97,11 +97,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboPerf)
   return constants;
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboPerf::Constants::Builder>)constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboPerf::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants newWithUnsafeDictionary:[self perfConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboPerf::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboPerf::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
+++ b/packages/remote-config/ios/RNFBConfig/RNFBConfigModule.mm
@@ -38,13 +38,12 @@ RCT_EXPORT_MODULE(NativeRNFBTurboConfig)
   return std::make_shared<facebook::react::NativeRNFBTurboConfigSpecJSI>(params);
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboConfig::Constants::Builder>)
-    constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboConfig::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants
       newWithUnsafeDictionary:[RNFBConfigHelper getConstantsForAppName:DEFAULT_APP_DISPLAY_NAME]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboConfig::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboConfig::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/packages/storage/ios/RNFBStorage/RNFBStorageModule.mm
+++ b/packages/storage/ios/RNFBStorage/RNFBStorageModule.mm
@@ -239,13 +239,12 @@ RCT_EXPORT_MODULE(NativeRNFBTurboStorage);
 #pragma mark -
 #pragma mark Constants
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboStorage::Constants::Builder>)
-    constantsToExport {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboStorage::Constants>)constantsToExport {
   return [_RCTTypedModuleConstants
       newWithUnsafeDictionary:[RNFBStorageHelper storageConstantsDictionary]];
 }
 
-- (facebook::react::ModuleConstants<JS::NativeRNFBTurboStorage::Constants::Builder>)getConstants {
+- (facebook::react::ModuleConstants<JS::NativeRNFBTurboStorage::Constants>)getConstants {
   return [self constantsToExport];
 }
 

--- a/tests/ios/Podfile
+++ b/tests/ios/Podfile
@@ -159,10 +159,25 @@ target 'testing' do
     rnfb_link_profile = (linkage.to_s == 'dynamic')
     installer.pods_project.targets.each do |target|
       target.build_configurations.each do |config|
-        config.build_settings["GCC_WARN_INHIBIT_ALL_WARNINGS"] = "YES"
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = min_ios_version_supported
         if target.name.include?('RNFB')
           apply_ios_native_coverage.call(config.build_settings, link_profile: rnfb_link_profile)
+
+          # Keep warnings visible on our own targets (unlike third-party deps above) and
+          # escalate one specific diagnostic to a hard build error: an Objective-C/C++ method
+          # whose return type disagrees with the protocol it implements. Clang only warns on
+          # this by default (-Wmismatched-return-types), it does not fail the build, which is
+          # exactly how a committed TurboModule Spec header (packages/*/ios/generated/**)
+          # drifted out of sync with its hand-written .mm implementation and shipped for weeks
+          # unnoticed (issue #9212: constantsToExport/getConstants returned
+          # ModuleConstants<...::Builder> against a generated protocol declaring
+          # ModuleConstants<...>). Scoped to this one diagnostic, not a blanket -Werror, so
+          # unrelated warning noise elsewhere in RNFB code doesn't start failing CI.
+          config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'NO'
+          other_cflags = config.build_settings['OTHER_CFLAGS'] || '$(inherited)'
+          config.build_settings['OTHER_CFLAGS'] = "#{other_cflags} -Werror=mismatched-return-types"
+        else
+          config.build_settings['GCC_WARN_INHIBIT_ALL_WARNINGS'] = 'YES'
         end
       end
     end


### PR DESCRIPTION
Fixes the same class of bug across every package that hits it, not just `app`.

`RNFBAppModule`, `RNFBUtilsModule`, `RNFBAuthModule`, `RNFBCrashlyticsModule`, `RNFBFiamModule`, `RNFBMessagingModule`, `RNFBPerfModule`, `RNFBConfigModule`, and `RNFBStorageModule` all declared `constantsToExport`/`getConstants` returning `ModuleConstants<...::Builder>`, while their committed generated Spec protocols (`packages/*/ios/generated/**`) declare `ModuleConstants<...>` with no `::Builder`. The mismatch was introduced across all of them by `7d58b6c01` (the RN 0.86 bump), which regenerated the headers but didn't touch the hand-written implementations.

Objective-C only warns on a return-type mismatch against a conformed protocol (`-Wmismatched-return-types`), it doesn't fail the build, and `tests/ios/Podfile` was unconditionally silencing all warnings on every pod target including RNFB's own (undoing the RNFB-only exclusion three lines above it, both added in the same commit). That's why this landed in a release without CI ever flagging it.

- Aligns the 9 return types (8 packages, `app` has two modules) with their generated protocols
- Adds a cross-package Jest parity test comparing each `.mm` implementation's return type against its generated header, no Xcode build needed
- Fixes the Podfile so RNFB's own targets keep their warnings, and escalates `-Wmismatched-return-types` specifically to a hard build error there, so this class of drift fails CI automatically for any current or future TurboModule package

Issues/PRS:
- fixes #9212
- Related issue  #9212
- Supersedes #9220 (which fixed the same bug but only in `app`.)

---
Maintainer note: Fixes CPRN-380
