### PR TITLE
fix(auth): [LOW] handle malformed action links

### DIFF
--- a/packages/auth/__tests__/auth.test.ts
+++ b/packages/auth/__tests__/auth.test.ts
@@ -247,6 +247,8 @@ describe('Auth', function () {
     it('`parseActionCodeURL` returns null for invalid action links', function () {
       expect(parseActionCodeURL('https://example.com/not-an-action-link')).toBeNull();
       expect(ActionCodeURL.parseLink('https://example.com/not-an-action-link')).toBeNull();
+      expect(parseActionCodeURL('https://example.com/?link=%')).toBeNull();
+      expect(ActionCodeURL.parseLink('https://example.com/?deep_link_id=%')).toBeNull();
     });
 
     it('`TotpSecret.generateQrCodeUrl` returns synchronously with default account and issuer', function () {

--- a/packages/auth/lib/ActionCodeURL.ts
+++ b/packages/auth/lib/ActionCodeURL.ts
@@ -141,9 +141,8 @@ export class ActionCodeURL {
    * @returns The {@link ActionCodeURL} object, or null if the link is invalid.
    */
   static parseLink(link: string): ActionCodeURL | null {
-    const actionLink = parseDeepLink(link);
-
     try {
+      const actionLink = parseDeepLink(link);
       const searchParams = querystringDecode(extractQuerystring(actionLink));
       const apiKey = searchParams.apiKey ?? null;
       const code = searchParams.oobCode ?? null;


### PR DESCRIPTION
🔥

## Summary

Malformed percent-encoding in an Authentication action link currently escapes the documented invalid-link handling because the deep-link parser runs before the existing `try` block. An externally supplied link such as one containing `link=%` or `deep_link_id=%` can therefore throw a `URIError` into application code instead of returning `null`.

This moves deep-link parsing into the existing error boundary so every malformed or invalid action link follows the documented `null` result.

## Risk

**LOW:** this is an availability and robustness issue at an external deep-link boundary. It does not bypass authentication or disclose data, but an unhandled exception can interrupt an application flow if the caller assumes the documented nullable result.

## Tests

- Added regression cases for malformed `link` and `deep_link_id` values.
- Focused auth Jest suite: 100 tests passed.
- Full Jest suite: 105 suites / 1,522 tests / 31 snapshots passed.
- `yarn tsc:compile`
- `yarn tsc:compile:consumer`
- `yarn lint:js`
- `yarn lint:deps`
