### PR TITLE
fix(app, expo): add missing Firebase imports

### DIFF
--- a/packages/app/plugin/__tests__/iosPlugin.test.ts
+++ b/packages/app/plugin/__tests__/iosPlugin.test.ts
@@ -110,4 +110,36 @@ describe('Config Plugin iOS Tests', function () {
     expect(twiceModifiedAppDelegate).toContain(singleImport);
     expect(twiceModifiedAppDelegate).not.toContain(doubleImport);
   });
+
+  it('adds the Firebase import to an Objective-C AppDelegate without the standard header import', function () {
+    const appDelegate = `#import <UIKit/UIKit.h>
+
+@implementation AppDelegate
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  return YES;
+}
+@end
+`;
+
+    const result = modifyObjcAppDelegate(appDelegate);
+    expect(result).toContain('#import <Firebase/Firebase.h>');
+    expect(result).toContain('[FIRApp configure];');
+  });
+
+  it('adds the Firebase import to a Swift AppDelegate without Expo', function () {
+    const appDelegate = `import UIKit
+import React
+
+class AppDelegate {
+  func configure() {
+    self.moduleName = "App"
+  }
+}
+`;
+
+    const result = modifySwiftAppDelegate(appDelegate);
+    expect(result).toContain('import FirebaseCore');
+    expect(result).toContain('FirebaseApp.configure()');
+  });
 });

--- a/packages/app/plugin/src/ios/appDelegate.ts
+++ b/packages/app/plugin/src/ios/appDelegate.ts
@@ -3,6 +3,36 @@ import { AppDelegateProjectFile } from '@expo/config-plugins/build/ios/Paths';
 import { mergeContents } from '@expo/config-plugins/build/utils/generateCode';
 import fs from 'fs';
 
+function addImport(
+  contents: string,
+  importLine: string,
+  existingImportMatcher: RegExp,
+  preferredAnchorMatcher: RegExp,
+  anyImportMatcher: RegExp,
+): string {
+  if (existingImportMatcher.test(contents)) {
+    return contents;
+  }
+
+  const newline = contents.includes('\r\n') ? '\r\n' : '\n';
+  const preferredAnchor = preferredAnchorMatcher.exec(contents);
+  if (preferredAnchor?.index !== undefined) {
+    const insertionPoint = preferredAnchor.index + preferredAnchor[0].length;
+    return `${contents.slice(0, insertionPoint)}${newline}${importLine}${contents.slice(
+      insertionPoint,
+    )}`;
+  }
+
+  const firstImport = anyImportMatcher.exec(contents);
+  if (firstImport?.index !== undefined) {
+    return `${contents.slice(0, firstImport.index)}${importLine}${newline}${contents.slice(
+      firstImport.index,
+    )}`;
+  }
+
+  return `${importLine}${newline}${contents}`;
+}
+
 export function modifyObjcAppDelegate(contents: string): string {
   const methodInvocationBlock = `[FIRApp configure];`;
   // https://regex101.com/r/mPgaq6/1
@@ -15,13 +45,13 @@ export function modifyObjcAppDelegate(contents: string): string {
     /-\s*\(BOOL\)\s*application:\s*\(UIApplication\s*\*\s*\)\s*\w+\s+didFinishLaunchingWithOptions:/g;
 
   // Add import
-  if (!contents.includes('#import <Firebase/Firebase.h>')) {
-    contents = contents.replace(
-      /#import "AppDelegate.h"/g,
-      `#import "AppDelegate.h"
-#import <Firebase/Firebase.h>`,
-    );
-  }
+  contents = addImport(
+    contents,
+    '#import <Firebase/Firebase.h>',
+    /^[ \t]*#import\s+<Firebase\/Firebase\.h>[ \t]*$/m,
+    /^[ \t]*#import\s+"AppDelegate\.h"[ \t]*$/m,
+    /^[ \t]*#import\b[^\r\n]*$/m,
+  );
 
   // To avoid potential issues with existing changes from older plugin versions
   if (contents.includes(methodInvocationBlock)) {
@@ -74,13 +104,13 @@ export function modifySwiftAppDelegate(contents: string): string {
     /(?:self\.moduleName\s*=\s*"([^"]*)")|(?:factory\.startReactNative\()/;
 
   // Add import
-  if (!contents.includes('import FirebaseCore')) {
-    contents = contents.replace(
-      /import Expo/g,
-      `import Expo
-import FirebaseCore`,
-    );
-  }
+  contents = addImport(
+    contents,
+    'import FirebaseCore',
+    /^[ \t]*import\s+FirebaseCore[ \t]*$/m,
+    /^[ \t]*import\s+Expo[ \t]*$/m,
+    /^[ \t]*import\b[^\r\n]*$/m,
+  );
 
   // To avoid potential issues with existing changes from older plugin versions
   if (contents.includes(methodInvocationBlock)) {


### PR DESCRIPTION
## What this fixes

- Ensures the Expo config plugin imports Firebase in custom Objective-C AppDelegates that do not import `AppDelegate.h`.
- Ensures the plugin imports FirebaseCore in custom Swift AppDelegates that do not import Expo.
- Preserves existing import placement for standard templates, newline style, and idempotence.

Without the import, the plugin could add `[FIRApp configure]` or `FirebaseApp.configure()` while leaving the generated native source uncompilable.

## Implementation

A shared import insertion helper now:

- recognizes an existing exact import;
- inserts after the conventional AppDelegate/Expo anchor when present;
- otherwise inserts before the first import;
- falls back to the start of an import-free file.

## Verification

Regression tests reproduce both failures on upstream `main` and pass with this change. The complete repository gates also pass:

- `yarn lerna:prepare`
- `yarn tests:jest --runInBand` — 103 suites, 1,481 tests, 31 snapshots
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- focused ESLint
- `git diff --check`

## Compatibility

No public API or breaking changes.