### PR TITLE
fix(storage): decode data URLs with custom content types

### DIFF
--- a/packages/storage/__tests__/StorageReference.test.ts
+++ b/packages/storage/__tests__/StorageReference.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from '@jest/globals';
+
+import Reference from '../lib/StorageReference';
+import { StringFormat } from '../lib/StorageStatics';
+import type { StorageInternal } from '../lib/types/internal';
+
+describe('StorageReference string uploads', () => {
+  it('decodes a data URL when metadata already provides a content type', () => {
+    const reference = new Reference({} as StorageInternal, '/file.txt');
+    const metadata = { contentType: 'text/custom' };
+
+    expect(
+      reference._updateString('data:text/plain;base64,aGVsbG8=', StringFormat.DATA_URL, metadata),
+    ).toEqual({
+      _format: StringFormat.BASE64,
+      _metadata: metadata,
+      _string: 'aGVsbG8=',
+    });
+  });
+});

--- a/packages/storage/e2e/StorageTask.e2e.js
+++ b/packages/storage/e2e/StorageTask.e2e.js
@@ -171,6 +171,21 @@ describe('storage() -> StorageTask', function () {
         uploadTaskSnapshot.metadata.should.be.an.Object();
       });
 
+      it('uploads a data_url with an explicit content type', async function () {
+        const { getStorage, ref, uploadString, StringFormat, TaskState } = storageModular;
+
+        const uploadTaskSnapshot = await uploadString(
+          ref(getStorage(), `${PATH}/putStringDataURLWithContentType.txt`),
+          'data:text/plain;base64,aGVsbG8=',
+          StringFormat.DATA_URL,
+          { contentType: 'text/custom' },
+        );
+
+        uploadTaskSnapshot.state.should.eql(TaskState.SUCCESS);
+        uploadTaskSnapshot.metadata.size.should.eql(5);
+        uploadTaskSnapshot.metadata.contentType.should.eql('text/custom');
+      });
+
       it('uploads a url encoded data_url formatted string', async function () {
         const { getStorage, ref, uploadString, StringFormat, TaskState } = storageModular;
 

--- a/packages/storage/lib/StorageReference.ts
+++ b/packages/storage/lib/StorageReference.ts
@@ -339,9 +339,9 @@ export default class Reference extends ReferenceBase implements StorageReference
           _metadata = {};
         }
         _metadata!.contentType = mediaType;
-        _string = base64String;
-        _format = StringFormat.BASE64;
       }
+      _string = base64String;
+      _format = StringFormat.BASE64;
     }
     return { _string, _metadata, _format };
   }


### PR DESCRIPTION
## Compatibility

- No public API or type changes.
- No breaking changes.
- Observable correction: data URL uploads with an explicit metadata contentType are now decoded before reaching the native base64-only upload path. Previously the complete data URL and unsupported data_url format were forwarded.

## What changed

- Always replace a validated data URL with its base64 payload and base64 format.
- Continue inferring contentType only when callers do not provide one.
- Add a focused unit regression and native Storage emulator coverage.

## Verification

- Regression test fails on upstream main and passes with this change.
- Full Jest: 104 suites, 1,480 tests, 31 snapshots.
- iOS App + Storage E2E: 141 passing, 7 pending.
- Android App + Storage E2E: 143 passing, 5 pending.
- Android assembleDebug, assembleAndroidTest, and lintDebug.
- lerna:prepare, JS lint, dependency-cruiser, Storage TypeScript, repository/consumer TypeScript, API reference, compare-types, Prettier, and diff checks.