### PR TITLE
fix(firestore, android): avoid Tasks.await wedging collection gets

### DIFF
--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/FirestoreAsyncTaskMap.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/FirestoreAsyncTaskMap.java
@@ -1,0 +1,39 @@
+package io.invertase.firebase.firestore;
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import com.google.android.gms.tasks.Continuation;
+import com.google.android.gms.tasks.Task;
+import java.util.concurrent.Executor;
+
+/**
+ * Maps Play Services {@link Task} results without blocking a shared executor thread.
+ *
+ * <p>Prefer {@link Task#continueWith(Executor, Continuation)} over {@code Tasks.call} + {@code
+ * Tasks.await}: an unbounded await on a single-thread module executor permanently wedges later work
+ * when the upstream Task never completes (for example a Firestore get orphaned across Auth
+ * sign-out).
+ */
+final class FirestoreAsyncTaskMap {
+  private FirestoreAsyncTaskMap() {}
+
+  static <TIn, TOut> Task<TOut> map(
+      Task<TIn> upstream, Executor executor, Continuation<TIn, TOut> continuation) {
+    return upstream.continueWith(executor, continuation);
+  }
+}

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/NativeRNFBTurboFirestoreDocument.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/NativeRNFBTurboFirestoreDocument.java
@@ -125,10 +125,13 @@ public class NativeRNFBTurboFirestoreDocument extends NativeRNFBTurboFirestoreDo
       source = Source.DEFAULT;
     }
 
