### PR TITLE
fix(analytics, ios): serialize session completion

### DIFF
--- a/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.mm
+++ b/packages/analytics/ios/RNFBAnalytics/RNFBAnalyticsModule.mm
@@ -171,26 +171,28 @@ RCT_EXPORT_MODULE(NativeRNFBTurboAnalytics)
   });
 
   [FIRAnalytics sessionIDWithCompletion:^(int64_t sessionID, NSError *_Nullable error) {
-    if (completed) {
-      return;
-    }
-    completed = YES;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (completed) {
+        return;
+      }
+      completed = YES;
 
-    // Occasionally sessionID is 0 despite nil error, reject as if it were an error
-    // https://github.com/firebase/firebase-ios-sdk/issues/15258
-    if (!error && [NSNumber numberWithLongLong:sessionID] == 0) {
-      DLog(@"getSessionId zero_without_error: sessionID=0 (firebase-ios-sdk#15258)");
-      return resolve([NSNull null]);
-    }
+      // Occasionally sessionID is 0 despite nil error, reject as if it were an error
+      // https://github.com/firebase/firebase-ios-sdk/issues/15258
+      if (!error && [NSNumber numberWithLongLong:sessionID] == 0) {
+        DLog(@"getSessionId zero_without_error: sessionID=0 (firebase-ios-sdk#15258)");
+        return resolve([NSNull null]);
+      }
 
-    if (error) {
-      DLog(@"getSessionId sdk_error: domain=%@ code=%ld description=%@", error.domain,
-           (long)error.code, error.localizedDescription ?: @"(none)");
-      return resolve([NSNull null]);
-    }
+      if (error) {
+        DLog(@"getSessionId sdk_error: domain=%@ code=%ld description=%@", error.domain,
+             (long)error.code, error.localizedDescription ?: @"(none)");
+        return resolve([NSNull null]);
+      }
 
-    DLog(@"getSessionId success: sessionID=%lld", sessionID);
-    return resolve([NSNumber numberWithLongLong:sessionID]);
+      DLog(@"getSessionId success: sessionID=%lld", sessionID);
+      return resolve([NSNumber numberWithLongLong:sessionID]);
+    });
   }];
 }
 


### PR DESCRIPTION
### Description

Serialize the iOS Analytics session-ID completion path on the main queue.

Firebase documents that `sessionIDWithCompletion:` invokes its completion handler on a system-defined global concurrent queue, while this bridge's timeout already runs on the main queue. Both paths read and mutate the same `__block BOOL completed`, so they can race at the timeout boundary and resolve the React Native promise twice.

The Firebase callback now marshals its completion work to the main queue before checking or updating `completed`. This makes the timeout and SDK callback mutually ordered while preserving the existing timeout, `null`, error, and successful session-ID behavior.

Firebase reference: https://firebase.google.com/docs/reference/ios/firebaseanalytics/api/reference/Classes/FIRAnalytics

### Breaking changes

None. Public APIs, types, timeout behavior, and resolved values are unchanged. The fix only prevents a race between the SDK completion and timeout paths.

### Related issues

No matching open issue found.

### Release Summary

Fixed a race that could resolve iOS Analytics `getSessionId()` more than once at the timeout boundary.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- iOS Objective-C/Objective-C++ lint: passing.
- Fresh iOS and macOS pod installs: passing.
- iOS simulator build: passing.
- macOS build: passing.
- Focused App + Analytics iOS E2E: 102 passing, 5 pending.
- `git diff --check`: passing.

No test file is changed: the synchronization boundary is native implementation detail, while the existing `getSessionId()` E2E coverage verifies successful native behavior.
