### PR TITLE
chore: set npm homepage to rnfirebase.io on published packages

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -11,6 +11,7 @@
     "compile": "bob build",
     "prepare": "yarn run build && yarn compile"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -30,6 +30,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs analytics android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs analytics ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/app-check/package.json
+++ b/packages/app-check/package.json
@@ -30,6 +30,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs app-check android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs app-check ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/app-distribution/package.json
+++ b/packages/app-distribution/package.json
@@ -30,6 +30,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs app-distribution android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs app-distribution ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -32,6 +32,7 @@
     "compile": "bob build",
     "prepare": "npm run build && npm run build:plugin && npm run compile"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -30,6 +30,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs auth android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs auth ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/crashlytics/package.json
+++ b/packages/crashlytics/package.json
@@ -30,6 +30,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs crashlytics android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs crashlytics ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -32,6 +32,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs database android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs database ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/firestore/package.json
+++ b/packages/firestore/package.json
@@ -31,6 +31,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs firestore android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs firestore ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -28,6 +28,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs functions android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs functions ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/in-app-messaging/package.json
+++ b/packages/in-app-messaging/package.json
@@ -28,6 +28,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs in-app-messaging android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs in-app-messaging ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/installations/package.json
+++ b/packages/installations/package.json
@@ -28,6 +28,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs installations android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs installations ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/messaging/package.json
+++ b/packages/messaging/package.json
@@ -30,6 +30,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs messaging android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs messaging ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/ml/package.json
+++ b/packages/ml/package.json
@@ -28,6 +28,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs ml android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs ml ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/perf/package.json
+++ b/packages/perf/package.json
@@ -30,6 +30,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs perf android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs perf ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/phone-number-verification/package.json
+++ b/packages/phone-number-verification/package.json
@@ -23,6 +23,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs phone-number-verification android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs phone-number-verification ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/remote-config/package.json
+++ b/packages/remote-config/package.json
@@ -28,6 +28,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs remote-config android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs remote-config ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -28,6 +28,7 @@
     "android:codegen": "node ../../scripts/codegen-package.mjs storage android",
     "ios:codegen": "node ../../scripts/codegen-package.mjs storage ios"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/packages/vertexai/package.json
+++ b/packages/vertexai/package.json
@@ -11,6 +11,7 @@
     "compile": "bob build",
     "prepare": "yarn run build && yarn compile"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",

--- a/scripts/_TEMPLATE_/package.json
+++ b/scripts/_TEMPLATE_/package.json
@@ -10,6 +10,7 @@
     "build:clean": "rimraf android/build && rimraf ios/build",
     "prepare": "yarn run build"
   },
+  "homepage": "https://rnfirebase.io",
   "repository": {
     "type": "git",
     "url": "https://github.com/invertase/react-native-firebase",


### PR DESCRIPTION
Adds `homepage` so npm (and scanners that key off it) can bind `@react-native-firebase/*` to https://rnfirebase.io. Repository URLs are unchanged. Private workspace and test apps are untouched.

Does not show on the registry until the next publish.

---
Maintainer note: Fixes internal CPRN-337