### PR TITLE
Enhance fetchConfig with expiration duration parameter

### DIFF
--- a/packages/remote-config/lib/index.ts
+++ b/packages/remote-config/lib/index.ts
@@ -576,8 +576,8 @@ export function fetchAndActivate(remoteConfig: RemoteConfig): Promise<boolean> {
 /**
  * Fetches and caches configuration from the Remote Config service.
  */
-export function fetchConfig(remoteConfig: RemoteConfig): Promise<void> {
-  return rc(remoteConfig).fetch();
+export function fetchConfig(remoteConfig: RemoteConfig, expirationDurationSeconds?: number): Promise<void> {
+  return rc(remoteConfig).fetch(expirationDurationSeconds);
 }
 
 /**

--- a/packages/remote-config/lib/index.ts
+++ b/packages/remote-config/lib/index.ts
@@ -576,7 +576,10 @@ export function fetchAndActivate(remoteConfig: RemoteConfig): Promise<boolean> {
 /**
  * Fetches and caches configuration from the Remote Config service.
  */
-export function fetchConfig(remoteConfig: RemoteConfig, expirationDurationSeconds?: number): Promise<void> {
+export function fetchConfig(
+  remoteConfig: RemoteConfig,
+  expirationDurationSeconds?: number
+): Promise<void> {
   return rc(remoteConfig).fetch(expirationDurationSeconds);
 }
 

--- a/packages/remote-config/lib/index.ts
+++ b/packages/remote-config/lib/index.ts
@@ -578,7 +578,7 @@ export function fetchAndActivate(remoteConfig: RemoteConfig): Promise<boolean> {
  */
 export function fetchConfig(
   remoteConfig: RemoteConfig,
-  expirationDurationSeconds?: number
+  expirationDurationSeconds?: number,
 ): Promise<void> {
   return rc(remoteConfig).fetch(expirationDurationSeconds);
 }


### PR DESCRIPTION

### Description

Added optional expiration duration parameter to fetchConfig function.

```jsx
// Before v26
import { fetch } from '@react-native-firebase/remote-config';
await fetch(getRemoteConfig(), 10_000);
// After v26
import { fetchConfig } from '@react-native-firebase/remote-config';
await fetchConfig(getRemoteConfig(), ...); // :( no way to pass down `expirationDurationSeconds` arg.
```

### Related issues


### Release Summary



### Checklist

- I read the [Contributor Guide](https://github.com/invertase/react-native-firebase/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
  - [x] Yes
- My change supports the following platforms;
  - [x] `Android`
  - [x] `iOS`
  - [ ] `Other` (macOS, web)
- My change includes tests;
  - [ ] `e2e` tests added or updated in `packages/\*\*/e2e`
  - [ ] `jest` tests added or updated in `packages/\*\*/__tests__`
- [ ] I have updated TypeScript types that are affected by my change.
- This is a breaking change;
  - [ ] Yes
  - [x] No



### Test Plan

...