### PR TITLE
fix(messaging): settle background notification work

### DIFF
--- a/packages/messaging/lib/index.ts
+++ b/packages/messaging/lib/index.ts
@@ -84,34 +84,36 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
       this.native.getConstants?.()?.isNotificationDelegationEnabled ?? false;
 
     AppRegistry.registerHeadlessTask('ReactNativeFirebaseMessagingHeadlessTask', () => {
-      if (!backgroundMessageHandler) {
+      const handler = backgroundMessageHandler;
+      if (!handler) {
         // eslint-disable-next-line no-console
         console.warn(
           'No background message handler has been set. Set a handler via the "setBackgroundMessageHandler" method.',
         );
         return () => Promise.resolve();
       }
-      return (remoteMessage: RemoteMessage) => backgroundMessageHandler!(remoteMessage);
+      return (remoteMessage: RemoteMessage) => Promise.resolve().then(() => handler(remoteMessage));
     });
 
     if (isIOS) {
       this.emitter.addListener(
         'messaging_message_received_background',
         (remoteMessage: RemoteMessage) => {
-          if (!backgroundMessageHandler) {
+          const handler = backgroundMessageHandler;
+          let handlerPromise: Promise<any>;
+          if (!handler) {
             // eslint-disable-next-line no-console
             console.warn(
               'No background message handler has been set. Set a handler via the "setBackgroundMessageHandler" method.',
             );
-            return Promise.resolve();
+            handlerPromise = Promise.resolve();
+          } else {
+            handlerPromise = Promise.resolve().then(() => handler(remoteMessage));
           }
 
-          const handlerPromise = Promise.resolve(backgroundMessageHandler(remoteMessage));
-          handlerPromise.finally(() => {
+          return handlerPromise.finally(() => {
             this.native.completeNotificationProcessing();
           });
-
-          return handlerPromise;
         },
       );
 


### PR DESCRIPTION
## Observable behavior / breaking changes

- No public API or type changes.
- A background handler that throws synchronously is now represented as the rejected Promise required by the handler contract instead of escaping before native completion cleanup.
- Apple notification processing is now completed even when no handler is present. Existing successful and rejected async handler results are preserved.

## What changed

- Start Android and Apple background handlers from a resolved Promise so synchronous throws follow the asynchronous task contract.
- Return the Apple `.finally()` chain itself, ensuring native completion is attached to the same observable Promise rather than creating a detached rejected Promise.
- Capture the selected handler before the microtask runs.
- Always call `completeNotificationProcessing` after an Apple background event, including the defensive no-handler path.

## Reproduction

An exact promise-semantics control showed that the previous code throws synchronously with zero cleanup calls and creates one detached unhandled rejection for an async failure. The new chain records one cleanup call for the synchronous failure while preserving its rejection.

## Verification

- Messaging ESLint and all 32 Jest tests
- Messaging package compile and TypeScript
- Dependency-cruiser and git diff --check
- Focused iOS App + Messaging E2E: 69 passing, 23 platform-pending
- Full Android debug app/test assembly and lint: 1,749 tasks, zero Messaging lint errors

No application dependency or lockfile changed.