### PR TITLE
fix(analytics): enforce documented input limits

### DIFF
--- a/packages/analytics/lib/index.ts
+++ b/packages/analytics/lib/index.ts
@@ -18,10 +18,10 @@
 import type { FirebaseApp } from '@react-native-firebase/app';
 import { Platform } from 'react-native';
 import {
-  isAlphaNumericUnderscore,
   isE164PhoneNumber,
   isIOS,
   isBoolean,
+  isFinite,
   isNull,
   isNumber,
   isObject,
@@ -170,6 +170,9 @@ const ReservedEventNames: readonly string[] = [
   'user_engagement',
 ] as const;
 
+const ReservedEventNamePrefixes = ['firebase_', 'google_', 'ga_'] as const;
+const ValidEventName = /^[a-zA-Z][a-zA-Z0-9_]{0,39}$/;
+
 const namespace = 'analytics';
 
 const nativeModuleName = 'NativeRNFBTurboAnalytics' as const;
@@ -189,16 +192,22 @@ class FirebaseAnalyticsModule extends FirebaseModule<typeof nativeModuleName> {
     }
 
     // check name is not a reserved event name
-    if (isOneOf(name, ReservedEventNames as any[])) {
+    if (ReservedEventNames.includes(name)) {
       throw new Error(
         `firebase.analytics().logEvent(*) 'name' the event name '${name}' is reserved and can not be used.`,
       );
     }
 
-    // name format validation
-    if (!isAlphaNumericUnderscore(name) || name.length > 40) {
+    if (ReservedEventNamePrefixes.some(prefix => name.startsWith(prefix))) {
       throw new Error(
-        `firebase.analytics().logEvent(*) 'name' invalid event name '${name}'. Names should contain 1 to 40 alphanumeric characters or underscores.`,
+        `firebase.analytics().logEvent(*) 'name' the event name '${name}' uses a reserved prefix and can not be used.`,
+      );
+    }
+
+    // name format validation
+    if (!ValidEventName.test(name)) {
+      throw new Error(
+        `firebase.analytics().logEvent(*) 'name' invalid event name '${name}'. Names must start with an alphabetic character and contain 1 to 40 alphanumeric characters or underscores.`,
       );
     }
 
@@ -231,6 +240,12 @@ class FirebaseAnalyticsModule extends FirebaseModule<typeof nativeModuleName> {
     if (!isNumber(milliseconds)) {
       throw new Error(
         "firebase.analytics().setSessionTimeoutDuration(*) 'milliseconds' expected a number value.",
+      );
+    }
+
+    if (!isFinite(milliseconds)) {
+      throw new Error(
+        "firebase.analytics().setSessionTimeoutDuration(*) 'milliseconds' expected a finite number value.",
       );
     }
 


### PR DESCRIPTION
### Description

Enforce Firebase Analytics' documented event-name and session-timeout constraints at the JavaScript boundary.

The existing event-name check allows names beginning with digits/underscores and names using the reserved `firebase_`, `google_`, and `ga_` prefixes. Firebase drops those events. The existing session-timeout check also treats `NaN` and infinities as valid numbers, allowing them to become invalid or misleading native durations.

This change:

- uses one exact event-name pattern requiring an alphabetic first character, 1–40 total alphanumeric/underscore characters;
- rejects all three documented reserved prefixes in addition to the existing reserved-name list;
- rejects non-finite session timeout values before they reach native code;
- removes the unnecessary mutable cast used to check the readonly reserved-name list.

Firebase event-name contract: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event

### Breaking changes

None for valid inputs. Public APIs and types are unchanged.

Observable validation correction: previously accepted invalid event names and non-finite timeout values now throw synchronously instead of being dropped by Firebase or converted into invalid native durations. Existing errors for non-number and negative timeout values are unchanged.

### Related issues

No matching open issue found.

### Release Summary

Validated Analytics event-name prefixes/first characters and finite session timeout durations.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [x] `Other`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Exact temporary public-API controls: baseline accepts names beginning with `1`/`_`, all three reserved prefixes, `NaN`, and both infinities; the fixed source rejects all eight cases with the intended validation errors. The controls were removed before commit.
- Analytics compile: passing.
- Existing Analytics Jest suites: 59/59 passing.
- Full JavaScript lint, dependency-cruiser validation, and TypeScript compile: passing.
- `git diff --check`: passing.
