### PR TITLE
fix(analytics): preserve omitted consent settings

### DIFF
--- a/packages/analytics/android/src/main/java/io/invertase/firebase/analytics/UniversalFirebaseAnalyticsModule.java
+++ b/packages/analytics/android/src/main/java/io/invertase/firebase/analytics/UniversalFirebaseAnalyticsModule.java
@@ -117,25 +117,27 @@ public class UniversalFirebaseAnalyticsModule extends UniversalFirebaseModule {
   Task<Void> setConsent(Bundle consentSettings) {
     return Tasks.call(
         () -> {
-          boolean analyticsStorage = consentSettings.getBoolean("analytics_storage");
-          boolean adStorage = consentSettings.getBoolean("ad_storage");
-          boolean adUserData = consentSettings.getBoolean("ad_user_data");
-          boolean adPersonalization = consentSettings.getBoolean("ad_personalization");
-
           Map<ConsentType, ConsentStatus> consentMap = new EnumMap<>(ConsentType.class);
-          consentMap.put(
-              ConsentType.ANALYTICS_STORAGE,
-              analyticsStorage ? ConsentStatus.GRANTED : ConsentStatus.DENIED);
-          consentMap.put(
-              ConsentType.AD_STORAGE, adStorage ? ConsentStatus.GRANTED : ConsentStatus.DENIED);
-          consentMap.put(
-              ConsentType.AD_USER_DATA, adUserData ? ConsentStatus.GRANTED : ConsentStatus.DENIED);
-          consentMap.put(
-              ConsentType.AD_PERSONALIZATION,
-              adPersonalization ? ConsentStatus.GRANTED : ConsentStatus.DENIED);
+          putConsent(
+              consentSettings, consentMap, "analytics_storage", ConsentType.ANALYTICS_STORAGE);
+          putConsent(consentSettings, consentMap, "ad_storage", ConsentType.AD_STORAGE);
+          putConsent(consentSettings, consentMap, "ad_user_data", ConsentType.AD_USER_DATA);
+          putConsent(
+              consentSettings, consentMap, "ad_personalization", ConsentType.AD_PERSONALIZATION);
 
           FirebaseAnalytics.getInstance(getContext()).setConsent(consentMap);
           return null;
         });
+  }
+
+  private static void putConsent(
+      Bundle consentSettings,
+      Map<ConsentType, ConsentStatus> consentMap,
+      String key,
+      ConsentType type) {
+    if (consentSettings.containsKey(key)) {
+      consentMap.put(
+          type, consentSettings.getBoolean(key) ? ConsentStatus.GRANTED : ConsentStatus.DENIED);
+    }
   }
 }

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.mm
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.mm
@@ -58,6 +58,15 @@ static NSArray<NSString *> *RNFBAnalyticsLongNumericParameterKeys(void) {
   return keys;
 }
 
+static void RNFBAnalyticsAddConsentStatus(NSMutableDictionary *consent,
+                                          NSDictionary *consentSettings, NSString *key,
+                                          FIRConsentType type) {
+  NSNumber *value = consentSettings[key];
+  if (value != nil) {
+    consent[type] = value.boolValue ? FIRConsentStatusGranted : FIRConsentStatusDenied;
+  }
+}
+
 @implementation RNFBAnalyticsModule
 #pragma mark -
 #pragma mark Module Setup
