### PR TITLE
fix(app): parse data URL payloads completely

### DIFF
--- a/packages/app/__tests__/common.test.ts
+++ b/packages/app/__tests__/common.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { Base64, getDataUrlParts } from '../lib/common';
+
+describe('common utilities', () => {
+  describe('getDataUrlParts', () => {
+    it('preserves commas after the data URL delimiter', () => {
+      expect(getDataUrlParts('data:text/plain,one,two')).toEqual({
+        base64String: Base64.btoa('one,two'),
+        mediaType: 'text/plain',
+      });
+    });
+
+    it('allows an empty data URL payload', () => {
+      expect(getDataUrlParts('data:text/plain,')).toEqual({
+        base64String: '',
+        mediaType: 'text/plain',
+      });
+    });
+
+    it('encodes decoded text as UTF-8 bytes', () => {
+      expect(getDataUrlParts('data:text/plain,%E2%9C%93')).toEqual({
+        base64String: '4pyT',
+        mediaType: 'text/plain',
+      });
+    });
+
+    it('only recognizes a base64 marker in the metadata suffix', () => {
+      expect(getDataUrlParts('data:text/plain,value;base64')).toEqual({
+        base64String: Base64.btoa('value;base64'),
+        mediaType: 'text/plain',
+      });
+    });
+
+    it.each(['text/plain,value', 'data:text/plain', 'data:text/plain,%E0%A4%A'])(
+      'rejects malformed data URL %s',
+      value => {
+        expect(getDataUrlParts(value)).toEqual({
+          base64String: undefined,
+          mediaType: undefined,
+        });
+      },
+    );
+  });
+});

--- a/packages/app/lib/common/index.ts
+++ b/packages/app/lib/common/index.ts
@@ -30,18 +30,29 @@ export { default as ReferenceBase } from './ReferenceBase';
 export type { DataUrlParts, Observer };
 
 export function getDataUrlParts(dataUrlString: string): DataUrlParts {
-  const isBase64 = dataUrlString.includes(';base64');
-  let [mediaType, base64String] = dataUrlString.split(',');
-  if (!mediaType || !base64String) {
+  const match = /^data:([^,]*?)(;base64)?,([\s\S]*)$/.exec(dataUrlString);
+  if (!match) {
     return { base64String: undefined, mediaType: undefined };
   }
-  mediaType = mediaType.replace('data:', '').replace(';base64', '');
-  if (base64String && base64String.includes('%')) {
-    base64String = decodeURIComponent(base64String);
+
+  const mediaType = match[1] || undefined;
+  let base64String = match[3] ?? '';
+
+  try {
+    if (base64String.includes('%')) {
+      base64String = decodeURIComponent(base64String);
+    }
+    if (!match[2]) {
+      const binaryString = encodeURIComponent(base64String).replace(
+        /%([0-9A-F]{2})/g,
+        (_, hex: string) => String.fromCharCode(Number.parseInt(hex, 16)),
+      );
+      base64String = Base64.btoa(binaryString);
+    }
+  } catch (_) {
+    return { base64String: undefined, mediaType: undefined };
   }
-  if (!isBase64) {
-    base64String = Base64.btoa(base64String);
-  }
+
   return { base64String, mediaType };
 }
 


### PR DESCRIPTION
## What changed

- Parse the data URL structure once and preserve every comma after its delimiter.
- Encode percent-decoded non-base64 payloads as UTF-8 bytes.
- Accept valid empty payloads, scope `;base64` detection to the metadata suffix, and return the existing invalid-parts result for malformed URLs.
- Add focused regression coverage for each corrected boundary.

## Compatibility and observable corrections

- No public API or type changes.
- Valid comma-bearing, empty, and non-ASCII data URLs now upload their complete intended bytes instead of being truncated, rejected, or throwing a Latin-1 error.
- Strings without the required `data:` prefix are now rejected instead of being accepted accidentally.
- Malformed percent escapes now reach Storage's normal invalid-data-URL error path instead of leaking a raw `URIError`.
- Consumers relying on the previous malformed-input acceptance or truncated payloads will observe the corrected result; no valid documented behavior is removed.

## Why

The previous implementation split on every comma, searched the entire URL for `;base64`, and passed decoded Unicode directly to a Latin-1-only encoder. This lost valid payload bytes and made parser behavior depend on payload text. The new boundary follows the same first-delimiter and UTF-8 rules used by the Firebase JavaScript Storage SDK.

## Verification

- Exact baseline regression: six of seven focused cases failed; all seven pass after the fix.
- Focused App/Storage Jest: 32 tests pass.
- Full Jest: 104 suites, 1,486 tests, 31 snapshots pass.
- `lerna:prepare`, JS lint, dependency-cruiser, library and consumer TypeScript compiles, API-reference generation, type comparison, and whitespace checks pass.
- Clean iOS build plus App/Storage E2E: 140 passing, seven known pending.
- Android build/lint plus App/Storage E2E: 142 passing, five known pending.
