### PR TITLE
fix(messaging): update cached settings after native success

### DIFF
--- a/packages/messaging/__tests__/messaging.test.ts
+++ b/packages/messaging/__tests__/messaging.test.ts
@@ -28,31 +28,35 @@ import {
   subscribeToTopic,
   unsubscribeFromTopic,
   isDeliveryMetricsExportToBigQueryEnabled,
+  isNotificationDelegationEnabled,
   isSupported,
   experimentalSetDeliveryMetricsExportedToBigQueryEnabled,
+  setNotificationDelegationEnabled,
   AuthorizationStatus,
   NotificationAndroidPriority,
   NotificationAndroidVisibility,
 } from '../lib';
 
-// @ts-ignore test
-import FirebaseModule from '../../app/lib/internal/FirebaseModule';
-
 describe('Messaging', function () {
   describe('modular', function () {
+    let nativeOverrides: Record<string, ReturnType<typeof jest.fn>>;
+
     beforeEach(function () {
-      // @ts-ignore test
-      jest.spyOn(FirebaseModule.prototype, 'native', 'get').mockImplementation(() => {
-        return new Proxy(
-          {},
-          {
-            get: () =>
-              jest.fn().mockResolvedValue({
-                result: true,
-              } as never),
-          },
-        );
-      });
+      nativeOverrides = {};
+      (
+        getMessaging() as ReturnType<typeof getMessaging> & {
+          _nativeModule: Record<string, unknown>;
+        }
+      )._nativeModule = new Proxy(
+        {},
+        {
+          get: (_target, property) =>
+            nativeOverrides[String(property)] ??
+            jest.fn().mockResolvedValue({
+              result: true,
+            } as never),
+        },
+      );
     });
 
     it('`getMessaging` function is properly exposed to end user', function () {
@@ -169,6 +173,53 @@ describe('Messaging', function () {
 
     it('`experimentalSetDeliveryMetricsExportedToBigQueryEnabled` function is properly exposed to end user', function () {
       expect(experimentalSetDeliveryMetricsExportedToBigQueryEnabled).toBeDefined();
+    });
+
+    describe('cached native settings', function () {
+      function mockNativeRejection(method: string, error: Error) {
+        nativeOverrides[method] = jest.fn().mockRejectedValue(error as never);
+      }
+
+      it('preserves auto-init state when the native update rejects', async function () {
+        const messaging = getMessaging();
+        const error = new Error('native update failed');
+        (messaging as typeof messaging & { _isAutoInitEnabled: boolean })._isAutoInitEnabled =
+          false;
+        mockNativeRejection('setAutoInitEnabled', error);
+
+        await expect(setAutoInitEnabled(messaging, true)).rejects.toBe(error);
+        expect(isAutoInitEnabled(messaging)).toBe(false);
+      });
+
+      it('preserves delivery-metrics state when the native update rejects', async function () {
+        const messaging = getMessaging();
+        const error = new Error('native update failed');
+        (
+          messaging as typeof messaging & {
+            _isDeliveryMetricsExportToBigQueryEnabled: boolean;
+          }
+        )._isDeliveryMetricsExportToBigQueryEnabled = false;
+        mockNativeRejection('setDeliveryMetricsExportToBigQuery', error);
+
+        await expect(
+          experimentalSetDeliveryMetricsExportedToBigQueryEnabled(messaging, true),
+        ).rejects.toBe(error);
+        expect(isDeliveryMetricsExportToBigQueryEnabled(messaging)).toBe(false);
+      });
+
+      it('preserves notification-delegation state when the native update rejects', async function () {
+        const messaging = getMessaging();
+        const error = new Error('native update failed');
+        (
+          messaging as typeof messaging & {
+            _isNotificationDelegationEnabled: boolean;
+          }
+        )._isNotificationDelegationEnabled = false;
+        mockNativeRejection('setNotificationDelegationEnabled', error);
+
+        await expect(setNotificationDelegationEnabled(messaging, true)).rejects.toBe(error);
+        expect(isNotificationDelegationEnabled(messaging)).toBe(false);
+      });
     });
 
     it('`AuthorizationStatus` static is exposed to end user', function () {

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -526,7 +526,7 @@ describe('messaging()', function () {
 
         should.equal(isNotificationDelegationEnabled(getMessaging()), false);
         await setNotificationDelegationEnabled(getMessaging(), true);
-        should.equal(isNotificationDelegationEnabled(getMessaging()), true);
+        should.equal(isNotificationDelegationEnabled(getMessaging()), Platform.android);
       });
     });
 

--- a/packages/messaging/lib/index.ts
+++ b/packages/messaging/lib/index.ts
@@ -161,8 +161,9 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
       throw new Error("getMessaging().setAutoInitEnabled(*) 'enabled' expected a boolean value.");
     }
 
-    this._isAutoInitEnabled = enabled;
-    return this.native.setAutoInitEnabled(enabled);
+    return this.native.setAutoInitEnabled(enabled).then(() => {
+      this._isAutoInitEnabled = enabled;
+    });
   }
 
   getInitialNotification(): Promise<RemoteMessage | null> {
@@ -473,8 +474,9 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
       );
     }
 
-    this._isDeliveryMetricsExportToBigQueryEnabled = enabled;
-    return this.native.setDeliveryMetricsExportToBigQuery(enabled);
+    return this.native.setDeliveryMetricsExportToBigQuery(enabled).then(() => {
+      this._isDeliveryMetricsExportToBigQueryEnabled = enabled;
+    });
   }
 
   setNotificationDelegationEnabled(enabled: boolean): Promise<void> {
@@ -484,12 +486,13 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
       );
     }
 
-    this._isNotificationDelegationEnabled = enabled;
     if (isIOS) {
       return Promise.resolve();
     }
 
-    return this.native.setNotificationDelegationEnabled(enabled);
+    return this.native.setNotificationDelegationEnabled(enabled).then(() => {
+      this._isNotificationDelegationEnabled = enabled;
+    });
   }
 
   async isSupported(): Promise<boolean> {


### PR DESCRIPTION
## What this fixes

Rejected native setting updates currently mutate the JavaScript cache first. After a rejection, these public getters can therefore report values that were never applied:

- `isAutoInitEnabled`
- `isDeliveryMetricsExportToBigQueryEnabled`
- `isNotificationDelegationEnabled`

This PR updates each cache only after the corresponding native promise resolves.

It also preserves the documented iOS notification-delegation behavior: delegation is Android-only, so the iOS getter remains `false` after the no-op setter resolves.

## Breaking changes

None. Successful Android/iOS setting updates are unchanged. Rejected updates now preserve their previous values, and iOS delegation now matches its existing documented `false`-only contract.

## Verification

- Exact baseline unit controls: 3 failures; all three caches incorrectly changed after native rejection.
- Fixed focused Jest: 35 passing.
- Full Jest: 103 suites, 1,482 tests, 31 snapshots passed.
- Focused iOS App + Messaging E2E: 69 passing, 23 pending.
- Focused Android App + Messaging E2E: 86 passing, 6 pending.
- Android unit tests and merged native coverage passed.
- `yarn lerna:prepare`
- `yarn lint:js`
- `yarn lint:deps`
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn reference:api`
- `yarn compare:types`
- `git diff --check`
