### PR TITLE
fix(analytics, web): serialize queue processing

### DIFF
--- a/packages/analytics/lib/web/api.ts
+++ b/packages/analytics/lib/web/api.ts
@@ -58,12 +58,13 @@ class AnalyticsApi implements IAnalyticsApi {
   private userProperties: AnalyticsUserProperties;
   private consent: AnalyticsConsent;
   private analyticsCollectionEnabled: boolean;
-  private started: boolean;
+  private processingQueue: boolean;
   private installationId: string | null;
   private debug: boolean;
   private currentScreen: string | null;
   private sessionId?: number;
   private cid?: string | null;
+  private cidPromise?: Promise<string>;
 
   constructor(appName: string, measurementId: string) {
     this.appName = appName;
@@ -76,7 +77,7 @@ class AnalyticsApi implements IAnalyticsApi {
     this.userProperties = {};
     this.consent = {};
     this.analyticsCollectionEnabled = true;
-    this.started = false;
+    this.processingQueue = false;
     this.installationId = null;
     this.debug = false;
     this.currentScreen = null;
@@ -170,9 +171,8 @@ class AnalyticsApi implements IAnalyticsApi {
   }
 
   private _startQueueProcessing(): void {
-    if (this.started) return;
+    if (this.queueTimer !== null || this.eventQueue.length === 0) return;
     this.sessionId = Math.floor(Date.now() / 1000);
-    this.started = true;
     this.queueTimer = setInterval(
       () => this._processQueue().catch(console.error),
       this.queueInterval,
@@ -180,23 +180,39 @@ class AnalyticsApi implements IAnalyticsApi {
   }
 
   private _stopQueueProcessing(): void {
-    if (!this.started) return;
-    this.started = false;
-    if (this.queueTimer) {
+    if (this.queueTimer !== null) {
       clearInterval(this.queueTimer);
+      this.queueTimer = null;
     }
   }
 
   private async _processQueue(): Promise<void> {
-    if (this.eventQueue.length === 0) return;
-    const events = this.eventQueue.splice(0, 5);
-    await this._sendEvents(events);
-    if (this.eventQueue.length === 0) {
-      this._stopQueueProcessing();
+    if (this.processingQueue || this.eventQueue.length === 0) return;
+    this.processingQueue = true;
+    try {
+      const events = this.eventQueue.splice(0, 5);
+      await this._sendEvents(events);
+    } finally {
+      this.processingQueue = false;
+      if (this.eventQueue.length === 0) {
+        this._stopQueueProcessing();
+      }
     }
   }
 
   async _getCid(): Promise<string> {
+    if (this.cid) {
+      return this.cid;
+    }
+    if (!this.cidPromise) {
+      this.cidPromise = this._loadOrCreateCid().finally(() => {
+        this.cidPromise = undefined;
+      });
+    }
+    return this.cidPromise;
+  }
+
+  private async _loadOrCreateCid(): Promise<string> {
     this.cid = await getItem('analytics:cid');
     if (this.cid) {
       return this.cid;


### PR DESCRIPTION
### Description

Serialize web Analytics queue drains and client-ID initialization.

The queue currently uses a 250 ms interval without tracking an in-flight drain. When client-ID storage or an Analytics request takes longer than that interval, later batches are removed and sent concurrently. This can reorder events, and the initial concurrent batches can independently read/create different client IDs.

This change:

- permits only one queue drain at a time, preserving batch order;
- shares one in-flight client-ID load/create promise across callers;
- uses the cached client ID after initialization;
- derives queue-running state from the timer itself and clears its reference on stop;
- avoids creating a permanent idle interval when collection is enabled with no queued events.

### Breaking changes

None. Public APIs, types, batching size, 250 ms cadence, payloads, and fire-and-forget behavior are unchanged. Event batches are now sent in queue order with one stable client ID.

### Related issues

No matching open issue found.

### Release Summary

Fixed overlapping web Analytics queue processing and concurrent client-ID initialization.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [x] `Other` (web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Exact temporary fake-timer controls: baseline starts two drains while the first remains pending, performs two concurrent client-ID reads, and retains one idle interval; the fixed source reports one drain, one client-ID read, and zero idle timers. All three controls pass after the fix and were removed before commit.
- Analytics compile: passing.
- Existing Analytics Jest suites: 59/59 passing.
- Full JavaScript lint, dependency-cruiser validation, and TypeScript compile: passing.
- `git diff --check`: passing.
