### PR TITLE
fix(app): preserve web Promise contracts

### DIFF
--- a/packages/app/__tests__/webAppModule.test.ts
+++ b/packages/app/__tests__/webAppModule.test.ts
@@ -16,6 +16,30 @@ jest.mock('../lib/internal/web/firebaseApp', () => ({
 
 const appModule = require('../lib/internal/web/RNFBAppModule.ts').default;
 
+describe('RNFBAppModule Promise contracts', () => {
+  it('matches native async configuration and event methods', async () => {
+    await expect(appModule.metaGetAll()).resolves.toEqual({});
+    await expect(appModule.jsonGetAll()).resolves.toEqual({});
+
+    await expect(
+      appModule.preferencesSetString('promise-contract', 'value'),
+    ).resolves.toBeUndefined();
+    await expect(appModule.preferencesGetAll()).resolves.toMatchObject({
+      'promise-contract': 'value',
+    });
+    await expect(appModule.preferencesClearAll()).resolves.toBeUndefined();
+
+    await expect(appModule.eventsGetListeners()).resolves.toMatchObject({
+      listeners: expect.any(Number),
+      queued: expect.any(Number),
+      events: expect.any(Object),
+    });
+    await expect(appModule.eventsPing('promise_contract_event', { value: true })).resolves.toEqual({
+      value: true,
+    });
+  });
+});
+
 describe('RNFBAppModule setImmediate guards', () => {
   describe('with setImmediate available', () => {
     beforeEach(() => {

--- a/packages/app/lib/internal/web/RNFBAppModule.ts
+++ b/packages/app/lib/internal/web/RNFBAppModule.ts
@@ -174,7 +174,7 @@ export default {
    *
    * @returns The meta data
    */
-  metaGetAll(): Record<string, never> {
+  async metaGetAll(): Promise<Record<string, never>> {
     return {};
   },
 
@@ -184,7 +184,7 @@ export default {
    *
    * @returns The JSON data for the firebase.json file.
    */
-  jsonGetAll(): Record<string, never> {
+  async jsonGetAll(): Promise<Record<string, never>> {
     return {};
   },
 
@@ -206,7 +206,7 @@ export default {
    * @param key - The key of the preference.
    * @param value - The value to set.
    */
-  preferencesSetString(key: string, value: string): void {
+  async preferencesSetString(key: string, value: string): Promise<void> {
     fakePreferencesStorage[key] = value;
   },
 
@@ -216,7 +216,7 @@ export default {
    *
    * @returns The preferences.
    */
-  preferencesGetAll(): PreferencesStorage {
+  async preferencesGetAll(): Promise<PreferencesStorage> {
     return Object.assign({}, fakePreferencesStorage);
   },
 
@@ -224,7 +224,7 @@ export default {
    * Clears all preferences.
    * Unsupported on web.
    */
-  preferencesClearAll(): void {
+  async preferencesClearAll(): Promise<void> {
     fakePreferencesStorage = {};
   },
 
@@ -269,7 +269,7 @@ export default {
    *
    * @returns The listeners for the event.
    */
-  eventsGetListeners(): ListenersMap {
+  async eventsGetListeners(): Promise<ListenersMap> {
     return eventsGetListenersMap();
   },
 
@@ -280,8 +280,9 @@ export default {
    * @param eventBody - The body of the event to send.
    * @returns void
    */
-  eventsPing(eventName: string, eventBody: any): void {
+  async eventsPing(eventName: string, eventBody: any): Promise<any> {
     eventsSendEvent(eventName, eventBody);
+    return eventBody;
   },
 
   /**


### PR DESCRIPTION
## What this fixes

The web App shim returned plain values from methods whose native specs and public contract are asynchronous. Code using `.then()` or `.catch()` therefore failed on web even though `await` appeared to work.

This makes the web implementations return real Promises for metadata, JSON config, preferences, listener diagnostics, and event pings. `eventsPing` now also resolves with the event body, matching the native implementations. Existing `await` behavior is unchanged.

## Verification

- Added a focused regression covering every corrected Promise contract
- Focused App Jest: 7/7 passed
- Full Jest: 104 suites passed
- `yarn lerna:prepare`
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- Focused ESLint and `git diff --check`

## Compatibility

No public API or type changes. This is a web-only runtime compatibility fix; callers already using `await` retain the same behavior, while Promise chaining now works consistently with native.