### PR TITLE
fix(analytics, web): preserve read-only navigator state

### DIFF
--- a/packages/analytics/lib/web/api.ts
+++ b/packages/analytics/lib/web/api.ts
@@ -151,10 +151,13 @@ class AnalyticsApi implements IAnalyticsApi {
   }
 
   private async _getInstallationId(): Promise<void> {
-    // @ts-ignore
-    if (navigator !== null) {
-      // @ts-ignore
-      (navigator as any).onLine = true;
+    const navigatorObject = globalThis.navigator;
+    if (navigatorObject && !('onLine' in navigatorObject) && Object.isExtensible(navigatorObject)) {
+      Object.defineProperty(navigatorObject, 'onLine', {
+        configurable: true,
+        value: true,
+        writable: true,
+      });
     }
     makeIDBAvailable();
     const app = getApp(this.appName);


### PR DESCRIPTION
### Description

Preserve the browser-provided `navigator.onLine` property while initializing Firebase Installations for the Analytics web implementation.

`Navigator.onLine` is a getter-only browser API. The current strict-mode assignment throws a `TypeError` before `makeIDBAvailable()` and `getId()` run, so the constructor's non-critical error handler silently leaves Analytics without a Firebase Installation ID.

The bridge now:

- leaves an existing browser `onLine` property untouched;
- adds the historical `true` fallback only when a custom navigator object does not expose the property and is extensible;
- uses `globalThis.navigator` so environments without a navigator do not fail during identifier lookup.

### Breaking changes

None. Public APIs, types, event payloads, and connectivity state are unchanged. Browser Analytics can now retrieve its installation ID without attempting to mutate a read-only platform property.

### Related issues

No matching open issue found.

### Release Summary

Fixed web Analytics installation-ID initialization with the browser's read-only `navigator.onLine` property.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [x] `Other` (web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Exact temporary Jest control with a getter-only `navigator.onLine`: baseline fails with `TypeError`; fixed source reaches the mocked Firebase Installations `getId()` call and passes. The control file is not included in the patch.
- Analytics compile and existing Jest suites: 59/59 passing.
- Full JavaScript lint, dependency-cruiser validation, and TypeScript compile: passing.
- `git diff --check`: passing.
