### PR TITLE
fix(messaging): serialize array data values as JSON

### DIFF
--- a/packages/messaging/__tests__/messaging.test.ts
+++ b/packages/messaging/__tests__/messaging.test.ts
@@ -37,6 +37,21 @@ import {
   NotificationAndroidVisibility,
 } from '../lib';
 
+import remoteMessageOptions from '../lib/remoteMessageOptions';
+
+describe('remoteMessageOptions', function () {
+  it('serializes array data values as JSON', function () {
+    const options = remoteMessageOptions('sender-id', {
+      data: {
+        items: [{ id: 1 }, { id: 2 }],
+      },
+      fcmOptions: {},
+    });
+
+    expect(options.data.items).toBe('[{"id":1},{"id":2}]');
+  });
+});
+
 describe('Messaging', function () {
   describe('modular', function () {
     let nativeOverrides: Record<string, ReturnType<typeof jest.fn>>;

--- a/packages/messaging/lib/remoteMessageOptions.ts
+++ b/packages/messaging/lib/remoteMessageOptions.ts
@@ -83,7 +83,7 @@ export default function remoteMessageOptions(
     for (const key in remoteMessage.data) {
       if (hasOwnProperty(remoteMessage.data, key)) {
         const value = remoteMessage.data[key];
-        if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
+        if (typeof value === 'object' && value !== null) {
           out.data[key] = JSON.stringify(value);
         } else {
           out.data[key] = String(value);


### PR DESCRIPTION
## What changed

- Serialize array-valued outgoing `RemoteMessage.data` entries with JSON, consistently with other object values.
- Add a focused regression test with nested objects.

## Observable behavior correction

- Arrays now retain their JSON structure. For example, `[{ id: 1 }]` becomes `[{"id":1}]` instead of `[object Object]`.
- This changes only the malformed wire value produced for array data. String, primitive, plain-object, and null serialization retain their existing behavior; there is no public API or type change.

## Why

The public `RemoteMessage.data` value type accepts objects, and the serializer already JSON-encodes objects. Its explicit array exclusion routed arrays through JavaScript string coercion instead, losing quoting and nested object data before Android's native `RemoteMessage.Builder` received it.

## Verification

- Exact baseline regression: expected `[{"id":1},{"id":2}]`, received `[object Object],[object Object]`.
- Focused Messaging Jest: 33 passing.
- Full Jest: 103 suites, 1,480 tests, 31 snapshots.
- Android App + Messaging E2E: 86 passing, 6 pending.
- Android unit and post-E2E coverage processing pass.
- `lerna:prepare`, JS lint, dependency-cruiser, both TypeScript compiles, API-reference generation, type-parity comparison, and `git diff --check` pass.
