### PR TITLE
fix(firestore): defer terminate cache eviction until shutdown completes

### DIFF
--- a/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
+++ b/packages/firestore/android/src/main/java/io/invertase/firebase/firestore/UniversalFirebaseFirestoreModule.java
@@ -161,15 +161,24 @@ public class UniversalFirebaseFirestoreModule extends UniversalFirebaseModule {
   Task<Void> terminate(String appName, String databaseId) {
     FirebaseFirestore firebaseFirestore = getFirestoreForApp(appName, databaseId);
     String firestoreKey = createFirestoreKey(appName, databaseId);
-    if (instanceCache.get(firestoreKey) != null) {
-      instanceCache.get(firestoreKey).clear();
-      instanceCache.remove(firestoreKey);
-    }
 
-    // Clear so a later connectFirestoreEmulator can attach the emulator to a freshly
-    // created FirebaseFirestore after terminate (mirrors iOS emulatorConfigs eviction).
-    emulatorConfigs.remove(firestoreKey);
-
-    return firebaseFirestore.terminate();
+    // Evict only after terminate completes (mirrors iOS). Clearing instanceCache /
+    // emulatorConfigs beforehand lets a concurrent getFirestoreForApp rebuild a
+    // non-emulator client while shutdown is in flight.
+    return firebaseFirestore
+        .terminate()
+        .continueWith(
+            getExecutor(),
+            task -> {
+              // Propagate failure without evicting (mirrors iOS success-only path).
+              // getResult() throws when terminate failed; do not clear caches first.
+              Void result = task.getResult();
+              if (instanceCache.get(firestoreKey) != null) {
+                instanceCache.get(firestoreKey).clear();
+                instanceCache.remove(firestoreKey);
+              }
+              emulatorConfigs.remove(firestoreKey);
+              return result;
+            });
   }
 }

--- a/packages/firestore/e2e/firestore.e2e.js
+++ b/packages/firestore/e2e/firestore.e2e.js
@@ -183,7 +183,12 @@ describe('firestore()', function () {
       // instanceCache using native FIRApp.name so a later getFirestore() is a fresh client.
       // Uses second-rnfb so the default suite instance stays intact. Path must be the
       // second-database collection (allowed by that DB's rules) — not firestore/.
+      //
+      // Suite-level this.retries(4) must not re-run this case after terminate cleared
+      // emulatorConfigs: a retry without reconnect talks to production and fails with
+      // permission-denied on second-database/. Always reconnect in finally.
       it('terminate then subsequent getDoc uses a fresh instance', async function () {
+        this.retries(0);
         if (Platform.other) {
           return;
         }
@@ -191,18 +196,28 @@ describe('firestore()', function () {
         const { getApp } = modular;
         const { getFirestore, getDoc, terminate, doc, setDoc, connectFirestoreEmulator } =
           firestoreModular;
-
-        const db = getFirestore(getApp(), 'second-rnfb');
+        const emuHost = getE2eEmulatorHost();
+        const emuPort = getE2eEmulatorPort('firestore');
+        const connect = db => connectFirestoreEmulator(db, emuHost, emuPort);
         const probePath = 'second-database/terminate-reuse-probe';
-        await setDoc(doc(db, probePath), { ok: true });
 
-        await terminate(db);
+        try {
+          const db = getFirestore(getApp(), 'second-rnfb');
+          // Idempotent if suite before() already connected; required after a prior terminate.
+          connect(db);
+          await setDoc(doc(db, probePath), { ok: true });
 
-        // Must not SIGABRT / FIRIllegalStateException from a cached terminated client.
-        const fresh = getFirestore(getApp(), 'second-rnfb');
-        connectFirestoreEmulator(fresh, getE2eEmulatorHost(), getE2eEmulatorPort('firestore'));
-        const snap = await getDoc(doc(fresh, probePath));
-        should(snap.exists()).equal(true);
+          await terminate(db);
+
+          // Must not SIGABRT / FIRIllegalStateException from a cached terminated client.
+          const fresh = getFirestore(getApp(), 'second-rnfb');
+          connect(fresh);
+          const snap = await getDoc(doc(fresh, probePath));
+          should(snap.exists()).equal(true);
+        } finally {
+          // Restore suite emulator wiring for later Second Database / firestore cases.
+          connect(getFirestore(getApp(), 'second-rnfb'));
+        }
       });
     });
 

--- a/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.mm
+++ b/packages/firestore/ios/RNFBFirestore/RNFBFirestoreModule.mm
@@ -225,25 +225,26 @@ RCT_EXPORT_MODULE(NativeRNFBTurboFirestore);
   FIRFirestore *instance = [RNFBFirestoreCommon getFirestoreForApp:firebaseApp
                                                         databaseId:databaseId];
 
-  // Evict with native FIRApp.name before terminate — same key namespace as getFirestoreForApp.
-  // Using the JS bridge appName ([DEFAULT]) is a no-op for the default app (__FIRAPP_DEFAULT),
-  // leaving a terminated instance cached and causing later SIGABRT.
-  NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:[firebaseApp name]
-                                                                   databaseId:databaseId];
-  [instanceCache removeObjectForKey:firestoreKey];
-
-  // emulatorConfigs is keyed by the JS bridge appName; clear so a later connectFirestoreEmulator
-  // can attach the emulator to a freshly created FIRFirestore after terminate.
-  if (emulatorConfigs != nil) {
-    NSString *emulatorKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
-                                                                    databaseId:databaseId];
-    [emulatorConfigs removeObjectForKey:emulatorKey];
-  }
-
+  // Evict only after terminate completes. Clearing instanceCache beforehand lets a concurrent
+  // getFirestoreForApp rebuild a production-hosted client while the singleton is still shutting
+  // down; later connectFirestoreEmulator is then too late and getDoc can hang (CI release flake).
+  // Cache key must be native FIRApp.name (__FIRAPP_DEFAULT), not the JS bridge name ([DEFAULT]).
   [instance terminateWithCompletion:^(NSError *error) {
     if (error) {
       [RNFBFirestoreCommon promiseRejectFirestoreException:reject error:error];
     } else {
+      NSString *firestoreKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:[firebaseApp name]
+                                                                       databaseId:databaseId];
+      [instanceCache removeObjectForKey:firestoreKey];
+
+      // emulatorConfigs is keyed by the JS bridge appName; clear so a later
+      // connectFirestoreEmulator can attach the emulator to a freshly created FIRFirestore.
+      if (emulatorConfigs != nil) {
+        NSString *emulatorKey = [RNFBFirestoreCommon createFirestoreKeyWithAppName:appName
+                                                                        databaseId:databaseId];
+        [emulatorConfigs removeObjectForKey:emulatorKey];
+      }
+
       resolve(nil);
     }
   }];

