### PR TITLE
fix(app, ios): pin SPM Firebase SDK and retain Measurement ObjC categories

### DIFF
--- a/docs/ios-spm.mdx
+++ b/docs/ios-spm.mdx
@@ -20,6 +20,9 @@ native application code do not change.
   does not provide `spm_dependency`.
 - SPM requires CocoaPods 1.10 or newer. React Native 0.75+ templates already
   satisfy this requirement.
+- SPM pins the Firebase iOS SDK to the same exact version CocoaPods uses
+  (`sdkVersions.ios.firebase` in `@react-native-firebase/app`). It does not
+  float to a newer 12.x release.
 
 SPM requires dynamic framework linkage:
 
@@ -118,8 +121,10 @@ pod-level SPM integration does not otherwise copy into the app bundle.
 RNFB automatically applies two build settings needed for SPM + dynamic
 linkage, on every `pod install`/`pod update`:
 
-- `-ObjC` in the app target's linker flags, so Release's dead-code stripping
-  does not drop Firebase's `FIRLibrary`/`FIRComponent` registration.
+- `-ObjC` in the app target's linker flags and on RNFB pod targets, so
+  Release's dead-code stripping does not drop Firebase's
+  `FIRLibrary`/`FIRComponent` registration or Measurement Objective-C
+  categories statically absorbed into `RNFBAnalytics`.
 - `SWIFT_ENABLE_EXPLICIT_MODULES = 'NO'` and `CLANG_ENABLE_EXPLICIT_MODULES =
 'NO'` on both the app project and the Pods project, so Xcode 26's explicit
   Swift and Clang modules don't fail to resolve Firebase's internal-only SPM

--- a/okf-bundle/ios-spm-native-imports.md
+++ b/okf-bundle/ios-spm-native-imports.md
@@ -3,7 +3,7 @@ type: Reference
 title: iOS SPM native integration decisions
 description: Why RNFB uses dual imports, Objective-C helpers for Swift Firebase products, and an app framework-embedding phase.
 tags: [ios, spm, cocoapods, imports, firebase, cxx-modules]
-timestamp: 2026-08-06T16:00:00Z
+timestamp: 2026-09-11T00:00:00Z
 ---
 
 # iOS SPM native integration decisions
@@ -214,6 +214,39 @@ Linear CPRN-292.
 Do **not** reintroduce comments or docs that claim firebase-ios-sdk products
 use `.library(type: .dynamic)`. That claim is false and misled debugging of
 the multi-pod sharing failure.
+
+## Exact SPM Firebase iOS SDK version
+
+CocoaPods already pins Firebase pods with an exact `version`
+(`spec.dependency pod, version` from `sdkVersions.ios.firebase`). SPM used
+`{ kind: 'upToNextMajorVersion', minimumVersion: version }` in both
+`firebase_dependency` (RN `spm_dependency` → Pods project) and
+`rnfirebase_add_spm_core_to_app_target` (user-project `package_references`).
+Xcode could therefore resolve a newer 12.x than the RNFB pin.
+
+SPM package requirement is `{ kind: 'exactVersion', version: version }` —
+the hash RN's `spm_dependency` and xcodeproj accept for an exact pin, equal
+to `sdkVersions.ios.firebase`. Do not change the CocoaPods Firebase pod
+version path.
+
+Reusing an existing user-project `package_references` entry, including the
+already-linked FirebaseCore healing path, must rewrite a leftover
+`upToNextMajorVersion` to that exact requirement. Leaving the old kind in
+place lets SPM keep floating after upgrade.
+
+## ObjC flag on RNFB pod targets
+
+`rnfirebase_apply_spm_build_settings` adds `-ObjC` to user-project native
+targets so Release dead-code stripping cannot drop FIRLibrary/FIRComponent
+registration. That is not enough when Analytics/Measurement is statically
+absorbed into `RNFBAnalytics` (automatic SPM libraries + dynamic pods):
+Measurement ObjC categories live in the pod's static link, not the app
+target. The same helper therefore adds `-ObjC` to every RNFB pod target
+(`OTHER_LDFLAGS`) as well. Non-RNFB Pods targets are unchanged. Do not add
+CocoaPods-only `IdentitySupport` on the SPM path.
+
+Consumer-facing version pin and `-ObjC` notes:
+[`docs/ios-spm.mdx`](../docs/ios-spm.mdx).
 
 ## App target FirebaseCore link: package dependency alone is not enough
 
