### PR TITLE
fix(app): isolate native routing keys

### DIFF
--- a/packages/app/__tests__/nativeModuleContract.test.ts
+++ b/packages/app/__tests__/nativeModuleContract.test.ts
@@ -50,6 +50,7 @@ describe('TurboModule wrapper contract (NewArch-AD-17.1)', function () {
     expect(methodB).toHaveBeenCalledTimes(1);
     expect(Object.keys(wrapped)).toContain('methodA');
     expect(Object.keys(wrapped)).toContain('methodB');
+    expect(wrapped.toString).toBeUndefined();
   });
 
   it('routes methods through a 2-host merge composite Proxy (NewArch-AD-14a)', function () {

--- a/packages/app/lib/internal/registry/nativeModule.ts
+++ b/packages/app/lib/internal/registry/nativeModule.ts
@@ -80,9 +80,9 @@ function createRoutingCompositeProxy(
   hosts: Array<{ module: Record<string, unknown> | undefined; argToPrepend: unknown[] }>,
   isTurboModule: boolean,
 ): WrappedNativeModule {
-  const routingMap: Record<string, RouteEntry> = {};
-  const memoizedMethods: Record<string, (...args: unknown[]) => unknown> = {};
-  const memoizedConstants: Record<string, unknown> = {};
+  const routingMap: Record<string, RouteEntry> = Object.create(null);
+  const memoizedMethods: Record<string, (...args: unknown[]) => unknown> = Object.create(null);
+  const memoizedConstants: Record<string, unknown> = Object.create(null);
 
   for (const { module, argToPrepend } of hosts) {
     if (!module) {


### PR DESCRIPTION
## What this fixes

Reading an inherited JavaScript property such as `toString` from a wrapped native module no longer gets mistaken for a routed native member and crashes while dereferencing a nonexistent route. This can occur during ordinary inspection or implicit coercion of the composite wrapper.

## Implementation

The composite router, method cache, and constant cache now use null-prototype dictionaries. Actual enumerable native members—including inherited TurboModule host methods—continue to be collected and routed unchanged.

## Verification

The exact baseline regression throws inside the wrapper getter; the permanent fixed assertion resolves the absent property as `undefined` while all existing single-host and merged-host routing checks pass. Complete repository gates pass:

- `yarn lerna:prepare`
- `yarn tests:jest --runInBand` — 103 suites, 1,479 tests, 31 snapshots
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- focused ESLint
- `git diff --check`

## Compatibility

No public API/type or breaking change. Routed native methods and constants retain their existing behavior.