### PR TITLE
fix(app): preserve memidb event listeners

### DIFF
--- a/packages/app/__tests__/memidb.test.js
+++ b/packages/app/__tests__/memidb.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import FakeEvent from '../lib/internal/web/memidb/lib/FakeEvent';
+import FakeEventTarget from '../lib/internal/web/memidb/lib/FakeEventTarget';
+
+describe('memidb event target', function () {
+  it('preserves registered listeners when removing an unknown listener', function () {
+    const target = new FakeEventTarget();
+    const firstListener = jest.fn();
+    const secondListener = jest.fn();
+
+    target.addEventListener('success', firstListener);
+    target.addEventListener('success', secondListener);
+    target.removeEventListener('success', jest.fn());
+    target.dispatchEvent(new FakeEvent('success'));
+
+    expect(firstListener).toHaveBeenCalledTimes(1);
+    expect(secondListener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/lib/internal/web/memidb/lib/FakeEventTarget.js
+++ b/packages/app/lib/internal/web/memidb/lib/FakeEventTarget.js
@@ -66,7 +66,9 @@ class FakeEventTarget {
         listener.type === type && listener.callback === callback && listener.capture === capture
       );
     });
-    this.listeners.splice(i, 1);
+    if (i >= 0) {
+      this.listeners.splice(i, 1);
+    }
   }
 
   // http://www.w3.org/TR/dom/#dispatching-events


### PR DESCRIPTION
## What this fixes

Removing an IndexedDB fallback listener that was never registered no longer deletes the last real listener. The prior `findIndex()` result of `-1` was passed directly to `splice(-1, 1)`, silently suppressing a legitimate request or transaction callback.

## Implementation

Only splice the listener array when a matching listener was found. Registered-listener removal behavior is unchanged.

## Verification

The exact baseline regression registers two success listeners, removes an unrelated callback, and observes that the second real listener is never called. Both listeners run with this change. Complete repository gates pass:

- `yarn lerna:prepare`
- `yarn tests:jest --runInBand` — 104 suites, 1,480 tests, 31 snapshots
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- focused ESLint
- `git diff --check`

## Compatibility

No public API/type or breaking change. This aligns the fallback EventTarget with standard no-op removal semantics.