### PR TITLE
fix(messaging, ios): preserve existing FIRMessaging delegate

### DIFF
--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -288,6 +288,20 @@ describe('messaging()', function () {
       });
     });
 
+    describe('native messaging delegate', function () {
+      it('preserves an existing iOS Firebase Messaging delegate', async function () {
+        if (!Platform.ios) {
+          this.skip();
+        }
+
+        const { NativeModules } = require('react-native');
+        should.equal(
+          await NativeModules.RNFBTestingCoverage.messagingPreservesExistingDelegate(),
+          true,
+        );
+      });
+    });
+
     describe('deleteToken()', function () {
       it('generate a new token after deleting', async function () {
         const { getMessaging, getToken, deleteToken } = messagingModular;

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.h
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNFBMessagingFIRMessagingDelegate : NSObject <FIRMessagingDelegate>
 
+@property(nonatomic, nullable, weak) id<FIRMessagingDelegate> originalDelegate;
+
 + (_Nonnull instancetype)sharedInstance;
 
 - (void)observe;

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+FIRMessagingDelegate.m
@@ -39,7 +39,11 @@
   __weak RNFBMessagingFIRMessagingDelegate *weakSelf = self;
   dispatch_once(&once, ^{
     RNFBMessagingFIRMessagingDelegate *strongSelf = weakSelf;
-    [FIRMessaging messaging].delegate = strongSelf;
+    FIRMessaging *messaging = [FIRMessaging messaging];
+    if (messaging.delegate != strongSelf) {
+      strongSelf.originalDelegate = messaging.delegate;
+      messaging.delegate = strongSelf;
+    }
   });
 }
 
@@ -54,16 +58,23 @@
   [[RNFBRCTEventEmitter shared] sendEventWithName:@"messaging_token_refresh"
                                              body:@{@"token" : fcmToken}];
 
-  // If the users AppDelegate implements messaging:didReceiveRegistrationToken: then call it
   SEL messaging_didReceiveRegistrationTokenSelector =
       NSSelectorFromString(@"messaging:didReceiveRegistrationToken:");
-  if ([[GULAppDelegateSwizzler sharedApplication].delegate
-          respondsToSelector:messaging_didReceiveRegistrationTokenSelector]) {
+  id<FIRMessagingDelegate> strongOriginalDelegate = self.originalDelegate;
+  if ([strongOriginalDelegate respondsToSelector:messaging_didReceiveRegistrationTokenSelector]) {
+    [strongOriginalDelegate messaging:messaging didReceiveRegistrationToken:fcmToken];
+  }
+
+  // Preserve the existing AppDelegate fallback for applications that implement the callback
+  // without assigning themselves as FIRMessaging.delegate.
+  id<UIApplicationDelegate> applicationDelegate =
+      [GULAppDelegateSwizzler sharedApplication].delegate;
+  if (applicationDelegate != strongOriginalDelegate &&
+      [applicationDelegate respondsToSelector:messaging_didReceiveRegistrationTokenSelector]) {
     void (*usersDidReceiveRegistrationTokenIMP)(id, SEL, FIRMessaging *, NSString *) =
         (typeof(usersDidReceiveRegistrationTokenIMP))&objc_msgSend;
-    usersDidReceiveRegistrationTokenIMP([GULAppDelegateSwizzler sharedApplication].delegate,
-                                        messaging_didReceiveRegistrationTokenSelector, messaging,
-                                        fcmToken);
+    usersDidReceiveRegistrationTokenIMP(
+        applicationDelegate, messaging_didReceiveRegistrationTokenSelector, messaging, fcmToken);
   }
 }
 

--- a/tests/ios/testing/AppDelegate.mm
+++ b/tests/ios/testing/AppDelegate.mm
@@ -27,6 +27,8 @@
 #import <React/RCTDefines.h>
 
 static NSString *const RNFBTestingMetroHost = @"127.0.0.1";
+static NSString *const RNFBTestingMessagingDelegateProbeKey =
+    @"rnfb_testing_messaging_delegate_called";
 static const NSTimeInterval RNFBTestingMetroProbeTimeoutSec = 10.0;
 
 static NSUInteger RNFBTestingMetroPortNumber(void)
@@ -213,6 +215,24 @@ static void RNFBTestingRegisterJavaScriptLoadObservers(id observer)
 }
 #endif
 
+@interface RNFBTestingMessagingDelegateProbe : NSObject <FIRMessagingDelegate>
+@end
+
+@implementation RNFBTestingMessagingDelegateProbe
+
+- (void)messaging:(FIRMessaging *)messaging didReceiveRegistrationToken:(NSString *)fcmToken
+{
+  [[NSUserDefaults standardUserDefaults] setBool:YES forKey:RNFBTestingMessagingDelegateProbeKey];
+}
+
+@end
+
+@interface AppDelegate ()
+
+@property(nonatomic, strong) RNFBTestingMessagingDelegateProbe *messagingDelegateProbe;
+
+@end
+
 @implementation AppDelegate
 - (void)rnfb_applicationLifecycleNotification:(NSNotification *)notification
 {
@@ -274,6 +294,8 @@ static void RNFBTestingRegisterJavaScriptLoadObservers(id observer)
     [FIRApp configure];
   }
   [FIRApp configureWithName:@"secondaryFromNative" options:[FIROptions defaultOptions]];
+  self.messagingDelegateProbe = [[RNFBTestingMessagingDelegateProbe alloc] init];
+  [FIRMessaging messaging].delegate = self.messagingDelegateProbe;
 
   self.moduleName = @"testing";
   // You can add your custom initial props in the dictionary below.

--- a/tests/ios/testing/RNFBTestingCoverageModule.m
+++ b/tests/ios/testing/RNFBTestingCoverageModule.m
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <FirebaseMessaging/FirebaseMessaging.h>
 #import <React/RCTBridgeModule.h>
 
 #import "RNFBTestingCoverageProfile.h"
@@ -18,6 +19,21 @@ RCT_EXPORT_METHOD(flush : (RCTPromiseResolveBlock)resolve rejecter : (RCTPromise
   } else {
     reject(@"coverage_flush_failed", @"Failed to write LLVM profile data", nil);
   }
+}
+
+RCT_EXPORT_METHOD(messagingPreservesExistingDelegate
+                  : (RCTPromiseResolveBlock)resolve rejecter
+                  : (RCTPromiseRejectBlock)reject)
+{
+  NSString *probeKey = @"rnfb_testing_messaging_delegate_called";
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults removeObjectForKey:probeKey];
+
+  id<FIRMessagingDelegate> delegate = [FIRMessaging messaging].delegate;
+  [delegate messaging:[FIRMessaging messaging] didReceiveRegistrationToken:@"rnfb-delegate-test"];
+
+  resolve(@([defaults boolForKey:probeKey]));
+  [defaults removeObjectForKey:probeKey];
 }
 
 @end


### PR DESCRIPTION
## What this fixes

- Preserves an existing `FIRMessagingDelegate` when React Native Firebase installs its token-refresh interceptor.
- Forwards registration-token callbacks to that original delegate after emitting `messaging_token_refresh`.
- Retains the existing AppDelegate fallback and avoids invoking it twice when it is also the original Firebase delegate.

Firebase documents assigning `FIRMessaging.delegate` after `FIRApp configure` as the supported registration-token callback path. React Native Firebase currently replaces a separately assigned delegate, so it silently stops receiving token refreshes.

https://firebase.google.com/docs/cloud-messaging/ios/get-started#set_the_messaging_delegate

## Breaking changes

None. This restores callbacks to the application delegate object that Firebase was already configured to notify. React Native Firebase events and the existing AppDelegate fallback are unchanged.

## Verification

- Exact native baseline control: failed (`false`) when a separate Firebase delegate was replaced.
- Fixed iOS App + Messaging E2E: 70 passing, 23 platform-pending.
- Fixed Android App + Messaging E2E: 86 passing, 7 platform-pending.
- iOS simulator, Android debug/test/lint (1,749 tasks), and macOS builds: successful.
- iOS LLVM coverage: every changed reachable production line executed.
- Android native unit and coverage processing: successful.
- `yarn lint:ios:check`
- `yarn lint:js`
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn reference:api`
- `yarn tests:jest` (103 suites, 1,479 tests)
- `yarn compare:types`
- `git diff --check`