### PR TITLE
fix(messaging, android): preserve stored JSON values

### DIFF
--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/JsonConvert.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/JsonConvert.java
@@ -27,11 +27,7 @@ public abstract class JsonConvert {
           jsonObject.put(key, readableMap.getBoolean(key));
           break;
         case Number:
-          try {
-            jsonObject.put(key, readableMap.getInt(key));
-          } catch (Exception e) {
-            jsonObject.put(key, readableMap.getDouble(key));
-          }
+          jsonObject.put(key, readableMap.getDouble(key));
           break;
         case String:
           jsonObject.put(key, readableMap.getString(key));
@@ -60,11 +56,7 @@ public abstract class JsonConvert {
           jsonArray.put(readableArray.getBoolean(i));
           break;
         case Number:
-          try {
-            jsonArray.put(readableArray.getInt(i));
-          } catch (Exception e) {
-            jsonArray.put(readableArray.getDouble(i));
-          }
+          jsonArray.put(readableArray.getDouble(i));
           break;
         case String:
           jsonArray.put(readableArray.getString(i));
@@ -82,14 +74,14 @@ public abstract class JsonConvert {
 
   public static WritableMap jsonToReact(JSONObject jsonObject) throws JSONException {
     WritableMap writableMap = Arguments.createMap();
-    Iterator iterator = jsonObject.keys();
+    Iterator<String> iterator = jsonObject.keys();
     while (iterator.hasNext()) {
-      String key = (String) iterator.next();
+      String key = iterator.next();
       Object value = jsonObject.get(key);
-      if (value instanceof Float || value instanceof Double) {
-        writableMap.putDouble(key, jsonObject.getDouble(key));
+      if (value instanceof Boolean) {
+        writableMap.putBoolean(key, jsonObject.getBoolean(key));
       } else if (value instanceof Number) {
-        writableMap.putInt(key, jsonObject.getInt(key));
+        writableMap.putDouble(key, jsonObject.getDouble(key));
       } else if (value instanceof String) {
         writableMap.putString(key, jsonObject.getString(key));
       } else if (value instanceof JSONObject) {
@@ -108,10 +100,10 @@ public abstract class JsonConvert {
     WritableArray writableArray = Arguments.createArray();
     for (int i = 0; i < jsonArray.length(); i++) {
       Object value = jsonArray.get(i);
-      if (value instanceof Float || value instanceof Double) {
-        writableArray.pushDouble(jsonArray.getDouble(i));
+      if (value instanceof Boolean) {
+        writableArray.pushBoolean(jsonArray.getBoolean(i));
       } else if (value instanceof Number) {
-        writableArray.pushInt(jsonArray.getInt(i));
+        writableArray.pushDouble(jsonArray.getDouble(i));
       } else if (value instanceof String) {
         writableArray.pushString(jsonArray.getString(i));
       } else if (value instanceof JSONObject) {


### PR DESCRIPTION
## Fixes and observable correction

Android Messaging persistence now preserves numeric precision and restores JSON booleans in maps and arrays.

React Native exposes JS numbers as doubles. The previous serializer called getInt first, which deliberately truncates doubles and never throws on current React Native. Consequently a notification sentTime such as 1750000000000 was persisted as 2147483647. The reverse converter also narrowed parsed integral values to 32-bit and silently omitted booleans.

## Breaking changes

No API or type changes. Restored Android initial/opened notifications now expose the correct millisecond sentTime and any future/persisted boolean or fractional fields instead of truncated or missing values. Code that relied on the previous incorrect sentTime may observe a changed value.

## Verification

- Exact temporary map/array controls reproduced baseline truncation for 1.5 and 1750000000000
- Fixed controls preserve fractional and wide numbers in maps and arrays and restore nested true/false values
- Messaging Android assemble and lint passed with zero errors
- Full Android debug app/test assembly and lint passed: 1,749 tasks
- Messaging Jest suite passed: 32 tests
- Google Java Format and git diff --check passed

Temporary test dependencies and code were removed before commit.