### PR TITLE
fix(messaging): validate APNs token input

### DIFF
--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -252,6 +252,20 @@ describe('messaging()', function () {
         }
       });
 
+      it('requires a non-empty, even-length hexadecimal token on Apple platforms', function () {
+        const { getMessaging, setAPNSToken } = messagingModular;
+        if (!Platform.ios && !Platform.macos) {
+          this.skip();
+        }
+
+        for (const token of ['', '0', 'xyz', '001z']) {
+          (() => setAPNSToken(getMessaging(), token)).should.throw(
+            Error,
+            /'token' expected a non-empty, even-length hexadecimal string/,
+          );
+        }
+      });
+
       it('resolves on android', async function () {
         const { getMessaging, setAPNSToken } = messagingModular;
         if (Platform.android) {

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.mm
@@ -230,8 +230,19 @@ RCT_EXPORT_MODULE(NativeRNFBTurboMessaging)
     tokenType = FIRMessagingAPNSTokenTypeSandbox;
   }
 
-  [[FIRMessaging messaging] setAPNSToken:[RNFBMessagingSerializer APNSTokenDataFromNSString:token]
-                                    type:tokenType];
+  NSData *tokenData = [RNFBMessagingSerializer APNSTokenDataFromNSString:token];
+  if (tokenData == nil) {
+    [RNFBSharedUtils
+        rejectPromiseWithUserInfo:reject
+                         userInfo:[@{
+                           @"code" : @"invalid-apns-token",
+                           @"message" : @"APNs token must be a non-empty, even-length hexadecimal "
+                                        @"string."
+                         } mutableCopy]];
+    return;
+  }
+
+  [[FIRMessaging messaging] setAPNSToken:tokenData type:tokenType];
   resolve([NSNull null]);
 }
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.h
@@ -29,7 +29,7 @@
 
 @interface RNFBMessagingSerializer : NSObject
 
-+ (NSData *)APNSTokenDataFromNSString:(NSString *)token;
++ (nullable NSData *)APNSTokenDataFromNSString:(NSString *)token;
 
 + (NSString *)APNSTokenFromNSData:(NSData *)tokenData;
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -20,20 +20,27 @@
 
 @implementation RNFBMessagingSerializer
 
-+ (NSData *)APNSTokenDataFromNSString:(NSString *)token {
++ (nullable NSData *)APNSTokenDataFromNSString:(NSString *)token {
   NSString *string = [token lowercaseString];
-  NSMutableData *data = [NSMutableData new];
-  unsigned char whole_byte;
-  char byte_chars[3] = {'\0', '\0', '\0'};
-  NSUInteger i = 0;
   NSUInteger length = string.length;
-  while (i < length - 1) {
-    char c = [string characterAtIndex:i++];
-    if (c < '0' || (c > '9' && c < 'a') || c > 'f') continue;
-    byte_chars[0] = c;
-    byte_chars[1] = [string characterAtIndex:i++];
-    whole_byte = strtol(byte_chars, NULL, 16);
-    [data appendBytes:&whole_byte length:1];
+  if (length == 0 || length % 2 != 0) {
+    return nil;
+  }
+
+  NSMutableData *data = [NSMutableData dataWithLength:length / 2];
+  unsigned char *bytes = data.mutableBytes;
+  for (NSUInteger i = 0; i < length; i += 2) {
+    unichar highCharacter = [string characterAtIndex:i];
+    unichar lowCharacter = [string characterAtIndex:i + 1];
+    if ((highCharacter < '0' || (highCharacter > '9' && highCharacter < 'a') ||
+         highCharacter > 'f') ||
+        (lowCharacter < '0' || (lowCharacter > '9' && lowCharacter < 'a') || lowCharacter > 'f')) {
+      return nil;
+    }
+
+    unsigned char high = highCharacter <= '9' ? highCharacter - '0' : highCharacter - 'a' + 10;
+    unsigned char low = lowCharacter <= '9' ? lowCharacter - '0' : lowCharacter - 'a' + 10;
+    bytes[i / 2] = (high << 4) | low;
   }
   return data;
 }

--- a/packages/messaging/lib/index.ts
+++ b/packages/messaging/lib/index.ts
@@ -352,6 +352,12 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
       return Promise.resolve();
     }
 
+    if (token.length === 0 || token.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(token)) {
+      throw new Error(
+        "getMessaging().setAPNSToken(*) 'token' expected a non-empty, even-length hexadecimal string.",
+      );
+    }
+
     return this.native.setAPNSToken(token, type);
   }
 


### PR DESCRIPTION
## Observable behavior / breaking changes

- No public API or type changes.
- Invalid Apple APNs token strings now throw synchronously at the JavaScript boundary and reject at the native boundary instead of being silently mangled. An empty token previously reached an unsigned length underflow and could raise an Objective-C range exception.
- Android remains a documented no-op and continues accepting any string without crossing the native APNs path.

## What changed

- Require Apple APNs tokens to be non-empty, even-length hexadecimal strings without hard-coding a token byte length.
- Defend the Objective-C bridge independently for old bundles and direct native calls.
- Decode into one pre-sized data buffer instead of repeatedly appending bytes.
- Add focused Apple E2E coverage for empty, odd-length, and non-hex values.

## Verification

- Messaging ESLint and 32 Jest tests
- Messaging package compile, TypeScript, and dependency-cruiser
- Google clang-format and git diff --check
- Fresh iOS pod install and full iOS simulator build
- Focused iOS App + Messaging E2E: 70 passing, 23 platform-pending
- Full macOS build
- Full Android debug app/test assembly and lint: 1,749 tasks, zero Messaging lint errors

Environment-only CocoaPods checksum drift was restored before commit. No application dependency or lockfile changed.