### PR TITLE
fix(auth): remove sensitive authentication logs

### DIFF
--- a/packages/auth/android/src/main/java/io/invertase/firebase/auth/NativeRNFBTurboAuth.java
+++ b/packages/auth/android/src/main/java/io/invertase/firebase/auth/NativeRNFBTurboAuth.java
@@ -195,8 +195,6 @@ public class NativeRNFBTurboAuth extends NativeRNFBTurboAuthSpec {
           } else {
             eventBody.putString("appName", appName); // for js side distribution
           }
-          Log.d(TAG, "addAuthStateListener:eventBody " + eventBody.toString());
-
           ReactNativeFirebaseEvent event =
               new ReactNativeFirebaseEvent("auth_state_changed", eventBody, appName);
           emitter.sendEvent(event);
@@ -1518,7 +1516,7 @@ public class NativeRNFBTurboAuth extends NativeRNFBTurboAuthSpec {
       final String requestKey,
       final double timeout,
       final boolean forceResend) {
-    Log.d(TAG, "verifyPhoneNumber:" + phoneNumber);
+    Log.d(TAG, "verifyPhoneNumber");
 
     FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
     final FirebaseAuth firebaseAuth = FirebaseAuth.getInstance(firebaseApp);

--- a/packages/auth/ios/RNFBAuth/RNFBAuthHelper.m
+++ b/packages/auth/ios/RNFBAuth/RNFBAuthHelper.m
@@ -1097,8 +1097,7 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
                                   if (error) {
                                     [self promiseRejectAuthException:reject error:error];
                                   } else {
-                                    DLog(@"verificationID: %@", verificationID)
-                                        resolve(verificationID);
+                                    resolve(verificationID);
                                   }
                                 }];
 }
@@ -1112,8 +1111,6 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
   FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
 
   DLog(@"verifyPhoneNumberForMultifactor using app: %@", firebaseApp.name);
-  DLog(@"verifyPhoneNumberForMultifactor phoneNumber: %@", phoneNumber);
-  DLog(@"verifyPhoneNumberForMultifactor sessionKey: %@", sessionKey);
   FIRMultiFactorSession *session = [cachedSessions get:sessionKey];
   if (session == nil) {
     [RNFBSharedUtils rejectPromiseWithUserInfo:reject
@@ -1152,8 +1149,6 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
       [[FIRPhoneAuthProvider providerWithAuth:[FIRAuth authWithApp:firebaseApp]]
           credentialWithVerificationID:verificationId
                       verificationCode:verificationCode];
-  DLog(@"credential: %@", credential);
-
   FIRMultiFactorAssertion *assertion =
       [FIRPhoneMultiFactorGenerator assertionWithCredential:credential];
 
@@ -1211,8 +1206,6 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
   DLog(@"using instance resolve generateTotpSecret: %@", firebaseApp.name);
 
   FIRMultiFactorSession *session = [cachedSessions get:sessionKey];
-  DLog(@"using sessionKey: %@", sessionKey);
-  DLog(@"using session: %@", session);
   [FIRTOTPMultiFactorGenerator
       generateSecretWithMultiFactorSession:session
                                 completion:^(FIRTOTPSecret *_Nullable totpSecret,
@@ -1222,9 +1215,7 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
                                   }
                                   else {
                                     NSString *secretKey = totpSecret.sharedSecretKey;
-                                    DLog(@"secretKey generated: %@", secretKey);
                                     [cachedTotpSecrets putReplacing:secretKey value:totpSecret];
-                                    DLog(@"cachedSecret: %@", [cachedTotpSecrets get:secretKey]);
                                     resolve(@{
                                       @"secretKey" : secretKey,
                                     });
@@ -1240,14 +1231,12 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
   FIRApp *firebaseApp = [RCTConvert firAppFromString:appName];
 
   DLog(@"generateQrCodeUrl using instance resolve generateQrCodeUrl: %@", firebaseApp.name);
-  DLog(@"generateQrCodeUrl using secretKey: %@", secretKey);
   FIRTOTPSecret *totpSecret = [cachedTotpSecrets get:secretKey];
   if (!totpSecret) {
     RNFBAuthThrowSyncErrorWithCode(@"invalid-multi-factor-secret",
                                    @"can't find secret for provided key");
   }
   NSString *url = [totpSecret generateQRCodeURLWithAccountName:account issuer:issuer];
-  DLog(@"generateQrCodeUrl got QR Code URL %@", url);
   return url;
 }
 
@@ -1256,9 +1245,7 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
            qrCodeUri:(NSString *)qrCodeUri {
   [self initializeSharedStateOnce];
 
-  DLog(@"generateQrCodeUrl using secretKey: %@", secretKey);
   FIRTOTPSecret *totpSecret = [cachedTotpSecrets get:secretKey];
-  DLog(@"openInOtpApp using qrCodeUri: %@", qrCodeUri);
   [totpSecret openInOTPAppWithQRCodeURL:qrCodeUri];
 }
 
@@ -1345,8 +1332,6 @@ static __strong RNFBAuthCacheRegistry *cachedTotpSecrets;
   DLog(@"using instance finalizeTotpEnrollment: %@", firebaseApp.name);
 
   FIRTOTPSecret *cachedTotpSecret = [cachedTotpSecrets get:totpSecret];
-  DLog(@"using totpSecretKey: %@", totpSecret);
-  DLog(@"using cachedSecret: %@", cachedTotpSecret);
   FIRTOTPMultiFactorAssertion *assertion =
       [FIRTOTPMultiFactorGenerator assertionForEnrollmentWithSecret:cachedTotpSecret
                                                     oneTimePassword:verificationCode];


### PR DESCRIPTION
Native Android and iOS auth code was logging authentication secrets and personal data to debug logs.

- Android: dropped the full `addAuthStateListener` event body log, trimmed the phone number out of the `verifyPhoneNumber` log
- iOS: removed `DLog` calls exposing `verificationID`, MFA `phoneNumber`/`sessionKey`, the sign-in `credential`, TOTP `sessionKey`/`session`/`secretKey`/cached secret, the QR provisioning URL, and the enrollment secret/cached secret

No behavior change, logging only. Validated with prepare, TS compile (lib + consumer), `yarn lint`, all 105 Jest suites (1522 tests, 31 snapshots), `yarn format:js`, and `yarn compare:types`.

Reported by @OskarEichler.