### PR TITLE
fix(app, ios): clear stale custom auth domains

### DIFF
--- a/packages/app/e2e/app.e2e.js
+++ b/packages/app/e2e/app.e2e.js
@@ -15,6 +15,8 @@
  *
  */
 
+const APP_MODULE = NativeModules.NativeRNFBTurboApp;
+
 describe('modular', function () {
   describe('firebase v9 modular', function () {
     it('it should allow read the default app from native', function () {
@@ -139,6 +141,47 @@ describe('modular', function () {
         should.equal(getApps().length, appCount);
         should.equal(getApps().includes('myname'), false);
       }
+    });
+
+    it('does not retain a custom auth domain after deleting an app', async function () {
+      if (!Platform.ios) return;
+
+      const name = `authdomaintest${FirebaseHelpers.id}`;
+      const config = FirebaseHelpers.app.config();
+      const appConfig = { name, automaticDataCollectionEnabled: true };
+      const appWithAuthDomain = await APP_MODULE.initializeApp(config, appConfig);
+      appWithAuthDomain.options.authDomain.should.equal(config.authDomain);
+      await APP_MODULE.deleteApp(name);
+
+      const { authDomain: _authDomain, ...configWithoutAuthDomain } = config;
+      const recreatedApp = await APP_MODULE.initializeApp(configWithoutAuthDomain, appConfig);
+      const recreatedAuthDomain = recreatedApp.options.authDomain;
+      await APP_MODULE.deleteApp(name);
+      should.equal(recreatedAuthDomain, undefined);
+    });
+
+    it('does not retain a custom auth domain after failed initialization', async function () {
+      if (!Platform.ios) return;
+
+      const name = `failedauthdomaintest${FirebaseHelpers.id}`;
+      const config = FirebaseHelpers.app.config();
+      const { authDomain: _authDomain, ...configWithoutAuthDomain } = config;
+      const appConfig = { name, automaticDataCollectionEnabled: true };
+      await APP_MODULE.initializeApp(configWithoutAuthDomain, appConfig);
+
+      let rejected = false;
+      try {
+        await APP_MODULE.initializeApp(config, appConfig);
+      } catch (_error) {
+        rejected = true;
+      }
+      rejected.should.equal(true);
+
+      await APP_MODULE.deleteApp(name);
+      const recoveredApp = await APP_MODULE.initializeApp(configWithoutAuthDomain, appConfig);
+      const recoveredAuthDomain = recoveredApp.options.authDomain;
+      await APP_MODULE.deleteApp(name);
+      should.equal(recoveredAuthDomain, undefined);
     });
 
     it('apps can be deleted, but only if it exists', async function () {

--- a/packages/app/ios/RNFBApp/RNFBAppModule.mm
+++ b/packages/app/ios/RNFBApp/RNFBAppModule.mm
@@ -41,7 +41,12 @@
 #endif
 
 @interface RNFBAppModule () <NativeRNFBTurboAppSpec, RCTInvalidating>
+
++ (void)setCustomDomain:(nullable NSString *)authDomain forAppName:(NSString *)appName;
+
 @end
+
+static NSMutableDictionary<NSString *, NSString *> *customAuthDomains;
 
 @implementation RNFBAppModule
 
@@ -200,6 +205,7 @@ RCT_EXPORT_MODULE(NativeRNFBTurboApp)
   RCTUnsafeExecuteOnMainQueueSync(^{
     FIRApp *firApp;
     NSString *appName = [appConfig valueForKey:@"name"];
+    NSString *authDomain = [options valueForKey:@"authDomain"];
 
     NSString *appId = [options valueForKey:@"appId"];
     NSString *messagingSenderId = [options valueForKey:@"messagingSenderId"];
@@ -223,13 +229,6 @@ RCT_EXPORT_MODULE(NativeRNFBTurboApp)
       firOptions.appGroupID = [options valueForKey:@"appGroupId"];
     }
 
-    if ([options valueForKey:@"authDomain"] != nil) {
-      DLog(@"RNFBAuth app: %@ customAuthDomain: %@", appName, [options valueForKey:@"authDomain"]);
-      if (customAuthDomains == nil) {
-        customAuthDomains = [[NSMutableDictionary alloc] init];
-      }
-      customAuthDomains[appName] = [options valueForKey:@"authDomain"];
-    }
     @try {
       if (!appName || [appName isEqualToString:DEFAULT_APP_DISPLAY_NAME]) {
         [FIRApp configureWithOptions:firOptions];
@@ -242,6 +241,8 @@ RCT_EXPORT_MODULE(NativeRNFBTurboApp)
       return [RNFBSharedUtils rejectPromiseWithExceptionDict:reject exception:exception];
     }
 
+    [RNFBAppModule setCustomDomain:authDomain forAppName:appName];
+
     firApp.dataCollectionDefaultEnabled =
         (BOOL)[appConfig valueForKey:@"automaticDataCollectionEnabled"];
 
@@ -249,11 +250,25 @@ RCT_EXPORT_MODULE(NativeRNFBTurboApp)
   });
 }
 
-static NSMutableDictionary<NSString *, NSString *> *customAuthDomains;
-
 + (NSString *)getCustomDomain:(NSString *)appName {
-  DLog(@"authDomains: %@", customAuthDomains);
-  return customAuthDomains[appName];
+  @synchronized(self) {
+    DLog(@"authDomains: %@", customAuthDomains);
+    return customAuthDomains[appName];
+  }
+}
+
++ (void)setCustomDomain:(nullable NSString *)authDomain forAppName:(NSString *)appName {
+  @synchronized(self) {
+    if (authDomain != nil) {
+      DLog(@"RNFBAuth app: %@ customAuthDomain: %@", appName, authDomain);
+      if (customAuthDomains == nil) {
+        customAuthDomains = [[NSMutableDictionary alloc] init];
+      }
+      customAuthDomains[appName] = authDomain;
+    } else {
+      [customAuthDomains removeObjectForKey:appName];
+    }
+  }
 }
 
 - (void)setLogLevel:(NSString *)logLevel {
@@ -288,10 +303,12 @@ static NSMutableDictionary<NSString *, NSString *> *customAuthDomains;
 
   [firApp deleteApp:^(BOOL success) {
     if (success) {
+      [RNFBAppModule setCustomDomain:nil forAppName:appName];
       resolve([NSNull null]);
     } else {
       [firApp deleteApp:^(BOOL success2) {
         if (success2) {
+          [RNFBAppModule setCustomDomain:nil forAppName:appName];
           resolve([NSNull null]);
         } else {
           reject(@"app/delete-app-failed", @"Failed to delete the specified app.", nil);

--- a/packages/app/ios/RNFBApp/RNFBSharedUtils.m
+++ b/packages/app/ios/RNFBApp/RNFBSharedUtils.m
@@ -64,8 +64,9 @@ static NSString *const RNFBErrorDomain = @"RNFBErrorDomain";
   // missing from android sdk - ios only:
   firAppOptions[@"clientId"] = firOptions.clientID;
   // not in FIROptions API but in JS SDK and project config JSON
-  if ([RNFBAppModule getCustomDomain:name] != nil) {
-    firAppOptions[@"authDomain"] = [RNFBAppModule getCustomDomain:name];
+  NSString *customAuthDomain = [RNFBAppModule getCustomDomain:name];
+  if (customAuthDomain != nil) {
+    firAppOptions[@"authDomain"] = customAuthDomain;
   }
 
   firAppDictionary[@"options"] = firAppOptions;


### PR DESCRIPTION
## What this fixes

The iOS App module recorded a secondary app's custom `authDomain` before Firebase accepted the app configuration and never removed it when the app was deleted. A later app with the same name could therefore receive an auth domain from a failed or deleted predecessor.

This update:

- records the domain only after Firebase configuration succeeds
- removes it when initialization omits the domain or deletion succeeds
- synchronizes access to the shared domain map
- reads the map once when serializing app options

## Verification

- Added direct native lifecycle regressions for delete/recreate and failed-initialize/recover
- Baseline: both returned `react-native-firebase-testing.firebaseapp.com` instead of `undefined`
- Fixed iOS App E2E: 41/41 passed
- Clean iOS simulator build passed
- Native LLVM coverage collected for the changed lifecycle/serialization paths
- Full Jest: 103 suites / 1,479 tests / 31 snapshots passed
- `yarn lerna:prepare`
- `yarn tsc:compile` and `yarn tsc:compile:consumer`
- `yarn lint:deps`, focused ESLint, and iOS formatting
- `yarn reference:api` and `yarn compare:types`
- `git diff --check`

Temporary harness configuration and pod-install-only lockfile checksum drift were removed before commit.

## Compatibility

No public API/type or breaking change. Correctly initialized apps retain their configured auth domain; only stale domains from failed or deleted app instances are removed.