### PR TITLE
fix(ci): [MEDIUM] verify yeetd package checksum

### DIFF
--- a/.github/workflows/tests_e2e_ios.yml
+++ b/.github/workflows/tests_e2e_ios.yml
@@ -312,6 +312,7 @@ jobs:
       - name: Install yeetd and fix iOS perf issues
         run: |
           wget https://github.com/biscuitehh/yeetd/releases/download/1.0/yeetd-normal.pkg
+          echo "adb04eb720581a32d94daef3ea61108c74494083a79f00836556a36214f354be  yeetd-normal.pkg" | shasum -a 256 -c -
           sudo installer -pkg yeetd-normal.pkg -target /
           yeetd &
           launchctl unload -w /System/Library/LaunchAgents/com.apple.ReportCrash.plist

--- a/scripts/tart/provision-toolchain.sh
+++ b/scripts/tart/provision-toolchain.sh
@@ -57,6 +57,7 @@ rnfb_tart_enable_ccache
 
 if ! command -v yeetd >/dev/null 2>&1; then
   wget -q https://github.com/biscuitehh/yeetd/releases/download/1.0/yeetd-normal.pkg -O /tmp/yeetd-normal.pkg
+  echo "adb04eb720581a32d94daef3ea61108c74494083a79f00836556a36214f354be  /tmp/yeetd-normal.pkg" | shasum -a 256 -c -
   sudo installer -pkg /tmp/yeetd-normal.pkg -target /
 fi
 rnfb_tart_start_yeetd


### PR DESCRIPTION
🔥

## Summary

The iOS E2E workflow and Tart provisioning script download the privileged `yeetd` installer from a release URL and execute it with `sudo` without verifying the downloaded bytes. A replaced or corrupted release asset would therefore run before the test build with host-level privileges.

This verifies the SHA-256 digest of the published 1.0 package before either installer invocation. A mismatch fails immediately and prevents installation.

## Risk

**MEDIUM:** exploitation requires compromise or replacement of the external release asset or its delivery path, but successful exploitation reaches a GitHub Actions runner or golden CI image with elevated privileges.

## Verification

- Re-downloaded the official 1.0 asset and independently confirmed SHA-256 `adb04eb720581a32d94daef3ea61108c74494083a79f00836556a36214f354be`.
- Confirmed the valid package passes verification.
- Confirmed a modified package is rejected.
- `bash -n scripts/tart/provision-toolchain.sh`
- ShellCheck passed with only the script's pre-existing exclusions.
- Workflow YAML parse and Prettier checks passed.
- `git diff --check`
