### PR TITLE
fix(app): support arbitrary web storage keys

### DIFF
--- a/packages/app/__tests__/webAppModule.test.ts
+++ b/packages/app/__tests__/webAppModule.test.ts
@@ -113,3 +113,34 @@ describe('RNFBAppModule setImmediate guards', () => {
     });
   });
 });
+
+describe('RNFBAppModule arbitrary keys', () => {
+  it('tracks event names that collide with Object prototype properties', async () => {
+    appModule.eventsAddListener('hasOwnProperty');
+    appModule.eventsAddListener('hasOwnProperty');
+    appModule.eventsAddListener('__proto__');
+
+    const events = (await appModule.eventsGetListeners()).events;
+    expect(events.hasOwnProperty).toBe(2);
+    expect(events['__proto__']).toBe(1);
+
+    appModule.eventsRemoveListener('hasOwnProperty', true);
+    appModule.eventsRemoveListener('__proto__', true);
+  });
+
+  it('does not expose the internal listener map', async () => {
+    const events = (await appModule.eventsGetListeners()).events;
+    events.externalMutation = 1;
+
+    expect((await appModule.eventsGetListeners()).events.externalMutation).toBeUndefined();
+  });
+
+  it('stores preference keys that collide with Object prototype properties', async () => {
+    await appModule.preferencesSetString('hasOwnProperty', 'method');
+    await appModule.preferencesSetString('__proto__', 'prototype');
+
+    const preferences = await appModule.preferencesGetAll();
+    expect(preferences.hasOwnProperty).toBe('method');
+    expect(preferences['__proto__']).toBe('prototype');
+  });
+});

--- a/packages/app/lib/internal/web/RNFBAppModule.ts
+++ b/packages/app/lib/internal/web/RNFBAppModule.ts
@@ -48,22 +48,22 @@ interface InitializeAppResult {
 let jsReady = false;
 let jsListenerCount = 0;
 let queuedEvents: QueuedEvent[] = [];
-let jsListeners: EventListeners = {};
+let jsListeners: EventListeners = Object.create(null);
 
 // For compatibility we have a fake preferences storage,
 // it does not persist across app restarts.
-let fakePreferencesStorage: PreferencesStorage = {};
+let fakePreferencesStorage: PreferencesStorage = Object.create(null);
 
 function eventsGetListenersMap(): ListenersMap {
   return {
     listeners: jsListenerCount,
     queued: queuedEvents.length,
-    events: jsListeners,
+    events: Object.assign(Object.create(null), jsListeners),
   };
 }
 
 function eventsSendEvent(eventName: string, eventBody: any): void {
-  if (!jsReady || !jsListeners.hasOwnProperty(eventName)) {
+  if (!jsReady || !Object.prototype.hasOwnProperty.call(jsListeners, eventName)) {
     const event: QueuedEvent = {
       eventName,
       eventBody,
@@ -217,7 +217,7 @@ export default {
    * @returns The preferences.
    */
   async preferencesGetAll(): Promise<PreferencesStorage> {
-    return Object.assign({}, fakePreferencesStorage);
+    return Object.assign(Object.create(null), fakePreferencesStorage);
   },
 
   /**
@@ -225,7 +225,7 @@ export default {
    * Unsupported on web.
    */
   async preferencesClearAll(): Promise<void> {
-    fakePreferencesStorage = {};
+    fakePreferencesStorage = Object.create(null);
   },
 
   /**
@@ -292,7 +292,7 @@ export default {
    */
   eventsAddListener(eventName: string): void {
     jsListenerCount++;
-    if (!jsListeners.hasOwnProperty(eventName)) {
+    if (!Object.prototype.hasOwnProperty.call(jsListeners, eventName)) {
       jsListeners[eventName] = 1;
     } else {
       if (jsListeners[eventName] !== undefined) {
@@ -313,7 +313,7 @@ export default {
    * @param all - Optional. Whether to remove all listeners for the event.
    */
   eventsRemoveListener(eventName: string, all?: boolean): void {
-    if (jsListeners.hasOwnProperty(eventName)) {
+    if (Object.prototype.hasOwnProperty.call(jsListeners, eventName)) {
       const count = jsListeners[eventName];
       if (count !== undefined) {
         if (count <= 1 || all) {


### PR DESCRIPTION
## What this fixes

- Prevents web event names such as `hasOwnProperty` from replacing the listener map method and crashing subsequent listener operations.
- Preserves event and preference keys such as `__proto__` instead of silently losing them through JavaScript prototype behavior.
- Stops `eventsGetListeners()` callers from mutating the internal listener registry.

These names are valid strings at the bridge boundary and native maps already support them.

## Implementation

The web shim now stores string-keyed data in null-prototype dictionaries, performs explicit own-property checks, and returns detached null-prototype snapshots.

## Verification

Exact baseline regressions failed with a TypeError and a lost preference value. All permanent focused cases now pass. Complete repository gates also pass:

- `yarn lerna:prepare`
- `yarn tests:jest --runInBand` — 103 suites, 1,482 tests, 31 snapshots
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- focused ESLint
- `git diff --check`

## Compatibility

No public API/type or breaking change. Ordinary event and preference keys retain their existing behavior.