### PR TITLE
docs: add when-to-use and GitHub/npm links to homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -10,6 +10,14 @@ React Native Firebase is the officially recommended collection of packages that 
 
 React Native Firebase fully supports React Native apps built using [React Native CLI](https://reactnative.dev/docs/environment-setup?guide=native) or using [Expo](https://docs.expo.dev/).
 
+**Source:** [github.com/invertase/react-native-firebase](https://github.com/invertase/react-native-firebase) &middot; **Packages:** [npmjs.com/org/react-native-firebase](https://www.npmjs.com/org/react-native-firebase) (`@react-native-firebase/app`, `@react-native-firebase/auth`, `@react-native-firebase/firestore`, and one package per Firebase service)
+
+## React Native Firebase vs firebase-js-sdk
+
+Use **React Native Firebase** (this project) when your app runs on Android and/or iOS: it wraps the native Firebase Android and iOS SDKs directly, so you get capabilities the web SDK cannot provide on mobile, like native app analytics, background/killed-state push notifications, and native Crashlytics crash reports.
+
+Use the plain **[firebase-js-sdk](https://github.com/firebase/firebase-js-sdk)** when you're targeting web, React Native Web, or another JavaScript-only environment with no native module support. React Native Firebase already falls back to firebase-js-sdk on those platforms; see [Other / Web](#other--web) below.
+
 ## Prerequisites
 
 Before getting started, the documentation assumes you are able to create a project with React Native and that you have an active Firebase project.


### PR DESCRIPTION
Adds a short "React Native Firebase vs firebase-js-sdk" section near the top of the homepage, plus obvious GitHub repo and npm org links, so an agent/scanner landing on the page doesn't have to follow install instructions to find either.

- New section explains when to reach for React Native Firebase (native Android/iOS apps needing native SDK capabilities like native app analytics, background/killed-state push notifications, and native Crashlytics crash reports) vs plain firebase-js-sdk (web/React Native Web/JavaScript-only), linking to the existing Other / Web section for the fallback path.
- Adds a source/packages line linking to the GitHub repo and the `@react-native-firebase` npm org.

Docs-only change, no JSON-LD/`.well-known` work (that's PRD-300) and no maintainer `AGENTS.md` install-path advertising (that's a separate ticket).

Maintainer note: Fixes internal CPRN-336
