### PR TITLE
fix(messaging, ios): run the completion handler when JS finishes a background message

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessaging+AppDelegate.m
@@ -163,12 +163,12 @@
       // If app is in background state, register background task to guarantee async queues aren't
       // frozen.
       sharedInstance.backgroundTaskId = [application beginBackgroundTaskWithExpirationHandler:^{
-        dispatch_get_main_queue(), ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
           if (sharedInstance.backgroundTaskId != UIBackgroundTaskInvalid) {
             [application endBackgroundTask:sharedInstance.backgroundTaskId];
             sharedInstance.backgroundTaskId = UIBackgroundTaskInvalid;
           }
-        };
+        });
       }];
 
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(25 * NSEC_PER_SEC)),

--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -228,7 +228,7 @@ RCT_EXPORT_METHOD(getIsHeadless : (RCTPromiseResolveBlock)resolve : (RCTPromiseR
 }
 
 RCT_EXPORT_METHOD(completeNotificationProcessing) {
-  dispatch_get_main_queue(), ^{
+  dispatch_async(dispatch_get_main_queue(), ^{
     RNFBMessagingAppDelegate *appDelegate = [RNFBMessagingAppDelegate sharedInstance];
     if (appDelegate.completionHandler) {
       appDelegate.completionHandler(UIBackgroundFetchResultNewData);
@@ -238,7 +238,7 @@ RCT_EXPORT_METHOD(completeNotificationProcessing) {
       [[UIApplication sharedApplication] endBackgroundTask:appDelegate.backgroundTaskId];
       appDelegate.backgroundTaskId = UIBackgroundTaskInvalid;
     }
-  };
+  });
 }
 
 RCT_EXPORT_METHOD(requestPermission


### PR DESCRIPTION
### Description

On 23.x–25.x, `completeNotificationProcessing` and the background task's expiration handler wrap their bodies in

```objc
dispatch_get_main_queue(), ^{ ... };
```

which is a comma expression: the block is created and discarded, never executed. The result:

- JS calls `completeNotificationProcessing()` as soon as the background handler resolves, but nothing happens natively. The fetch completion handler is only called by the 25 s fallback timer, so every data-only message holds a background task open for 25 s regardless of how fast the handler finishes, and iOS budgets the app's future background delivery on that.
- The expiration handler never ends the task either, so a handler that outlives the timer leaves the task open until the system terminates the app.

This is the `dispatch_async` form that `main` has had since the TurboModules migration (`e56c7f406`, v26.0.0), backported unchanged. `release-v24` has the identical lines.

### Related issues

None filed; the fix on `main` was part of a larger rewrite and not called out.

### Release Summary

fix(messaging, ios): complete background message processing as soon as the JS handler resolves instead of after the 25 s fallback timer

### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [ ] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/**/e2e`
  - [ ] `jest` tests added or updated in `packages/**/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No

### Test Plan

Measured on an iPhone 16 running iOS 27 with a release-configuration build, sending a `content-available` data message to the backgrounded app and reading the unified log (`UIKit:BackgroundTask` plus a marker logged when the JS handler resolves):

- Before: JS handler resolved ~100 ms after `didReceiveRemoteNotification`; `Ending background task` logged at +25.03 s, on two separate messages.
- After: `Ending background task` logged at +103 ms, 4 ms after the JS handler resolved.

:fire: