### PR TITLE
fix(messaging): preserve registration state on failure

### DIFF
--- a/packages/messaging/e2e/z-apns-registration-timeout.e2e.js
+++ b/packages/messaging/e2e/z-apns-registration-timeout.e2e.js
@@ -100,6 +100,11 @@ describe('messaging() APNs registration timeout', function () {
     } else {
       should.exist(settled.error, 'reject path must provide an error');
       settled.error.code.should.equal('messaging/registration-timeout');
+      should.equal(
+        isDeviceRegisteredForRemoteMessages(getMessaging()),
+        false,
+        'rejected registration must preserve the previous state',
+      );
     }
   });
 

--- a/packages/messaging/lib/index.ts
+++ b/packages/messaging/lib/index.ts
@@ -309,8 +309,9 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
       );
     }
 
-    this._isRegisteredForRemoteNotifications = true;
-    return this.native.registerForRemoteNotifications();
+    return this.native.registerForRemoteNotifications().then(() => {
+      this._isRegisteredForRemoteNotifications = true;
+    });
   }
 
   /**
@@ -320,8 +321,9 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
     if (isAndroid) {
       return Promise.resolve();
     }
-    this._isRegisteredForRemoteNotifications = false;
-    return this.native.unregisterForRemoteNotifications();
+    return this.native.unregisterForRemoteNotifications().then(() => {
+      this._isRegisteredForRemoteNotifications = false;
+    });
   }
 
   /**


### PR DESCRIPTION
## What this fixes

A rejected iOS `registerDeviceForRemoteMessages()` call currently sets the JavaScript registration cache to `true` before native registration completes. As a result, `isDeviceRegisteredForRemoteMessages` reports a registration that never happened.

This PR updates the cached state only after the native registration or unregistration promise resolves.

## Behavior

- Failed registration preserves the previous unregistered state.
- Failed unregistration preserves the previous registered state.
- Successful registration and unregistration behavior is unchanged.
- Android behavior is unchanged.

## Breaking changes

None. This corrects state reporting after rejected native operations.

## Verification

- Baseline iOS E2E reproduced the issue exactly: 68 passing, 23 pending, 1 failing.
- Fixed iOS E2E: 69 passing, 23 pending.
- Android E2E: 86 passing, 6 pending.
- Android unit tests and native coverage processing passed.
- Jest: 103 suites, 1,479 tests, 31 snapshots passed.
- `yarn lint:js`
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn reference:api`
- `yarn compare:types`
- `git diff --check`