@@ -501,6 +534,15 @@ invariants:
   consumer's checked-in `.pbxproj` instead of treating a declared-but-unlinked
   dependency as already done; and `rnfirebase_remove_spm_core_from_app_target`
   removes both artifacts symmetrically;
+- SPM firebase-ios-sdk package requirement is `{ kind: 'exactVersion',
+  version: version }` equal to `sdkVersions.ios.firebase` in both
+  `firebase_dependency` and app-target `package_references`; reusing an
+  existing package reference still rewrites leftover `upToNextMajorVersion`.
+  CocoaPods Firebase pod versions stay exact `spec.dependency` pins;
+- `rnfirebase_apply_spm_build_settings` still adds `-ObjC` to user-project
+  native targets **and** every RNFB pod target (so `RNFBAnalytics` keeps
+  Measurement categories); do not add CocoaPods-only `IdentitySupport` on
+  the SPM path;
 - `embed_frameworks_from`'s Archive `UninstalledProducts` path still skips
   frameworks whose internal binary is missing or not `dynamically linked`
   (`file -b`), so static CocoaPods products are never copied into the app

--- a/okf-bundle/packages/app/index.md
+++ b/okf-bundle/packages/app/index.md
@@ -3,7 +3,7 @@ type: Reference
 title: "@react-native-firebase/app"
 description: Knowledge index for the core app package — Firebase app lifecycle, Expo config plugin, and iOS SPM / CocoaPods integration helpers.
 tags: [app, expo, ios, spm, cocoapods, firebase, integration, test-expo, test-rn-bare]
-timestamp: 2026-09-03T00:00:00Z
+timestamp: 2026-09-11T00:00:00Z
 ---
 
 # @react-native-firebase/app
@@ -18,7 +18,7 @@ The workspace RN CLI prebuilt RNCore iOS **build** fixture (`test-rn-bare/`) is 
 
 ## Documents
 
