### PR TITLE
fix(messaging): make FCM options optional

### DIFF
--- a/packages/messaging/lib/types/messaging.ts
+++ b/packages/messaging/lib/types/messaging.ts
@@ -95,7 +95,7 @@ export interface RemoteMessage {
   /**
    * Options for features provided by the FCM SDK for Web.
    */
-  fcmOptions: FcmOptions;
+  fcmOptions?: FcmOptions;
 
   /**
    * Priority - android-specific, undefined on non-android platforms, default PRIORITY_UNKNOWN

--- a/packages/messaging/type-test.ts
+++ b/packages/messaging/type-test.ts
@@ -168,7 +168,6 @@ sendMessage(modularMessaging1, {
     title: 'Modular Test',
     body: 'Modular Test body',
   },
-  fcmOptions: {},
 }).then(() => {
   console.log('Modular message sent');
 });


### PR DESCRIPTION
## What changed

- Make `RemoteMessage.fcmOptions` optional.
- Update the compile-time `sendMessage` fixture to verify a message without web-only FCM options.

## Compatibility

- This is a type-only loosening with no runtime behavior change and no breaking changes.
- Existing messages that include `fcmOptions` continue to type-check unchanged.

## Why

`fcmOptions` contains web-only features and is absent from normal native incoming messages. The Android `sendMessage` serializer also does not require or consume it. Requiring the property forced TypeScript users to add an empty object that had no runtime effect; Firebase's corresponding message payload field is optional as well.

## Verification

- Exact baseline TypeScript compile failed because the fixture omitted `fcmOptions`.
- `lerna:prepare`, JS lint, dependency-cruiser, library and consumer TypeScript compiles, API-reference generation, type-parity comparison, and `git diff --check` pass.
- Full Jest: 103 suites, 1,479 tests, 31 snapshots.
