### PR TITLE
fix(messaging, ios): serialize notification badges as strings

### DIFF
--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -102,6 +102,19 @@ describe('messaging()', function () {
     }
   });
 
+  it('serializes iOS notification badges as strings', async function () {
+    if (!Platform.ios) {
+      this.skip();
+    }
+
+    const { getRNFBTesting } = require('../../app/e2e/helpers');
+    const message = await getRNFBTesting().serializeMessagingUserInfo({
+      aps: { badge: 7 },
+    });
+
+    message.notification.ios.badge.should.equal('7');
+  });
+
   before(async function () {
     // our device registration tests require permissions. Set them up
     const { getMessaging, requestPermission } = messagingModular;

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingSerializer.m
@@ -157,8 +157,9 @@
 
     // iOS only
     // message.notification.ios.badge
-    if (apsDict[@"badge"] != nil) {
-      notificationIOS[@"badge"] = apsDict[@"badge"];
+    id badge = apsDict[@"badge"];
+    if (badge != nil) {
+      notificationIOS[@"badge"] = [badge description];
     }
 
     // message.notification.*


### PR DESCRIPTION
## What changed

- Serialize the iOS `aps.badge` value as a string, matching the public `RemoteMessage.notification.ios.badge?: string` contract.
- Add a direct native serializer E2E regression check.

## Observable behavior correction

- A numeric APNs badge such as `7` now reaches JavaScript as `"7"` instead of the previously undocumented numeric value `7`.
- There is no public API or type change. Consumers that relied on the accidental numeric runtime value should parse the documented string when they need a number.

## Why

The iOS serializer forwarded the native `NSNumber` directly across the bridge while the public TypeScript API documents a string. Converting at the serializer boundary keeps runtime behavior consistent with the published contract.

## Verification

- Baseline native E2E reproduced the mismatch (`7` versus `"7"`).
- iOS Messaging E2E: 70 passing, 23 pending.
- Android Messaging E2E: 86 passing, 7 pending.
- Changed iOS native lines are covered by the generated LLVM coverage report.
- Full Jest: 103 suites, 1,479 tests, 31 snapshots.
- JS lint, iOS formatting, dependency-cruiser, library and consumer TypeScript compilation, API-reference generation, type-parity comparison, Android unit/coverage, and `git diff --check` all pass.
