### PR TITLE
fix(app, android): clear stale custom auth domains

### DIFF
--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/app/NativeRNFBTurboApp.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/app/NativeRNFBTurboApp.java
@@ -35,11 +35,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class NativeRNFBTurboApp extends NativeRNFBTurboAppSpec implements LifecycleEventListener {
   private static final String TAG = "App";
 
-  public static Map<String, String> authDomains = new HashMap<>();
+  public static final Map<String, String> authDomains = new ConcurrentHashMap<>();
 
   NativeRNFBTurboApp(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -134,6 +135,7 @@ public class NativeRNFBTurboApp extends NativeRNFBTurboAppSpec implements Lifecy
 
     if (firebaseApp != null) {
       firebaseApp.delete();
+      authDomains.remove(appName);
     }
 
     promise.resolve(null);

--- a/packages/app/android/src/reactnative/java/io/invertase/firebase/common/RCTConvertFirebase.java
+++ b/packages/app/android/src/reactnative/java/io/invertase/firebase/common/RCTConvertFirebase.java
@@ -57,8 +57,9 @@ public class RCTConvertFirebase {
     options.put("messagingSenderId", appOptions.getGcmSenderId());
     options.put("storageBucket", appOptions.getStorageBucket());
 
-    if (NativeRNFBTurboApp.authDomains.get(name) != null) {
-      options.put("authDomain", NativeRNFBTurboApp.authDomains.get(name));
+    String authDomain = NativeRNFBTurboApp.authDomains.get(name);
+    if (authDomain != null) {
+      options.put("authDomain", authDomain);
     }
 
     root.put("options", options);

--- a/packages/app/android/src/test/java/io/invertase/firebase/app/NativeRNFBTurboAppTest.java
+++ b/packages/app/android/src/test/java/io/invertase/firebase/app/NativeRNFBTurboAppTest.java
@@ -37,6 +37,7 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
 import io.invertase.firebase.common.RCTConvertFirebase;
 import io.invertase.firebase.common.ReactNativeFirebaseEventEmitter;
 import io.invertase.firebase.common.ReactNativeFirebaseJSON;
@@ -207,6 +208,28 @@ public class NativeRNFBTurboAppTest {
   }
 
   @Test
+  public void firebaseAppToMap_includesOnlyConfiguredAuthDomain() {
+    FirebaseApp firebaseApp = mock(FirebaseApp.class);
+    FirebaseOptions options = mock(FirebaseOptions.class);
+    when(firebaseApp.getName()).thenReturn("secondary");
+    when(firebaseApp.getOptions()).thenReturn(options);
+
+    NativeRNFBTurboApp.configureAuthDomain("secondary", "example.firebaseapp.com");
+    Map<String, Object> appWithAuthDomain = RCTConvertFirebase.firebaseAppToMap(firebaseApp);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> optionsWithAuthDomain =
+        (Map<String, Object>) appWithAuthDomain.get("options");
+    assertEquals("example.firebaseapp.com", optionsWithAuthDomain.get("authDomain"));
+
+    NativeRNFBTurboApp.configureAuthDomain("secondary", null);
+    Map<String, Object> appWithoutAuthDomain = RCTConvertFirebase.firebaseAppToMap(firebaseApp);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> optionsWithoutAuthDomain =
+        (Map<String, Object>) appWithoutAuthDomain.get("options");
+    assertFalse(optionsWithoutAuthDomain.containsKey("authDomain"));
+  }
+
+  @Test
   public void setAutomaticDataCollectionEnabled_delegatesToFirebaseApp() {
     FirebaseApp firebaseApp = mock(FirebaseApp.class);
     try (MockedStatic<FirebaseApp> firebaseApps = mockStatic(FirebaseApp.class)) {
@@ -223,6 +246,7 @@ public class NativeRNFBTurboAppTest {
   public void deleteApp_deletesWhenInstancePresent() {
     FirebaseApp firebaseApp = mock(FirebaseApp.class);
     Promise promise = mock(Promise.class);
+    NativeRNFBTurboApp.configureAuthDomain("secondary", "example.firebaseapp.com");
     try (MockedStatic<FirebaseApp> firebaseApps = mockStatic(FirebaseApp.class)) {
       firebaseApps.when(() -> FirebaseApp.getInstance("secondary")).thenReturn(firebaseApp);
 
@@ -230,6 +254,7 @@ public class NativeRNFBTurboAppTest {
       module.deleteApp("secondary", promise);
 
       verify(firebaseApp).delete();
+      assertFalse(NativeRNFBTurboApp.authDomains.containsKey("secondary"));
       verify(promise).resolve(null);
     }
   }


### PR DESCRIPTION
## Fixes

- Clear a secondary app’s cached custom `authDomain` after successful deletion, preventing a later app with the same name from inheriting stale configuration.
- Make the shared auth-domain cache thread-safe for bridge and serialization access.
- Read each cached domain once while serializing app options.

## Verification

- Added a regression assertion to the existing Android delete-app unit test; it failed before the fix and passes after it.
- `:packages:app:testDebugUnitTest`
- `:packages:app:assembleDebug`
- `:packages:app:lintDebug` (only the four existing generated-spec `StringFormatTrivial` warnings)
- `yarn lint:android` formatter completed with no additional formatting changes; its diff guard sees only this intentional native patch.
- `yarn tests:jest --runInBand` (104 suites, 1,480 tests)
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:deps`
- `yarn reference:api`
- `yarn compare:types`
- `git diff --check`

## Compatibility

No public JavaScript, TypeScript, native module, or generated-spec API changes.