### PR TITLE
fix(messaging, ios): emit onMessage for foreground pushes with content-available: 0

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -122,7 +122,7 @@ struct {
     // Don't send an event if contentAvailable is true -
     // application:didReceiveRemoteNotification will send the event for us, we
     // don't want to duplicate them
-    if (!notificationDict[@"contentAvailable"]) {
+    if (![notificationDict[@"contentAvailable"] boolValue]) {
       [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_message_received"
                                                  body:notificationDict];
     }


### PR DESCRIPTION
### Description

On iOS, `onMessage` is never emitted for a foreground push whose payload sets
`aps.content-available: 0`. `willPresentNotification` guards emission on **key presence**
(`!notificationDict[@"contentAvailable"]`), but the serializer stores `@(NO)` for `0`, which is
non-nil — so the event is skipped as if it were a silent push. The comment above the guard
describes the intent in terms of the value ("if contentAvailable is true").

Compare the value instead:

```diff
-    if (!notificationDict[@"contentAvailable"]) {
+    if (![notificationDict[@"contentAvailable"] boolValue]) {
```

Genuine silent pushes (`content-available: 1`) are still skipped, preserving de-duplication
with `application:didReceiveRemoteNotification:`.

Full analysis, reproduction payloads and history in #9228.

### Related issues

Fixes #9228

### Release Summary

iOS: `onMessage` is now emitted for foreground pushes that explicitly set `content-available: 0`.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Manual on a physical iOS 26.5.1 device (`@react-native-firebase/messaging` 19.3.0), native
delegate streamed via `xcrun devicectl device process launch --console`.

- Before: `content-available: 0` payload reaches `willPresentNotification`, no
  `messaging_message_received` emitted, JS `onMessage` never called. Same payload without the
  key fires normally.
- After: the same payload fires `onMessage`; serialized message carries `"contentAvailable": false`.

No ObjC test harness exists for this delegate path; happy to add a payload-variant e2e case if
maintainers point at the preferred shape.
