### PR TITLE
docs: replace missing utils export with getUtils and FilePath in examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -171,7 +171,7 @@ Describe your issue here
 <!-- Thanks for reading this far down ❤️  -->
 <!-- High quality, detailed issues are much easier to triage for maintainers -->
 
-<!-- For bonus points, if you put a 🔥 (:fire:) emojii at the start of the issue title we'll know -->
+<!-- For bonus points, if you put a 🔥 (:fire:) emoji at the start of the issue title we'll know -->
 <!-- that you took the time to fill this out correctly, or, at least read this far -->
 
 ---

--- a/docs/app/utils.mdx
+++ b/docs/app/utils.mdx
@@ -14,12 +14,12 @@ When working with modules such as [Cloud Storage](/storage), you may need to kno
 current directory paths. Rather than installing a separate module, the library provides useful statics
 which can be used.
 
-Access the `FilePath` static via utils:
+Import `FilePath` directly from the app package:
 
 ```js
-import { utils } from '@react-native-firebase/app';
+import { FilePath } from '@react-native-firebase/app';
 
-console.log(utils.FilePath.PICTURES_DIRECTORY);
+console.log(FilePath.PICTURES_DIRECTORY);
 ```
 
 # Test Lab
@@ -35,11 +35,11 @@ data collection. Such functionality can be carried out by taking advantage of th
 > Be aware, `isRunningInTestLab` is Android only property!
 
 ```js
-import { utils } from '@react-native-firebase/app';
+import { getUtils } from '@react-native-firebase/app';
 import { getAnalytics, setAnalyticsCollectionEnabled } from '@react-native-firebase/analytics';
 
 async function bootstrap() {
-  if (utils().isRunningInTestLab) {
+  if (getUtils().isRunningInTestLab) {
     await setAnalyticsCollectionEnabled(getAnalytics(), false);
   }
 }
@@ -55,9 +55,9 @@ separate package.
 > it is `undefined` (including when the native value is empty).
 
 ```js
-import { utils } from '@react-native-firebase/app';
+import { getUtils } from '@react-native-firebase/app';
 
-const version = utils().appVersion;
+const version = getUtils().appVersion;
 if (version) {
   console.log('App version:', version);
 }
@@ -68,11 +68,11 @@ if (version) {
 It is useful to know if the Android device has play services available, and what to do in response to certain use cases:
 
 ```js
-import { utils } from '@react-native-firebase/app';
+import { getUtils } from '@react-native-firebase/app';
 
 async function checkPlayServicesExample() {
   const { status, isAvailable, hasResolution, isUserResolvableError } =
-    utils().playServicesAvailability;
+    getUtils().playServicesAvailability;
   // all good and valid \o/
   if (isAvailable) return Promise.resolve();
   // if the user can resolve the issue i.e by updating play services
@@ -83,19 +83,19 @@ async function checkPlayServicesExample() {
         // SERVICE_MISSING - Google Play services is missing on this device.
         // show something to user
         // and then attempt to install if necessary
-        return utils().makePlayServicesAvailable();
+        return getUtils().makePlayServicesAvailable();
       case 2:
         // SERVICE_VERSION_UPDATE_REQUIRED - The installed version of Google Play services is out of date.
         // show something to user
         // and then attempt to update if necessary
-        return utils().resolutionForPlayServices();
+        return getUtils().resolutionForPlayServices();
 
       default:
         // some default dialog / component?
         // use the link below to tailor response to status codes to suit your use case
         // https://developers.google.com/android/reference/com/google/android/gms/common/ConnectionResult#SERVICE_VERSION_UPDATE_REQUIRED
-        if (isUserResolvableError) return utils().promptForPlayServices();
-        if (hasResolution) return utils().resolutionForPlayServices();
+        if (isUserResolvableError) return getUtils().promptForPlayServices();
+        if (hasResolution) return getUtils().resolutionForPlayServices();
     }
   }
   // There's no way to resolve play services on this device

--- a/docs/messaging/usage/index.mdx
+++ b/docs/messaging/usage/index.mdx
@@ -435,7 +435,7 @@ import { getMessaging, unsubscribeFromTopic } from '@react-native-firebase/messa
 
 const messaging = getMessaging();
 
-unsubscribeFromTopic(messaging, 'weather').then(() => console.log('Unsubscribed fom the topic!'));
+unsubscribeFromTopic(messaging, 'weather').then(() => console.log('Unsubscribed from the topic!'));
 ```
 
 # firebase.json

--- a/docs/storage/usage/index.mdx
+++ b/docs/storage/usage/index.mdx
@@ -80,7 +80,7 @@ library provides [Utils](/app/utils) to help identify device directories:
 import React, { useEffect } from 'react';
 import { View, Button } from 'react-native';
 
-import { utils } from '@react-native-firebase/app';
+import { FilePath } from '@react-native-firebase/app';
 import { getStorage, ref, putFile } from '@react-native-firebase/storage';
 
 function App() {
@@ -91,7 +91,7 @@ function App() {
     <View>
       <Button
         onPress={async () => {
-          const pathToFile = `${utils.FilePath.PICTURES_DIRECTORY}/black-t-shirt-sm.png`;
+          const pathToFile = `${FilePath.PICTURES_DIRECTORY}/black-t-shirt-sm.png`;
           await putFile(reference, pathToFile);
         }}
       />

--- a/docs/storage/usage/index.mdx
+++ b/docs/storage/usage/index.mdx
@@ -74,7 +74,7 @@ const reference = ref(getStorage(), '/images/t-shirts/black-t-shirt-sm.png');
 
 To upload a file directly from the users device, the `putFile` method on a reference accepts a string path to the file
 on the users device. For example, you may be creating an app which uploads users photos. The React Native Firebase
-library provides [Utils](/app/utils) to help identify device directories:
+library provides [utilities](/app/utils) such as `FilePath` to help identify device directories:
 
 ```jsx
 import React, { useEffect } from 'react';


### PR DESCRIPTION
`docs/app/utils.mdx` and `docs/storage/usage/index.mdx` import `utils` from `@react-native-firebase/app`, but the package has no runtime export by that name: `packages/app/lib/index.ts` re-exports `./modular`, which exposes `getUtils(app?)` and the `FilePath` constant (`Utils` is a type-only export). Copying those samples fails at runtime. They now use `getUtils()` and `FilePath`, matching the v26 migration guide.

Also fixes two typos: `emojii` in the bug report template and `fom` in the messaging usage doc.

:fire: