### PR TITLE
fix(app): make debug native proxies behavior-safe

### DIFF
--- a/packages/app/__tests__/nativeModuleResolver.test.ts
+++ b/packages/app/__tests__/nativeModuleResolver.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, jest } from '@jest/globals';
 import { TurboModuleRegistry } from 'react-native';
 import { getReactNativeModule } from '../lib/internal/nativeModuleAndroidIos';
+import {
+  getReactNativeModule as getWebReactNativeModule,
+  setReactNativeModule as setWebReactNativeModule,
+} from '../lib/internal/nativeModuleWeb';
 
 describe('getReactNativeModule (NewArch-AD-6 Phase R)', function () {
   it('throws when TurboModuleRegistry has no module for the name', function () {
@@ -10,5 +14,81 @@ describe('getReactNativeModule (NewArch-AD-6 Phase R)', function () {
     expect(() => getReactNativeModule(unknownModule)).toThrow(
       `Native module ${unknownModule} is not registered.`,
     );
+  });
+
+  it('does not let debug serialization change a native call', function () {
+    const moduleName = 'NativeRNFBTurboDebugSerializationTest';
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    circular.bigint = BigInt(1);
+    const nativeModule = { echo: jest.fn((value: unknown) => value) };
+    jest.mocked(TurboModuleRegistry.get).mockReturnValueOnce(nativeModule as any);
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    globalThis.RNFBDebug = true;
+
+    try {
+      const resolvedModule = getReactNativeModule(moduleName);
+      expect((resolvedModule.echo as (value: unknown) => unknown)(circular)).toBe(circular);
+    } finally {
+      globalThis.RNFBDebug = false;
+      debugSpy.mockRestore();
+    }
+  });
+
+  it('preserves non-Promise results with a non-callable then property', function () {
+    const moduleName = 'NativeRNFBTurboDebugThenTest';
+    const result = { then: false };
+    jest.mocked(TurboModuleRegistry.get).mockReturnValueOnce({ getResult: () => result } as any);
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    globalThis.RNFBDebug = true;
+
+    try {
+      const resolvedModule = getReactNativeModule(moduleName);
+      expect((resolvedModule.getResult as () => unknown)()).toBe(result);
+    } finally {
+      globalThis.RNFBDebug = false;
+      debugSpy.mockRestore();
+    }
+  });
+
+  it('does not let a failing debug console change a native call', function () {
+    const moduleName = 'NativeRNFBTurboDebugConsoleTest';
+    jest
+      .mocked(TurboModuleRegistry.get)
+      .mockReturnValueOnce({ echo: (value: string) => value } as any);
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {
+      throw new Error('console unavailable');
+    });
+    globalThis.RNFBDebug = true;
+
+    try {
+      const resolvedModule = getReactNativeModule(moduleName);
+      expect((resolvedModule.echo as (value: string) => string)('value')).toBe('value');
+    } finally {
+      globalThis.RNFBDebug = false;
+      debugSpy.mockRestore();
+    }
+  });
+
+  it('binds and memoizes web debug module methods', function () {
+    const moduleName = 'NativeRNFBTurboWebDebugTest';
+    const nativeModule = {
+      value: 'bound',
+      getValue() {
+        return this.value;
+      },
+    };
+    setWebReactNativeModule(moduleName, nativeModule);
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    globalThis.RNFBDebug = true;
+
+    try {
+      const resolvedModule = getWebReactNativeModule(moduleName)!;
+      expect((resolvedModule.getValue as () => string)()).toBe('bound');
+      expect(getWebReactNativeModule(moduleName)).toBe(resolvedModule);
+    } finally {
+      globalThis.RNFBDebug = false;
+      debugSpy.mockRestore();
+    }
   });
 });

--- a/packages/app/lib/internal/nativeModuleAndroidIos.ts
+++ b/packages/app/lib/internal/nativeModuleAndroidIos.ts
@@ -1,5 +1,5 @@
-/* eslint-disable no-console */
 import { TurboModuleRegistry } from 'react-native';
+import { createNativeModuleDebugProxy } from './nativeModuleDebug';
 
 const DYNAMIC_CONSTANT_KEYS = new Set(['androidPlayServices']);
 
@@ -64,45 +64,7 @@ export function getReactNativeModule(moduleName: string): Record<string, unknown
     return debugProxy;
   }
 
-  debugProxy = new Proxy(nativeModule as Record<string, unknown>, {
-    ownKeys(target) {
-      const keys: string[] = [];
-      for (const key in target) {
-        keys.push(key);
-      }
-      return keys;
-    },
-    get: (_, name) => {
-      const prop = (nativeModule as Record<string, unknown>)[name as string];
-      if (typeof prop !== 'function') return prop;
-      return (...args: unknown[]) => {
-        console.debug(
-          `[RNFB->Native][🔵] ${moduleName}.${String(name)} -> ${JSON.stringify(args)}`,
-        );
-        const result: unknown = (prop as (...args: unknown[]) => unknown).apply(nativeModule, args);
-        if (result && typeof result === 'object' && 'then' in result) {
-          return (result as Promise<unknown>).then(
-            (res: unknown) => {
-              console.debug(
-                `[RNFB<-Native][🟢] ${moduleName}.${String(name)} <- ${JSON.stringify(res)}`,
-              );
-              return res;
-            },
-            (err: unknown) => {
-              console.debug(
-                `[RNFB<-Native][🔴] ${moduleName}.${String(name)} <- ${JSON.stringify(err)}`,
-              );
-              throw err;
-            },
-          );
-        }
-        console.debug(
-          `[RNFB<-Native][🟢] ${moduleName}.${String(name)} <- ${JSON.stringify(result)}`,
-        );
-        return result;
-      };
-    },
-  });
+  debugProxy = createNativeModuleDebugProxy(moduleName, nativeModule);
   memoizedDebugProxies.set(moduleName, debugProxy);
   return debugProxy;
 }

--- a/packages/app/lib/internal/nativeModuleDebug.ts
+++ b/packages/app/lib/internal/nativeModuleDebug.ts
@@ -1,0 +1,97 @@
+/* eslint-disable no-console */
+
+function serializeDebugValue(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  try {
+    const serialized = JSON.stringify(value, (_key, currentValue: unknown) => {
+      if (typeof currentValue === 'bigint') {
+        return `${currentValue}n`;
+      }
+      if (currentValue instanceof Error) {
+        return { name: currentValue.name, message: currentValue.message };
+      }
+      if (currentValue && typeof currentValue === 'object') {
+        if (seen.has(currentValue)) {
+          return '[Circular]';
+        }
+        seen.add(currentValue);
+      }
+      return currentValue;
+    });
+    return serialized ?? String(value);
+  } catch (_error) {
+    return '[Unserializable]';
+  }
+}
+
+function logDebug(message: string): void {
+  try {
+    console.debug(message);
+  } catch (_error) {
+    // Debug logging must not change native module behavior.
+  }
+}
+
+export function createNativeModuleDebugProxy(
+  moduleName: string,
+  nativeModule: Record<string, unknown>,
+): Record<string, unknown> {
+  return new Proxy(nativeModule, {
+    ownKeys(target) {
+      const keys: string[] = [];
+      for (const key in target) {
+        keys.push(key);
+      }
+      return keys;
+    },
+    get: (_, name) => {
+      const prop = nativeModule[name as string];
+      if (typeof prop !== 'function') return prop;
+
+      return (...args: unknown[]) => {
+        logDebug(
+          `[RNFB->Native][🔵] ${moduleName}.${String(name)} -> ${serializeDebugValue(args)}`,
+        );
+
+        let result: unknown;
+        try {
+          result = Reflect.apply(prop, nativeModule, args);
+        } catch (error) {
+          logDebug(
+            `[RNFB<-Native][🔴] ${moduleName}.${String(name)} <- ${serializeDebugValue(error)}`,
+          );
+          throw error;
+        }
+
+        if (
+          result &&
+          typeof result === 'object' &&
+          typeof (result as Promise<unknown>).then === 'function'
+        ) {
+          return (result as Promise<unknown>).then(
+            resolvedValue => {
+              logDebug(
+                `[RNFB<-Native][🟢] ${moduleName}.${String(name)} <- ${serializeDebugValue(
+                  resolvedValue,
+                )}`,
+              );
+              return resolvedValue;
+            },
+            error => {
+              logDebug(
+                `[RNFB<-Native][🔴] ${moduleName}.${String(name)} <- ${serializeDebugValue(error)}`,
+              );
+              throw error;
+            },
+          );
+        }
+
+        logDebug(
+          `[RNFB<-Native][🟢] ${moduleName}.${String(name)} <- ${serializeDebugValue(result)}`,
+        );
+        return result;
+      };
+    },
+  });
+}

--- a/packages/app/lib/internal/nativeModuleWeb.ts
+++ b/packages/app/lib/internal/nativeModuleWeb.ts
@@ -1,12 +1,13 @@
-/* eslint-disable no-console */
 import RNFBAppModule from './web/RNFBAppModule';
 import { APP_NATIVE_MODULE } from './constants';
+import { createNativeModuleDebugProxy } from './nativeModuleDebug';
 
 // Register before exporting getters — RNFBNativeEventEmitter instantiates during circular imports.
 const nativeModuleRegistry: Record<string, Record<string, unknown>> = {
   RNFBAppModule: RNFBAppModule as unknown as Record<string, unknown>,
   [APP_NATIVE_MODULE]: RNFBAppModule as unknown as Record<string, unknown>,
 };
+const memoizedDebugProxies = new Map<string, Record<string, unknown>>();
 
 export function getReactNativeModule(moduleName: string): Record<string, unknown> | undefined {
   const nativeModule = nativeModuleRegistry[moduleName];
@@ -17,45 +18,13 @@ export function getReactNativeModule(moduleName: string): Record<string, unknown
   if (!globalThis.RNFBDebug) {
     return nativeModule;
   }
-  return new Proxy(nativeModule, {
-    ownKeys(target) {
-      const keys: string[] = [];
-      for (const key in target) {
-        keys.push(key);
-      }
-      return keys;
-    },
-    get: (_, name) => {
-      const prop = nativeModule[name as string];
-      if (typeof prop !== 'function') return prop;
-      return (...args: unknown[]) => {
-        console.debug(
-          `[RNFB->Native][🔵] ${moduleName}.${String(name)} -> ${JSON.stringify(args)}`,
-        );
-        const result: unknown = (prop as (...args: unknown[]) => unknown)(...args);
-        if (result && typeof result === 'object' && 'then' in result) {
-          return (result as Promise<unknown>).then(
-            (res: unknown) => {
-              console.debug(
-                `[RNFB<-Native][🟢] ${moduleName}.${String(name)} <- ${JSON.stringify(res)}`,
-              );
-              return res;
-            },
-            (err: unknown) => {
-              console.debug(
-                `[RNFB<-Native][🔴] ${moduleName}.${String(name)} <- ${JSON.stringify(err)}`,
-              );
-              throw err;
-            },
-          );
-        }
-        console.debug(
-          `[RNFB<-Native][🟢] ${moduleName}.${String(name)} <- ${JSON.stringify(result)}`,
-        );
-        return result;
-      };
-    },
-  });
+
+  let debugProxy = memoizedDebugProxies.get(moduleName);
+  if (!debugProxy) {
+    debugProxy = createNativeModuleDebugProxy(moduleName, nativeModule);
+    memoizedDebugProxies.set(moduleName, debugProxy);
+  }
+  return debugProxy;
 }
 
 export function setReactNativeModule(
@@ -63,4 +32,5 @@ export function setReactNativeModule(
   nativeModule: Record<string, unknown>,
 ): void {
   nativeModuleRegistry[moduleName] = nativeModule;
+  memoizedDebugProxies.delete(moduleName);
 }


### PR DESCRIPTION
## What this fixes

RNFB debug logging could change otherwise valid native-module calls:

- circular or BigInt arguments/results made `JSON.stringify` throw
- a replaced/throwing `console.debug` prevented calls from running
- any object with a `then` property was treated as a Promise, even when `then` was not callable
- web proxy methods were called without their module receiver, breaking methods that use `this`
- web returned a fresh proxy on every resolution

The two platform implementations now share one behavior-safe debug proxy. It serializes circular/BigInt/Error values defensively, contains console failures, preserves synchronous errors, recognizes only callable Promise-like results, binds methods to their module, and memoizes/invalidate web proxies consistently.

## Verification

- Added focused regressions for circular + BigInt values, non-callable `then`, console failures, web receiver binding, and web proxy identity
- Baseline failed on circular serialization and unbound web methods
- Fixed focused App Jest: 5/5 passed
- Full Jest: 103 suites / 1,483 tests / 31 snapshots passed
- App E2E with `RNFBDebug` enabled: iOS 39/39 and Android 39/39 passed
- `yarn lerna:prepare`
- `yarn tsc:compile` and `yarn tsc:compile:consumer`
- `yarn lint:deps` and focused ESLint
- `yarn reference:api` and `yarn compare:types`
- `git diff --check`

Temporary debug harness configuration was removed before commit.

## Compatibility

No public API/type or breaking change. Non-debug behavior is untouched. Debug mode now observes calls without changing their receiver, return value, or failure behavior.