### PR TITLE
fix(messaging, ios): normalize sent time

### DIFF
--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -72,6 +72,19 @@ describe('messaging()', function () {
     message.notification.should.eql({ ios: { sound: 'tone.aiff' } });
   });
 
+  it('serializes iOS sent times as epoch milliseconds', async function () {
+    if (!Platform.ios) {
+      this.skip();
+    }
+
+    const { getRNFBTesting } = require('../../app/e2e/helpers');
+    const message = await getRNFBTesting().serializeMessagingUserInfo({
+      'google.c.a.ts': '1522880044',
+    });
+
+    message.sentTime.should.equal(1522880044000);
+  });
+
   before(async function () {
     // our device registration tests require permissions. Set them up
     const { getMessaging, requestPermission } = messagingModular;

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -78,11 +78,28 @@ describe('messaging()', function () {
     }
 
     const { getRNFBTesting } = require('../../app/e2e/helpers');
-    const message = await getRNFBTesting().serializeMessagingUserInfo({
-      'google.c.a.ts': '1522880044',
-    });
+    for (const timestamp of ['1522880044', 1522880044]) {
+      const message = await getRNFBTesting().serializeMessagingUserInfo({
+        'google.c.a.ts': timestamp,
+      });
 
-    message.sentTime.should.equal(1522880044000);
+      message.sentTime.should.equal(1522880044000);
+    }
+  });
+
+  it('ignores malformed iOS sent times', async function () {
+    if (!Platform.ios) {
+      this.skip();
+    }
+
+    const { getRNFBTesting } = require('../../app/e2e/helpers');
+    for (const timestamp of ['', '-1', '1.5', '1522880044invalid']) {
+      const message = await getRNFBTesting().serializeMessagingUserInfo({
+        'google.c.a.ts': timestamp,
+      });
+
+      message.should.not.have.property('sentTime');
+    }
   });
 
   before(async function () {

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -17,6 +17,7 @@
 
 #import "RNFBMessagingSerializer.h"
 #import <React/RCTConvert.h>
+#include <limits.h>
 
 @implementation RNFBMessagingSerializer
 
@@ -95,7 +96,13 @@
 
     // message.sentTime
     if ([key isEqualToString:@"google.c.a.ts"]) {
-      message[@"sentTime"] = userInfo[key];
+      id timestamp = userInfo[key];
+      if ([timestamp respondsToSelector:@selector(longLongValue)]) {
+        long long sentTimeSeconds = [timestamp longLongValue];
+        if (sentTimeSeconds > 0 && sentTimeSeconds <= LLONG_MAX / 1000) {
+          message[@"sentTime"] = @(sentTimeSeconds * 1000);
+        }
+      }
       continue;
     }
 

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -97,8 +97,21 @@
     // message.sentTime
     if ([key isEqualToString:@"google.c.a.ts"]) {
       id timestamp = userInfo[key];
-      if ([timestamp respondsToSelector:@selector(longLongValue)]) {
-        long long sentTimeSeconds = [timestamp longLongValue];
+      NSString *timestampString = nil;
+      if ([timestamp isKindOfClass:[NSString class]]) {
+        timestampString = timestamp;
+      } else if ([timestamp isKindOfClass:[NSNumber class]]) {
+        timestampString = [timestamp stringValue];
+      }
+
+      BOOL isDecimalInteger = timestampString.length > 0;
+      for (NSUInteger i = 0; i < timestampString.length && isDecimalInteger; i++) {
+        unichar character = [timestampString characterAtIndex:i];
+        isDecimalInteger = character >= '0' && character <= '9';
+      }
+
+      if (isDecimalInteger) {
+        long long sentTimeSeconds = timestampString.longLongValue;
         if (sentTimeSeconds > 0 && sentTimeSeconds <= LLONG_MAX / 1000) {
           message[@"sentTime"] = @(sentTimeSeconds * 1000);
         }


### PR DESCRIPTION
## Fix

iOS now exposes `RemoteMessage.sentTime` as a numeric epoch-millisecond value, matching the public contract and Android behavior. FCM supplies `google.c.a.ts` as epoch seconds (commonly a string); the serializer now validates the numeric representation, converts seconds to milliseconds, and rejects non-positive or overflowing values.

A direct iOS native regression test exercises the serializer with the same timestamp shape used by the Firebase iOS SDK tests.

## Breaking behavior correction

On iOS, `sentTime` changes from a string containing epoch seconds (for example, `"1522880044"`) to a number containing epoch milliseconds (`1522880044000`). Consumers that parsed or compared the accidental string/seconds value must use the documented number/milliseconds contract. Android behavior is unchanged.

## Validation

- Reproduced on the previous implementation: the assertion received string `"1522880044"` instead of numeric `1522880044000`
- iOS App + Messaging E2E: 70 passing, 23 pending
- Android App + Messaging E2E: 86 passing, 7 pending
- Processed iOS LLVM coverage confirms every changed production line executed
- iOS test application build succeeded
- Android test application build and lint succeeded (0 errors)
- Messaging Jest suite: 32 passing
- `yarn lint:ios:check`
- `yarn lint:js`
- `git diff --check`