### PR TITLE
fix(analytics, web): preserve session lifetime

### DIFF
--- a/packages/analytics/lib/web/api.ts
+++ b/packages/analytics/lib/web/api.ts
@@ -45,7 +45,10 @@ function generateGAClientId(): string {
 interface AnalyticsEvent {
   name: string;
   params: AnalyticsEventParameters;
+  sessionId: number;
 }
+
+const DEFAULT_SESSION_TIMEOUT_MS = 1_800_000;
 
 class AnalyticsApi implements IAnalyticsApi {
   public readonly appName: string;
@@ -63,6 +66,7 @@ class AnalyticsApi implements IAnalyticsApi {
   private debug: boolean;
   private currentScreen: string | null;
   private sessionId?: number;
+  private lastEventTime?: number;
   private cid?: string | null;
   private cidPromise?: Promise<string>;
 
@@ -144,9 +148,19 @@ class AnalyticsApi implements IAnalyticsApi {
 
   logEvent(eventName: string, eventParams: AnalyticsEventParameters = {}): void {
     if (!this.analyticsCollectionEnabled) return;
+    const eventTime = Date.now();
+    if (
+      this.sessionId === undefined ||
+      this.lastEventTime === undefined ||
+      eventTime - this.lastEventTime >= DEFAULT_SESSION_TIMEOUT_MS
+    ) {
+      this.sessionId = Math.floor(eventTime / 1000);
+    }
+    this.lastEventTime = eventTime;
     this.eventQueue.push({
       name: eventName,
       params: { ...this.defaultEventParameters, ...eventParams },
+      sessionId: this.sessionId,
     });
     this._startQueueProcessing();
   }
@@ -175,7 +189,6 @@ class AnalyticsApi implements IAnalyticsApi {
 
   private _startQueueProcessing(): void {
     if (this.queueTimer !== null || this.eventQueue.length === 0) return;
-    this.sessionId = Math.floor(Date.now() / 1000);
     this.queueTimer = setInterval(
       () => this._processQueue().catch(console.error),
       this.queueInterval,
@@ -254,7 +267,7 @@ class AnalyticsApi implements IAnalyticsApi {
         en: event.name,
         cid,
         pscdl: 'noapi',
-        sid: String(this.sessionId),
+        sid: String(event.sessionId),
         'ep.origin': 'firebase',
         _z: 'fetch',
         _p: '' + Date.now(),


### PR DESCRIPTION
### Description

Preserve a web Analytics session across queue runs until the documented 30-minute inactivity timeout.

The current implementation creates `sessionId` whenever queue processing starts and clears the timer whenever the queue drains. As a result, two events more than 250 ms apart receive different session IDs even when the user remains active, inflating session counts and breaking session attribution.

The bridge now derives the session from event activity:

- consecutive events retain the current session ID;
- 30 minutes of inactivity starts a new session, matching Google Analytics' default;
- each queued event captures its session ID when logged, so delayed network processing cannot relabel an older event.

Google Analytics session behavior: https://support.google.com/analytics/answer/12798876

Firebase Analytics default timeout: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics#setSessionTimeoutDuration(long)

### Breaking changes

None. Public APIs, types, payload format, and queue timing are unchanged.

Observable reporting correction: events logged within one active 30-minute window now share a session instead of creating a new session whenever the 250 ms queue drains. Session totals and attribution may therefore become more accurate and lower than the previously inflated web values.

### Related issues

No matching open issue found.

### Release Summary

Fixed web Analytics session IDs resetting whenever the event queue briefly drained.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [ ] `iOS`
  - [x] `Other` (web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Exact temporary fake-clock/fetch control: baseline emits different `sid` values for events one second apart; the fixed source keeps them equal and rotates `sid` after exactly 30 minutes of inactivity. The control was removed before commit.
- Analytics compile: passing.
- Existing Analytics Jest suites: 59/59 passing.
- Full JavaScript lint, dependency-cruiser validation, and TypeScript compile: passing.
- `git diff --check`: passing.