--- a/tests/.detoxrc.js
+++ b/tests/.detoxrc.js
@@ -159,6 +159,10 @@ for (let slot = 0; slot < 5; slot += 1) {
     device: `simulator-slot${slot}`,
     app: 'ios.debug',
   };
+  configurations[`ios.sim.release.slot${slot}`] = {
+    device: `simulator-slot${slot}`,
+    app: 'ios.release',
+  };
   configurations[`android.emu.debug.slot${slot}`] = {
     device: `emulator-slot${slot}`,
     app: `android.debug.slot${slot}`,


### PR DESCRIPTION
## Summary
- Evict Firestore `instanceCache` / `emulatorConfigs` only after `terminate` succeeds (iOS + Android), so a concurrent `getFirestore` cannot rebuild a non-emulator client while shutdown is still in flight.
- Harden the terminate-reuse e2e: disable suite retries for that case, reconnect the emulator before/after terminate, and restore `second-rnfb` in `finally`.
- Add slotted `ios.sim.release.slotN` Detox configs for release e2e on parallel slots.

Root cause of the post-#9283 CI flake: pre-completion eviction allowed a production-hosted client during terminate; release hangs on `getDoc`, and mocha `retries(4)` then hit production rules (`permission-denied`).

- Related to #9280

## Test plan
- [x] `yarn lerna:prepare`, `tsc:compile` / consumer / `reference:api`, `lint:js`, `lint:ios:check`, Java format clean, `tests:jest`, `format:js`, `compare:types`
- [x] `yarn tests:android:unit`
- [x] iOS slot-3 release: terminate case 5/5; firestore area release 762 passing
- [ ] CI matrix (esp. iOS release + Android e2e) on this PR
- [ ] Android firestore area `:test-cover` not re-run after post-review success-only `getResult()` ordering (failure-path only)

---
Maintainer note: Related to internal CPRN-414