-* Cross-cutting durable SPM decisions: [iOS SPM native integration](../../ios-spm-native-imports.md) ([app-target FirebaseCore link](../../ios-spm-native-imports.md#app-target-firebasecore-link-package-dependency-alone-is-not-enough); [Expo precompiled linkage repair](../../ios-spm-native-imports.md#expo-precompiled-module-linkage-repair))
+* Cross-cutting durable SPM decisions: [iOS SPM native integration](../../ios-spm-native-imports.md) ([app-target FirebaseCore link](../../ios-spm-native-imports.md#app-target-firebasecore-link-package-dependency-alone-is-not-enough); [exact SPM Firebase SDK version](../../ios-spm-native-imports.md#exact-spm-firebase-ios-sdk-version); [ObjC flag on RNFB pod targets](../../ios-spm-native-imports.md#objc-flag-on-rnfb-pod-targets); [Expo precompiled linkage repair](../../ios-spm-native-imports.md#expo-precompiled-module-linkage-repair))
 
 ## Related repository files
 

--- a/packages/app/__tests__/firebase_spm_shape_test.rb
+++ b/packages/app/__tests__/firebase_spm_shape_test.rb
@@ -163,6 +163,9 @@ if RNFIREBASE_SPM_SHAPE_CHECK_GEMS_AVAILABLE
       assert_equal 'https://github.com/firebase/firebase-ios-sdk.git', pkg.repositoryURL
       assert_equal({ kind: 'upToNextMajorVersion', minimumVersion: '12.10.0' }, pkg.requirement)
 
+      pkg.requirement = { kind: 'exactVersion', version: '12.10.0' }
+      assert_equal({ kind: 'exactVersion', version: '12.10.0' }, pkg.requirement)
+
       ref = project.new(ref_class)
       ref.product_name = 'FirebaseCore'
       ref.package = pkg

--- a/packages/app/__tests__/firebase_spm_test.rb
+++ b/packages/app/__tests__/firebase_spm_test.rb
@@ -483,7 +483,7 @@ class FirebaseSpmTest < Minitest::Test
     call = spm_calls[0]
     assert_equal spec, call[:spec]
     assert_equal 'https://github.com/firebase/firebase-ios-sdk.git', call[:url]
-    assert_equal({ kind: 'upToNextMajorVersion', minimumVersion: '12.10.0' }, call[:requirement])
+    assert_equal({ kind: 'exactVersion', version: '12.10.0' }, call[:requirement])
     assert_equal ['FirebaseAuth'], call[:products]
   end
 
@@ -750,6 +750,7 @@ class FirebaseSpmTest < Minitest::Test
     ref = target.package_product_dependencies[0]
     assert_equal 'FirebaseCore', ref.product_name
     assert_equal RNFirebaseSPM.url, ref.package.repositoryURL
+    assert_equal({ kind: 'exactVersion', version: '12.10.0' }, ref.package.requirement)
 
     search_path = '${SYMROOT}/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/'
     target.build_configurations.each do |config|
@@ -848,6 +849,7 @@ class FirebaseSpmTest < Minitest::Test
 
     assert_equal 1, user_project.root_object.package_references.length
     assert_same existing_pkg, user_project.root_object.package_references[0]
+    assert_equal({ kind: 'exactVersion', version: '12.10.0' }, existing_pkg.requirement)
     assert_equal 1, target.package_product_dependencies.length
     assert_same existing_pkg, target.package_product_dependencies[0].package
     assert_equal 1, user_project.save_count
@@ -902,12 +904,103 @@ class FirebaseSpmTest < Minitest::Test
     assert_same existing_ref, target.package_product_dependencies[0]
     assert_equal 1, user_project.root_object.package_references.length
     assert_same existing_pkg, user_project.root_object.package_references[0]
+    assert_equal({ kind: 'exactVersion', version: '12.10.0' }, existing_pkg.requirement)
     assert_equal 1, user_project.save_count
 
     search_path = '${SYMROOT}/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}/'
     target.build_configurations.each do |config|
       assert_includes target.build_settings(config.name)['SWIFT_INCLUDE_PATHS'], search_path
     end
+  end
+
+  def test_add_core_pins_already_linked_package_to_exact_version
+    load_firebase_spm
+    RNFirebaseSPM.activate!('12.10.0')
+
+    existing_pkg = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference.new
+    existing_pkg.repositoryURL = RNFirebaseSPM.url
+    existing_pkg.requirement = { kind: 'upToNextMajorVersion', minimumVersion: '12.0.0' }
+
+    existing_ref = Xcodeproj::Project::Object::XCSwiftPackageProductDependency.new
+    existing_ref.package = existing_pkg
+    existing_ref.product_name = 'FirebaseCore'
+
+    target = MockTarget.new(['[CP] Embed Pods Frameworks'], package_product_dependencies: [existing_ref])
+    build_file = Xcodeproj::Project::Object::PBXBuildFile.new
+    build_file.product_ref = existing_ref
+    target.frameworks_build_phase.files << build_file
+
+    user_project = MockUserProject.new([target], package_references: [existing_pkg])
+    installer = MockInstaller.new([MockAggregateTarget.new(user_project)])
+
+    rnfirebase_add_spm_core_to_app_target(installer)
+
+    assert_equal({ kind: 'exactVersion', version: '12.10.0' }, existing_pkg.requirement)
+    assert_equal 1, target.package_product_dependencies.length
+    assert_same existing_ref, target.package_product_dependencies[0]
+    assert_equal 1, target.frameworks_build_phase.files.length
+    assert_equal 1, user_project.save_count
+  end
+
+  def test_add_core_already_linked_exact_version_does_not_resave
+    load_firebase_spm
+    RNFirebaseSPM.activate!('12.10.0')
+
+    existing_pkg = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference.new
+    existing_pkg.repositoryURL = RNFirebaseSPM.url
+    existing_pkg.requirement = { kind: 'exactVersion', version: '12.10.0' }
+
+    existing_ref = Xcodeproj::Project::Object::XCSwiftPackageProductDependency.new
+    existing_ref.package = existing_pkg
+    existing_ref.product_name = 'FirebaseCore'
+
+    target = MockTarget.new(['[CP] Embed Pods Frameworks'], package_product_dependencies: [existing_ref])
+    build_file = Xcodeproj::Project::Object::PBXBuildFile.new
+    build_file.product_ref = existing_ref
+    target.frameworks_build_phase.files << build_file
+
+    user_project = MockUserProject.new([target], package_references: [existing_pkg])
+    installer = MockInstaller.new([MockAggregateTarget.new(user_project)])
+
+    rnfirebase_add_spm_core_to_app_target(installer)
+
+    assert_equal({ kind: 'exactVersion', version: '12.10.0' }, existing_pkg.requirement)
+    assert_equal 0, user_project.save_count
+  end
+
+  def test_pin_spm_package_requirement_noops_without_writable_package
+    load_firebase_spm
+    RNFirebaseSPM.activate!('12.10.0')
+
+    refute rnfirebase_pin_spm_package_requirement!(nil)
+    refute rnfirebase_pin_spm_package_requirement!(Object.new)
+  end
+
+  def test_pin_spm_package_requirement_noops_when_already_exact
+    load_firebase_spm
+    RNFirebaseSPM.activate!('12.10.0')
+
+    pkg = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference.new
+    pkg.requirement = { kind: 'exactVersion', version: '12.10.0' }
+
+    refute rnfirebase_pin_spm_package_requirement!(pkg)
+    assert_equal({ kind: 'exactVersion', version: '12.10.0' }, pkg.requirement)
+  end
+
+  def test_rnfb_pod_target_predicate
+    load_firebase_spm
+
+    analytics = MockTarget.new([])
+    analytics.name = 'RNFBAnalytics'
+    assert rnfirebase_rnfb_pod_target?(analytics)
+    app_pod = MockTarget.new([])
+    app_pod.name = 'RNFBApp'
+    assert rnfirebase_rnfb_pod_target?(app_pod)
+    refute rnfirebase_rnfb_pod_target?(MockTarget.new([]))
+    other = MockTarget.new([])
+    other.name = 'React-Core'
+    refute rnfirebase_rnfb_pod_target?(other)
+    refute rnfirebase_rnfb_pod_target?(Object.new)
   end
 
   # ── rnfirebase_apply_spm_build_settings ──
@@ -925,10 +1018,13 @@ class FirebaseSpmTest < Minitest::Test
 
     user_target = MockTarget.new(['[CP] Embed Pods Frameworks'])
     user_project = MockUserProject.new([user_target])
-    pods_target = MockTarget.new([])
+    analytics_pod = MockTarget.new([])
+    analytics_pod.name = 'RNFBAnalytics'
+    other_pod = MockTarget.new([])
+    other_pod.name = 'React-Core'
     pods_project = MockPodsProject.new(
       uuid_prefix: 'ABCDEF',
-      targets: [pods_target]
+      targets: [analytics_pod, other_pod]
     )
     installer = MockInstaller.new(
       [MockAggregateTarget.new(user_project)],
@@ -942,7 +1038,13 @@ class FirebaseSpmTest < Minitest::Test
       assert_equal 'NO', config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES']
       assert_equal 'NO', config.build_settings['CLANG_ENABLE_EXPLICIT_MODULES']
     end
-    pods_target.build_configurations.each do |config|
+    analytics_pod.build_configurations.each do |config|
+      assert_includes config.build_settings['OTHER_LDFLAGS'], '-ObjC'
+      assert_equal 'NO', config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES']
+      assert_equal 'NO', config.build_settings['CLANG_ENABLE_EXPLICIT_MODULES']
+    end
+    other_pod.build_configurations.each do |config|
+      refute_includes rnfirebase_build_setting_list(config.build_settings['OTHER_LDFLAGS']), '-ObjC'
       assert_equal 'NO', config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES']
       assert_equal 'NO', config.build_settings['CLANG_ENABLE_EXPLICIT_MODULES']
     end
@@ -963,12 +1065,18 @@ class FirebaseSpmTest < Minitest::Test
       config.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
     end
     user_project = MockUserProject.new([user_target])
-    pods_target = MockTarget.new([])
-    pods_target.build_configurations.each do |config|
+    analytics_pod = MockTarget.new([], name: 'RNFBAnalytics')
+    analytics_pod.build_configurations.each do |config|
+      config.build_settings['OTHER_LDFLAGS'] = '$(inherited) -ObjC'
       config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
       config.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
     end
-    pods_project = MockPodsProject.new(uuid_prefix: 'ABCDEF', targets: [pods_target])
+    other_pod = MockTarget.new([], name: 'React-Core')
+    other_pod.build_configurations.each do |config|
+      config.build_settings['SWIFT_ENABLE_EXPLICIT_MODULES'] = 'NO'
+      config.build_settings['CLANG_ENABLE_EXPLICIT_MODULES'] = 'NO'
+    end
+    pods_project = MockPodsProject.new(uuid_prefix: 'ABCDEF', targets: [analytics_pod, other_pod])
     installer = MockInstaller.new(
       [MockAggregateTarget.new(user_project)],
       pods_project: pods_project
@@ -982,6 +1090,12 @@ class FirebaseSpmTest < Minitest::Test
     assert_equal 0, pods_project.save_count
     user_target.build_configurations.each do |config|
       assert_equal '$(inherited) -ObjC', config.build_settings['OTHER_LDFLAGS']
+    end
+    analytics_pod.build_configurations.each do |config|
+      assert_equal '$(inherited) -ObjC', config.build_settings['OTHER_LDFLAGS']
+    end
+    other_pod.build_configurations.each do |config|
+      refute_includes rnfirebase_build_setting_list(config.build_settings['OTHER_LDFLAGS']), '-ObjC'
     end
   end
 

--- a/packages/app/firebase_spm.rb
+++ b/packages/app/firebase_spm.rb
@@ -80,7 +80,7 @@ module RNFirebaseSPM
     # least one podspec in this install, and which Firebase SDK `version` it
     # resolved with. Called once, from `firebase_dependency` itself, the
     # first time it successfully takes the SPM path. `version` is stored so
-    # `rnfirebase_add_spm_core_to_app_target` can declare the same minimum
+    # `rnfirebase_add_spm_core_to_app_target` can declare the same exact
     # version requirement on the app target's own FirebaseCore product
     # dependency, without needing its own separate copy of it.
     def activate!(version)
@@ -96,7 +96,7 @@ module RNFirebaseSPM
     # without going through `activate!` above (e.g. a future refactor that
     # assigns the flag directly instead of calling it), and every downstream
     # helper that trusts this return value -- including one that links
-    # FirebaseCore into the app target at a specific minimum version -- would
+    # FirebaseCore into the app target at a specific exact version -- would
     # silently operate on incomplete state instead. Raising `Pod::Informative`
     # here (this file's own user-facing `pod install`-time error class, same
     # as `rnfirebase_fail_if_spm_static_linkage!` below) turns that into a
@@ -117,7 +117,7 @@ module RNFirebaseSPM
 
     # The Firebase SDK version `firebase_dependency` resolved with, recorded
     # by `activate!` above -- used by `rnfirebase_add_spm_core_to_app_target`
-    # to declare the same minimum version requirement on the app target's own
+    # to declare the same exact version requirement on the app target's own
     # FirebaseCore product dependency.
     attr_reader :version
 
@@ -183,6 +183,35 @@ def rnfirebase_build_setting_list(current)
   else
     current.dup
   end
+end
+
+# Exact firebase-ios-sdk SPM requirement. CocoaPods already pins `version`
+# exactly via `spec.dependency pod, version`. SPM used to declare
+# `upToNextMajorVersion`, which lets Xcode resolve a newer 12.x than
+# `sdkVersions.ios.firebase`. `{ kind: 'exactVersion', version: version }`
+# is the Xcode/xcodeproj requirement hash RN's `spm_dependency` passes
+# through unchanged.
+def rnfirebase_spm_package_requirement(version)
+  { kind: 'exactVersion', version: version }
+end
+
+# Rewrites a leftover `upToNextMajorVersion` (or any other kind) on an
+# existing `XCRemoteSwiftPackageReference` to the exact pin. Returns true
+# when the requirement changed so callers can mark the project dirty.
+def rnfirebase_pin_spm_package_requirement!(pkg, version = RNFirebaseSPM.version) # rubocop:disable Naming/PredicateMethod
+  return false if pkg.nil? || !pkg.respond_to?(:requirement=)
+
+  desired = rnfirebase_spm_package_requirement(version)
+  return false if pkg.requirement == desired
+
+  pkg.requirement = desired
+  true
+end
+
+# True for RNFB CocoaPods targets (`RNFBApp`, `RNFBAnalytics`, ...). Used to
+# apply `-ObjC` on the pod that statically absorbs Analytics/Measurement.
+def rnfirebase_rnfb_pod_target?(target)
+  target.respond_to?(:name) && target.name.to_s.start_with?('RNFB')
 end
 
 def rnfirebase_spm_embed_script
@@ -867,6 +896,10 @@ def rnfirebase_add_spm_core_to_app_target(installer)
       # already-linked one -- it has to check the build phase itself.
       existing_ref = target.package_product_dependencies.find { |dep| dep.product_name == 'FirebaseCore' }
       if existing_ref
+        # Pin even when the link is already healthy: a prior RNFB version
+        # may have committed `upToNextMajorVersion` on this package
+        # reference, and leaving that kind in place lets SPM float.
+        project_modified ||= rnfirebase_pin_spm_package_requirement!(existing_ref.package)
         next if target.frameworks_build_phase.files.any? { |bf| bf.product_ref == existing_ref }
 
         # Healing path: reuse the dependency (and its package reference)
@@ -877,10 +910,12 @@ def rnfirebase_add_spm_core_to_app_target(installer)
         pkg = project.root_object.package_references.find do |candidate|
           candidate.instance_of?(pkg_class) && candidate.repositoryURL == RNFirebaseSPM.url
         end
-        unless pkg
+        if pkg
+          project_modified ||= rnfirebase_pin_spm_package_requirement!(pkg)
+        else
           pkg = project.new(pkg_class)
           pkg.repositoryURL = RNFirebaseSPM.url
-          pkg.requirement = { kind: 'upToNextMajorVersion', minimumVersion: RNFirebaseSPM.version }
+          pkg.requirement = rnfirebase_spm_package_requirement(RNFirebaseSPM.version)
           project.root_object.package_references << pkg
         end
 
@@ -1086,17 +1121,18 @@ end
 # `rnfirebase_hook_cocoapods_post_install!` above -- so you normally never
 # need to call this yourself.
 #
-# 1. `-ObjC` in `OTHER_LDFLAGS` (app target, every configuration): under SPM
-#    + dynamic linkage, dead-code stripping can drop Objective-C
-#    classes/categories that are only ever discovered via runtime reflection
-#    rather than a direct static reference -- e.g. Firebase's
-#    FIRLibrary/FIRComponent registration used by RNFBCrashlyticsInitProvider
-#    -- which otherwise crashes the app at launch, but only in Release/
-#    Archive builds (a TestFlight-only failure that's hard to reproduce from
-#    a local Debug build). `-ObjC` forces the linker to keep any object file
-#    that defines an ObjC class/category, without disabling dead-code
-#    stripping or optimizations for anything else, so it doesn't meaningfully
-#    grow the binary or slow down Release builds.
+# 1. `-ObjC` in `OTHER_LDFLAGS` (app target *and* every RNFB pod target,
+#    every configuration): under SPM + dynamic linkage, dead-code stripping
+#    can drop Objective-C classes/categories that are only ever discovered
+#    via runtime reflection rather than a direct static reference -- e.g.
+#    Firebase's FIRLibrary/FIRComponent registration used by
+#    RNFBCrashlyticsInitProvider, and GoogleAppMeasurement categories
+#    statically absorbed into RNFBAnalytics. App-target `-ObjC` does not
+#    keep categories linked into a pod. Without pod-level `-ObjC` those
+#    categories can vanish and Measurement/Remote Config can explode or
+#    hang. `-ObjC` forces the linker to keep any object file that defines
+#    an ObjC class/category, without disabling dead-code stripping or
+#    optimizations for anything else.
 #
 # 2. `SWIFT_ENABLE_EXPLICIT_MODULES = 'NO'` and `CLANG_ENABLE_EXPLICIT_MODULES
 #    = 'NO'` (app target and Pods project, every configuration): Xcode 26
@@ -1187,6 +1223,15 @@ def rnfirebase_apply_spm_build_settings(installer)
   pods_modified = false
   pods_project.targets.each do |target|
     target.build_configurations.each do |config|
+      # Analytics/Measurement ObjC categories live on the pod that
+      # statically absorbs those SPM products. App-target `-ObjC` does
+      # not keep them. Apply to every RNFB pod target (not only
+      # RNFBAnalytics) so each static absorption site retains categories.
+      if rnfirebase_rnfb_pod_target?(target)
+        ldflags_changed = add_flag.call(config.build_settings, 'OTHER_LDFLAGS', '-ObjC')
+        pods_modified ||= ldflags_changed
+      end
+
       explicit_modules_settings.each do |setting|
         unless config.build_settings[setting] == 'NO'
           config.build_settings[setting] = 'NO'
@@ -1217,7 +1262,7 @@ def firebase_dependency(spec, version, spm_products, pods)
     end
     spm_dependency(spec,
                    url: RNFirebaseSPM.url,
-                   requirement: { kind: 'upToNextMajorVersion', minimumVersion: version },
+                   requirement: rnfirebase_spm_package_requirement(version),
                    products: spm_products)
   else
     if defined?(Pod::UI)

--- a/tests/ios/testing.xcodeproj/project.pbxproj
+++ b/tests/ios/testing.xcodeproj/project.pbxproj
@@ -809,8 +809,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 12.15.0;
+				kind = exactVersion;
+				version = 12.18.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
SPM was resolving firebase-ios-sdk upToNextMajor from 12.18.0 and landing on 12.19.0, which hung or crashed live Remote Config e2e. CocoaPods stayed on exact 12.18.0.

This pins the SPM package to the declared SDK version and keeps `-ObjC` on RNFB pods so Measurement categories are not stripped.

---
Maintainer note: Fixes internal CPRN-447