### PR TITLE
fix(app): support prototype-named apps

### DIFF
--- a/packages/app/__tests__/app.test.ts
+++ b/packages/app/__tests__/app.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import { NativeModules } from 'react-native';
 import {
   deleteApp,
   registerVersion,
@@ -11,6 +12,22 @@ import {
 import { Logger, LogLevel } from '../lib/internal/logger';
 import { NativeFirebaseError } from '../lib/internal';
 import Base64 from '../lib/common/Base64';
+import FirebaseModule from '../lib/internal/FirebaseModule';
+import { getOrCreateModularInstance } from '../lib/internal/registry/modular';
+import type { ModuleConfig } from '../lib/types/internal';
+
+const nativeAppModule = NativeModules.NativeRNFBTurboApp;
+nativeAppModule.initializeApp = jest.fn(() => Promise.resolve());
+nativeAppModule.deleteApp = jest.fn(() => Promise.resolve());
+
+const firebaseOptions = {
+  apiKey: 'api-key',
+  appId: 'app-id',
+  databaseURL: 'https://example.firebaseio.com',
+  messagingSenderId: 'sender-id',
+  projectId: 'project-id',
+  storageBucket: 'example.appspot.com',
+};
 
 describe('App', function () {
   describe('modular', function () {
@@ -46,6 +63,27 @@ describe('App', function () {
 
     it('`setLogLevel` function is properly exposed to end user', function () {
       expect(setLogLevel).toBeDefined();
+    });
+
+    it.each(['toString', '__proto__'])('supports the app name %s', async function (name) {
+      const app = await initializeApp(firebaseOptions, name);
+      const namespace = `registry-${name}`;
+      const config: ModuleConfig = {
+        namespace,
+        nativeModuleName: 'NativeRNFBTurboApp',
+        hasMultiAppSupport: true,
+      };
+
+      try {
+        expect(getApp(name)).toBe(app);
+        expect(getOrCreateModularInstance(FirebaseModule, config, app)).toBe(
+          getOrCreateModularInstance(FirebaseModule, config, app),
+        );
+        expect(Object.prototype.hasOwnProperty.call(Object.prototype, namespace)).toBe(false);
+      } finally {
+        await deleteApp(app);
+        delete (Object.prototype as Record<string, unknown>)[namespace];
+      }
     });
 
     it('`onLog()` is called when using Logger (currently only VertexAI uses `onLog()`)', function () {

--- a/packages/app/lib/internal/registry/app.ts
+++ b/packages/app/lib/internal/registry/app.ts
@@ -27,7 +27,7 @@ type FirebaseAppConfig = ReactNativeFirebase.FirebaseAppConfig;
 type FirebaseAppOptions = ReactNativeFirebase.FirebaseAppOptions;
 type ReactNativeAsyncStorage = ReactNativeFirebase.ReactNativeAsyncStorage;
 
-const APP_REGISTRY: Record<string, FirebaseApp> = {};
+const APP_REGISTRY: Record<string, FirebaseApp> = Object.create(null);
 let onAppCreateFn: ((app: FirebaseApp) => void) | null = null;
 const onAppDestroyCallbacks: Array<(app: FirebaseApp) => void> = [];
 let initializedNativeApps = false;

--- a/packages/app/lib/internal/registry/modular.ts
+++ b/packages/app/lib/internal/registry/modular.ts
@@ -31,7 +31,7 @@ type ModularModuleClass<T extends FirebaseModule> = new (
 ) => T;
 
 // app.name -> instanceKey -> module instance
-const MODULAR_INSTANCES: Record<string, Record<string, FirebaseModule>> = {};
+const MODULAR_INSTANCES: Record<string, Record<string, FirebaseModule>> = Object.create(null);
 
 let destroyHookRegistered = false;
 function ensureDestroyHook(): void {
@@ -82,7 +82,7 @@ export function getOrCreateModularInstance<T extends FirebaseModule>(
   const key = customUrlOrRegion ? `${customUrlOrRegion}:${namespace}` : namespace;
 
   if (!MODULAR_INSTANCES[_app.name]) {
-    MODULAR_INSTANCES[_app.name] = {};
+    MODULAR_INSTANCES[_app.name] = Object.create(null);
   }
 
   if (!MODULAR_INSTANCES[_app.name]![key]) {


### PR DESCRIPTION
## What this fixes

- Allows valid secondary Firebase app names that match JavaScript Object prototype properties, including `toString` and `__proto__`.
- Prevents per-app modular instance caching from traversing or writing through inherited objects for those names.

Previously both names were rejected as already registered before native initialization. The modular cache could additionally attach module entries to inherited prototype objects.

## Implementation

The app registry and both levels of the modular-instance registry now use null-prototype dictionaries. Lookup, memoization, deletion, and `Object.values()` behavior otherwise remain unchanged.

## Verification

Permanent focused cases initialize, resolve, memoize modules for, and delete both names while asserting no Object prototype pollution. Both fail on upstream `main`. Complete repository gates pass:

- `yarn lerna:prepare`
- `yarn tests:jest --runInBand` — 103 suites, 1,481 tests, 31 snapshots
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- focused ESLint
- `git diff --check`

## Compatibility

No public API/type or breaking change. This expands valid app-name handling to match the existing non-empty-string contract.