### PR TITLE
fix(messaging, ios): preserve notification settings handler

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+UNUserNotificationCenter.m
@@ -178,13 +178,13 @@ struct {
   id<UNUserNotificationCenterDelegate> strongOriginalDelegate = _originalDelegate;
   if (strongOriginalDelegate != nil && originalDelegateRespondsTo.openSettingsForNotification) {
     [strongOriginalDelegate userNotificationCenter:center openSettingsForNotification:notification];
-  } else {
-    NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
-    [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_settings_for_notification_opened"
-                                               body:notificationDict];
-
-    _didOpenSettingsForNotification = YES;
   }
+
+  NSDictionary *notificationDict = [RNFBMessagingSerializer notificationToDict:notification];
+  [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_settings_for_notification_opened"
+                                             body:notificationDict];
+
+  _didOpenSettingsForNotification = YES;
 }
 
 @end


### PR DESCRIPTION
## Fix

When an application UNUserNotificationCenter delegate implements openSettingsForNotification, React Native Firebase now forwards the callback to that delegate and still emits its own messaging_settings_for_notification_opened event. Previously, forwarding used an either/or branch that silently disabled setOpenSettingsForNotificationsHandler and quit-state tracking.

## Breaking changes

None. This restores the documented React Native Firebase handler while preserving the application delegate callback.

## Verification

- Messaging ESLint passed
- Messaging Jest suite passed: 32 tests
- Full iOS debug test-app build passed after a fresh pod install
- Full macOS test-app build passed
- git diff --check passed