### PR TITLE
fix(analytics, android): guard item conversion

### DIFF
--- a/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/NativeRNFBTurboAnalytics.java
+++ b/packages/analytics/android/src/reactnative/java/io/invertase/firebase/analytics/NativeRNFBTurboAnalytics.java
@@ -271,12 +271,13 @@ public class NativeRNFBTurboAnalytics extends NativeRNFBTurboAnalyticsSpec {
       return null;
     }
 
-    ArrayList itemsArray = (ArrayList) bundle.getSerializable(FirebaseAnalytics.Param.ITEMS);
-    if (itemsArray != null) {
+    Object itemsValue = bundle.get(FirebaseAnalytics.Param.ITEMS);
+    if (itemsValue instanceof ArrayList<?>) {
+      ArrayList<?> itemsArray = (ArrayList<?>) itemsValue;
       if (itemsArray.isEmpty()) {
         bundle.putParcelableArray(FirebaseAnalytics.Param.ITEMS, new Bundle[0]);
       } else {
-        ArrayList<Bundle> validBundles = new ArrayList<>();
+        ArrayList<Bundle> validBundles = new ArrayList<>(itemsArray.size());
         for (Object item : itemsArray) {
           if (item instanceof Bundle) {
             Bundle itemBundle = (Bundle) item;


### PR DESCRIPTION
### Description

Guard Android Analytics item conversion before treating the bridge value as an `ArrayList`.

`toBundle` currently calls deprecated `Bundle#getSerializable` and casts its result directly. Although the typed ecommerce APIs provide an item array, dynamic/custom event input can carry another serializable value under `items`; that raises `ClassCastException` synchronously before Firebase can handle or discard the invalid parameter.

The converter now:

- reads the value through `Bundle#get`;
- converts it only when it is actually an `ArrayList<?>`;
- uses a typed local instead of a raw collection;
- pre-sizes the converted `Bundle` list to the source item count.

Valid item arrays, empty-array conversion, numeric coercion, and filtering of non-Bundle array entries are unchanged.

### Breaking changes

None. Public APIs, types, and valid event payloads are unchanged. A non-array dynamic `items` value is now left for Firebase's normal validation instead of throwing a bridge `ClassCastException`.

### Related issues

No matching open issue found.

### Release Summary

Prevented Android Analytics item conversion from crashing on a non-array dynamic value.

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [ ] `iOS`
  - [ ] `Other`
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change. (No types are affected.)
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

- Exact temporary Robolectric test using the real `JavaOnlyMap -> Arguments.toBundle -> toBundle` bridge path: baseline fails with `ClassCastException` for `items: "invalid"`; the fixed source preserves the value without throwing. Temporary test/dependencies were removed before commit.
- Google Java Format: passing with JDK 21.
- Android native unit task: passing.
- Full Android debug app/test assembly and lint: passing.
- `git diff --check`: passing.