@@ -271,18 +280,15 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAnalytics)
            resolve:(RCTPromiseResolveBlock)resolve
             reject:(RCTPromiseRejectBlock)reject {
   @try {
-    BOOL analyticsStorage = [consentSettings[@"analytics_storage"] boolValue];
-    BOOL adStorage = [consentSettings[@"ad_storage"] boolValue];
-    BOOL adUserData = [consentSettings[@"ad_user_data"] boolValue];
-    BOOL adPersonalization = [consentSettings[@"ad_personalization"] boolValue];
-    [FIRAnalytics setConsent:@{
-      FIRConsentTypeAnalyticsStorage : analyticsStorage ? FIRConsentStatusGranted
-                                                        : FIRConsentStatusDenied,
-      FIRConsentTypeAdStorage : adStorage ? FIRConsentStatusGranted : FIRConsentStatusDenied,
-      FIRConsentTypeAdUserData : adUserData ? FIRConsentStatusGranted : FIRConsentStatusDenied,
-      FIRConsentTypeAdPersonalization : adPersonalization ? FIRConsentStatusGranted
-                                                          : FIRConsentStatusDenied,
-    }];
+    NSMutableDictionary *consent = [NSMutableDictionary dictionaryWithCapacity:4];
+    RNFBAnalyticsAddConsentStatus(consent, consentSettings, @"analytics_storage",
+                                  FIRConsentTypeAnalyticsStorage);
+    RNFBAnalyticsAddConsentStatus(consent, consentSettings, @"ad_storage", FIRConsentTypeAdStorage);
+    RNFBAnalyticsAddConsentStatus(consent, consentSettings, @"ad_user_data",
+                                  FIRConsentTypeAdUserData);
+    RNFBAnalyticsAddConsentStatus(consent, consentSettings, @"ad_personalization",
+                                  FIRConsentTypeAdPersonalization);
+    [FIRAnalytics setConsent:consent];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
   }

--- a/packages/analytics/lib/web/api.ts
+++ b/packages/analytics/lib/web/api.ts
@@ -254,7 +254,7 @@ class AnalyticsApi implements IAnalyticsApi {
         queryParams.append('ep.debug_mode', '1');
       }
 
-      if (this.consent && !this.consent.ad_personalization) {
+      if (this.consent.ad_personalization === false) {
         queryParams.append('npa', '1');
       } else {
         queryParams.append('npa', '0');


### PR DESCRIPTION
### Description

Fix partial Analytics consent updates so omitted consent types retain their previous status, matching the Firebase SDK contract.

- Android now adds only keys present in the React Native `Bundle`; missing booleans no longer default to `false`/denied.
- iOS now adds only keys present in the consent dictionary; messaging `nil` no longer becomes `false`/denied.
- Web now marks traffic non-personalized (`npa=1`) only after an explicit `ad_personalization: false`; an unset value keeps the default `npa=0`.

Firebase documents this behavior for both [Android `ConsentType`](https://firebase.google.com/docs/reference/kotlin/com/google/firebase/analytics/FirebaseAnalytics.ConsentType) and [Apple `FIRConsentType`](https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Type-Definitions): omitting a type retains its previous status.

### Breaking changes

No public API or type changes.

This is an observable behavior correction: a partial `setConsent` call no longer implicitly revokes every omitted consent type, and web events are no longer marked non-personalized unless personalization was explicitly denied.

### Related issues

No matching open issue found.

### Release Summary

Fixed Analytics partial consent updates incorrectly treating omitted settings as denied on Android, iOS, and web.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Analytics compile and Jest: 59/59 passing.
- Full JavaScript lint, dependency-cruiser validation, and TypeScript compile: passing.
- Android Java formatting, iOS formatting, and `git diff --check`: passing.
- Android native unit suite: passing.
- Fresh iOS/macOS pod installs and Android/iOS/macOS builds: passing.
- Focused app + Analytics E2E:
  - Android: 102 passing, 5 pending.
  - iOS: 102 passing, 5 pending.
  - macOS: 95 passing, 6 pending.
- Full E2E with coverage:
  - iOS: 1,461 passing, 91 pending; 413 coverage files.
  - macOS: 1,281 passing, 44 pending; 422 coverage files.
  - Android: 1,483 passing, 66 pending. Two unrelated phone-number-verification cases failed because the SIM-less emulator could not fetch verification-support information; all Analytics cases passed.
- Focused web request assertion confirmed `npa` values of `0`, `1`, and `0` for unset, explicitly denied, and explicitly granted personalization respectively.
