### PR TITLE
fix(analytics, ios): stop transaction scan after match

### DIFF
--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsLogTransaction.swift
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsLogTransaction.swift
@@ -51,12 +51,12 @@ import StoreKit
     }
 
     var foundTransaction: StoreKit.Transaction?
-    for await result in StoreKit.Transaction.all {
+    transactionSearch: for await result in StoreKit.Transaction.all {
       switch result {
       case let .verified(transaction):
         if transaction.id == id {
           foundTransaction = transaction
-          break
+          break transactionSearch
         }
       case .unverified:
         continue


### PR DESCRIPTION
### Description

Stop iterating `StoreKit.Transaction.all` as soon as the requested verified transaction is found.

The existing unlabeled `break` exits only the surrounding `switch`; it does not exit the `for await` loop. A successful lookup therefore continued scanning every remaining StoreKit transaction before logging the already-found match. The labeled loop exit preserves selection and error behavior while avoiding unnecessary asynchronous iteration for users with transaction history after the match.

### Breaking changes

None. Public APIs, types, transaction verification, logging, and not-found behavior are unchanged.

### Related issues

No matching open issue found.

### Release Summary

Stopped the iOS Analytics `logTransaction` lookup after finding its matching verified StoreKit transaction.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [x] `Other` (macOS compilation)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- iOS formatting check: passing.
- Analytics compile: passing.
- Fresh iOS pod install: passing.
- iOS simulator build: passing.
- macOS build: passing.
- Focused app + Analytics iOS E2E: 102 passing, 5 pending, including both `logTransaction` validation/not-found paths.
- `git diff --check`: passing.