-    Tasks.call(
+    // Non-blocking: do not Tasks.await on the shared single-thread module executor.
+    // See FirestoreAsyncTaskMap / issue #9278.
+    FirestoreAsyncTaskMap.map(
+            documentReference.get(source),
             turboSupport.getExecutor(),
-            () -> {
-              DocumentSnapshot documentSnapshot = Tasks.await(documentReference.get(source));
+            task -> {
+              DocumentSnapshot documentSnapshot = task.getResult();
               return snapshotToWritableMap(appName, databaseId, documentSnapshot);
             })
         .addOnCompleteListener(

--- a/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
+++ b/packages/firestore/android/src/reactnative/java/io/invertase/firebase/firestore/ReactNativeFirebaseFirestoreQuery.java
@@ -24,7 +24,6 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.tasks.Task;
-import com.google.android.gms.tasks.Tasks;
 import com.google.firebase.firestore.FieldPath;
 import com.google.firebase.firestore.Filter;
 import com.google.firebase.firestore.Query;
@@ -56,10 +55,13 @@ public class ReactNativeFirebaseFirestoreQuery {
   }
 
   public Task<WritableMap> get(Executor executor, Source source) {
-    return Tasks.call(
+    // Non-blocking: do not Tasks.await on the shared single-thread module executor.
+    // See FirestoreAsyncTaskMap / issue #9278.
+    return FirestoreAsyncTaskMap.map(
+        query.get(source),
         executor,
-        () -> {
-          QuerySnapshot querySnapshot = Tasks.await(query.get(source));
+        task -> {
+          QuerySnapshot querySnapshot = task.getResult();
           return snapshotToWritableMap(this.appName, this.databaseId, "get", querySnapshot, null);
         });
   }

--- a/packages/firestore/android/src/test/java/io/invertase/firebase/firestore/FirestoreAsyncTaskMapTest.java
+++ b/packages/firestore/android/src/test/java/io/invertase/firebase/firestore/FirestoreAsyncTaskMapTest.java
@@ -1,0 +1,156 @@
+package io.invertase.firebase.firestore;
+
+/*
+ * Copyright (c) 2016-present Invertase Limited & Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this library except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+
+/**
+ * Regression for unbounded blocking work on a shared single-thread executor (issue #9278). {@link
+ * FirestoreAsyncTaskMap#map} must leave the executor free while the upstream Task is still pending.
+ *
+ * <p>Plain JUnit4 (AndroidTest-AD-1). Does not call {@code Tasks.await} directly — that path loads
+ * {@code Looper.getMainLooper()} via Play Services Tasks internals and is not mockable without
+ * Robolectric.
+ */
+public class FirestoreAsyncTaskMapTest {
+
+  @Test
+  public void map_pendingUpstream_doesNotBlockSharedSingleThreadExecutor() throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      TaskCompletionSource<String> neverCompletes = new TaskCompletionSource<>();
+      CountDownLatch subsequentWork = new CountDownLatch(1);
+
+      FirestoreAsyncTaskMap.map(
+          neverCompletes.getTask(), executor, task -> task.getResult() + "-mapped");
+
+      executor.execute(subsequentWork::countDown);
+
+      assertTrue(
+          "subsequent work on the same single-thread executor must run while upstream Task is"
+              + " still pending (continueWith must not occupy the thread waiting)",
+          subsequentWork.await(2, TimeUnit.SECONDS));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void blockingWorkOnSharedExecutor_wedgesSubsequentWork() throws Exception {
+    // Negative control: same queue-occupancy failure mode as Tasks.call + Tasks.await on the
+    // module executor. Uses a latch stand-in because Tasks.await needs a real Looper on JVM.
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      CountDownLatch blockForever = new CountDownLatch(1);
+      CountDownLatch awaitStarted = new CountDownLatch(1);
+      CountDownLatch subsequentWork = new CountDownLatch(1);
+
+      executor.execute(
+          () -> {
+            try {
+              awaitStarted.countDown();
+              blockForever.await();
+            } catch (InterruptedException ignored) {
+              Thread.currentThread().interrupt();
+            }
+          });
+
+      assertTrue(
+          "blocking work must start on the shared executor",
+          awaitStarted.await(2, TimeUnit.SECONDS));
+      executor.execute(subsequentWork::countDown);
+
+      assertFalse(
+          "blocking work on the single-thread executor wedges later work",
+          subsequentWork.await(500, TimeUnit.MILLISECONDS));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void map_completedUpstream_appliesContinuationOnExecutor() throws Exception {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      TaskCompletionSource<String> source = new TaskCompletionSource<>();
+      CountDownLatch done = new CountDownLatch(1);
+      AtomicReference<String> mapped = new AtomicReference<>();
+
+      FirestoreAsyncTaskMap.map(
+          source.getTask(),
+          executor,
+          task -> {
+            String value = task.getResult() + "-mapped";
+            mapped.set(value);
+            done.countDown();
+            return value;
+          });
+
+      source.setResult("ok");
+
+      assertTrue(done.await(2, TimeUnit.SECONDS));
+      assertEquals("ok-mapped", mapped.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void map_failedUpstream_preservesOriginalExceptionOnContinuationTask() throws Exception {
+    // documentGet / query.get call task.getResult() inside continueWith; Play Services Tasks
+    // unwraps RuntimeExecutionException so the continuation Task fails with the original cause.
+    // That is the exception shape passed to rejectPromiseFirestoreException (issue #9278).
+    // Poll isComplete() — addOnCompleteListener(no executor) loads Looper via TaskExecutors.
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      TaskCompletionSource<String> source = new TaskCompletionSource<>();
+      Exception original = new Exception("firestore-shaped-upstream-failure");
+
+      Task<String> mapped =
+          FirestoreAsyncTaskMap.map(
+              source.getTask(), executor, task -> task.getResult() + "-mapped");
+
+      source.setException(original);
+
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+      while (!mapped.isComplete() && System.nanoTime() < deadline) {
+        Thread.sleep(10);
+      }
+
+      assertTrue("continuation Task must complete after failed upstream", mapped.isComplete());
+      assertFalse(mapped.isSuccessful());
+      assertNotNull(mapped.getException());
+      assertSame(original, mapped.getException());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}

--- a/packages/firestore/e2e/DocumentReference/get.e2e.js
+++ b/packages/firestore/e2e/DocumentReference/get.e2e.js
@@ -60,5 +60,45 @@ describe('firestore.doc().get()', function () {
       snapshot.metadata.fromCache.should.equal(true);
       await deleteDoc(ref);
     });
+
+    // Android documentGet: getOptions null / missing "source" → Source.DEFAULT (L125).
+    // Modular getDoc always passes { source: 'default' }; DocumentReference.get() does not.
+    it('gets data when DocumentReference.get omits options', async function () {
+      const { getFirestore, doc, setDoc, deleteDoc } = firestoreModular;
+
+      const ref = doc(getFirestore(), `${COLLECTION}/get-omit-options`);
+      const data = { foo: 'omit', bar: 1 };
+      await setDoc(ref, data);
+      const snapshot = await ref.get();
+      snapshot.data().should.eql(jet.contextify(data));
+      await deleteDoc(ref);
+    });
+
+    it('gets data when DocumentReference.get passes empty options', async function () {
+      const { getFirestore, doc, setDoc, deleteDoc } = firestoreModular;
+
+      const ref = doc(getFirestore(), `${COLLECTION}/get-empty-options`);
+      const data = { foo: 'empty', bar: 2 };
+      await setDoc(ref, data);
+      const snapshot = await ref.get({});
+      snapshot.data().should.eql(jet.contextify(data));
+      await deleteDoc(ref);
+    });
+
+    // Android documentGet failure arm → rejectPromiseFirestoreException (L142).
+    it('rejects when getting a missing document from cache', async function () {
+      if (Platform.other) {
+        return;
+      }
+      const { getFirestore, doc, getDocFromCache } = firestoreModular;
+
+      const ref = doc(getFirestore(), `${COLLECTION}/never-cached-${Date.now()}`);
+      try {
+        await getDocFromCache(ref);
+        return Promise.reject(new Error('Did not throw an Error.'));
+      } catch (error) {
+        error.code.should.equal('firestore/unavailable');
+      }
+    });
   });
 });

--- a/packages/firestore/lib/FirestoreDocumentReference.ts
+++ b/packages/firestore/lib/FirestoreDocumentReference.ts
@@ -167,8 +167,10 @@ export default class DocumentReference<
       );
     }
 
+    // Always pass an object: iOS TurboModule SpecDocumentGetGetOptions is a C++
+    // reference; undefined/null here SIGSEGVs in documentGet (see PR #9279 CI).
     return this._firestore.native
-      .documentGet(this.path, options)
+      .documentGet(this.path, options ?? {})
       .then(
         (data: unknown) =>
           new FirestoreDocumentSnapshotClass!(


### PR DESCRIPTION
- Fixes #9278

## Summary
Android Firestore query/document `get` used unbounded `Tasks.await` on the shared single-thread module executor, so one never-completing get could permanently stall later `getDocs`/`getDoc`. This switches those paths to `Task.continueWith` (same non-blocking style as aggregates / iOS).

Also always pass `{}` when `DocumentReference.get` omits options so iOS TurboModule does not SIGSEGV on a null `SpecDocumentGetGetOptions` reference.

Somewhat speculative without a reporter repro for the sign-out trigger; the executor wedge mechanism and the regression unit test are solid either way, which is why this is a draft.

## Test plan
- [x] JVM: `FirestoreAsyncTaskMapTest` (pending upstream does not block single-thread executor; failed-upstream exception shape)
- [x] Slot-3 Android firestore-narrowed e2e (763) + Jacoco 100% on touched lines
- [ ] Reporter repro / regression once available
- [ ] iOS e2e green after options `{}` normalization

---
Maintainer note: Fixes internal CPRN-406