### PR TITLE
fix(messaging): pass sent message IDs to listeners

### DIFF
--- a/packages/messaging/__tests__/messaging.test.ts
+++ b/packages/messaging/__tests__/messaging.test.ts
@@ -38,6 +38,7 @@ import {
 } from '../lib';
 
 import remoteMessageOptions from '../lib/remoteMessageOptions';
+import { SharedEventEmitter } from '@react-native-firebase/app/dist/module/internal';
 
 describe('remoteMessageOptions', function () {
   it('serializes array data values as JSON', function () {
@@ -152,6 +153,16 @@ describe('Messaging', function () {
 
     it('`onMessageSent` function is properly exposed to end user', function () {
       expect(onMessageSent).toBeDefined();
+    });
+
+    it('`onMessageSent` passes the sent message ID to its listener', function () {
+      const listener = jest.fn();
+      const unsubscribe = onMessageSent(getMessaging(), listener);
+
+      SharedEventEmitter.emit('messaging_message_sent', { messageId: 'message-id' });
+
+      expect(listener).toHaveBeenCalledWith('message-id');
+      unsubscribe();
     });
 
     it('`onSendError` function is properly exposed to end user', function () {

--- a/packages/messaging/e2e/messaging.e2e.js
+++ b/packages/messaging/e2e/messaging.e2e.js
@@ -501,6 +501,24 @@ describe('messaging()', function () {
           return Promise.resolve();
         }
       });
+
+      it('passes the sent message ID to the listener', async function () {
+        if (!Platform.android) {
+          this.skip();
+        }
+
+        const { getMessaging, onMessageSent } = messagingModular;
+        const spy = sinon.spy();
+        const unsubscribe = onMessageSent(getMessaging(), spy);
+
+        await NativeModules.NativeRNFBTurboApp.eventsPing('messaging_message_sent', {
+          messageId: 'message-id',
+        });
+        await Utils.spyToBeCalledOnceAsync(spy);
+
+        spy.firstCall.args[0].should.equal('message-id');
+        unsubscribe();
+      });
     });
 
     describe('onSendError()', function () {

--- a/packages/messaging/lib/index.ts
+++ b/packages/messaging/lib/index.ts
@@ -390,7 +390,10 @@ class FirebaseMessagingModule extends FirebaseModule<typeof nativeModuleName> im
       throw new Error("getMessaging().onMessageSent(*) 'listener' expected a function.");
     }
 
-    const subscription = this.emitter.addListener('messaging_message_sent', listener);
+    const subscription = this.emitter.addListener(
+      'messaging_message_sent',
+      (event: { messageId: string }) => listener(event.messageId),
+    );
     return () => {
       subscription.remove();
     };


### PR DESCRIPTION
## What changed

- Unwrap the native `{ messageId }` event body before calling `onMessageSent` listeners.
- Add unit and Android native-bridge regressions for the public callback contract.

## Observable behavior correction

- `onMessageSent` listeners now receive the documented message-ID string instead of the accidental `{ messageId: string }` object.
- Consumers that worked around the incorrect runtime shape should remove the object unwrap. The public API and TypeScript signature are unchanged.

## Why

Android intentionally emits a map so the React Native event bridge can carry the message ID. Unlike the token-refresh listener, `onMessageSent` forwarded that transport wrapper directly to application code even though its public callback has always been typed and documented as `(messageId: string) => any`.

## Verification

- Exact baseline shared-event regression received `{ messageId: "message-id" }`; the fixed listener receives `"message-id"`.
- Focused Messaging Jest: 33 passing.
- Android native-bridge Messaging E2E: 87 passing, 6 pending.
- Full Jest: 103 suites, 1,480 tests, 31 snapshots.
- Android unit checks, `lerna:prepare`, JS lint, dependency-cruiser, both TypeScript compiles, API-reference generation, type-parity comparison, and `git diff --check` pass.
