### PR TITLE
fix(app): reject FileReader startup failures

### DIFF
--- a/packages/app/__tests__/app.test.ts
+++ b/packages/app/__tests__/app.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../lib';
 import { Logger } from '../lib/internal/logger';
 import { NativeFirebaseError } from '../lib/internal';
+import Base64 from '../lib/common/Base64';
 
 describe('App', function () {
   describe('modular', function () {
@@ -71,6 +72,26 @@ describe('App', function () {
       } finally {
         // eslint-disable-next-line no-console
         console.info = origInfo;
+      }
+    });
+  });
+
+  describe('Base64', function () {
+    it('rejects when FileReader cannot start reading a Blob', async function () {
+      const OriginalFileReader = globalThis.FileReader;
+
+      class ThrowingFileReader {
+        readAsDataURL(): void {
+          throw new Error('read failed');
+        }
+      }
+
+      globalThis.FileReader = ThrowingFileReader as unknown as typeof FileReader;
+
+      try {
+        await expect(Base64.fromData(new Blob())).rejects.toThrow('read failed');
+      } finally {
+        globalThis.FileReader = OriginalFileReader;
       }
     });
   });

--- a/packages/app/lib/common/Base64.ts
+++ b/packages/app/lib/common/Base64.ts
@@ -17,7 +17,6 @@
 
 // @ts-expect-error - No type declarations available
 import binaryToBase64 from 'react-native/Libraries/Utilities/binaryToBase64';
-import { promiseDefer } from './promise';
 
 const CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 
@@ -90,23 +89,18 @@ export interface Base64Result {
  */
 function fromData(data: Blob | ArrayBuffer | Uint8Array): Promise<Base64Result> {
   if (data instanceof Blob) {
-    const fileReader = new FileReader();
-    const { resolve, reject, promise } = promiseDefer<Base64Result>();
+    return new Promise<Base64Result>((resolve, reject) => {
+      const fileReader = new FileReader();
 
-    fileReader.readAsDataURL(data);
+      fileReader.onloadend = () => {
+        if (fileReader.result) {
+          resolve({ string: fileReader.result, format: 'data_url' });
+        }
+      };
 
-    fileReader.onloadend = () => {
-      if (fileReader?.result) {
-        resolve?.({ string: fileReader.result, format: 'data_url' });
-      }
-    };
-
-    fileReader.onerror = event => {
-      fileReader?.abort();
-      reject?.(event);
-    };
-
-    return promise;
+      fileReader.onerror = event => reject(event);
+      fileReader.readAsDataURL(data);
+    });
   }
 
   if (data instanceof ArrayBuffer || data instanceof Uint8Array) {


### PR DESCRIPTION
## What this fixes

`Base64.fromData(blob)` now rejects its returned Promise when `FileReader.readAsDataURL()` cannot start. Previously that failure escaped synchronously even though the method declares and is consumed as a Promise, bypassing Storage upload rejection handling.

## Implementation

The Blob path now uses a native Promise executor, installs handlers before starting the read, and relies on the executor to convert synchronous FileReader exceptions into rejections. This also removes the unnecessary deferred-Promise bookkeeping.

## Verification

The exact baseline regression throws synchronously; the permanent fixed case observes the expected rejected Promise. Complete repository gates pass:

- `yarn lerna:prepare`
- `yarn tests:jest --runInBand` — 103 suites, 1,480 tests, 31 snapshots
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- focused ESLint
- `git diff --check`

## Compatibility

Observable correction: FileReader startup failures now reject asynchronously instead of throwing synchronously. Successful Blob, ArrayBuffer, and Uint8Array conversions are unchanged; there is no type change.