### PR TITLE
fix(app): retain global logger configuration

### DIFF
--- a/packages/app/__tests__/app.test.ts
+++ b/packages/app/__tests__/app.test.ts
@@ -8,7 +8,7 @@ import {
   getApp,
   setLogLevel,
 } from '../lib';
-import { Logger } from '../lib/internal/logger';
+import { Logger, LogLevel } from '../lib/internal/logger';
 import { NativeFirebaseError } from '../lib/internal';
 
 describe('App', function () {
@@ -69,8 +69,43 @@ describe('App', function () {
           }),
         );
       } finally {
+        onLog(null);
         // eslint-disable-next-line no-console
         console.info = origInfo;
+      }
+    });
+
+    it('applies the global log level to Logger instances created later', function () {
+      setLogLevel('error');
+
+      try {
+        expect(new Logger('late-logger').logLevel).toBe(LogLevel.ERROR);
+      } finally {
+        setLogLevel('info');
+      }
+    });
+
+    it('applies the global log handler to Logger instances created later', function () {
+      const spy = jest.fn();
+      onLog(spy, { level: 'warn' });
+
+      try {
+        const logger = new Logger('late-logger');
+        logger.logHandler = jest.fn();
+        logger.info('ignored');
+        logger.warn('captured');
+
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            args: ['captured'],
+            level: 'warn',
+            message: 'captured',
+            type: 'late-logger',
+          }),
+        );
+      } finally {
+        onLog(null);
       }
     });
   });

--- a/packages/app/lib/internal/logger.ts
+++ b/packages/app/lib/internal/logger.ts
@@ -108,6 +108,50 @@ const defaultLogHandler: LogHandler = (instance, logType, ...args) => {
 
 const defaultLogLevel = LogLevel.INFO;
 
+let currentLogLevel = defaultLogLevel;
+let currentUserLogHandler: LogHandler | null = null;
+
+function createUserLogHandler(
+  logCallback: LogCallback | null,
+  options?: LogOptions,
+): LogHandler | null {
+  if (logCallback === null) {
+    return null;
+  }
+
+  const customLogLevel = options?.level ? levelStringToEnum[options.level] : null;
+  return (instance, level, ...args) => {
+    const message = args
+      .map(arg => {
+        if (arg == null) {
+          return null;
+        } else if (typeof arg === 'string') {
+          return arg;
+        } else if (typeof arg === 'number' || typeof arg === 'boolean') {
+          return arg.toString();
+        } else if (arg instanceof Error) {
+          return arg.message;
+        } else {
+          try {
+            return JSON.stringify(arg);
+          } catch (_ignored) {
+            return null;
+          }
+        }
+      })
+      .filter(arg => arg)
+      .join(' ');
+    if (level >= (customLogLevel ?? instance.logLevel)) {
+      logCallback({
+        level: LogLevelReversed[level]!.toLowerCase() as LogLevelString,
+        message,
+        args,
+        type: instance.name,
+      });
+    }
+  };
+}
+
 /**
  * A container for all of the Logger instances
  */
@@ -118,9 +162,9 @@ export const instances: Logger[] = [];
  */
 export class Logger {
   name: string;
-  private _logLevel: LogLevel = defaultLogLevel;
+  private _logLevel: LogLevel = currentLogLevel;
   private _logHandler: LogHandler = defaultLogHandler;
-  private _userLogHandler: LogHandler | null = null;
+  private _userLogHandler: LogHandler | null = currentUserLogHandler;
 
   /**
    * Gives you an instance of a Logger to capture messages according to
@@ -215,9 +259,11 @@ export class Logger {
  * Sets the log level for all Logger instances
  */
 export function setLogLevel(level: LogLevelString | LogLevel): void {
-  instances.forEach(inst => {
-    inst.setLogLevel(level);
-  });
+  const normalizedLevel = typeof level === 'string' ? levelStringToEnum[level] : level;
+  currentLogLevel = normalizedLevel;
+  for (const instance of instances) {
+    instance.setLogLevel(normalizedLevel);
+  }
 }
 
 // Alias for compatibility
@@ -227,44 +273,8 @@ export const setLogLevelInternal = setLogLevel;
  * Sets a custom user log handler for all Logger instances
  */
 export function setUserLogHandler(logCallback: LogCallback | null, options?: LogOptions): void {
+  currentUserLogHandler = createUserLogHandler(logCallback, options);
   for (const instance of instances) {
-    let customLogLevel: LogLevel | null = null;
-    if (options?.level) {
-      customLogLevel = levelStringToEnum[options.level];
-    }
-    if (logCallback === null) {
-      instance.userLogHandler = null;
-    } else {
-      instance.userLogHandler = (_instance, level, ...args) => {
-        const message = args
-          .map(arg => {
-            if (arg == null) {
-              return null;
-            } else if (typeof arg === 'string') {
-              return arg;
-            } else if (typeof arg === 'number' || typeof arg === 'boolean') {
-              return arg.toString();
-            } else if (arg instanceof Error) {
-              return arg.message;
-            } else {
-              try {
-                return JSON.stringify(arg);
-              } catch (_ignored) {
-                return null;
-              }
-            }
-          })
-          .filter(arg => arg)
-          .join(' ');
-        if (level >= (customLogLevel ?? _instance.logLevel)) {
-          logCallback({
-            level: LogLevelReversed[level]!.toLowerCase() as LogLevelString,
-            message,
-            args,
-            type: _instance.name,
-          });
-        }
-      };
-    }
+    instance.userLogHandler = currentUserLogHandler;
   }
 }


### PR DESCRIPTION
## What this fixes

`setLogLevel()` and `onLog()` only updated Logger instances that already existed. A Firebase package loaded after either call therefore started with the default INFO level and no user callback, silently ignoring the application-wide configuration. This is observable with lazy or dynamic loading of the AI package.

The App logger now retains the current global level and user handler so future Logger instances inherit both. Existing instances are still updated immediately. Level normalization is performed once per global update.

## Verification

- Added exact late-construction regressions for both the global level and callback threshold
- Baseline: both regressions failed (INFO instead of ERROR; callback received zero calls)
- Fixed focused App Jest: 12/12 passed
- Full Jest: 103 suites / 1,481 tests / 31 snapshots passed
- `yarn lerna:prepare`
- `yarn tsc:compile` and `yarn tsc:compile:consumer`
- `yarn lint:deps` and focused ESLint
- `yarn reference:api` and `yarn compare:types`
- `git diff --check`

## Compatibility

No public API/type or breaking change. This restores the documented application-wide behavior for Logger instances created after configuration; already-created Logger behavior is unchanged.