### PR TITLE
fix(messaging, ios): run background task expiration cleanup

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -241,12 +241,12 @@
       // If app is in background state, register background task to guarantee async queues aren't
       // frozen.
       sharedInstance.backgroundTaskId = [application beginBackgroundTaskWithExpirationHandler:^{
-        dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
           if (sharedInstance.backgroundTaskId != UIBackgroundTaskInvalid) {
             [application endBackgroundTask:sharedInstance.backgroundTaskId];
             sharedInstance.backgroundTaskId = UIBackgroundTaskInvalid;
           }
-        };
+        });
       }];
 
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(25 * NSEC_PER_SEC)),


### PR DESCRIPTION
## Summary

- execute the iOS background-task expiration cleanup instead of discarding the cleanup block
- dispatch cleanup to the main queue, preserving serialized access to `backgroundTaskId`
- ensure an expired background task is ended and reset when JavaScript does not finish handling the message

The current expiration handler evaluates a comma expression whose block is never invoked, so iOS expiration can leave the task active until the process is suspended or terminated.

## Validation

- `yarn lint:ios:check`
- fresh `yarn tests:ios:pod:install`
- `yarn tests:ios:build`
- focused iOS app + messaging coverage: 69 passing, 23 pending
- full iOS coverage: 1,461 passing, 91 pending
- `yarn tests:android:unit`
- `yarn tests:android:build`
- focused Android app + messaging coverage: 86 passing, 6 pending
- full Android coverage: 1,485 passing, 66 pending
- fresh `yarn tests:macos:pod:install`
- `yarn tests:macos:build`
- full macOS coverage: 1,281 passing, 44 pending
- `git diff --check`

The native expiration callback is controlled by iOS and cannot be deterministically triggered by the current e2e harness; the complete native app suites provide regression coverage.

## Breaking changes

None.