### PR TITLE
fix(analytics): validate hashed conversion inputs

### DIFF
--- a/packages/analytics/__tests__/analytics.test.ts
+++ b/packages/analytics/__tests__/analytics.test.ts
@@ -270,12 +270,96 @@ describe('Analytics', function () {
       );
     });
 
+    it('`initiateOnDeviceConversionMeasurementWithHashedPhoneNumber` throws if not a string before E.164', function () {
+      expect(() =>
+        // @ts-ignore
+        initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(getAnalytics(), true),
+      ).toThrow(
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a string value.",
+      );
+    });
+
     it('`initiateOnDeviceConversionMeasurementWithHashedPhoneNumber` should throw if the value is in E.164 format', function () {
       expect(() =>
         initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(getAnalytics(), '+1234567890'),
       ).toThrow(
-        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a sha256-hashed value of a phone number in E.164 format.",
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a 64-character SHA-256 hex string of a phone number in E.164 format, not an E.164 number.",
       );
+    });
+
+    describe('SHA-256 hex validation for hashed on-device conversion', function () {
+      const validLower = '0123456789abcdef'.repeat(4);
+      const validUpper = '0123456789ABCDEF'.repeat(4);
+      const empty = '';
+      const shortEven = validLower.slice(0, 32);
+      const oddLength = validLower.slice(0, 63);
+      const tooLong = `${validLower}aa`;
+      const nonHex = 'g'.repeat(64);
+
+      const hashedEmailHexError =
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedEmailAddress(*) 'hashedEmailAddress' expected a 64-character SHA-256 hex string.";
+      const hashedPhoneHexError =
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a 64-character SHA-256 hex string.";
+
+      it.each([
+        ['empty', empty],
+        ['short', shortEven],
+        ['odd-length', oddLength],
+        ['too long', tooLong],
+        ['non-hex', nonHex],
+      ])(
+        '`initiateOnDeviceConversionMeasurementWithHashedEmailAddress` rejects a %s value',
+        function (_label, hashedEmailAddress) {
+          expect(() =>
+            initiateOnDeviceConversionMeasurementWithHashedEmailAddress(
+              getAnalytics(),
+              hashedEmailAddress,
+            ),
+          ).toThrow(hashedEmailHexError);
+        },
+      );
+
+      it.each([
+        ['empty', empty],
+        ['short', shortEven],
+        ['odd-length', oddLength],
+        ['too long', tooLong],
+        ['non-hex', nonHex],
+      ])(
+        '`initiateOnDeviceConversionMeasurementWithHashedPhoneNumber` rejects a %s value',
+        function (_label, hashedPhoneNumber) {
+          expect(() =>
+            initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(
+              getAnalytics(),
+              hashedPhoneNumber,
+            ),
+          ).toThrow(hashedPhoneHexError);
+        },
+      );
+
+      it('`initiateOnDeviceConversionMeasurementWithHashedEmailAddress` accepts a lowercase 64-character hex string', async function () {
+        await expect(
+          initiateOnDeviceConversionMeasurementWithHashedEmailAddress(getAnalytics(), validLower),
+        ).resolves.toBeUndefined();
+      });
+
+      it('`initiateOnDeviceConversionMeasurementWithHashedEmailAddress` accepts an uppercase 64-character hex string', async function () {
+        await expect(
+          initiateOnDeviceConversionMeasurementWithHashedEmailAddress(getAnalytics(), validUpper),
+        ).resolves.toBeUndefined();
+      });
+
+      it('`initiateOnDeviceConversionMeasurementWithHashedPhoneNumber` accepts a lowercase 64-character hex string', async function () {
+        await expect(
+          initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(getAnalytics(), validLower),
+        ).resolves.toBeUndefined();
+      });
+
+      it('`initiateOnDeviceConversionMeasurementWithHashedPhoneNumber` accepts an uppercase 64-character hex string', async function () {
+        await expect(
+          initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(getAnalytics(), validUpper),
+        ).resolves.toBeUndefined();
+      });
     });
 
     it('`initiateOnDeviceConversionMeasurementWithPhoneNumber` function is properly exposed to end user', function () {

--- a/packages/analytics/e2e/analytics.e2e.js
+++ b/packages/analytics/e2e/analytics.e2e.js
@@ -593,6 +593,144 @@ describe('analytics()', function () {
       });
     });
 
