### PR TITLE
fix(messaging, android): preserve stored message integrity

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -6,7 +6,6 @@ import static io.invertase.firebase.messaging.ReactNativeFirebaseMessagingSerial
 import static io.invertase.firebase.messaging.ReactNativeFirebaseMessagingSerializer.remoteMessageToWritableMap;
 
 import android.util.Log;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.firebase.messaging.RemoteMessage;
 import io.invertase.firebase.common.ReactNativeFirebaseJSON;
@@ -92,8 +91,11 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
   @Deprecated
   @Override
   public RemoteMessage getFirebaseMessage(String remoteMessageId) {
-    ReadableMap messageMap = getFirebaseMessageMap(remoteMessageId);
+    WritableMap messageMap = getFirebaseMessageMap(remoteMessageId);
     if (messageMap != null) {
+      if (!messageMap.hasKey("to")) {
+        messageMap.putString("to", remoteMessageId);
+      }
       return remoteMessageFromReadableMap(messageMap);
     }
     return null;
@@ -106,7 +108,6 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
     if (remoteMessageString != null) {
       try {
         WritableMap remoteMessageMap = jsonToReact(new JSONObject(remoteMessageString));
-        remoteMessageMap.putString("to", remoteMessageId);
         return remoteMessageMap;
       } catch (JSONException e) {
         e.printStackTrace();
@@ -127,7 +128,13 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
   }
 
   private String removeRemoteMessageId(String remoteMessageId, String notificationIds) {
-    return notificationIds.replace(remoteMessageId + DELIMITER, "");
+    StringBuilder remainingIds = new StringBuilder(notificationIds.length());
+    for (String notificationId : convertToArray(notificationIds)) {
+      if (!notificationId.equals(remoteMessageId)) {
+        remainingIds.append(notificationId).append(DELIMITER);
+      }
+    }
+    return remainingIds.toString();
   }
 
   private List<String> convertToArray(String string) {


### PR DESCRIPTION
## Fixes and observable correction

- Restored notification maps now preserve their serialized `to` recipient instead of replacing it with the message ID.
- Clearing a notification now removes only the exact stored ID instead of every matching substring.

The deprecated API still receives the historical synthetic `to` fallback when a stored message has no recipient, so it can continue reconstructing a Firebase RemoteMessage.

## Breaking changes

No API or type changes. Apps that read `RemoteMessage.to` from an Android initial/opened notification will now receive the original Firebase recipient rather than the incorrect message ID. This is an observable correctness change for code that depended on the previous erroneous value.

## Why

The comma-delimited ID list previously used unrestricted String.replace. For IDs `123` and `23`, clearing `23` transformed `123,23,` into `1`, corrupting retention bookkeeping and leaving the `123` payload orphaned.

## Verification

- Exact temporary Robolectric control: baseline produced `1`; fixed source preserves `123,`
- All existing Android native unit checks passed
- Messaging Android assemble and lint passed with zero errors
- Full Android debug app/test assembly and lint passed: 1,749 tasks
- Messaging Jest suite passed: 32 tests
- Google Java Format and git diff --check passed

Temporary test scaffolding was removed before commit.