### PR TITLE
fix(app): preserve empty memory storage values

### DIFF
--- a/packages/app/__tests__/app.test.ts
+++ b/packages/app/__tests__/app.test.ts
@@ -15,6 +15,12 @@ import Base64 from '../lib/common/Base64';
 import FirebaseModule from '../lib/internal/FirebaseModule';
 import { getOrCreateModularInstance } from '../lib/internal/registry/modular';
 import type { ModuleConfig } from '../lib/types/internal';
+import {
+  getItem,
+  removeItem,
+  setItem,
+  setReactNativeAsyncStorageInternal,
+} from '../lib/internal/asyncStorage';
 
 const nativeAppModule = NativeModules.NativeRNFBTurboApp;
 nativeAppModule.initializeApp = jest.fn(() => Promise.resolve());
@@ -165,6 +171,19 @@ describe('App', function () {
         await expect(Base64.fromData(new Blob())).rejects.toThrow('read failed');
       } finally {
         globalThis.FileReader = OriginalFileReader;
+      }
+    });
+  });
+
+  describe('memory AsyncStorage', function () {
+    it('round-trips an empty string', async function () {
+      setReactNativeAsyncStorageInternal();
+
+      try {
+        await setItem('empty-value', '');
+        await expect(getItem('empty-value')).resolves.toBe('');
+      } finally {
+        await removeItem('empty-value');
       }
     });
   });

--- a/packages/app/lib/internal/asyncStorage.ts
+++ b/packages/app/lib/internal/asyncStorage.ts
@@ -29,11 +29,7 @@ const asyncStorageMemory: AsyncStorageStatic = {
     return Promise.resolve();
   },
   getItem(key: string): Promise<string | null> {
-    const hasValue = memoryStorage.has(key);
-    if (hasValue) {
-      return Promise.resolve(memoryStorage.get(key) || null);
-    }
-    return Promise.resolve(null);
+    return Promise.resolve(memoryStorage.get(key) ?? null);
   },
   removeItem(key: string): Promise<void> {
     memoryStorage.delete(key);
@@ -61,16 +57,16 @@ export function isMemoryStorage(): boolean {
 }
 
 // Set an item in storage with the React Native Firebase prefix
-export async function setItem(key: string, value: string): Promise<void> {
-  return await asyncStorage.setItem(prefix + key, value);
+export function setItem(key: string, value: string): Promise<void> {
+  return asyncStorage.setItem(prefix + key, value);
 }
 
 // Get an item from storage with the React Native Firebase prefix
-export async function getItem(key: string): Promise<string | null> {
-  return await asyncStorage.getItem(prefix + key);
+export function getItem(key: string): Promise<string | null> {
+  return asyncStorage.getItem(prefix + key);
 }
 
 // Remove an item from storage with the React Native Firebase prefix
-export async function removeItem(key: string): Promise<void> {
-  return await asyncStorage.removeItem(prefix + key);
+export function removeItem(key: string): Promise<void> {
+  return asyncStorage.removeItem(prefix + key);
 }


### PR DESCRIPTION
## What this fixes

The in-memory AsyncStorage fallback now returns a stored empty string as `""` instead of converting it to `null`. This restores the AsyncStorage contract: only a missing key returns `null`.

## Implementation

- Use nullish fallback on the single Map lookup, preserving all defined strings including `""`.
- Return the underlying prefixed storage Promises directly instead of adding redundant async/await wrappers.

## Verification

The exact round-trip regression returns `null` on upstream `main` and `""` with this change. Complete repository gates pass:

- `yarn lerna:prepare`
- `yarn tests:jest --runInBand` — 103 suites, 1,480 tests, 31 snapshots
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- focused ESLint
- `git diff --check`

## Compatibility

Observable correction: an explicitly stored empty string now round-trips instead of appearing absent. Non-empty and missing values are unchanged; there is no public type break.