### PR TITLE
fix(messaging, android): support disabled notification storage

### DIFF
--- a/okf-bundle/packages/messaging/index.md
+++ b/okf-bundle/packages/messaging/index.md
@@ -5,7 +5,7 @@ Knowledge for FCM messaging native behavior, primarily the iOS `UNUserNotificati
 ## Documents
 
 * [iOS UNUserNotificationCenter delegate forwarding](ios-notification-delegate-forwarding.md) — `completionHandler` exactly-once contract, delegate chaining design, regression history (#8754 → #8786 → #9049 / #9050)
-* Native integration probes (`completesNonFCMRemoteNotification`, `messagingPreservesExistingDelegate`) — [running e2e § test-app native modules](../../testing/running-e2e.md#test-app-native-modules); product-line hits in `coverage/ios-native/lcov.info` — [coverage design § two test native modules](../../testing/coverage-design.md#test-native-modules)
+* Native integration probes (`completesNonFCMRemoteNotification`, `messagingPreservesExistingDelegate`, `messagingStoreSupportsDisabledStorage`) — [running e2e § test-app native modules](../../testing/running-e2e.md#test-app-native-modules); product-line hits in `coverage/ios-native/lcov.info` — [coverage design § two test native modules](../../testing/coverage-design.md#test-native-modules)
 * [iOS APNs registration on Simulator](ios-apns-simulator-registration.md) — intentional ARM64 Simulator skip of UIKit register + global-queue `registration-timeout`
 
 ## Related repository files

--- a/okf-bundle/testing/coverage-design.md
+++ b/okf-bundle/testing/coverage-design.md
@@ -383,7 +383,7 @@ The Detox host has **two** native modules. Do **not** conflate them.
 | **`RNFBTestingCoverage`** | Legacy `RCTBridgeModule` | **This doc.** Coverage flush only: `NativeModules.RNFBTestingCoverage.flush()` from Jet `after` in `tests/app.js`. |
 | **`NativeRNFBTesting`** | TurboModule | E2e **integration probes**, not flush — spec, native paths, JS accessor: [running e2e § test-app native modules](running-e2e.md#test-app-native-modules). |
 
-**Probe hits in native LCOV:** Messaging e2e `getRNFBTesting().completesNonFCMRemoteNotification()` and `getRNFBTesting().messagingPreservesExistingDelegate()` exercise product sources (for example `RNFBMessaging+AppDelegate.m` non-FCM `completionHandler`). After iOS `:test-cover` and `yarn tests:ios:test:process-coverage`, those lines appear as hits in `coverage/ios-native/lcov.info`. Record them in the [coverage evidence package](#coverage-evidence-package); passing probes are not a substitute for that LCOV.
+**Probe hits in native LCOV:** Messaging e2e `getRNFBTesting().completesNonFCMRemoteNotification()` and `getRNFBTesting().messagingPreservesExistingDelegate()` exercise product sources (for example `RNFBMessaging+AppDelegate.m` non-FCM `completionHandler`). Android e2e `getRNFBTesting().messagingStoreSupportsDisabledStorage()` exercises `ReactNativeFirebaseMessagingStoreImpl` disabled-storage paths. After iOS `:test-cover` and `yarn tests:ios:test:process-coverage`, those lines appear as hits in `coverage/ios-native/lcov.info`. Record them in the [coverage evidence package](#coverage-evidence-package); passing probes are not a substitute for that LCOV.
 
 # Critical invariants
 

--- a/okf-bundle/testing/running-e2e.md
+++ b/okf-bundle/testing/running-e2e.md
@@ -93,6 +93,7 @@ The Detox host exposes **two** native modules. Coverage flush is **not** this Tu
 - **iOS:** `tests/ios/testing/RNFBTestingTurboModule.{h,mm}`
 - **Android:** `tests/android/app/src/main/java/com/invertase/testing/NativeRNFBTesting.kt` — unsupported methods **resolve `false`**
 - **JS:** `getRNFBTesting()` in `packages/app/e2e/helpers.js` via `TurboModuleRegistry.get('NativeRNFBTesting')`
+- **Probes:** `messagingPreservesExistingDelegate`, `completesNonFCMRemoteNotification` (iOS); `messagingStoreSupportsDisabledStorage` (Android). Cross-platform methods resolve `false` on the unsupported platform.
 - Production packages must **not** ship this TurboModule (test-app only).
 
 Probe hits in `coverage/ios-native/lcov.info`: [coverage design § two test native modules](coverage-design.md#test-native-modules). Test-app vs library codegen (not committed; wipe derived `tests/ios/build/generated/ios`; gitignore `tests/ios/Package.swift` and sibling app dumps): [NewArch-AD-5](../new-architecture/architecture-decisions.md#newarch-ad-5--commit-generated-code--accepted).

--- a/packages/app/firebase-schema.json
+++ b/packages/app/firebase-schema.json
@@ -120,7 +120,7 @@
           "type": "array"
         },
         "messaging_max_stored_notifications": {
-          "description": "Controls how many notifications are retained on-device for background storage. Configuration priority order is SharedPreferences -> firebase.json -> AndroidManifest. Default 100. Very small values may cause unwanted excessive deletions, large values or large message contents run the risk of OutOfMemoryErrors.",
+          "description": "Controls how many notifications are retained on-device for background storage. Values less than or equal to zero disable storage and clear previously retained notifications. Configuration priority order is SharedPreferences -> firebase.json -> AndroidManifest. Default 100. Very small positive values may cause unwanted excessive deletions, large values or large message contents run the risk of OutOfMemoryErrors.",
           "type": "number"
         },
         "perf_auto_collection_enabled": {

--- a/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
+++ b/packages/messaging/android/src/main/java/io/invertase/firebase/messaging/ReactNativeFirebaseMessagingStoreImpl.java
@@ -66,18 +66,24 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
 
   @Override
   public void storeFirebaseMessage(RemoteMessage remoteMessage) {
+    UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
+    int limit = getMaxNotificationSize();
+    String notificationIds = preferences.getStringValue(S_KEY_ALL_NOTIFICATION_IDS, "");
+    List<String> allNotificationList = convertToArray(notificationIds);
+    int retainedNotificationCount = limit > 0 ? limit - 1 : 0;
+    while (!allNotificationList.isEmpty()
+        && allNotificationList.size() > retainedNotificationCount) {
+      clearFirebaseMessage(allNotificationList.get(0));
+      allNotificationList.remove(0);
+    }
+
+    if (limit <= 0) {
+      return;
+    }
+
     try {
       String remoteMessageString =
           reactToJSON(remoteMessageToWritableMap(remoteMessage)).toString();
-      UniversalFirebasePreferences preferences = UniversalFirebasePreferences.getSharedInstance();
-
-      int limit = getMaxNotificationSize();
-      String notificationIds = preferences.getStringValue(S_KEY_ALL_NOTIFICATION_IDS, "");
-      List<String> allNotificationList = convertToArray(notificationIds);
-      while (allNotificationList.size() > limit - 1) {
-        clearFirebaseMessage(allNotificationList.get(0));
-        allNotificationList.remove(0);
-      }
 
       notificationIds = preferences.getStringValue(S_KEY_ALL_NOTIFICATION_IDS, "");
       preferences.setStringValue(remoteMessage.getMessageId(), remoteMessageString);
@@ -138,6 +144,9 @@ public class ReactNativeFirebaseMessagingStoreImpl implements ReactNativeFirebas
   }
 
   private List<String> convertToArray(String string) {
+    if (string.isEmpty()) {
+      return new ArrayList<>();
+    }
     return new ArrayList<>(Arrays.asList(string.split(DELIMITER)));
   }
 }

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -324,6 +324,17 @@ describe('messaging()', function () {
       });
     });
 
+    describe('notification storage', function () {
+      it('can be disabled on android', async function () {
+        if (!Platform.android) {
+          this.skip();
+        }
+
+        const { getRNFBTesting } = require('../../app/e2e/helpers');
+        should.equal(await getRNFBTesting().messagingStoreSupportsDisabledStorage(), true);
+      });
+    });
+
     describe('deleteToken()', function () {
       it('generate a new token after deleting', async function () {
         const { getMessaging, getToken, deleteToken } = messagingModular;

--- a/tests/android/app/build.gradle
+++ b/tests/android/app/build.gradle
@@ -149,6 +149,10 @@ dependencies {
   // The version of react-native is set by the React Native Gradle Plugin
   implementation("com.facebook.react:react-android")
 
+  def firebaseBomVersion = new JsonSlurper().parseText(new File('../node_modules/@react-native-firebase/app/package.json').text).sdkVersions.android.firebase
+  compileOnly platform("com.google.firebase:firebase-bom:${firebaseBomVersion}")
+  compileOnly "com.google.firebase:firebase-messaging"
+
   implementation("androidx.annotation:annotation:${rootProject.ext.androidxAnnotationVersion}")
   implementation("androidx.appcompat:appcompat:${rootProject.ext.appCompatVersion}")
   implementation("androidx.core:core:${rootProject.ext.supportLibVersion}")
@@ -173,7 +177,6 @@ dependencies {
     exclude module: "protobuf-lite"
   }
 
-  def firebaseBomVersion = new JsonSlurper().parseText(new File('../node_modules/@react-native-firebase/app/package.json').text).sdkVersions.android.firebase
   androidTestImplementation platform("com.google.firebase:firebase-bom:${firebaseBomVersion}")
   androidTestImplementation "com.google.firebase:firebase-appcheck-debug-testing"
 }

--- a/tests/android/app/src/main/java/com/invertase/testing/NativeRNFBTesting.kt
+++ b/tests/android/app/src/main/java/com/invertase/testing/NativeRNFBTesting.kt
@@ -1,9 +1,12 @@
 package com.invertase.testing
 
+import android.content.Context
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
+import com.google.firebase.messaging.RemoteMessage
+import io.invertase.firebase.messaging.ReactNativeFirebaseMessagingStoreImpl
 
-/** Test-app TurboModule: platform-specific probes no-op on Android. */
+/** Test-app TurboModule: platform-specific probes no-op on unsupported platforms. */
 class NativeRNFBTesting(reactContext: ReactApplicationContext) :
   NativeRNFBTestingSpec(reactContext) {
 
@@ -13,5 +16,62 @@ class NativeRNFBTesting(reactContext: ReactApplicationContext) :
 
   override fun completesNonFCMRemoteNotification(promise: Promise) {
     promise.resolve(false)
+  }
+
+  override fun messagingStoreSupportsDisabledStorage(promise: Promise) {
+    val preferences =
+      reactApplicationContext.getSharedPreferences(PREFERENCES_FILE, Context.MODE_PRIVATE)
+    val maxNotificationSize =
+      ReactNativeFirebaseMessagingStoreImpl::class.java.getDeclaredField("maxNotificationSize")
+    val retainedMessage =
+      RemoteMessage.Builder("testing@fcm.googleapis.com")
+        .setMessageId(RETAINED_MESSAGE_ID)
+        .build()
+    val discardedMessage =
+      RemoteMessage.Builder("testing@fcm.googleapis.com")
+        .setMessageId(DISCARDED_MESSAGE_ID)
+        .build()
+
+    try {
+      preferences
+        .edit()
+        .remove(ALL_NOTIFICATION_IDS)
+        .remove(RETAINED_MESSAGE_ID)
+        .remove(DISCARDED_MESSAGE_ID)
+        .putInt(MAX_STORED_NOTIFICATIONS, 1)
+        .apply()
+      maxNotificationSize.isAccessible = true
+      maxNotificationSize.setInt(null, -1)
+
+      val store = ReactNativeFirebaseMessagingStoreImpl()
+      store.storeFirebaseMessage(retainedMessage)
+
+      preferences.edit().putInt(MAX_STORED_NOTIFICATIONS, 0).apply()
+      maxNotificationSize.setInt(null, -1)
+      store.storeFirebaseMessage(discardedMessage)
+      promise.resolve(
+        store.getFirebaseMessageMap(RETAINED_MESSAGE_ID) == null &&
+          store.getFirebaseMessageMap(DISCARDED_MESSAGE_ID) == null,
+      )
+    } catch (e: Exception) {
+      promise.reject("messaging_store_failed", "Failed to disable notification storage", e)
+    } finally {
+      preferences
+        .edit()
+        .remove(MAX_STORED_NOTIFICATIONS)
+        .remove(ALL_NOTIFICATION_IDS)
+        .remove(RETAINED_MESSAGE_ID)
+        .remove(DISCARDED_MESSAGE_ID)
+        .apply()
+      maxNotificationSize.setInt(null, -1)
+    }
+  }
+
+  companion object {
+    private const val PREFERENCES_FILE = "io.invertase.firebase"
+    private const val MAX_STORED_NOTIFICATIONS = "messaging_max_stored_notifications"
+    private const val ALL_NOTIFICATION_IDS = "all_notification_ids"
+    private const val RETAINED_MESSAGE_ID = "rnfb-retained-storage-test"
+    private const val DISCARDED_MESSAGE_ID = "rnfb-disabled-storage-test"
   }
 }

--- a/tests/ios/testing/RNFBTestingTurboModule.mm
+++ b/tests/ios/testing/RNFBTestingTurboModule.mm
@@ -46,4 +46,11 @@ RCT_EXPORT_MODULE(NativeRNFBTesting)
   resolve(@(completed));
 }
 
+- (void)messagingStoreSupportsDisabledStorage:(RCTPromiseResolveBlock)resolve
+                                     reject:(RCTPromiseRejectBlock)reject
+{
+  // Android-only probe — SharedPreferences / messaging store path is not used on iOS.
+  resolve(@(NO));
+}
+
 @end

--- a/tests/specs/NativeRNFBTesting.ts
+++ b/tests/specs/NativeRNFBTesting.ts
@@ -10,6 +10,8 @@ export interface Spec extends TurboModule {
   messagingPreservesExistingDelegate(): Promise<boolean>;
   /** iOS: RNFBMessagingAppDelegate completes fetch handler for non-FCM remote notifications. */
   completesNonFCMRemoteNotification(): Promise<boolean>;
+  /** Android: messaging store clears / skips persistence when max stored notifications is <= 0. */
+  messagingStoreSupportsDisabledStorage(): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>('NativeRNFBTesting');


### PR DESCRIPTION
## What this fixes

- Treats `messaging_max_stored_notifications <= 0` as disabled storage.
- Clears notifications retained before storage was disabled.
- Prevents the `IndexOutOfBoundsException` currently raised when the configured limit is zero or negative.
- Preserves the existing any-number configuration contract without silently clamping values.

## Behavior

Positive values retain their existing meaning. Zero and negative values now disable notification persistence instead of crashing while pruning an empty list. The schema documents this observable correction.

## Breaking changes

None. This defines behavior for a configuration that currently crashes; positive limits are unchanged.

## Verification

- Baseline regression: Android e2e fails with `IndexOutOfBoundsException: Failed to disable notification storage`.
- Android native build: 1,749 tasks, successful.
- Android Messaging e2e: 87 passing, 6 platform-pending.
- Android unit suite and merged JaCoCo report: successful; every changed reachable store line covered.
- iOS native build: successful.
- iOS Messaging e2e: 69 passing, 24 platform-pending.
- `yarn lint:js`
- `yarn lint:android`
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn reference:api`
- `yarn tests:jest` (103 suites, 1,479 tests)
- `yarn compare:types`
- `git diff --check`