+    describe('on-device conversion measurement with hashed credentials', function () {
+      const validLower = '0123456789abcdef'.repeat(4);
+      const validUpper = '0123456789ABCDEF'.repeat(4);
+      const empty = '';
+      const shortEven = validLower.slice(0, 32);
+      const oddLength = validLower.slice(0, 63);
+      const tooLong = `${validLower}aa`;
+      const nonHex = 'g'.repeat(64);
+
+      function expectHexContractError(error, apiLabel) {
+        const message = error + '';
+        if (!message.includes('64-character SHA-256 hex string')) {
+          fail(`Should have returned a hex-length error for ${apiLabel}: ${message}`);
+        }
+      }
+
+      [
+        ['empty', empty],
+        ['short', shortEven],
+        ['odd-length', oddLength],
+        ['too long', tooLong],
+        ['non-hex', nonHex],
+      ].forEach(function ([label, value]) {
+        it(`rejects a ${label} hashed email via JS validation`, async function () {
+          try {
+            const { getAnalytics, initiateOnDeviceConversionMeasurementWithHashedEmailAddress } =
+              analyticsModular;
+            await initiateOnDeviceConversionMeasurementWithHashedEmailAddress(
+              getAnalytics(),
+              value,
+            );
+            fail(`Should have returned an error for ${label} hashed email`);
+          } catch (e) {
+            expectHexContractError(e, `hashed email (${label})`);
+          }
+        });
+
+        it(`rejects a ${label} hashed phone via JS validation`, async function () {
+          try {
+            const { getAnalytics, initiateOnDeviceConversionMeasurementWithHashedPhoneNumber } =
+              analyticsModular;
+            await initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(getAnalytics(), value);
+            fail(`Should have returned an error for ${label} hashed phone`);
+          } catch (e) {
+            expectHexContractError(e, `hashed phone (${label})`);
+          }
+        });
+      });
+
+      it('rejects an E.164 phone number used as a hashed phone', async function () {
+        try {
+          const { getAnalytics, initiateOnDeviceConversionMeasurementWithHashedPhoneNumber } =
+            analyticsModular;
+          await initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(
+            getAnalytics(),
+            '+14155551212',
+          );
+          fail('Should have returned an error for an E.164 hashed phone');
+        } catch (e) {
+          const message = e + '';
+          if (!message.includes('64-character SHA-256 hex string') || !message.includes('E.164')) {
+            fail(`Should have returned an E.164 hashed-phone error: ${message}`);
+          }
+        }
+      });
+
+      it('accepts a lowercase 64-character hashed email (reaches native on iOS)', async function () {
+        const { getAnalytics, initiateOnDeviceConversionMeasurementWithHashedEmailAddress } =
+          analyticsModular;
+        await initiateOnDeviceConversionMeasurementWithHashedEmailAddress(
+          getAnalytics(),
+          validLower,
+        );
+      });
+
+      it('accepts an uppercase 64-character hashed email (reaches native on iOS)', async function () {
+        const { getAnalytics, initiateOnDeviceConversionMeasurementWithHashedEmailAddress } =
+          analyticsModular;
+        await initiateOnDeviceConversionMeasurementWithHashedEmailAddress(
+          getAnalytics(),
+          validUpper,
+        );
+      });
+
+      it('accepts a lowercase 64-character hashed phone (reaches native on iOS)', async function () {
+        const { getAnalytics, initiateOnDeviceConversionMeasurementWithHashedPhoneNumber } =
+          analyticsModular;
+        await initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(
+          getAnalytics(),
+          validLower,
+        );
+      });
+
+      it('accepts an uppercase 64-character hashed phone (reaches native on iOS)', async function () {
+        const { getAnalytics, initiateOnDeviceConversionMeasurementWithHashedPhoneNumber } =
+          analyticsModular;
+        await initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(
+          getAnalytics(),
+          validUpper,
+        );
+      });
+
+      // Bypass JS validation so iOS decoder reject paths actually execute.
+      [
+        ['empty', empty],
+        ['odd-length', oddLength],
+        ['non-hex', nonHex],
+      ].forEach(function ([label, value]) {
+        it(`iOS native decoder rejects a ${label} hashed email`, async function () {
+          if (!Platform.ios) {
+            this.skip();
+          }
+          try {
+            await NativeModules.NativeRNFBTurboAnalytics.initiateOnDeviceConversionMeasurementWithHashedEmailAddress(
+              value,
+            );
+            fail(`Native hashed email should have rejected ${label}`);
+          } catch (e) {
+            expectHexContractError(e, `native hashed email (${label})`);
+          }
+        });
+
+        it(`iOS native decoder rejects a ${label} hashed phone`, async function () {
+          if (!Platform.ios) {
+            this.skip();
+          }
+          try {
+            await NativeModules.NativeRNFBTurboAnalytics.initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(
+              value,
+            );
+            fail(`Native hashed phone should have rejected ${label}`);
+          } catch (e) {
+            expectHexContractError(e, `native hashed phone (${label})`);
+          }
+        });
+      });
+    });
+
     // Test this last so it does not stop delivery to DebugView
     describe('setAnalyticsCollectionEnabled()', function () {
       it('false', async function () {

--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.mm
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.mm
@@ -67,6 +67,37 @@ static void RNFBAnalyticsAddConsentStatus(NSMutableDictionary *consent,
   }
 }
 
+static int RNFBAnalyticsHexDigit(unichar character) {
+  if (character >= '0' && character <= '9') {
+    return character - '0';
+  }
+  if (character >= 'a' && character <= 'f') {
+    return character - 'a' + 10;
+  }
+  if (character >= 'A' && character <= 'F') {
+    return character - 'A' + 10;
+  }
+  return -1;
+}
+
+static NSData *RNFBAnalyticsDataFromSHA256HexString(NSString *hexString) {
+  if (hexString.length != 64) {
+    return nil;
+  }
+
+  unsigned char bytes[32];
+  for (NSUInteger i = 0; i < sizeof(bytes); i++) {
+    int high = RNFBAnalyticsHexDigit([hexString characterAtIndex:i * 2]);
+    int low = RNFBAnalyticsHexDigit([hexString characterAtIndex:i * 2 + 1]);
+    if (high < 0 || low < 0) {
+      return nil;
+    }
+    bytes[i] = (high << 4) | low;
+  }
+
+  return [NSData dataWithBytes:bytes length:sizeof(bytes)];
+}
+
 @implementation RNFBAnalyticsModule
 #pragma mark -
 #pragma mark Module Setup
@@ -233,7 +264,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAnalytics)
                                                             resolve:(RCTPromiseResolveBlock)resolve
                                                              reject:(RCTPromiseRejectBlock)reject {
   @try {
-    NSData *emailAddress = [self dataFromHexString:hashedEmailAddress];
+    NSData *emailAddress = RNFBAnalyticsDataFromSHA256HexString(hashedEmailAddress);
+    if (emailAddress == nil) {
+      reject(@"firebase_analytics", @"Expected a 64-character SHA-256 hex string", nil);
+      return;
+    }
     [FIRAnalytics initiateOnDeviceConversionMeasurementWithHashedEmailAddress:emailAddress];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
@@ -258,7 +293,11 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAnalytics)
                                                            resolve:(RCTPromiseResolveBlock)resolve
                                                             reject:(RCTPromiseRejectBlock)reject {
   @try {
-    NSData *phoneNumber = [self dataFromHexString:hashedPhoneNumber];
+    NSData *phoneNumber = RNFBAnalyticsDataFromSHA256HexString(hashedPhoneNumber);
+    if (phoneNumber == nil) {
+      reject(@"firebase_analytics", @"Expected a 64-character SHA-256 hex string", nil);
+      return;
+    }
     [FIRAnalytics initiateOnDeviceConversionMeasurementWithHashedPhoneNumber:phoneNumber];
   } @catch (NSException *exception) {
     return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
@@ -352,22 +391,6 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAnalytics)
 /// @param value Nullable string value
 - (NSString *)convertNSNullToNil:(NSString *)value {
   return [value isEqual:[NSNull null]] ? nil : value;
-}
-
-/// Converts a hex string to NSData
-/// @param hexString A hex string (e.g., SHA256 hash as 64-character hex string)
-/// @return NSData containing the decoded bytes (e.g., 32 bytes for SHA256)
-- (NSData *)dataFromHexString:(NSString *)hexString {
-  NSMutableData *data = [NSMutableData dataWithCapacity:hexString.length / 2];
-  unsigned char wholeByte;
-  char byteChars[3] = {'\0', '\0', '\0'};
-  for (NSUInteger i = 0; i < hexString.length; i += 2) {
-    byteChars[0] = [hexString characterAtIndex:i];
-    byteChars[1] = [hexString characterAtIndex:i + 1];
-    wholeByte = strtol(byteChars, NULL, 16);
-    [data appendBytes:&wholeByte length:1];
-  }
-  return data;
 }
 
 @end

--- a/packages/analytics/lib/index.ts
+++ b/packages/analytics/lib/index.ts
@@ -176,6 +176,7 @@ const ValidEventName = /^[a-zA-Z][a-zA-Z0-9_]{0,39}$/;
 const namespace = 'analytics';
 
 const nativeModuleName = 'NativeRNFBTurboAnalytics' as const;
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/i;
 
 class FirebaseAnalyticsModule extends FirebaseModule<typeof nativeModuleName> {
   logEvent(
@@ -882,6 +883,12 @@ class FirebaseAnalyticsModule extends FirebaseModule<typeof nativeModuleName> {
       );
     }
 
+    if (!SHA256_HEX_PATTERN.test(hashedEmailAddress)) {
+      throw new Error(
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedEmailAddress(*) 'hashedEmailAddress' expected a 64-character SHA-256 hex string.",
+      );
+    }
+
     if (!isIOS) {
       return Promise.resolve();
     }
@@ -922,6 +929,12 @@ class FirebaseAnalyticsModule extends FirebaseModule<typeof nativeModuleName> {
     if (!isString(hashedPhoneNumber)) {
       throw new Error(
         "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a string value.",
+      );
+    }
+
+    if (!SHA256_HEX_PATTERN.test(hashedPhoneNumber)) {
+      throw new Error(
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a 64-character SHA-256 hex string.",
       );
     }
 
@@ -1845,7 +1858,7 @@ export function initiateOnDeviceConversionMeasurementWithEmailAddress(
  * `logTransaction`, non-iOS platforms do not reject.
  *
  * @param analytics Analytics instance.
- * @param hashedEmailAddress sha256-hashed of normalized email address, properly formatted complete with domain name e.g, 'user@example.com'
+ * @param hashedEmailAddress SHA-256 hash of the normalized email address, encoded as a 64-character hex string.
  */
 export function initiateOnDeviceConversionMeasurementWithHashedEmailAddress(
   analytics: Analytics,
@@ -1882,7 +1895,7 @@ export function initiateOnDeviceConversionMeasurementWithPhoneNumber(
  * `logTransaction`, non-iOS platforms do not reject.
  *
  * @param analytics Analytics instance.
- * @param hashedPhoneNumber sha256-hashed of normalized phone number in E.164 format - that is a leading + sign, then up to 15 digits, no dashes or spaces.
+ * @param hashedPhoneNumber SHA-256 hash of the normalized E.164 phone number, encoded as a 64-character hex string.
  */
 export function initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(
   analytics: Analytics,

--- a/packages/analytics/lib/index.ts
+++ b/packages/analytics/lib/index.ts
@@ -920,15 +920,15 @@ class FirebaseAnalyticsModule extends FirebaseModule<typeof nativeModuleName> {
   initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(
     hashedPhoneNumber: string,
   ): Promise<void> {
-    if (isE164PhoneNumber(hashedPhoneNumber)) {
-      throw new Error(
-        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a sha256-hashed value of a phone number in E.164 format.",
-      );
-    }
-
     if (!isString(hashedPhoneNumber)) {
       throw new Error(
         "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a string value.",
+      );
+    }
+
+    if (isE164PhoneNumber(hashedPhoneNumber)) {
+      throw new Error(
+        "firebase.analytics().initiateOnDeviceConversionMeasurementWithHashedPhoneNumber(*) 'hashedPhoneNumber' expected a 64-character SHA-256 hex string of a phone number in E.164 format, not an E.164 number.",
       );
     }
 


### PR DESCRIPTION
### Description

Validate and safely decode the SHA-256 values passed to the hashed on-device conversion APIs.

React Native exposes the hashes as hex strings, while Firebase's Apple SDK requires the decoded 32-byte SHA-256 value. The previous decoder accepted any string, parsed non-hex pairs as lossy zero-like bytes, and indexed past the end of odd-length input. It could therefore pass malformed data to Firebase or raise an Objective-C exception.

This change:

- requires exactly 64 hexadecimal characters at the public JavaScript boundary;
- validates the same contract again at the native boundary;
- decodes directly into a bounded 32-byte buffer;
- documents the React Native hex-string representation.

Firebase's [on-device conversion guide](https://firebase.google.com/docs/tutorials/ads-ios-on-device-measurement/step-3#use-hashed-credentials) specifies that the SDK value must be a 32-byte SHA-256 digest rather than a hexadecimal string; this bridge decodes the validated 64-character representation before calling it.

### Breaking changes

No public API or type changes.

This is an observable input-validation correction: malformed, non-hex, or non-64-character hash strings now reject instead of being silently decoded into invalid bytes or triggering an out-of-bounds exception. Valid lowercase and uppercase SHA-256 hex strings are unchanged.

### Related issues

No matching open issue found.

### Release Summary

Validated and safely decoded hashed Analytics on-device conversion inputs on iOS.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android` (shared JavaScript validation/no-op contract)
  - [x] `iOS`
  - [x] `Other` (shared validation and macOS compilation)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Analytics compile and existing Jest suites: 59/59 passing.
- Focused temporary boundary control: 7/7 passing across valid lower/uppercase hashes, empty/short/long/odd/non-hex input; no test file is included in the patch.
- Full JavaScript lint, dependency-cruiser validation, and TypeScript compile: passing.
- iOS formatting and `git diff --check`: passing.
- Fresh iOS and macOS pod installs: passing.
- Android, iOS simulator, and macOS builds: passing.
- Android native unit suite: passing.
- Focused app + Analytics iOS E2E with valid hashed email and phone calls reaching native: 104 passing, 5 pending.
